### PR TITLE
Adding #elif defined(__FreeBSD__)

### DIFF
--- a/src/compat-endian.h
+++ b/src/compat-endian.h
@@ -17,6 +17,8 @@
 #define bswap_64(x) OSSwapInt64(x)
 #define _NEED_ENDIAN_COMPAT
 
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
Allows the building of timescaledb under FreeBSD 11.