### PR TITLE
Add better error checking for index creation.

### DIFF
--- a/sql/main/ddl.sql
+++ b/sql/main/ddl.sql
@@ -119,7 +119,7 @@ BEGIN
         hypertable_row.id,
         hypertable_row.schema_name,
         (SELECT relname FROM pg_class WHERE oid = indexrelid::regclass),
-        _timescaledb_internal.get_general_index_definition(indexrelid, indrelid)
+        _timescaledb_internal.get_general_index_definition(indexrelid, indrelid, hypertable_row)
     )
     WHERE indrelid = main_table;
 END

--- a/sql/main/ddl_triggers.sql
+++ b/sql/main/ddl_triggers.sql
@@ -39,8 +39,8 @@ BEGIN
                 RETURN;
             END IF;
 
-            def = _timescaledb_internal.get_general_index_definition(info.objid, table_oid);
             hypertable_row := _timescaledb_internal.hypertable_from_main_table(table_oid);
+            def = _timescaledb_internal.get_general_index_definition(info.objid, table_oid, hypertable_row);
 
             PERFORM _timescaledb_meta_api.add_index(
                 hypertable_row.id,

--- a/sql/main/ddl_util.sql
+++ b/sql/main/ddl_util.sql
@@ -4,19 +4,65 @@
   and  /*INDEX_NAME*/
 */
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_general_index_definition(
-    index_oid regclass,
-    table_oid regclass)
+    index_oid       REGCLASS,
+    table_oid       REGCLASS,
+    hypertable_row  _timescaledb_catalog.hypertable
+)
 RETURNS text
 LANGUAGE plpgsql VOLATILE AS
 $BODY$
 DECLARE
-    def TEXT;
+    def             TEXT;
+    index_name      TEXT;
+    c               INTEGER;
+    index_row       RECORD;
+    missing_column  TEXT;
 BEGIN
     -- Get index definition
     def := pg_get_indexdef(index_oid);
 
     IF def IS NULL THEN
-        RAISE EXCEPTION 'Cannot process index with definition (no index name matched: %)', index_oid::TEXT;
+        RAISE EXCEPTION 'Cannot process index with no definition: %', index_oid::TEXT;
+    END IF;
+
+    SELECT * INTO STRICT index_row FROM pg_index WHERE indexrelid = index_oid;
+
+    IF index_row.indisunique THEN
+        --unique index must contain time and all partition columns from all epochs
+        SELECT count(*) INTO c
+        FROM pg_attribute
+        WHERE attrelid = table_oid AND
+              attnum = ANY(index_row.indkey) AND
+              attname = hypertable_row.time_column_name;
+
+        IF c < 1 THEN
+            RAISE EXCEPTION 'Cannot create a unique index without the % column', hypertable_row.time_column_name
+            USING ERRCODE = 'IO103';
+        END IF;
+
+        --get any partitioning columns that are not included in the index.
+        SELECT partitioning_column INTO missing_column
+        FROM _timescaledb_catalog.partition_epoch
+        WHERE hypertable_id = hypertable_row.id AND
+              partitioning_column NOT IN (
+                SELECT attname
+                FROM pg_attribute
+                WHERE attrelid = table_oid AND
+                attnum = ANY(index_row.indkey)
+            );
+
+        IF missing_column IS NOT NULL THEN
+            RAISE EXCEPTION 'Cannot create a unique index without the partitioning column: %', missing_column
+            USING ERRCODE = 'IO103';
+        END IF;
+    END IF;
+
+
+    SELECT count(*) INTO c
+    FROM regexp_matches(def, 'ON '||table_oid::TEXT || ' USING', 'g');
+    IF c <> 1 THEN
+         RAISE EXCEPTION 'Cannot process index with definition(no table name match): %', def
+         USING ERRCODE = 'IO103';
     END IF;
 
     def := replace(def, 'ON '|| table_oid::TEXT || ' USING', 'ON /*TABLE_NAME*/ USING');
@@ -24,11 +70,16 @@ BEGIN
     -- Replace index name with /*INDEX_NAME*/
     -- Index name is never schema qualified
     -- Mixed case identifiers are properly handled.
-    SELECT replace(
-            def,
-            'INDEX '|| format('%I', (SELECT c.relname FROM pg_catalog.pg_class AS c WHERE c.oid = index_oid AND c.relkind = 'i'::CHAR) ) || ' ON',
-            'INDEX /*INDEX_NAME*/ ON')
-    INTO def;
+    SELECT format('%I', c.relname) INTO STRICT index_name FROM pg_catalog.pg_class AS c WHERE c.oid = index_oid AND c.relkind = 'i'::CHAR;
+
+    SELECT count(*) INTO c
+    FROM regexp_matches(def, 'INDEX '|| index_name || ' ON', 'g');
+    IF c <> 1 THEN
+         RAISE EXCEPTION 'Cannot process index with definition(no index name match): %', def
+         USING ERRCODE = 'IO103';
+    END IF;
+
+    def := replace(def, 'INDEX '|| index_name || ' ON',  'INDEX /*INDEX_NAME*/ ON');
 
     RETURN def;
 END

--- a/src/errors.h
+++ b/src/errors.h
@@ -15,6 +15,7 @@
 --IO100 - GROUP: DDL errors
 --IO101 - operation not supported
 --IO102 - bad hypertable definition
+--IO103 - bad hypertable index definition
 --IO110 - hypertable already exists
 --I0120 - node already exists
 --I0130 - user already exists
@@ -22,6 +23,7 @@
 #define ERRCODE_IO_DDL_ERRORS MAKE_SQLSTATE('I','O','1','0','0')
 #define ERRCODE_IO_OPERATION_NOT_SUPPORTED MAKE_SQLSTATE('I','O','1','0','1')
 #define ERRCODE_IO_BAD_HYPERTABLE_DEFINITION MAKE_SQLSTATE('I','O','1','0','2')
+#define ERRCODE_IO_BAD_HYPERTABLE_INDEX_DEFINITION MAKE_SQLSTATE('I','O','1','0','3')
 #define ERRCODE_IO_HYPERTABLE_EXISTS MAKE_SQLSTATE('I','O','1','1','0')
 #define ERRCODE_IO_NODE_EXISTS MAKE_SQLSTATE('I','O','1','2','0')
 #define ERRCODE_IO_USER_EXISTS MAKE_SQLSTATE('I','O','1','3','0')

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -50,6 +50,7 @@ EXCEPTION
     WHEN duplicate_object THEN
         --mute error
 END$$;
+CREATE SCHEMA IF NOT EXISTS "customSchema" AUTHORIZATION alt_usr;
 \c single alt_usr
 \dt
              List of relations
@@ -92,19 +93,41 @@ CREATE TABLE PUBLIC."Hypertable_1" (
   sensor_4 NUMERIC NOT NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
+\set ON_ERROR_STOP 0
+CREATE SCHEMA IF NOT EXISTS "customSchema";
+psql:include/ddl_ops_1.sql:14: ERROR:  permission denied for database single
+\set ON_ERROR_STOP 1
+CREATE TABLE "customSchema"."Hypertable_1" (
+  time BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  temp_c int NOT NULL DEFAULT -1,
+  humidity numeric NULL DEFAULT 0,
+  sensor_1 NUMERIC NULL DEFAULT 1,
+  sensor_2 NUMERIC NOT NULL DEFAULT 1,
+  sensor_3 NUMERIC NOT NULL DEFAULT 1,
+  sensor_4 NUMERIC NOT NULL DEFAULT 1
+);
+CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
  create_hypertable 
 -------------------
  
 (1 row)
 
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |  table_name   | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name |      time_column_type       | created_on | chunk_time_interval 
-----+-------------+---------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+-----------------------------+------------+---------------------
-  1 | public      | one_Partition | one_Partition          | _hyper_1                | one_Partition         | _hyper_1_root   |                  1 | STICKY    | timeCustom       | bigint                      | single     |       2592000000000
-  2 | public      | 1dim          | _timescaledb_internal  | _hyper_2                | _timescaledb_internal | _hyper_2_root   |                  1 | STICKY    | time             | timestamp without time zone | single     |       2592000000000
-  3 | public      | Hypertable_1  | _timescaledb_internal  | _hyper_3                | _timescaledb_internal | _hyper_3_root   |                  1 | STICKY    | time             | bigint                      | single     |       2592000000000
-(3 rows)
+ id | schema_name  |  table_name   | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name |      time_column_type       | created_on | chunk_time_interval 
+----+--------------+---------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+-----------------------------+------------+---------------------
+  1 | public       | one_Partition | one_Partition          | _hyper_1                | one_Partition         | _hyper_1_root   |                  1 | STICKY    | timeCustom       | bigint                      | single     |       2592000000000
+  2 | public       | 1dim          | _timescaledb_internal  | _hyper_2                | _timescaledb_internal | _hyper_2_root   |                  1 | STICKY    | time             | timestamp without time zone | single     |       2592000000000
+  3 | public       | Hypertable_1  | _timescaledb_internal  | _hyper_3                | _timescaledb_internal | _hyper_3_root   |                  1 | STICKY    | time             | bigint                      | single     |       2592000000000
+  4 | customSchema | Hypertable_1  | _timescaledb_internal  | _hyper_4                | _timescaledb_internal | _hyper_4_root   |                  1 | STICKY    | time             | bigint                      | single     |       2592000000000
+(4 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_index;
  hypertable_id | main_schema_name |             main_index_name              |                                                              definition                                                               | created_on 
@@ -115,19 +138,52 @@ SELECT * FROM _timescaledb_catalog.hypertable_index;
              1 | public           | one_Partition_timeCustom_series_2_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_2) WHERE (series_2 IS NOT NULL)       | single
              1 | public           | one_Partition_timeCustom_series_bool_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE (series_bool IS NOT NULL) | single
              3 | public           | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
-(6 rows)
+             4 | customSchema     | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
+(7 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");
 CREATE INDEX "ind_humidity" ON PUBLIC."Hypertable_1" (time, "humidity");
 CREATE INDEX "ind_sensor_1" ON PUBLIC."Hypertable_1" (time, "sensor_1");
 INSERT INTO PUBLIC."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
 VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+CREATE UNIQUE INDEX "Unique1" ON PUBLIC."Hypertable_1" (time, "Device_id");
+CREATE UNIQUE INDEX "Unique1" ON "customSchema"."Hypertable_1" (time);
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000001, 'dev1', 30, 70, 1, 2, 3, 100);
+SELECT * FROM _timescaledb_catalog.hypertable_index;
+ hypertable_id | main_schema_name |             main_index_name              |                                                              definition                                                               | created_on 
+---------------+------------------+------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------+------------
+             1 | public           | one_Partition_device_id_timeCustom_idx   | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree (device_id, "timeCustom" DESC NULLS LAST) WHERE (device_id IS NOT NULL)     | single
+             1 | public           | one_Partition_timeCustom_series_0_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_0) WHERE (series_0 IS NOT NULL)       | single
+             1 | public           | one_Partition_timeCustom_series_1_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_1) WHERE (series_1 IS NOT NULL)       | single
+             1 | public           | one_Partition_timeCustom_series_2_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_2) WHERE (series_2 IS NOT NULL)       | single
+             1 | public           | one_Partition_timeCustom_series_bool_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE (series_bool IS NOT NULL) | single
+             3 | public           | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
+             4 | customSchema     | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
+             3 | public           | Hypertable_1_time_temp_c_idx             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", temp_c)                                                            | single
+             3 | public           | ind_humidity                             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", humidity)                                                          | single
+             3 | public           | ind_sensor_1                             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", sensor_1)                                                          | single
+             3 | public           | Unique1                                  | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                | single
+             4 | customSchema     | Unique1                                  | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time")                                                             | single
+(12 rows)
+
 --expect error cases
 \set ON_ERROR_STOP 0
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 31, 71, 72, 4, 1, 102);
+psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "22-Unique1"
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" ("Device_id");
+psql:include/ddl_ops_1.sql:58: ERROR:  Cannot create a unique index without the time column
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (time);
+psql:include/ddl_ops_1.sql:59: ERROR:  Cannot create a unique index without the partitioning column: Device_id
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (sensor_1);
+psql:include/ddl_ops_1.sql:60: ERROR:  Cannot create a unique index without the time column
 UPDATE ONLY PUBLIC."Hypertable_1" SET time = 0 WHERE TRUE;
-psql:include/ddl_ops_1.sql:25: ERROR:  UPDATE ONLY not supported on hypertables
+psql:include/ddl_ops_1.sql:61: ERROR:  UPDATE ONLY not supported on hypertables
 DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
-psql:include/ddl_ops_1.sql:26: ERROR:  DELETE ONLY not currently supported on hypertables
+psql:include/ddl_ops_1.sql:62: ERROR:  DELETE ONLY not currently supported on hypertables
 \set ON_ERROR_STOP 1
 \ir include/ddl_ops_2.sql
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN temp_f INTEGER NOT NULL DEFAULT 31;

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -21,35 +21,84 @@ CREATE TABLE PUBLIC."Hypertable_1" (
   sensor_4 NUMERIC NOT NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
+\set ON_ERROR_STOP 0
+CREATE SCHEMA IF NOT EXISTS "customSchema";
+\set ON_ERROR_STOP 1
+CREATE TABLE "customSchema"."Hypertable_1" (
+  time BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  temp_c int NOT NULL DEFAULT -1,
+  humidity numeric NULL DEFAULT 0,
+  sensor_1 NUMERIC NULL DEFAULT 1,
+  sensor_2 NUMERIC NOT NULL DEFAULT 1,
+  sensor_3 NUMERIC NOT NULL DEFAULT 1,
+  sensor_4 NUMERIC NOT NULL DEFAULT 1
+);
+CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
  create_hypertable 
 -------------------
  
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |  table_name  | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name | time_column_type | created_on | chunk_time_interval 
-----+-------------+--------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+------------------+------------+---------------------
-  1 | public      | Hypertable_1 | _timescaledb_internal  | _hyper_1                | _timescaledb_internal | _hyper_1_root   |                  1 | STICKY    | time             | bigint           | single     |       2592000000000
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+ create_hypertable 
+-------------------
+ 
 (1 row)
+
+SELECT * FROM _timescaledb_catalog.hypertable;
+ id | schema_name  |  table_name  | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name | time_column_type | created_on | chunk_time_interval 
+----+--------------+--------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+------------------+------------+---------------------
+  1 | public       | Hypertable_1 | _timescaledb_internal  | _hyper_1                | _timescaledb_internal | _hyper_1_root   |                  1 | STICKY    | time             | bigint           | single     |       2592000000000
+  2 | customSchema | Hypertable_1 | _timescaledb_internal  | _hyper_2                | _timescaledb_internal | _hyper_2_root   |                  1 | STICKY    | time             | bigint           | single     |       2592000000000
+(2 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_index;
  hypertable_id | main_schema_name |         main_index_name         |                                   definition                                    | created_on 
 ---------------+------------------+---------------------------------+---------------------------------------------------------------------------------+------------
              1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
-(1 row)
+             2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
+(2 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");
 CREATE INDEX "ind_humidity" ON PUBLIC."Hypertable_1" (time, "humidity");
 CREATE INDEX "ind_sensor_1" ON PUBLIC."Hypertable_1" (time, "sensor_1");
 INSERT INTO PUBLIC."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
 VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+CREATE UNIQUE INDEX "Unique1" ON PUBLIC."Hypertable_1" (time, "Device_id");
+CREATE UNIQUE INDEX "Unique1" ON "customSchema"."Hypertable_1" (time);
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000001, 'dev1', 30, 70, 1, 2, 3, 100);
+SELECT * FROM _timescaledb_catalog.hypertable_index;
+ hypertable_id | main_schema_name |         main_index_name         |                                       definition                                       | created_on 
+---------------+------------------+---------------------------------+----------------------------------------------------------------------------------------+------------
+             1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             1 | public           | Hypertable_1_time_temp_c_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", temp_c)             | single
+             1 | public           | ind_humidity                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", humidity)           | single
+             1 | public           | ind_sensor_1                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", sensor_1)           | single
+             1 | public           | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
+             2 | customSchema     | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time")              | single
+(7 rows)
+
 --expect error cases
 \set ON_ERROR_STOP 0
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 31, 71, 72, 4, 1, 102);
+psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "7-Unique1"
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" ("Device_id");
+psql:include/ddl_ops_1.sql:58: ERROR:  Cannot create a unique index without the time column
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (time);
+psql:include/ddl_ops_1.sql:59: ERROR:  Cannot create a unique index without the partitioning column: Device_id
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (sensor_1);
+psql:include/ddl_ops_1.sql:60: ERROR:  Cannot create a unique index without the time column
 UPDATE ONLY PUBLIC."Hypertable_1" SET time = 0 WHERE TRUE;
-psql:include/ddl_ops_1.sql:25: ERROR:  UPDATE ONLY not supported on hypertables
+psql:include/ddl_ops_1.sql:61: ERROR:  UPDATE ONLY not supported on hypertables
 DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
-psql:include/ddl_ops_1.sql:26: ERROR:  DELETE ONLY not currently supported on hypertables
+psql:include/ddl_ops_1.sql:62: ERROR:  DELETE ONLY not currently supported on hypertables
 \set ON_ERROR_STOP 1
 SELECT * FROM PUBLIC."Hypertable_1";
         time         | Device_id | temp_c | humidity | sensor_1 | sensor_2 | sensor_3 | sensor_4 
@@ -90,6 +139,7 @@ EXPLAIN (costs off) SELECT * FROM ONLY PUBLIC."Hypertable_1";
  sensor_3  | numeric | not null default 1             | main     |              | 
  sensor_4  | numeric | not null default 1             | main     |              | 
 Indexes:
+    "Unique1" UNIQUE, btree ("time", "Device_id")
     "Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
     "Hypertable_1_time_temp_c_idx" btree ("time", temp_c)
     "ind_humidity" btree ("time", humidity)
@@ -126,6 +176,7 @@ Child tables: _timescaledb_internal._hyper_1_0_replica
  sensor_3  | numeric | not null default 1             | main     |              | 
  sensor_4  | numeric | not null default 1             | main     |              | 
 Indexes:
+    "5-Unique1" UNIQUE, btree ("time", "Device_id")
     "1-Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
     "2-Hypertable_1_time_temp_c_idx" btree ("time", temp_c)
     "3-ind_humidity" btree ("time", humidity)
@@ -139,7 +190,8 @@ SELECT * FROM _timescaledb_catalog.default_replica_node;
  database_name | hypertable_id | replica_id 
 ---------------+---------------+------------
  single        |             1 |          0
-(1 row)
+ single        |             2 |          0
+(2 rows)
 
 \ir include/ddl_ops_2.sql
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN temp_f INTEGER NOT NULL DEFAULT 31;
@@ -187,6 +239,7 @@ ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_4 BIGINT NOT NULL DEFAULT 13
  sensor_3         | bigint  | not null default 131 | plain    |              | 
  sensor_4         | bigint  | not null default 131 | plain    |              | 
 Indexes:
+    "Unique1" UNIQUE, btree ("time", "Device_id")
     "Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
     "ind_humidity" btree ("time", humidity)
 Triggers:

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -21,35 +21,84 @@ CREATE TABLE PUBLIC."Hypertable_1" (
   sensor_4 NUMERIC NOT NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
+\set ON_ERROR_STOP 0
+CREATE SCHEMA IF NOT EXISTS "customSchema";
+\set ON_ERROR_STOP 1
+CREATE TABLE "customSchema"."Hypertable_1" (
+  time BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  temp_c int NOT NULL DEFAULT -1,
+  humidity numeric NULL DEFAULT 0,
+  sensor_1 NUMERIC NULL DEFAULT 1,
+  sensor_2 NUMERIC NOT NULL DEFAULT 1,
+  sensor_3 NUMERIC NOT NULL DEFAULT 1,
+  sensor_4 NUMERIC NOT NULL DEFAULT 1
+);
+CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
  create_hypertable 
 -------------------
  
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |  table_name  | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name | time_column_type | created_on | chunk_time_interval 
-----+-------------+--------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+------------------+------------+---------------------
-  1 | public      | Hypertable_1 | _timescaledb_internal  | _hyper_1                | _timescaledb_internal | _hyper_1_root   |                  1 | STICKY    | time             | bigint           | single     |       2592000000000
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+ create_hypertable 
+-------------------
+ 
 (1 row)
+
+SELECT * FROM _timescaledb_catalog.hypertable;
+ id | schema_name  |  table_name  | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name | time_column_type | created_on | chunk_time_interval 
+----+--------------+--------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+------------------+------------+---------------------
+  1 | public       | Hypertable_1 | _timescaledb_internal  | _hyper_1                | _timescaledb_internal | _hyper_1_root   |                  1 | STICKY    | time             | bigint           | single     |       2592000000000
+  2 | customSchema | Hypertable_1 | _timescaledb_internal  | _hyper_2                | _timescaledb_internal | _hyper_2_root   |                  1 | STICKY    | time             | bigint           | single     |       2592000000000
+(2 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_index;
  hypertable_id | main_schema_name |         main_index_name         |                                   definition                                    | created_on 
 ---------------+------------------+---------------------------------+---------------------------------------------------------------------------------+------------
              1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
-(1 row)
+             2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
+(2 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");
 CREATE INDEX "ind_humidity" ON PUBLIC."Hypertable_1" (time, "humidity");
 CREATE INDEX "ind_sensor_1" ON PUBLIC."Hypertable_1" (time, "sensor_1");
 INSERT INTO PUBLIC."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
 VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+CREATE UNIQUE INDEX "Unique1" ON PUBLIC."Hypertable_1" (time, "Device_id");
+CREATE UNIQUE INDEX "Unique1" ON "customSchema"."Hypertable_1" (time);
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000001, 'dev1', 30, 70, 1, 2, 3, 100);
+SELECT * FROM _timescaledb_catalog.hypertable_index;
+ hypertable_id | main_schema_name |         main_index_name         |                                       definition                                       | created_on 
+---------------+------------------+---------------------------------+----------------------------------------------------------------------------------------+------------
+             1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             1 | public           | Hypertable_1_time_temp_c_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", temp_c)             | single
+             1 | public           | ind_humidity                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", humidity)           | single
+             1 | public           | ind_sensor_1                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", sensor_1)           | single
+             1 | public           | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
+             2 | customSchema     | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time")              | single
+(7 rows)
+
 --expect error cases
 \set ON_ERROR_STOP 0
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 31, 71, 72, 4, 1, 102);
+psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "7-Unique1"
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" ("Device_id");
+psql:include/ddl_ops_1.sql:58: ERROR:  Cannot create a unique index without the time column
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (time);
+psql:include/ddl_ops_1.sql:59: ERROR:  Cannot create a unique index without the partitioning column: Device_id
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (sensor_1);
+psql:include/ddl_ops_1.sql:60: ERROR:  Cannot create a unique index without the time column
 UPDATE ONLY PUBLIC."Hypertable_1" SET time = 0 WHERE TRUE;
-psql:include/ddl_ops_1.sql:25: ERROR:  UPDATE ONLY not supported on hypertables
+psql:include/ddl_ops_1.sql:61: ERROR:  UPDATE ONLY not supported on hypertables
 DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
-psql:include/ddl_ops_1.sql:26: ERROR:  DELETE ONLY not currently supported on hypertables
+psql:include/ddl_ops_1.sql:62: ERROR:  DELETE ONLY not currently supported on hypertables
 \set ON_ERROR_STOP 1
 SELECT * FROM PUBLIC."Hypertable_1";
         time         | Device_id | temp_c | humidity | sensor_1 | sensor_2 | sensor_3 | sensor_4 
@@ -57,20 +106,21 @@ SELECT * FROM PUBLIC."Hypertable_1";
  1257894000000000000 | dev1      |     30 |       70 |        1 |        2 |        3 |      100
 (1 row)
 
-EXPLAIN SELECT * FROM PUBLIC."Hypertable_1";
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Append  (cost=0.00..13.50 rows=352 width=204)
-   ->  Seq Scan on _hyper_1_0_replica  (cost=0.00..0.00 rows=1 width=204)
-   ->  Seq Scan on _hyper_1_1_0_partition  (cost=0.00..0.00 rows=1 width=204)
-   ->  Seq Scan on _hyper_1_1_0_1_data  (cost=0.00..13.50 rows=350 width=204)
+EXPLAIN (costs off) SELECT * FROM PUBLIC."Hypertable_1";
+                QUERY PLAN                
+------------------------------------------
+ Append
+   ->  Seq Scan on _hyper_1_0_replica
+   ->  Seq Scan on _hyper_1_1_0_partition
+   ->  Seq Scan on _hyper_1_1_0_1_data
 (4 rows)
 
 SELECT * FROM _timescaledb_catalog.default_replica_node;
  database_name | hypertable_id | replica_id 
 ---------------+---------------+------------
  single        |             1 |          0
-(1 row)
+ single        |             2 |          0
+(2 rows)
 
 \ir include/ddl_ops_2.sql
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN temp_f INTEGER NOT NULL DEFAULT 31;
@@ -118,6 +168,7 @@ ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_4 BIGINT NOT NULL DEFAULT 13
  sensor_3         | bigint  | not null default 131 | plain    |              | 
  sensor_4         | bigint  | not null default 131 | plain    |              | 
 Indexes:
+    "Unique1" UNIQUE, btree ("time", "Device_id")
     "Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
     "ind_humidity" btree ("time", humidity)
 Triggers:
@@ -154,6 +205,7 @@ Child tables: _timescaledb_internal._hyper_1_0_replica
  sensor_3         | bigint  | not null default 131   | plain    |              | 
  sensor_4         | bigint  | not null default 131   | plain    |              | 
 Indexes:
+    "5-Unique1" UNIQUE, btree ("time", "Device_id")
     "1-Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
     "3-ind_humidity" btree ("time", humidity)
 Check constraints:

--- a/test/sql/alternate_users.sql
+++ b/test/sql/alternate_users.sql
@@ -8,6 +8,8 @@ EXCEPTION
         --mute error
 END$$;
 
+CREATE SCHEMA IF NOT EXISTS "customSchema" AUTHORIZATION alt_usr;
+
 \c single alt_usr
 \dt
 

--- a/test/sql/ddl_single.sql
+++ b/test/sql/ddl_single.sql
@@ -4,7 +4,7 @@
 \ir include/ddl_ops_1.sql
 
 SELECT * FROM PUBLIC."Hypertable_1";
-EXPLAIN SELECT * FROM PUBLIC."Hypertable_1";
+EXPLAIN (costs off) SELECT * FROM PUBLIC."Hypertable_1";
 SELECT * FROM _timescaledb_catalog.default_replica_node;
 
 \ir include/ddl_ops_2.sql

--- a/test/sql/include/ddl_ops_1.sql
+++ b/test/sql/include/ddl_ops_1.sql
@@ -10,7 +10,26 @@ CREATE TABLE PUBLIC."Hypertable_1" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
 
+\set ON_ERROR_STOP 0
+CREATE SCHEMA IF NOT EXISTS "customSchema";
+\set ON_ERROR_STOP 1
+
+CREATE TABLE "customSchema"."Hypertable_1" (
+  time BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  temp_c int NOT NULL DEFAULT -1,
+  humidity numeric NULL DEFAULT 0,
+  sensor_1 NUMERIC NULL DEFAULT 1,
+  sensor_2 NUMERIC NOT NULL DEFAULT 1,
+  sensor_3 NUMERIC NOT NULL DEFAULT 1,
+  sensor_4 NUMERIC NOT NULL DEFAULT 1
+);
+CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
+
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
+
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+
 SELECT * FROM _timescaledb_catalog.hypertable;
 SELECT * FROM _timescaledb_catalog.hypertable_index;
 
@@ -20,8 +39,25 @@ CREATE INDEX "ind_sensor_1" ON PUBLIC."Hypertable_1" (time, "sensor_1");
 
 INSERT INTO PUBLIC."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
 VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+
+
+CREATE UNIQUE INDEX "Unique1" ON PUBLIC."Hypertable_1" (time, "Device_id");
+CREATE UNIQUE INDEX "Unique1" ON "customSchema"."Hypertable_1" (time);
+
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 30, 70, 1, 2, 3, 100);
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000001, 'dev1', 30, 70, 1, 2, 3, 100);
+
+SELECT * FROM _timescaledb_catalog.hypertable_index;
+
 --expect error cases
 \set ON_ERROR_STOP 0
+INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
+VALUES(1257894000000000000, 'dev1', 31, 71, 72, 4, 1, 102);
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" ("Device_id");
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (time);
+CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (sensor_1);
 UPDATE ONLY PUBLIC."Hypertable_1" SET time = 0 WHERE TRUE;
 DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
This PR adds more regression tests for index creation and tests for more
user-errors. Significantly, it checks for the presence of both the time
and spaced-partition columns in unique indexes. This is needed because
Timescale cannot guarantee uniqueness if colliding rows don't land in the
same chunk.