### PR TITLE
Fixes command tag return for INSERTS on hypertables.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ SRCS = \
 	src/partitioning.c \
 	src/insert.c \
 	src/planner.c \
+	src/executor.c \
 	src/process_utility.c \
 	src/sort_transform.c \
 	src/insert_chunk_state.c \

--- a/src/executor.c
+++ b/src/executor.c
@@ -1,0 +1,39 @@
+#include <postgres.h>
+#include <executor/executor.h>
+
+#include "executor.h"
+
+static ExecutorRun_hook_type prev_ExecutorRun_hook;
+static uint64 additional_tuples;
+
+void
+executor_add_number_tuples_processed(uint64 count)
+{
+	additional_tuples += count;
+}
+
+static void
+timescaledb_ExecutorRun(QueryDesc *queryDesc,
+						ScanDirection direction,
+						uint64 count)
+{
+	additional_tuples = 0;
+	if (prev_ExecutorRun_hook)
+		(*prev_ExecutorRun_hook) (queryDesc, direction, count);
+	else
+		standard_ExecutorRun(queryDesc, direction, count);
+	queryDesc->estate->es_processed += additional_tuples;
+}
+
+void
+_executor_init(void)
+{
+	prev_ExecutorRun_hook = ExecutorRun_hook;
+	ExecutorRun_hook = timescaledb_ExecutorRun;
+}
+
+void
+_executor_fini(void)
+{
+	ExecutorRun_hook = prev_ExecutorRun_hook;
+}

--- a/src/executor.h
+++ b/src/executor.h
@@ -1,0 +1,10 @@
+#ifndef TIMESCALEDB_EXECUTOR_H
+#define TIMESCALEDB_EXECUTOR_H
+#include <postgres.h>
+
+extern void _executor_init(void);
+extern void _executor_fini(void);
+
+extern void executor_add_number_tuples_processed(uint64 count);
+
+#endif /*  TIMESCALEDB_EXECUTOR_H */

--- a/src/init.c
+++ b/src/init.c
@@ -3,6 +3,8 @@
 #include <access/xact.h>
 #include <commands/extension.h>
 
+#include "executor.h"
+
 #define MIN_SUPPORTED_VERSION_STR "9.6"
 #define MIN_SUPPORTED_VERSION_NUM 90600
 
@@ -40,15 +42,21 @@ _PG_init(void)
 	_chunk_cache_init();
 	_cache_invalidate_init();
 	_planner_init();
+	_executor_init();
 	_process_utility_init();
 }
 
 void
 _PG_fini(void)
 {
+	/*
+	 * Order of items should be strict reverse order of _PG_init. Please
+	 * document any exceptions.
+	 */
 	_process_utility_fini();
+	_executor_fini();
 	_planner_fini();
 	_cache_invalidate_fini();
-	_hypertable_cache_fini();
 	_chunk_cache_fini();
+	_hypertable_cache_fini();
 }

--- a/src/insert.c
+++ b/src/insert.c
@@ -32,6 +32,7 @@
 #include "chunk.h"
 #include "insert_chunk_state.h"
 #include "insert_statement_state.h"
+#include "executor.h"
 
 static void
 insert_main_table_cleanup(InsertStatementState **state_p)
@@ -139,6 +140,12 @@ insert_main_table_trigger(PG_FUNCTION_ARGS)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	/*
+	 * add 1 to the number of processed tuples in the commandTag. Without this
+	 * tuples that return NULL in before triggers are not counted.
+	 */
+	executor_add_number_tuples_processed(1);
 
 	/* Return NULL since we do not want the tuple in the trigger's table */
 	return PointerGetDatum(NULL);


### PR DESCRIPTION
Previously, an INSERT on a hypertable would always return
INSERT 0 0 as the command tag. This makes it return the proper
number of items inserted for the second number. Fixes #28.