### PR TITLE
Fixes command tag return for COPY on hypertables.

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -12,6 +12,12 @@ executor_add_number_tuples_processed(uint64 count)
 	additional_tuples += count;
 }
 
+uint64
+executor_get_additional_tuples_processed()
+{
+	return additional_tuples;
+}
+
 static void
 timescaledb_ExecutorRun(QueryDesc *queryDesc,
 						ScanDirection direction,

--- a/src/executor.h
+++ b/src/executor.h
@@ -6,5 +6,6 @@ extern void _executor_init(void);
 extern void _executor_fini(void);
 
 extern void executor_add_number_tuples_processed(uint64 count);
+extern uint64 executor_get_additional_tuples_processed(void);
 
 #endif   /* TIMESCALEDB_EXECUTOR_H */

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -33,16 +33,24 @@ SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associ
  
 (1 row)
 
+--output command tags
+\set QUIET off
 BEGIN;
+BEGIN
 \COPY "one_Partition" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
+COPY 3
 COMMIT;
+COMMIT
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 (1257987600000000000, 'dev1', 1.5, 1),
 (1257987600000000000, 'dev1', 1.5, 2),
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
+INSERT 0 4
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+INSERT 0 1
+\set QUIET on
 DO $$
 BEGIN
     CREATE ROLE alt_usr LOGIN;

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -33,16 +33,24 @@ SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associ
  
 (1 row)
 
+--output command tags
+\set QUIET off
 BEGIN;
+BEGIN
 \COPY "one_Partition" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
+COPY 3
 COMMIT;
+COMMIT
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 (1257987600000000000, 'dev1', 1.5, 1),
 (1257987600000000000, 'dev1', 1.5, 2),
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
+INSERT 0 4
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+INSERT 0 1
+\set QUIET on
 \d+ "one_Partition".*
 Index "one_Partition.1-one_Partition_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -24,6 +24,8 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_1) 
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition' );
+--output command tags
+\set QUIET off
 BEGIN;
 \COPY "one_Partition" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -34,6 +36,7 @@ INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894002000000000, 'dev1', 2.5, 3);
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on
 \o
 SELECT * FROM "one_Partition" ORDER BY "timeCustom", device_id;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/sql/include/insert_single.sql
+++ b/test/sql/include/insert_single.sql
@@ -18,6 +18,8 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_boo
 
 SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition' );
 
+--output command tags
+\set QUIET off
 BEGIN;
 \COPY "one_Partition" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -30,3 +32,4 @@ INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on


### PR DESCRIPTION
Previously, COPY on hypertables always returned 'COPY 0' in the
command tag. Now, returns the correct count. Fixes #40.