### PR TITLE
Disable query optimization on regular tables (non-hypertables)

### DIFF
--- a/src/hypertable_cache.c
+++ b/src/hypertable_cache.c
@@ -184,6 +184,10 @@ hypertable_cache_invalidate_callback(void)
 Hypertable *
 hypertable_cache_get_entry(Cache *cache, Oid relid)
 {
+	if (!OidIsValid(relid))
+	{
+		return NULL;
+	}
 	return hypertable_cache_get_entry_with_table(cache, relid, NULL, NULL);
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -5,6 +5,7 @@
 #include <utils/datetime.h>
 #include <catalog/pg_type.h>
 #include <catalog/namespace.h>
+#include <utils/guc.h>
 
 #include "utils.h"
 #include "nodes/nodes.h"
@@ -351,4 +352,14 @@ timestamptz_bucket(PG_FUNCTION_ARGS)
 		result *= period;
 	}
 	PG_RETURN_TIMESTAMPTZ(result);
+}
+
+inline bool
+util_config_default_off(const char *name)
+{
+	const char *result = GetConfigOption(name, true, true);
+
+	if (result != NULL && strlen(result) == 2 && strncmp(result, "on", 2) == 0)
+		return true;
+	return false;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -33,10 +33,10 @@ extern char *internal_time_to_column_literal_sql(int64 internal_time, Oid type);
 #define CACHE6_elog(a,b,c,d,e,f,g)
 #endif
 
-
 extern FmgrInfo *create_fmgr(char *schema, char *function_name, int num_args);
 extern RangeVar *makeRangeVarFromRelid(Oid relid);
 extern int	int_cmp(const void *a, const void *b);
+extern bool util_config_default_off(const char *name);
 
 #define DATUM_GET(values, attno) \
 	values[attno-1]

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -55,6 +55,15 @@ SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name
 
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
+CREATE TABLE PUBLIC.plain_table (
+  time TIMESTAMPTZ NOT NULL,
+  series_0 DOUBLE PRECISION NULL,
+  series_1 DOUBLE PRECISION NULL,
+  series_2 DOUBLE PRECISION NULL
+);
+CREATE INDEX "time_plain_plain_table" ON PUBLIC.plain_table (time DESC, series_0);
+INSERT INTO plain_table SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
+INSERT INTO plain_table SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
 --non-aggregates use MergeAppend in both optimized and non-optimized
 EXPLAIN (costs off) SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
                              QUERY PLAN                             
@@ -427,3 +436,66 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
  19990 | 19994.5 | 29990 | 141.401909099017
 (2 rows)
 
+--plain tables shouldnt be optimized by default
+EXPLAIN (costs off)
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+FROM plain_table 
+WHERE time < to_timestamp(900) 
+GROUP BY t 
+ORDER BY t DESC 
+LIMIT 2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, "time")) DESC
+         ->  HashAggregate
+               Group Key: date_trunc('minute'::text, "time")
+               ->  Seq Scan on plain_table
+                     Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(7 rows)
+
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+FROM plain_table 
+WHERE time < to_timestamp(900) 
+GROUP BY t 
+ORDER BY t DESC 
+LIMIT 2;
+              t               |  avg  |  min  |       avg        
+------------------------------+-------+-------+------------------
+ Wed Dec 31 16:14:00 1969 PST | 869.5 | 10840 | 29.4858228711055
+ Wed Dec 31 16:13:00 1969 PST | 809.5 | 10780 | 28.4500853206775
+(2 rows)
+
+--can turn on plain table optimizations
+BEGIN;
+    SET LOCAL timescaledb.optimize_plain_tables= 'on';
+    EXPLAIN (costs off)
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+    FROM plain_table 
+    WHERE time < to_timestamp(900) 
+    GROUP BY t 
+    ORDER BY t DESC 
+    LIMIT 2;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Limit
+   ->  GroupAggregate
+         Group Key: date_trunc('minute'::text, "time")
+         ->  Index Scan using time_plain_plain_table on plain_table
+               Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(5 rows)
+
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+    FROM plain_table 
+    WHERE time < to_timestamp(900) 
+    GROUP BY t 
+    ORDER BY t DESC 
+    LIMIT 2;
+              t               |  avg  |  min  |       avg        
+------------------------------+-------+-------+------------------
+ Wed Dec 31 16:14:00 1969 PST | 869.5 | 10840 | 29.4858228711055
+ Wed Dec 31 16:13:00 1969 PST | 809.5 | 10780 | 28.4500853206775
+(2 rows)
+
+ROLLBACK;

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -9,7 +9,7 @@ CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
 SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
-SET timescaledb.disable_optimizations= 'true';
+SET timescaledb.disable_optimizations= 'on';
 \ir include/sql_query_results.sql
 CREATE TABLE PUBLIC.hyper_1 (
   time TIMESTAMP NOT NULL,
@@ -56,6 +56,15 @@ SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name
 
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
+CREATE TABLE PUBLIC.plain_table (
+  time TIMESTAMPTZ NOT NULL,
+  series_0 DOUBLE PRECISION NULL,
+  series_1 DOUBLE PRECISION NULL,
+  series_2 DOUBLE PRECISION NULL
+);
+CREATE INDEX "time_plain_plain_table" ON PUBLIC.plain_table (time DESC, series_0);
+INSERT INTO plain_table SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
+INSERT INTO plain_table SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
 --non-aggregates use MergeAppend in both optimized and non-optimized
 EXPLAIN (costs off) SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
                              QUERY PLAN                             
@@ -398,3 +407,68 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
  19990 | 19994.5 | 29990 | 141.401909099017
 (2 rows)
 
+--plain tables shouldnt be optimized by default
+EXPLAIN (costs off)
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+FROM plain_table 
+WHERE time < to_timestamp(900) 
+GROUP BY t 
+ORDER BY t DESC 
+LIMIT 2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, "time")) DESC
+         ->  HashAggregate
+               Group Key: date_trunc('minute'::text, "time")
+               ->  Seq Scan on plain_table
+                     Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(7 rows)
+
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+FROM plain_table 
+WHERE time < to_timestamp(900) 
+GROUP BY t 
+ORDER BY t DESC 
+LIMIT 2;
+              t               |  avg  |  min  |       avg        
+------------------------------+-------+-------+------------------
+ Wed Dec 31 16:14:00 1969 PST | 869.5 | 10840 | 29.4858228711055
+ Wed Dec 31 16:13:00 1969 PST | 809.5 | 10780 | 28.4500853206775
+(2 rows)
+
+--can turn on plain table optimizations
+BEGIN;
+    SET LOCAL timescaledb.optimize_plain_tables= 'on';
+    EXPLAIN (costs off)
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+    FROM plain_table 
+    WHERE time < to_timestamp(900) 
+    GROUP BY t 
+    ORDER BY t DESC 
+    LIMIT 2;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, "time")) DESC
+         ->  HashAggregate
+               Group Key: date_trunc('minute'::text, "time")
+               ->  Seq Scan on plain_table
+                     Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(7 rows)
+
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+    FROM plain_table 
+    WHERE time < to_timestamp(900) 
+    GROUP BY t 
+    ORDER BY t DESC 
+    LIMIT 2;
+              t               |  avg  |  min  |       avg        
+------------------------------+-------+-------+------------------
+ Wed Dec 31 16:14:00 1969 PST | 869.5 | 10840 | 29.4858228711055
+ Wed Dec 31 16:13:00 1969 PST | 809.5 | 10780 | 28.4500853206775
+(2 rows)
+
+ROLLBACK;

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -1,14 +1,14 @@
 --make sure diff only has explain output not result output
 \! diff ../results/sql_query_results_optimized.out ../results/sql_query_results_unoptimized.out 
 11a12
-> SET timescaledb.disable_optimizations= 'true';
-83,84c84,85
+> SET timescaledb.disable_optimizations= 'on';
+92,93c93,94
 <                                               QUERY PLAN                                              
 < ------------------------------------------------------------------------------------------------------
 ---
 >                                    QUERY PLAN                                   
 > --------------------------------------------------------------------------------
-86,92c87,92
+95,101c96,101
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, _hyper_1_0_replica."time"))
 <          ->  Result
@@ -23,16 +23,16 @@
 >                Group Key: date_trunc('minute'::text, _hyper_1_0_replica."time")
 >                ->  Result
 >                      ->  Append
-94,95d93
+103,104d102
 <                      ->  Sort
 <                            Sort Key: (date_trunc('minute'::text, _hyper_1_1_0_partition."time")) DESC
-97,98c95,96
+106,107c104,105
 <                      ->  Index Scan using "1-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-126,132c124,129
+135,141c133,138
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, _hyper_1_0_replica."time"))
 <          ->  Result
@@ -47,10 +47,10 @@
 >                Group Key: date_trunc('minute'::text, _hyper_1_0_replica."time")
 >                ->  Result
 >                      ->  Append
-135,136d131
+144,145d140
 <                      ->  Sort
 <                            Sort Key: (date_trunc('minute'::text, _hyper_1_1_0_partition."time")) DESC
-139,141c134,136
+148,150c143,145
 <                      ->  Index Scan using "1-time_plain" on _hyper_1_1_0_1_data
 <                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 < (16 rows)
@@ -58,13 +58,13 @@
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 >                                  Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (13 rows)
-212,213c207,208
+221,222c216,217
 <                                                  QUERY PLAN                                                 
 < ------------------------------------------------------------------------------------------------------------
 ---
 >                                       QUERY PLAN                                      
 > --------------------------------------------------------------------------------------
-215,221c210,215
+224,230c219,224
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_0_replica."time"))
 <          ->  Result
@@ -79,22 +79,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, _hyper_1_0_replica."time")
 >                ->  Result
 >                      ->  Append
-223,224d216
+232,233d225
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_0_partition."time")) DESC
-226,227c218,219
+235,236c227,228
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-239,240c231,232
+248,249c240,241
 <                                                                            QUERY PLAN                                                                           
 < ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                                 QUERY PLAN                                                                
 > ------------------------------------------------------------------------------------------------------------------------------------------
-242,248c234,239
+251,257c243,248
 <    ->  GroupAggregate
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
@@ -109,22 +109,22 @@
 >                Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)
 >                ->  Result
 >                      ->  Append
-250,251d240
+259,260d249
 <                      ->  Sort
 <                            Sort Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_0_partition."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
-253,254c242,243
+262,263c251,252
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-266,267c255,256
+275,276c264,265
 <                                                               QUERY PLAN                                                              
 < --------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                    QUERY PLAN                                                   
 > ----------------------------------------------------------------------------------------------------------------
-269,275c258,263
+278,284c267,272
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)))
 <          ->  Result
@@ -139,22 +139,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval))
 >                ->  Result
 >                      ->  Append
-277,278d264
+286,287d273
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_0_partition."time" - '@ 30 secs'::interval))) DESC
-280,281c266,267
+289,290c275,276
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-293,294c279,280
+302,303c288,289
 <                                                                            QUERY PLAN                                                                           
 < ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                                 QUERY PLAN                                                                
 > ------------------------------------------------------------------------------------------------------------------------------------------
-296,302c282,287
+305,311c291,296
 <    ->  GroupAggregate
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
@@ -169,22 +169,22 @@
 >                Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)
 >                ->  Result
 >                      ->  Append
-304,305d288
+313,314d297
 <                      ->  Sort
 <                            Sort Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_0_partition."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
-307,308c290,291
+316,317c299,300
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-320,321c303,304
+329,330c312,313
 <                                                  QUERY PLAN                                                 
 < ------------------------------------------------------------------------------------------------------------
 ---
 >                                       QUERY PLAN                                      
 > --------------------------------------------------------------------------------------
-323,329c306,311
+332,338c315,320
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_0_replica."time"))
 <          ->  Result
@@ -199,22 +199,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, _hyper_2_0_replica."time")
 >                ->  Result
 >                      ->  Append
-331,332d312
+340,341d321
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_0_partition."time")) DESC
-334,335c314,315
+343,344c323,324
 <                      ->  Index Scan using "2-time_plain_tz" on _hyper_2_2_0_2_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_2_2_0_2_data
 > (10 rows)
-347,348c327,328
+356,357c336,337
 <                                                                 QUERY PLAN                                                                 
 < -------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                      QUERY PLAN                                                      
 > ---------------------------------------------------------------------------------------------------------------------
-350,356c330,335
+359,365c339,344
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_2_0_replica."time")::timestamp without time zone))
 <          ->  Result
@@ -229,22 +229,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, (_hyper_2_0_replica."time")::timestamp without time zone)
 >                ->  Result
 >                      ->  Append
-358,359d336
+367,368d345
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, (_hyper_2_2_0_partition."time")::timestamp without time zone)) DESC
-361,362c338,339
+370,371c347,348
 <                      ->  Index Scan using "2-time_plain_tz" on _hyper_2_2_0_2_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_2_2_0_2_data
 > (10 rows)
-374,375c351,352
+383,384c360,361
 <                                        QUERY PLAN                                       
 < ----------------------------------------------------------------------------------------
 ---
 >                             QUERY PLAN                            
 > ------------------------------------------------------------------
-377,383c354,359
+386,392c363,368
 <    ->  GroupAggregate
 <          Group Key: (((_hyper_3_0_replica."time" / 10) * 10))
 <          ->  Result
@@ -259,10 +259,10 @@
 >                Group Key: ((_hyper_3_0_replica."time" / 10) * 10)
 >                ->  Result
 >                      ->  Append
-385,386d360
+394,395d369
 <                      ->  Sort
 <                            Sort Key: (((_hyper_3_3_0_partition."time" / 10) * 10)) DESC
-388,391c362,365
+397,400c371,374
 <                      ->  Index Scan using "3-time_plain_int" on _hyper_3_3_0_3_data
 <                      ->  Index Scan using "4-time_plain_int" on _hyper_3_3_0_4_data
 <                      ->  Index Scan using "5-time_plain_int" on _hyper_3_3_0_5_data
@@ -272,13 +272,13 @@
 >                            ->  Seq Scan on _hyper_3_3_0_4_data
 >                            ->  Seq Scan on _hyper_3_3_0_5_data
 > (12 rows)
-403,404c377,378
+412,413c386,387
 <                                              QUERY PLAN                                             
 < ----------------------------------------------------------------------------------------------------
 ---
 >                                   QUERY PLAN                                  
 > ------------------------------------------------------------------------------
-406,412c380,385
+415,421c389,394
 <    ->  GroupAggregate
 <          Group Key: (((((_hyper_3_0_replica."time" - 2) / 10) * 10) + 2))
 <          ->  Result
@@ -293,10 +293,10 @@
 >                Group Key: ((((_hyper_3_0_replica."time" - 2) / 10) * 10) + 2)
 >                ->  Result
 >                      ->  Append
-414,415d386
+423,424d395
 <                      ->  Sort
 <                            Sort Key: (((((_hyper_3_3_0_partition."time" - 2) / 10) * 10) + 2)) DESC
-417,420c388,391
+426,429c397,400
 <                      ->  Index Scan using "3-time_plain_int" on _hyper_3_3_0_3_data
 <                      ->  Index Scan using "4-time_plain_int" on _hyper_3_3_0_4_data
 <                      ->  Index Scan using "5-time_plain_int" on _hyper_3_3_0_5_data
@@ -306,3 +306,23 @@
 >                            ->  Seq Scan on _hyper_3_3_0_4_data
 >                            ->  Seq Scan on _hyper_3_3_0_5_data
 > (12 rows)
+480,481c451,452
+<                                           QUERY PLAN                                           
+< -----------------------------------------------------------------------------------------------
+---
+>                                            QUERY PLAN                                            
+> -------------------------------------------------------------------------------------------------
+483,487c454,460
+<    ->  GroupAggregate
+<          Group Key: date_trunc('minute'::text, "time")
+<          ->  Index Scan using time_plain_plain_table on plain_table
+<                Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+< (5 rows)
+---
+>    ->  Sort
+>          Sort Key: (date_trunc('minute'::text, "time")) DESC
+>          ->  HashAggregate
+>                Group Key: date_trunc('minute'::text, "time")
+>                ->  Seq Scan on plain_table
+>                      Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+> (7 rows)

--- a/test/sql/sql_query_results_unoptimized.sql
+++ b/test/sql/sql_query_results_unoptimized.sql
@@ -2,5 +2,5 @@
 \ir include/create_single_db.sql
 \o
 
-SET timescaledb.disable_optimizations= 'true';
+SET timescaledb.disable_optimizations= 'on';
 \ir include/sql_query_results.sql


### PR DESCRIPTION
This PR disables query optimizations on regular tables by default.
The option timescaledb.optimize_plain_tables = 'on' enables them
again. timescaledb.disable_optimizations = 'on' disables all
optimizations (note the change from 'true' to 'on').