### PR TITLE
Add default indexes for hypertables

### DIFF
--- a/sql/main/tables.sql
+++ b/sql/main/tables.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.chunk_replica_node_index (
     main_index_name   NAME    NOT NULL,
     definition        TEXT    NOT NULL,
     PRIMARY KEY (schema_name, table_name, index_name),
-    FOREIGN KEY (schema_name, table_name) REFERENCES _timescaledb_catalog.chunk_replica_node (schema_name, table_name),
+    FOREIGN KEY (schema_name, table_name) REFERENCES _timescaledb_catalog.chunk_replica_node (schema_name, table_name) ON DELETE CASCADE,
     FOREIGN KEY (main_schema_name, main_index_name) REFERENCES _timescaledb_catalog.hypertable_index (main_schema_name, main_index_name) ON DELETE CASCADE
 );
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_replica_node_index', '');

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -145,9 +145,13 @@ SELECT * FROM _timescaledb_catalog.hypertable_index;
              1 | public           | one_Partition_timeCustom_series_1_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_1) WHERE (series_1 IS NOT NULL)       | single
              1 | public           | one_Partition_timeCustom_series_2_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_2) WHERE (series_2 IS NOT NULL)       | single
              1 | public           | one_Partition_timeCustom_series_bool_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE (series_bool IS NOT NULL) | single
+             1 | public           | one_Partition_timeCustom_idx             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC)                                                         | single
+             2 | public           | 1dim_time_idx                            | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                                                               | single
              3 | public           | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
+             3 | public           | Hypertable_1_time_idx                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                                                               | single
              4 | customSchema     | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
-(7 rows)
+             4 | customSchema     | Hypertable_1_time_idx                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                                                               | single
+(11 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");
 CREATE INDEX "ind_humidity" ON PUBLIC."Hypertable_1" (time, "humidity");
@@ -168,20 +172,24 @@ SELECT * FROM _timescaledb_catalog.hypertable_index;
              1 | public           | one_Partition_timeCustom_series_1_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_1) WHERE (series_1 IS NOT NULL)       | single
              1 | public           | one_Partition_timeCustom_series_2_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_2) WHERE (series_2 IS NOT NULL)       | single
              1 | public           | one_Partition_timeCustom_series_bool_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE (series_bool IS NOT NULL) | single
+             1 | public           | one_Partition_timeCustom_idx             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("timeCustom" DESC)                                                         | single
+             2 | public           | 1dim_time_idx                            | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                                                               | single
              3 | public           | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
+             3 | public           | Hypertable_1_time_idx                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                                                               | single
              4 | customSchema     | Hypertable_1_time_Device_id_idx          | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                       | single
+             4 | customSchema     | Hypertable_1_time_idx                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                                                               | single
              3 | public           | Hypertable_1_time_temp_c_idx             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", temp_c)                                                            | single
              3 | public           | ind_humidity                             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", humidity)                                                          | single
              3 | public           | ind_sensor_1                             | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", sensor_1)                                                          | single
              3 | public           | Unique1                                  | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")                                                | single
              4 | customSchema     | Unique1                                  | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time")                                                             | single
-(12 rows)
+(16 rows)
 
 --expect error cases
 \set ON_ERROR_STOP 0
 INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
 VALUES(1257894000000000000, 'dev1', 31, 71, 72, 4, 1, 102);
-psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "22-Unique1"
+psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "28-Unique1"
 CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" ("Device_id");
 psql:include/ddl_ops_1.sql:58: ERROR:  Cannot create a unique index without the time column
 CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (time);
@@ -208,6 +216,8 @@ ALTER TABLE my_ht ADD COLUMN val2 integer;
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -228,6 +238,8 @@ ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
  val    | integer | 
  val2   | integer | 
  val3   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -244,6 +256,8 @@ psql:include/ddl_ops_1.sql:81: NOTICE:  column "val3" of relation "my_ht" alread
  val    | integer | 
  val2   | integer | 
  val3   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -258,6 +272,8 @@ ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -273,11 +289,157 @@ psql:include/ddl_ops_1.sql:89: NOTICE:  column "val3" of relation "my_ht" does n
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
     _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
 
+--default indexes--
+--both created
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" btree ("Device_id", "Time" DESC)
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--only time
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time", "Device_id");
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Time_Device_id_idx" btree ("Time", "Device_id")
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--only partition
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" btree ("Device_id", "Time" DESC)
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--null space
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--disable index creation
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
 \ir include/ddl_ops_2.sql
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN temp_f INTEGER NOT NULL DEFAULT 31;
 ALTER TABLE PUBLIC."Hypertable_1" DROP COLUMN temp_c;

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -58,8 +58,10 @@ SELECT * FROM _timescaledb_catalog.hypertable_index;
  hypertable_id | main_schema_name |         main_index_name         |                                   definition                                    | created_on 
 ---------------+------------------+---------------------------------+---------------------------------------------------------------------------------+------------
              1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
+             1 | public           | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)         | single
              2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
-(2 rows)
+             2 | customSchema     | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)         | single
+(4 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");
 CREATE INDEX "ind_humidity" ON PUBLIC."Hypertable_1" (time, "humidity");
@@ -76,19 +78,21 @@ SELECT * FROM _timescaledb_catalog.hypertable_index;
  hypertable_id | main_schema_name |         main_index_name         |                                       definition                                       | created_on 
 ---------------+------------------+---------------------------------+----------------------------------------------------------------------------------------+------------
              1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             1 | public           | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                | single
              2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             2 | customSchema     | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                | single
              1 | public           | Hypertable_1_time_temp_c_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", temp_c)             | single
              1 | public           | ind_humidity                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", humidity)           | single
              1 | public           | ind_sensor_1                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", sensor_1)           | single
              1 | public           | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
              2 | customSchema     | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time")              | single
-(7 rows)
+(9 rows)
 
 --expect error cases
 \set ON_ERROR_STOP 0
 INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
 VALUES(1257894000000000000, 'dev1', 31, 71, 72, 4, 1, 102);
-psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "7-Unique1"
+psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "9-Unique1"
 CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" ("Device_id");
 psql:include/ddl_ops_1.sql:58: ERROR:  Cannot create a unique index without the time column
 CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (time);
@@ -115,6 +119,8 @@ ALTER TABLE my_ht ADD COLUMN val2 integer;
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -135,6 +141,8 @@ ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
  val    | integer | 
  val2   | integer | 
  val3   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -151,6 +159,8 @@ psql:include/ddl_ops_1.sql:81: NOTICE:  column "val3" of relation "my_ht" alread
  val    | integer | 
  val2   | integer | 
  val3   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -165,6 +175,8 @@ ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -180,11 +192,157 @@ psql:include/ddl_ops_1.sql:89: NOTICE:  column "val3" of relation "my_ht" does n
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
     _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
 
+--default indexes--
+--both created
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" btree ("Device_id", "Time" DESC)
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--only time
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time", "Device_id");
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Time_Device_id_idx" btree ("Time", "Device_id")
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--only partition
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" btree ("Device_id", "Time" DESC)
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--null space
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--disable index creation
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
 SELECT * FROM PUBLIC."Hypertable_1";
         time         | Device_id | temp_c | humidity | sensor_1 | sensor_2 | sensor_3 | sensor_4 
 ---------------------+-----------+--------+----------+----------+----------+----------+----------
@@ -226,6 +384,7 @@ EXPLAIN (costs off) SELECT * FROM ONLY PUBLIC."Hypertable_1";
 Indexes:
     "Unique1" UNIQUE, btree ("time", "Device_id")
     "Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
+    "Hypertable_1_time_idx" btree ("time" DESC)
     "Hypertable_1_time_temp_c_idx" btree ("time", temp_c)
     "ind_humidity" btree ("time", humidity)
     "ind_sensor_1" btree ("time", sensor_1)
@@ -261,11 +420,12 @@ Child tables: _timescaledb_internal._hyper_1_0_replica
  sensor_3  | numeric | not null default 1             | main     |              | 
  sensor_4  | numeric | not null default 1             | main     |              | 
 Indexes:
-    "5-Unique1" UNIQUE, btree ("time", "Device_id")
+    "6-Unique1" UNIQUE, btree ("time", "Device_id")
     "1-Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
-    "2-Hypertable_1_time_temp_c_idx" btree ("time", temp_c)
-    "3-ind_humidity" btree ("time", humidity)
-    "4-ind_sensor_1" btree ("time", sensor_1)
+    "2-Hypertable_1_time_idx" btree ("time" DESC)
+    "3-Hypertable_1_time_temp_c_idx" btree ("time", temp_c)
+    "4-ind_humidity" btree ("time", humidity)
+    "5-ind_sensor_1" btree ("time", sensor_1)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key("Device_id", 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key("Device_id", 32768) <= '32767'::smallint)
     "time_range" CHECK ("time" >= '1257892416000000000'::bigint AND "time" <= '1257895007999999999'::bigint)
@@ -328,6 +488,7 @@ ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_4 BIGINT NOT NULL DEFAULT 13
 Indexes:
     "Unique1" UNIQUE, btree ("time", "Device_id")
     "Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
+    "Hypertable_1_time_idx" btree ("time" DESC)
     "ind_humidity" btree ("time", humidity)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -58,8 +58,10 @@ SELECT * FROM _timescaledb_catalog.hypertable_index;
  hypertable_id | main_schema_name |         main_index_name         |                                   definition                                    | created_on 
 ---------------+------------------+---------------------------------+---------------------------------------------------------------------------------+------------
              1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
+             1 | public           | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)         | single
              2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
-(2 rows)
+             2 | customSchema     | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)         | single
+(4 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");
 CREATE INDEX "ind_humidity" ON PUBLIC."Hypertable_1" (time, "humidity");
@@ -76,19 +78,21 @@ SELECT * FROM _timescaledb_catalog.hypertable_index;
  hypertable_id | main_schema_name |         main_index_name         |                                       definition                                       | created_on 
 ---------------+------------------+---------------------------------+----------------------------------------------------------------------------------------+------------
              1 | public           | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             1 | public           | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                | single
              2 | customSchema     | Hypertable_1_time_Device_id_idx | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id")        | single
+             2 | customSchema     | Hypertable_1_time_idx           | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time" DESC)                | single
              1 | public           | Hypertable_1_time_temp_c_idx    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", temp_c)             | single
              1 | public           | ind_humidity                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", humidity)           | single
              1 | public           | ind_sensor_1                    | CREATE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", sensor_1)           | single
              1 | public           | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time", "Device_id") | single
              2 | customSchema     | Unique1                         | CREATE UNIQUE INDEX /*INDEX_NAME*/ ON /*TABLE_NAME*/ USING btree ("time")              | single
-(7 rows)
+(9 rows)
 
 --expect error cases
 \set ON_ERROR_STOP 0
 INSERT INTO "customSchema"."Hypertable_1"(time, "Device_id", temp_c, humidity, sensor_1, sensor_2, sensor_3, sensor_4)
 VALUES(1257894000000000000, 'dev1', 31, 71, 72, 4, 1, 102);
-psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "7-Unique1"
+psql:include/ddl_ops_1.sql:57: ERROR:  duplicate key value violates unique constraint "9-Unique1"
 CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" ("Device_id");
 psql:include/ddl_ops_1.sql:58: ERROR:  Cannot create a unique index without the time column
 CREATE UNIQUE INDEX "Unique2" ON PUBLIC."Hypertable_1" (time);
@@ -115,6 +119,8 @@ ALTER TABLE my_ht ADD COLUMN val2 integer;
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -135,6 +141,8 @@ ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
  val    | integer | 
  val2   | integer | 
  val3   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -151,6 +159,8 @@ psql:include/ddl_ops_1.sql:81: NOTICE:  column "val3" of relation "my_ht" alread
  val    | integer | 
  val2   | integer | 
  val3   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -165,6 +175,8 @@ ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
@@ -180,11 +192,157 @@ psql:include/ddl_ops_1.sql:89: NOTICE:  column "val3" of relation "my_ht" does n
  time   | bigint  | 
  val    | integer | 
  val2   | integer | 
+Indexes:
+    "my_ht_time_idx" btree ("time" DESC)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
     _timescaledb_main_insert_trigger BEFORE INSERT ON my_ht FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
     _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON my_ht FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
 
+--default indexes--
+--both created
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" btree ("Device_id", "Time" DESC)
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--only time
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time", "Device_id");
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Time_Device_id_idx" btree ("Time", "Device_id")
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--only partition
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" btree ("Device_id", "Time" DESC)
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--null space
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "Hypertable_1_with_default_index_enabled_Time_idx" btree ("Time" DESC)
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
+--disable index creation
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\d+ "Hypertable_1_with_default_index_enabled"
+         Table "public.Hypertable_1_with_default_index_enabled"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ Time      | bigint  | not null  | plain    |              | 
+ Device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Triggers:
+    _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
+    _timescaledb_main_insert_trigger BEFORE INSERT ON "Hypertable_1_with_default_index_enabled" FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.main_table_insert_trigger()
+    _timescaledb_modify_trigger BEFORE DELETE OR UPDATE ON "Hypertable_1_with_default_index_enabled" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.on_unsupported_main_table()
+
+ROLLBACK;
 SELECT * FROM PUBLIC."Hypertable_1";
         time         | Device_id | temp_c | humidity | sensor_1 | sensor_2 | sensor_3 | sensor_4 
 ---------------------+-----------+--------+----------+----------+----------+----------+----------
@@ -257,6 +415,7 @@ ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_4 BIGINT NOT NULL DEFAULT 13
 Indexes:
     "Unique1" UNIQUE, btree ("time", "Device_id")
     "Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
+    "Hypertable_1_time_idx" btree ("time" DESC)
     "ind_humidity" btree ("time", humidity)
 Triggers:
     _timescaledb_main_after_insert_trigger AFTER INSERT ON "Hypertable_1" FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_internal.main_table_after_insert_trigger()
@@ -292,9 +451,10 @@ Child tables: _timescaledb_internal._hyper_1_0_replica
  sensor_3         | bigint  | not null default 131   | plain    |              | 
  sensor_4         | bigint  | not null default 131   | plain    |              | 
 Indexes:
-    "5-Unique1" UNIQUE, btree ("time", "Device_id")
+    "6-Unique1" UNIQUE, btree ("time", "Device_id")
     "1-Hypertable_1_time_Device_id_idx" btree ("time", "Device_id")
-    "3-ind_humidity" btree ("time", humidity)
+    "2-Hypertable_1_time_idx" btree ("time" DESC)
+    "4-ind_humidity" btree ("time", humidity)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key("Device_id", 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key("Device_id", 32768) <= '32767'::smallint)
     "time_range" CHECK ("time" >= '1257892416000000000'::bigint AND "time" <= '1257895007999999999'::bigint)

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -11,6 +11,7 @@ SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there i
 \o
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
+CREATE INDEX ON drop_chunk_test1(time DESC);
 SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
  create_hypertable 
 -------------------
@@ -133,6 +134,7 @@ SELECT * FROM _timescaledb_catalog.chunk_replica_node;
 (18 rows)
 
 SELECT _timescaledb_meta.drop_chunks_older_than(2);
+NOTICE:  index "1-drop_chunk_test1_time_idx" does not exist, skipping
  drop_chunks_older_than 
 ------------------------
  
@@ -196,6 +198,7 @@ SELECT * FROM _timescaledb_catalog.chunk_replica_node;
 (16 rows)
 
 SELECT _timescaledb_meta.drop_chunks_older_than(3, 'drop_chunk_test1');
+NOTICE:  index "2-drop_chunk_test1_time_idx" does not exist, skipping
  drop_chunks_older_than 
 ------------------------
  

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -11,13 +11,13 @@ SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there i
 \o
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
-SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1);
+SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
  create_hypertable 
 -------------------
  
 (1 row)
 
-SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1);
+SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1, create_default_indexes=>false);
  create_hypertable 
 -------------------
  

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -44,75 +44,74 @@ Index "_timescaledb_internal.1-two_Partitions_device_id_timeCustom_idx"
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_1_data", predicate (device_id IS NOT NULL)
 
-Index "_timescaledb_internal.10-two_Partitions_timeCustom_series_2_idx"
+Index "_timescaledb_internal.10-two_Partitions_timeCustom_series_1_idx"
+   Column   |       Type       |  Definition  | Storage 
+------------+------------------+--------------+---------
+ timeCustom | bigint           | "timeCustom" | plain
+ series_1   | double precision | series_1     | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_1 IS NOT NULL)
+
+Index "_timescaledb_internal.11-two_Partitions_timeCustom_series_2_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_2   | double precision | series_2     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_2 IS NOT NULL)
 
-Index "_timescaledb_internal.11-two_Partitions_timeCustom_series_bool_idx"
+Index "_timescaledb_internal.12-two_Partitions_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_bool IS NOT NULL)
 
-Index "_timescaledb_internal.12-two_Partitions_timeCustom_device_id_idx"
+Index "_timescaledb_internal.13-two_Partitions_timeCustom_device_id_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  timeCustom | bigint | "timeCustom" | plain
  device_id  | text   | device_id    | extended
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data"
 
-Index "_timescaledb_internal.13-two_Partitions_device_id_timeCustom_idx"
+Index "_timescaledb_internal.14-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_2_data"
+
+Index "_timescaledb_internal.15-two_Partitions_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  device_id  | text   | device_id    | extended
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (device_id IS NOT NULL)
 
-Index "_timescaledb_internal.14-two_Partitions_timeCustom_series_0_idx"
+Index "_timescaledb_internal.16-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_0 IS NOT NULL)
 
-Index "_timescaledb_internal.15-two_Partitions_timeCustom_series_1_idx"
+Index "_timescaledb_internal.17-two_Partitions_timeCustom_series_1_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_1   | double precision | series_1     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_1 IS NOT NULL)
 
-Index "_timescaledb_internal.16-two_Partitions_timeCustom_series_2_idx"
+Index "_timescaledb_internal.18-two_Partitions_timeCustom_series_2_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_2   | double precision | series_2     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_2 IS NOT NULL)
 
-Index "_timescaledb_internal.17-two_Partitions_timeCustom_series_bool_idx"
+Index "_timescaledb_internal.19-two_Partitions_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_bool IS NOT NULL)
-
-Index "_timescaledb_internal.18-two_Partitions_timeCustom_device_id_idx"
-   Column   |  Type  |  Definition  | Storage  
-------------+--------+--------------+----------
- timeCustom | bigint | "timeCustom" | plain
- device_id  | text   | device_id    | extended
-btree, for table "_timescaledb_internal._hyper_1_1_0_3_data"
-
-Index "_timescaledb_internal.19-two_Partitions_device_id_timeCustom_idx"
-   Column   |  Type  |  Definition  | Storage  
-------------+--------+--------------+----------
- device_id  | text   | device_id    | extended
- timeCustom | bigint | "timeCustom" | plain
-btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (device_id IS NOT NULL)
 
 Index "_timescaledb_internal.2-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
@@ -121,39 +120,65 @@ Index "_timescaledb_internal.2-two_Partitions_timeCustom_series_0_idx"
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_1_data", predicate (series_0 IS NOT NULL)
 
-Index "_timescaledb_internal.20-two_Partitions_timeCustom_series_0_idx"
+Index "_timescaledb_internal.20-two_Partitions_timeCustom_device_id_idx"
+   Column   |  Type  |  Definition  | Storage  
+------------+--------+--------------+----------
+ timeCustom | bigint | "timeCustom" | plain
+ device_id  | text   | device_id    | extended
+btree, for table "_timescaledb_internal._hyper_1_1_0_3_data"
+
+Index "_timescaledb_internal.21-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_3_data"
+
+Index "_timescaledb_internal.22-two_Partitions_device_id_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage  
+------------+--------+--------------+----------
+ device_id  | text   | device_id    | extended
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (device_id IS NOT NULL)
+
+Index "_timescaledb_internal.23-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_0 IS NOT NULL)
 
-Index "_timescaledb_internal.21-two_Partitions_timeCustom_series_1_idx"
+Index "_timescaledb_internal.24-two_Partitions_timeCustom_series_1_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_1   | double precision | series_1     | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_1 IS NOT NULL)
 
-Index "_timescaledb_internal.22-two_Partitions_timeCustom_series_2_idx"
+Index "_timescaledb_internal.25-two_Partitions_timeCustom_series_2_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_2   | double precision | series_2     | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_2 IS NOT NULL)
 
-Index "_timescaledb_internal.23-two_Partitions_timeCustom_series_bool_idx"
+Index "_timescaledb_internal.26-two_Partitions_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_bool IS NOT NULL)
 
-Index "_timescaledb_internal.24-two_Partitions_timeCustom_device_id_idx"
+Index "_timescaledb_internal.27-two_Partitions_timeCustom_device_id_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  timeCustom | bigint | "timeCustom" | plain
  device_id  | text   | device_id    | extended
+btree, for table "_timescaledb_internal._hyper_1_2_0_4_data"
+
+Index "_timescaledb_internal.28-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data"
 
 Index "_timescaledb_internal.3-two_Partitions_timeCustom_series_1_idx"
@@ -184,26 +209,25 @@ Index "_timescaledb_internal.6-two_Partitions_timeCustom_device_id_idx"
  device_id  | text   | device_id    | extended
 btree, for table "_timescaledb_internal._hyper_1_1_0_1_data"
 
-Index "_timescaledb_internal.7-two_Partitions_device_id_timeCustom_idx"
+Index "_timescaledb_internal.7-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_1_data"
+
+Index "_timescaledb_internal.8-two_Partitions_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  device_id  | text   | device_id    | extended
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (device_id IS NOT NULL)
 
-Index "_timescaledb_internal.8-two_Partitions_timeCustom_series_0_idx"
+Index "_timescaledb_internal.9-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_0 IS NOT NULL)
-
-Index "_timescaledb_internal.9-two_Partitions_timeCustom_series_1_idx"
-   Column   |       Type       |  Definition  | Storage 
-------------+------------------+--------------+---------
- timeCustom | bigint           | "timeCustom" | plain
- series_1   | double precision | series_1     | plain
-btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_1 IS NOT NULL)
 
                   Table "_timescaledb_internal._hyper_1_0_replica"
    Column    |       Type       | Modifiers | Storage  | Stats target | Description 
@@ -234,6 +258,7 @@ Indexes:
     "4-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
     "5-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
     "6-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "7-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '16383'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257892416000000000'::bigint AND "timeCustom" <= '1257895007999999999'::bigint)
@@ -249,12 +274,13 @@ Inherits: _timescaledb_internal._hyper_1_1_0_partition
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "10-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
-    "11-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
-    "12-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
-    "7-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "8-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "9-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "10-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "11-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "12-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "13-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "14-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
+    "8-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "9-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '16383'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257897600000000000'::bigint AND "timeCustom" <= '1257900191999999999'::bigint)
@@ -270,12 +296,13 @@ Inherits: _timescaledb_internal._hyper_1_1_0_partition
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "13-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "14-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "15-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
-    "16-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
-    "17-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
-    "18-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "15-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "16-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
+    "17-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "18-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "19-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "20-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "21-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '16383'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257985728000000000'::bigint AND "timeCustom" <= '1257988319999999999'::bigint)
@@ -307,12 +334,13 @@ Child tables: _timescaledb_internal._hyper_1_1_0_1_data,
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "19-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "20-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "21-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
-    "22-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
-    "23-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
-    "24-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "22-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "23-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
+    "24-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "25-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "26-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "27-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "28-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '16384'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '32767'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257892416000000000'::bigint AND "timeCustom" <= '1257895007999999999'::bigint)
@@ -373,29 +401,33 @@ drop cascades to table _timescaledb_internal._hyper_1_1_0_3_data
 drop cascades to table _timescaledb_internal._hyper_1_2_0_partition
 drop cascades to table _timescaledb_internal._hyper_1_2_0_4_data
 NOTICE:  index "1-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
-NOTICE:  index "7-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
-NOTICE:  index "13-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
-NOTICE:  index "19-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
+NOTICE:  index "8-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
+NOTICE:  index "15-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
+NOTICE:  index "22-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
 NOTICE:  index "2-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
-NOTICE:  index "8-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
-NOTICE:  index "14-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
-NOTICE:  index "20-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
+NOTICE:  index "9-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
+NOTICE:  index "16-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
+NOTICE:  index "23-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
 NOTICE:  index "3-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
-NOTICE:  index "9-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
-NOTICE:  index "15-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
-NOTICE:  index "21-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
+NOTICE:  index "10-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
+NOTICE:  index "17-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
+NOTICE:  index "24-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
 NOTICE:  index "4-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
-NOTICE:  index "10-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
-NOTICE:  index "16-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
-NOTICE:  index "22-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
+NOTICE:  index "11-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
+NOTICE:  index "18-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
+NOTICE:  index "25-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
 NOTICE:  index "5-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
-NOTICE:  index "11-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
-NOTICE:  index "17-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
-NOTICE:  index "23-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
+NOTICE:  index "12-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
+NOTICE:  index "19-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
+NOTICE:  index "26-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
 NOTICE:  index "6-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
-NOTICE:  index "12-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
-NOTICE:  index "18-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
-NOTICE:  index "24-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
+NOTICE:  index "13-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
+NOTICE:  index "20-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
+NOTICE:  index "27-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
+NOTICE:  index "7-two_Partitions_timeCustom_idx" does not exist, skipping
+NOTICE:  index "14-two_Partitions_timeCustom_idx" does not exist, skipping
+NOTICE:  index "21-two_Partitions_timeCustom_idx" does not exist, skipping
+NOTICE:  index "28-two_Partitions_timeCustom_idx" does not exist, skipping
 SELECT * FROM _timescaledb_catalog.hypertable;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | root_schema_name | root_table_name | replication_factor | placement | time_column_name | time_column_type | created_on | chunk_time_interval 
 ----+-------------+------------+------------------------+-------------------------+------------------+-----------------+--------------------+-----------+------------------+------------------+------------+---------------------

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -52,75 +52,74 @@ Index "_timescaledb_internal.1-two_Partitions_device_id_timeCustom_idx"
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_1_data", predicate (device_id IS NOT NULL)
 
-Index "_timescaledb_internal.10-two_Partitions_timeCustom_series_2_idx"
+Index "_timescaledb_internal.10-two_Partitions_timeCustom_series_1_idx"
+   Column   |       Type       |  Definition  | Storage 
+------------+------------------+--------------+---------
+ timeCustom | bigint           | "timeCustom" | plain
+ series_1   | double precision | series_1     | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_1 IS NOT NULL)
+
+Index "_timescaledb_internal.11-two_Partitions_timeCustom_series_2_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_2   | double precision | series_2     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_2 IS NOT NULL)
 
-Index "_timescaledb_internal.11-two_Partitions_timeCustom_series_bool_idx"
+Index "_timescaledb_internal.12-two_Partitions_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_bool IS NOT NULL)
 
-Index "_timescaledb_internal.12-two_Partitions_timeCustom_device_id_idx"
+Index "_timescaledb_internal.13-two_Partitions_timeCustom_device_id_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  timeCustom | bigint | "timeCustom" | plain
  device_id  | text   | device_id    | extended
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data"
 
-Index "_timescaledb_internal.13-two_Partitions_device_id_timeCustom_idx"
+Index "_timescaledb_internal.14-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_2_data"
+
+Index "_timescaledb_internal.15-two_Partitions_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  device_id  | text   | device_id    | extended
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (device_id IS NOT NULL)
 
-Index "_timescaledb_internal.14-two_Partitions_timeCustom_series_0_idx"
+Index "_timescaledb_internal.16-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_0 IS NOT NULL)
 
-Index "_timescaledb_internal.15-two_Partitions_timeCustom_series_1_idx"
+Index "_timescaledb_internal.17-two_Partitions_timeCustom_series_1_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_1   | double precision | series_1     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_1 IS NOT NULL)
 
-Index "_timescaledb_internal.16-two_Partitions_timeCustom_series_2_idx"
+Index "_timescaledb_internal.18-two_Partitions_timeCustom_series_2_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_2   | double precision | series_2     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_2 IS NOT NULL)
 
-Index "_timescaledb_internal.17-two_Partitions_timeCustom_series_bool_idx"
+Index "_timescaledb_internal.19-two_Partitions_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_3_data", predicate (series_bool IS NOT NULL)
-
-Index "_timescaledb_internal.18-two_Partitions_timeCustom_device_id_idx"
-   Column   |  Type  |  Definition  | Storage  
-------------+--------+--------------+----------
- timeCustom | bigint | "timeCustom" | plain
- device_id  | text   | device_id    | extended
-btree, for table "_timescaledb_internal._hyper_1_1_0_3_data"
-
-Index "_timescaledb_internal.19-two_Partitions_device_id_timeCustom_idx"
-   Column   |  Type  |  Definition  | Storage  
-------------+--------+--------------+----------
- device_id  | text   | device_id    | extended
- timeCustom | bigint | "timeCustom" | plain
-btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (device_id IS NOT NULL)
 
 Index "_timescaledb_internal.2-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
@@ -129,39 +128,65 @@ Index "_timescaledb_internal.2-two_Partitions_timeCustom_series_0_idx"
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_1_data", predicate (series_0 IS NOT NULL)
 
-Index "_timescaledb_internal.20-two_Partitions_timeCustom_series_0_idx"
+Index "_timescaledb_internal.20-two_Partitions_timeCustom_device_id_idx"
+   Column   |  Type  |  Definition  | Storage  
+------------+--------+--------------+----------
+ timeCustom | bigint | "timeCustom" | plain
+ device_id  | text   | device_id    | extended
+btree, for table "_timescaledb_internal._hyper_1_1_0_3_data"
+
+Index "_timescaledb_internal.21-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_3_data"
+
+Index "_timescaledb_internal.22-two_Partitions_device_id_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage  
+------------+--------+--------------+----------
+ device_id  | text   | device_id    | extended
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (device_id IS NOT NULL)
+
+Index "_timescaledb_internal.23-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_0 IS NOT NULL)
 
-Index "_timescaledb_internal.21-two_Partitions_timeCustom_series_1_idx"
+Index "_timescaledb_internal.24-two_Partitions_timeCustom_series_1_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_1   | double precision | series_1     | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_1 IS NOT NULL)
 
-Index "_timescaledb_internal.22-two_Partitions_timeCustom_series_2_idx"
+Index "_timescaledb_internal.25-two_Partitions_timeCustom_series_2_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_2   | double precision | series_2     | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_2 IS NOT NULL)
 
-Index "_timescaledb_internal.23-two_Partitions_timeCustom_series_bool_idx"
+Index "_timescaledb_internal.26-two_Partitions_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data", predicate (series_bool IS NOT NULL)
 
-Index "_timescaledb_internal.24-two_Partitions_timeCustom_device_id_idx"
+Index "_timescaledb_internal.27-two_Partitions_timeCustom_device_id_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  timeCustom | bigint | "timeCustom" | plain
  device_id  | text   | device_id    | extended
+btree, for table "_timescaledb_internal._hyper_1_2_0_4_data"
+
+Index "_timescaledb_internal.28-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_2_0_4_data"
 
 Index "_timescaledb_internal.3-two_Partitions_timeCustom_series_1_idx"
@@ -192,26 +217,25 @@ Index "_timescaledb_internal.6-two_Partitions_timeCustom_device_id_idx"
  device_id  | text   | device_id    | extended
 btree, for table "_timescaledb_internal._hyper_1_1_0_1_data"
 
-Index "_timescaledb_internal.7-two_Partitions_device_id_timeCustom_idx"
+Index "_timescaledb_internal.7-two_Partitions_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_1_data"
+
+Index "_timescaledb_internal.8-two_Partitions_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  device_id  | text   | device_id    | extended
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (device_id IS NOT NULL)
 
-Index "_timescaledb_internal.8-two_Partitions_timeCustom_series_0_idx"
+Index "_timescaledb_internal.9-two_Partitions_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_0 IS NOT NULL)
-
-Index "_timescaledb_internal.9-two_Partitions_timeCustom_series_1_idx"
-   Column   |       Type       |  Definition  | Storage 
-------------+------------------+--------------+---------
- timeCustom | bigint           | "timeCustom" | plain
- series_1   | double precision | series_1     | plain
-btree, for table "_timescaledb_internal._hyper_1_1_0_2_data", predicate (series_1 IS NOT NULL)
 
                   Table "_timescaledb_internal._hyper_1_0_replica"
    Column    |       Type       | Modifiers | Storage  | Stats target | Description 
@@ -242,6 +266,7 @@ Indexes:
     "4-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
     "5-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
     "6-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "7-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '16383'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257892416000000000'::bigint AND "timeCustom" <= '1257895007999999999'::bigint)
@@ -257,12 +282,13 @@ Inherits: _timescaledb_internal._hyper_1_1_0_partition
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "10-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
-    "11-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
-    "12-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
-    "7-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "8-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "9-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "10-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "11-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "12-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "13-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "14-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
+    "8-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "9-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '16383'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257897600000000000'::bigint AND "timeCustom" <= '1257900191999999999'::bigint)
@@ -278,12 +304,13 @@ Inherits: _timescaledb_internal._hyper_1_1_0_partition
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "13-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "14-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "15-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
-    "16-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
-    "17-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
-    "18-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "15-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "16-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
+    "17-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "18-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "19-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "20-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "21-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '16383'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257985728000000000'::bigint AND "timeCustom" <= '1257988319999999999'::bigint)
@@ -315,12 +342,13 @@ Child tables: _timescaledb_internal._hyper_1_1_0_1_data,
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "19-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "20-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "21-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
-    "22-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
-    "23-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
-    "24-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "22-two_Partitions_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "23-two_Partitions_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
+    "24-two_Partitions_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "25-two_Partitions_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "26-two_Partitions_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "27-two_Partitions_timeCustom_device_id_idx" btree ("timeCustom" DESC NULLS LAST, device_id)
+    "28-two_Partitions_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '16384'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '32767'::smallint)
     "time_range" CHECK ("timeCustom" >= '1257892416000000000'::bigint AND "timeCustom" <= '1257895007999999999'::bigint)

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -59,47 +59,66 @@ Index "one_Partition.1-one_Partition_device_id_timeCustom_idx"
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "one_Partition._hyper_1_1_0_1_data", predicate (device_id IS NOT NULL)
 
-Index "one_Partition.10-one_Partition_timeCustom_series_bool_idx"
+Index "one_Partition.10-one_Partition_timeCustom_series_2_idx"
+   Column   |       Type       |  Definition  | Storage 
+------------+------------------+--------------+---------
+ timeCustom | bigint           | "timeCustom" | plain
+ series_2   | double precision | series_2     | plain
+btree, for table "one_Partition._hyper_1_1_0_2_data", predicate (series_2 IS NOT NULL)
+
+Index "one_Partition.11-one_Partition_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "one_Partition._hyper_1_1_0_2_data", predicate (series_bool IS NOT NULL)
 
-Index "one_Partition.11-one_Partition_device_id_timeCustom_idx"
+Index "one_Partition.12-one_Partition_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "one_Partition._hyper_1_1_0_2_data"
+
+Index "one_Partition.13-one_Partition_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  device_id  | text   | device_id    | extended
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "one_Partition._hyper_1_1_0_3_data", predicate (device_id IS NOT NULL)
 
-Index "one_Partition.12-one_Partition_timeCustom_series_0_idx"
+Index "one_Partition.14-one_Partition_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "one_Partition._hyper_1_1_0_3_data", predicate (series_0 IS NOT NULL)
 
-Index "one_Partition.13-one_Partition_timeCustom_series_1_idx"
+Index "one_Partition.15-one_Partition_timeCustom_series_1_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_1   | double precision | series_1     | plain
 btree, for table "one_Partition._hyper_1_1_0_3_data", predicate (series_1 IS NOT NULL)
 
-Index "one_Partition.14-one_Partition_timeCustom_series_2_idx"
+Index "one_Partition.16-one_Partition_timeCustom_series_2_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_2   | double precision | series_2     | plain
 btree, for table "one_Partition._hyper_1_1_0_3_data", predicate (series_2 IS NOT NULL)
 
-Index "one_Partition.15-one_Partition_timeCustom_series_bool_idx"
+Index "one_Partition.17-one_Partition_timeCustom_series_bool_idx"
    Column    |  Type   |  Definition  | Storage 
 -------------+---------+--------------+---------
  timeCustom  | bigint  | "timeCustom" | plain
  series_bool | boolean | series_bool  | plain
 btree, for table "one_Partition._hyper_1_1_0_3_data", predicate (series_bool IS NOT NULL)
+
+Index "one_Partition.18-one_Partition_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "one_Partition._hyper_1_1_0_3_data"
 
 Index "one_Partition.2-one_Partition_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
@@ -129,33 +148,32 @@ Index "one_Partition.5-one_Partition_timeCustom_series_bool_idx"
  series_bool | boolean | series_bool  | plain
 btree, for table "one_Partition._hyper_1_1_0_1_data", predicate (series_bool IS NOT NULL)
 
-Index "one_Partition.6-one_Partition_device_id_timeCustom_idx"
+Index "one_Partition.6-one_Partition_timeCustom_idx"
+   Column   |  Type  |  Definition  | Storage 
+------------+--------+--------------+---------
+ timeCustom | bigint | "timeCustom" | plain
+btree, for table "one_Partition._hyper_1_1_0_1_data"
+
+Index "one_Partition.7-one_Partition_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  
 ------------+--------+--------------+----------
  device_id  | text   | device_id    | extended
  timeCustom | bigint | "timeCustom" | plain
 btree, for table "one_Partition._hyper_1_1_0_2_data", predicate (device_id IS NOT NULL)
 
-Index "one_Partition.7-one_Partition_timeCustom_series_0_idx"
+Index "one_Partition.8-one_Partition_timeCustom_series_0_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_0   | double precision | series_0     | plain
 btree, for table "one_Partition._hyper_1_1_0_2_data", predicate (series_0 IS NOT NULL)
 
-Index "one_Partition.8-one_Partition_timeCustom_series_1_idx"
+Index "one_Partition.9-one_Partition_timeCustom_series_1_idx"
    Column   |       Type       |  Definition  | Storage 
 ------------+------------------+--------------+---------
  timeCustom | bigint           | "timeCustom" | plain
  series_1   | double precision | series_1     | plain
 btree, for table "one_Partition._hyper_1_1_0_2_data", predicate (series_1 IS NOT NULL)
-
-Index "one_Partition.9-one_Partition_timeCustom_series_2_idx"
-   Column   |       Type       |  Definition  | Storage 
-------------+------------------+--------------+---------
- timeCustom | bigint           | "timeCustom" | plain
- series_2   | double precision | series_2     | plain
-btree, for table "one_Partition._hyper_1_1_0_2_data", predicate (series_2 IS NOT NULL)
 
                       Table "one_Partition._hyper_1_0_replica"
    Column    |       Type       | Modifiers | Storage  | Stats target | Description 
@@ -184,6 +202,7 @@ Indexes:
     "3-one_Partition_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
     "4-one_Partition_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
     "5-one_Partition_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "6-one_Partition_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "time_range" CHECK ("timeCustom" >= '1257892416000000000'::bigint AND "timeCustom" <= '1257895007999999999'::bigint)
 Inherits: "one_Partition"._hyper_1_1_0_partition
@@ -198,11 +217,12 @@ Inherits: "one_Partition"._hyper_1_1_0_partition
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "10-one_Partition_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
-    "6-one_Partition_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "7-one_Partition_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "8-one_Partition_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
-    "9-one_Partition_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "10-one_Partition_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "11-one_Partition_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "12-one_Partition_timeCustom_idx" btree ("timeCustom" DESC)
+    "7-one_Partition_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "8-one_Partition_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
+    "9-one_Partition_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
 Check constraints:
     "time_range" CHECK ("timeCustom" >= '1257897600000000000'::bigint AND "timeCustom" <= '1257900191999999999'::bigint)
 Inherits: "one_Partition"._hyper_1_1_0_partition
@@ -217,11 +237,12 @@ Inherits: "one_Partition"._hyper_1_1_0_partition
  series_2    | double precision |           | plain    |              | 
  series_bool | boolean          |           | plain    |              | 
 Indexes:
-    "11-one_Partition_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
-    "12-one_Partition_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
-    "13-one_Partition_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
-    "14-one_Partition_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
-    "15-one_Partition_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "13-one_Partition_device_id_timeCustom_idx" btree (device_id, "timeCustom" DESC NULLS LAST) WHERE device_id IS NOT NULL
+    "14-one_Partition_timeCustom_series_0_idx" btree ("timeCustom" DESC NULLS LAST, series_0) WHERE series_0 IS NOT NULL
+    "15-one_Partition_timeCustom_series_1_idx" btree ("timeCustom" DESC NULLS LAST, series_1) WHERE series_1 IS NOT NULL
+    "16-one_Partition_timeCustom_series_2_idx" btree ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL
+    "17-one_Partition_timeCustom_series_bool_idx" btree ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL
+    "18-one_Partition_timeCustom_idx" btree ("timeCustom" DESC)
 Check constraints:
     "time_range" CHECK ("timeCustom" >= '1257985728000000000'::bigint AND "timeCustom" <= '1257988319999999999'::bigint)
 Inherits: "one_Partition"._hyper_1_1_0_partition

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -89,7 +89,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE devi
          Output: _hyper_1_2_0_4_data."timeCustom", _hyper_1_2_0_4_data.device_id, _hyper_1_2_0_4_data.series_0, _hyper_1_2_0_4_data.series_1, _hyper_1_2_0_4_data.series_2, _hyper_1_2_0_4_data.series_bool
          Recheck Cond: (_hyper_1_2_0_4_data.device_id = 'dev2'::text)
          Filter: (_timescaledb_catalog.get_partition_for_key(_hyper_1_2_0_4_data.device_id, 32768) = '17190'::smallint)
-         ->  Bitmap Index Scan on "19-two_Partitions_device_id_timeCustom_idx"
+         ->  Bitmap Index Scan on "22-two_Partitions_device_id_timeCustom_idx"
                Index Cond: (_hyper_1_2_0_4_data.device_id = 'dev2'::text)
 (13 rows)
 
@@ -107,7 +107,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE devi
          Output: _hyper_1_2_0_4_data."timeCustom", _hyper_1_2_0_4_data.device_id, _hyper_1_2_0_4_data.series_0, _hyper_1_2_0_4_data.series_1, _hyper_1_2_0_4_data.series_2, _hyper_1_2_0_4_data.series_bool
          Recheck Cond: (_hyper_1_2_0_4_data.device_id = 'dev2'::text)
          Filter: (_timescaledb_catalog.get_partition_for_key(_hyper_1_2_0_4_data.device_id, 32768) = '17190'::smallint)
-         ->  Bitmap Index Scan on "19-two_Partitions_device_id_timeCustom_idx"
+         ->  Bitmap Index Scan on "22-two_Partitions_device_id_timeCustom_idx"
                Index Cond: (_hyper_1_2_0_4_data.device_id = 'dev2'::text)
 (13 rows)
 
@@ -125,7 +125,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE 'dev
          Output: _hyper_1_2_0_4_data."timeCustom", _hyper_1_2_0_4_data.device_id, _hyper_1_2_0_4_data.series_0, _hyper_1_2_0_4_data.series_1, _hyper_1_2_0_4_data.series_2, _hyper_1_2_0_4_data.series_bool
          Recheck Cond: ('dev2'::text = _hyper_1_2_0_4_data.device_id)
          Filter: (_timescaledb_catalog.get_partition_for_key(_hyper_1_2_0_4_data.device_id, 32768) = '17190'::smallint)
-         ->  Bitmap Index Scan on "19-two_Partitions_device_id_timeCustom_idx"
+         ->  Bitmap Index Scan on "22-two_Partitions_device_id_timeCustom_idx"
                Index Cond: ('dev2'::text = _hyper_1_2_0_4_data.device_id)
 (13 rows)
 
@@ -157,11 +157,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" ORDER BY "t
                      Output: _hyper_1_2_0_partition."timeCustom", _hyper_1_2_0_partition.device_id, _hyper_1_2_0_partition.series_0, _hyper_1_2_0_partition.series_1, _hyper_1_2_0_partition.series_2, _hyper_1_2_0_partition.series_bool
          ->  Index Scan using "6-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_1_data
                Output: _hyper_1_1_0_1_data."timeCustom", _hyper_1_1_0_1_data.device_id, _hyper_1_1_0_1_data.series_0, _hyper_1_1_0_1_data.series_1, _hyper_1_1_0_1_data.series_2, _hyper_1_1_0_1_data.series_bool
-         ->  Index Scan using "12-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_2_data
+         ->  Index Scan using "13-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_2_data
                Output: _hyper_1_1_0_2_data."timeCustom", _hyper_1_1_0_2_data.device_id, _hyper_1_1_0_2_data.series_0, _hyper_1_1_0_2_data.series_1, _hyper_1_1_0_2_data.series_2, _hyper_1_1_0_2_data.series_bool
-         ->  Index Scan using "18-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_3_data
+         ->  Index Scan using "20-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_3_data
                Output: _hyper_1_1_0_3_data."timeCustom", _hyper_1_1_0_3_data.device_id, _hyper_1_1_0_3_data.series_0, _hyper_1_1_0_3_data.series_1, _hyper_1_1_0_3_data.series_2, _hyper_1_1_0_3_data.series_bool
-         ->  Index Scan using "24-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_0_4_data
+         ->  Index Scan using "27-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_0_4_data
                Output: _hyper_1_2_0_4_data."timeCustom", _hyper_1_2_0_4_data.device_id, _hyper_1_2_0_4_data.series_0, _hyper_1_2_0_4_data.series_1, _hyper_1_2_0_4_data.series_2, _hyper_1_2_0_4_data.series_bool
 (27 rows)
 
@@ -193,11 +193,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
                      Filter: (_hyper_1_2_0_partition.series_1 IS NOT NULL)
          ->  Index Scan using "3-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_1_data
                Output: _hyper_1_1_0_1_data."timeCustom", _hyper_1_1_0_1_data.device_id, _hyper_1_1_0_1_data.series_0, _hyper_1_1_0_1_data.series_1, _hyper_1_1_0_1_data.series_2, _hyper_1_1_0_1_data.series_bool
-         ->  Index Scan using "9-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_2_data
+         ->  Index Scan using "10-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_2_data
                Output: _hyper_1_1_0_2_data."timeCustom", _hyper_1_1_0_2_data.device_id, _hyper_1_1_0_2_data.series_0, _hyper_1_1_0_2_data.series_1, _hyper_1_1_0_2_data.series_2, _hyper_1_1_0_2_data.series_bool
-         ->  Index Scan using "15-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_3_data
+         ->  Index Scan using "17-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_3_data
                Output: _hyper_1_1_0_3_data."timeCustom", _hyper_1_1_0_3_data.device_id, _hyper_1_1_0_3_data.series_0, _hyper_1_1_0_3_data.series_1, _hyper_1_1_0_3_data.series_2, _hyper_1_1_0_3_data.series_bool
-         ->  Index Scan using "21-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_2_0_4_data
+         ->  Index Scan using "24-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_2_0_4_data
                Output: _hyper_1_2_0_4_data."timeCustom", _hyper_1_2_0_4_data.device_id, _hyper_1_2_0_4_data.series_0, _hyper_1_2_0_4_data.series_1, _hyper_1_2_0_4_data.series_2, _hyper_1_2_0_4_data.series_bool
 (30 rows)
 
@@ -230,13 +230,13 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
          ->  Index Scan using "3-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_1_data
                Output: _hyper_1_1_0_1_data."timeCustom", _hyper_1_1_0_1_data.device_id, _hyper_1_1_0_1_data.series_0, _hyper_1_1_0_1_data.series_1, _hyper_1_1_0_1_data.series_2, _hyper_1_1_0_1_data.series_bool
                Index Cond: (_hyper_1_1_0_1_data.series_1 > '1'::double precision)
-         ->  Index Scan using "9-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_2_data
+         ->  Index Scan using "10-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_2_data
                Output: _hyper_1_1_0_2_data."timeCustom", _hyper_1_1_0_2_data.device_id, _hyper_1_1_0_2_data.series_0, _hyper_1_1_0_2_data.series_1, _hyper_1_1_0_2_data.series_2, _hyper_1_1_0_2_data.series_bool
                Index Cond: (_hyper_1_1_0_2_data.series_1 > '1'::double precision)
-         ->  Index Scan using "15-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_3_data
+         ->  Index Scan using "17-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_0_3_data
                Output: _hyper_1_1_0_3_data."timeCustom", _hyper_1_1_0_3_data.device_id, _hyper_1_1_0_3_data.series_0, _hyper_1_1_0_3_data.series_1, _hyper_1_1_0_3_data.series_2, _hyper_1_1_0_3_data.series_bool
                Index Cond: (_hyper_1_1_0_3_data.series_1 > '1'::double precision)
-         ->  Index Scan using "21-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_2_0_4_data
+         ->  Index Scan using "24-two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_2_0_4_data
                Output: _hyper_1_2_0_4_data."timeCustom", _hyper_1_2_0_4_data.device_id, _hyper_1_2_0_4_data.series_0, _hyper_1_2_0_4_data.series_1, _hyper_1_2_0_4_data.series_2, _hyper_1_2_0_4_data.series_bool
                Index Cond: (_hyper_1_2_0_4_data.series_1 > '1'::double precision)
 (34 rows)
@@ -269,11 +269,11 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                            Output: _hyper_1_2_0_partition."timeCustom", _hyper_1_2_0_partition.series_0
                ->  Index Scan using "6-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_1_data
                      Output: _hyper_1_1_0_1_data."timeCustom", _hyper_1_1_0_1_data.series_0
-               ->  Index Scan using "12-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_2_data
+               ->  Index Scan using "13-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_2_data
                      Output: _hyper_1_1_0_2_data."timeCustom", _hyper_1_1_0_2_data.series_0
-               ->  Index Scan using "18-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_3_data
+               ->  Index Scan using "20-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_0_3_data
                      Output: _hyper_1_1_0_3_data."timeCustom", _hyper_1_1_0_3_data.series_0
-               ->  Index Scan using "24-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_0_4_data
+               ->  Index Scan using "27-two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_0_4_data
                      Output: _hyper_1_2_0_4_data."timeCustom", _hyper_1_2_0_4_data.series_0
 (30 rows)
 

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -17,7 +17,7 @@ CREATE TABLE PUBLIC.hyper_1 (
   series_2 DOUBLE PRECISION NULL
 );
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1);
+SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
  create_hypertable 
 -------------------
  
@@ -32,7 +32,7 @@ CREATE TABLE PUBLIC.hyper_1_tz (
   series_2 DOUBLE PRECISION NULL
 );
 CREATE INDEX "time_plain_tz" ON PUBLIC.hyper_1_tz (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1);
+SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
  create_hypertable 
 -------------------
  
@@ -47,7 +47,7 @@ CREATE TABLE PUBLIC.hyper_1_int (
   series_2 DOUBLE PRECISION NULL
 );
 CREATE INDEX "time_plain_int" ON PUBLIC.hyper_1_int (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000);
+SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000, create_default_indexes=>FALSE);
  create_hypertable 
 -------------------
  

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -18,7 +18,7 @@ CREATE TABLE PUBLIC.hyper_1 (
   series_2 DOUBLE PRECISION NULL
 );
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1);
+SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
  create_hypertable 
 -------------------
  
@@ -33,7 +33,7 @@ CREATE TABLE PUBLIC.hyper_1_tz (
   series_2 DOUBLE PRECISION NULL
 );
 CREATE INDEX "time_plain_tz" ON PUBLIC.hyper_1_tz (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1);
+SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
  create_hypertable 
 -------------------
  
@@ -48,7 +48,7 @@ CREATE TABLE PUBLIC.hyper_1_int (
   series_2 DOUBLE PRECISION NULL
 );
 CREATE INDEX "time_plain_int" ON PUBLIC.hyper_1_int (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000);
+SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000, create_default_indexes=>FALSE);
  create_hypertable 
 -------------------
  

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -43,6 +43,32 @@ insert into test_tspace values ('2017-01-20T09:00:02', 22.3, 'dev7');
 
 --verify that the table chunk has the correct tablespace
 \d+ _timescaledb_internal.*
+    Index "_timescaledb_internal.1-test_tspace_time_idx"
+ Column |            Type             | Definition | Storage 
+--------+-----------------------------+------------+---------
+ time   | timestamp without time zone | "time"     | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_1_data"
+
+ Index "_timescaledb_internal.2-test_tspace_device_id_time_idx"
+  Column   |            Type             | Definition | Storage  
+-----------+-----------------------------+------------+----------
+ device_id | text                        | device_id  | extended
+ time      | timestamp without time zone | "time"     | plain
+btree, for table "_timescaledb_internal._hyper_1_1_0_1_data"
+
+    Index "_timescaledb_internal.3-test_tspace_time_idx"
+ Column |            Type             | Definition | Storage 
+--------+-----------------------------+------------+---------
+ time   | timestamp without time zone | "time"     | plain
+btree, for table "_timescaledb_internal._hyper_1_2_0_2_data"
+
+ Index "_timescaledb_internal.4-test_tspace_device_id_time_idx"
+  Column   |            Type             | Definition | Storage  
+-----------+-----------------------------+------------+----------
+ device_id | text                        | device_id  | extended
+ time      | timestamp without time zone | "time"     | plain
+btree, for table "_timescaledb_internal._hyper_1_2_0_2_data"
+
                       Table "_timescaledb_internal._hyper_1_0_replica"
   Column   |            Type             | Modifiers | Storage  | Stats target | Description 
 -----------+-----------------------------+-----------+----------+--------------+-------------
@@ -59,6 +85,9 @@ Child tables: _timescaledb_internal._hyper_1_1_0_partition,
  time      | timestamp without time zone |           | plain    |              | 
  temp      | double precision            |           | plain    |              | 
  device_id | text                        |           | extended |              | 
+Indexes:
+    "1-test_tspace_time_idx" btree ("time" DESC)
+    "2-test_tspace_device_id_time_idx" btree (device_id, "time" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '0'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '16383'::smallint)
     "time_range" CHECK ("time" >= 'Sat Dec 24 16:00:00 2016'::timestamp without time zone AND "time" <= 'Mon Jan 23 15:59:59.999999 2017'::timestamp without time zone)
@@ -82,6 +111,9 @@ Child tables: _timescaledb_internal._hyper_1_1_0_1_data
  time      | timestamp without time zone |           | plain    |              | 
  temp      | double precision            |           | plain    |              | 
  device_id | text                        |           | extended |              | 
+Indexes:
+    "3-test_tspace_time_idx" btree ("time" DESC)
+    "4-test_tspace_device_id_time_idx" btree (device_id, "time" DESC)
 Check constraints:
     "partition" CHECK (_timescaledb_catalog.get_partition_for_key(device_id, 32768) >= '16384'::smallint AND _timescaledb_catalog.get_partition_for_key(device_id, 32768) <= '32767'::smallint)
     "time_range" CHECK ("time" >= 'Sat Dec 24 16:00:00 2016'::timestamp without time zone AND "time" <= 'Mon Jan 23 15:59:59.999999 2017'::timestamp without time zone)
@@ -110,4 +142,8 @@ Child tables: _timescaledb_internal._hyper_1_0_replica
 --cleanup
 drop table test_tspace;
 NOTICE:  drop cascades to 5 other objects
+NOTICE:  index "1-test_tspace_time_idx" does not exist, skipping
+NOTICE:  index "3-test_tspace_time_idx" does not exist, skipping
+NOTICE:  index "2-test_tspace_device_id_time_idx" does not exist, skipping
+NOTICE:  index "4-test_tspace_device_id_time_idx" does not exist, skipping
 drop tablespace tspace1;

--- a/test/sql/drop_chunks.sql
+++ b/test/sql/drop_chunks.sql
@@ -4,8 +4,8 @@
 
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
-SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1);
-SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1);
+SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
+SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 
 SELECT c.id AS chunk_id, pr.partition_id, pr.hypertable_id, crn.schema_name AS chunk_schema, crn.table_name AS chunk_table, c.start_time, c.end_time
 FROM _timescaledb_catalog.chunk c

--- a/test/sql/drop_chunks.sql
+++ b/test/sql/drop_chunks.sql
@@ -4,6 +4,7 @@
 
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
+CREATE INDEX ON drop_chunk_test1(time DESC);
 SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 

--- a/test/sql/include/ddl_ops_1.sql
+++ b/test/sql/include/ddl_ops_1.sql
@@ -88,3 +88,61 @@ ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 -- Should skip and not error
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 \d my_ht
+
+--default indexes--
+--both created
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+\d+ "Hypertable_1_with_default_index_enabled"
+ROLLBACK;
+
+--only time
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time", "Device_id");
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+\d+ "Hypertable_1_with_default_index_enabled"
+ROLLBACK;
+
+--only partition
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+\d+ "Hypertable_1_with_default_index_enabled"
+ROLLBACK;
+
+--null space
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+\d+ "Hypertable_1_with_default_index_enabled"
+ROLLBACK;
+
+--disable index creation
+BEGIN;
+CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
+  "Time" BIGINT NOT NULL,
+  "Device_id" TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+\d+ "Hypertable_1_with_default_index_enabled"
+ROLLBACK;

--- a/test/sql/include/sql_query_results.sql
+++ b/test/sql/include/sql_query_results.sql
@@ -6,7 +6,7 @@ CREATE TABLE PUBLIC.hyper_1 (
 );
 
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1);
+SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
 INSERT INTO hyper_1 SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
 INSERT INTO hyper_1 SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
 
@@ -18,7 +18,7 @@ CREATE TABLE PUBLIC.hyper_1_tz (
 );
 
 CREATE INDEX "time_plain_tz" ON PUBLIC.hyper_1_tz (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1);
+SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
 INSERT INTO hyper_1_tz SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
 INSERT INTO hyper_1_tz SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
 
@@ -30,7 +30,7 @@ CREATE TABLE PUBLIC.hyper_1_int (
 );
 
 CREATE INDEX "time_plain_int" ON PUBLIC.hyper_1_int (time DESC, series_0);
-SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000);
+SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000, create_default_indexes=>FALSE);
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
 


### PR DESCRIPTION
Changed create_hypertable to add time DESC and partitioning_column, time DESC
indexes by default (the latter only if partitioning column not null).
Indexes only created if there is no index on time and
partitioning_column, time respectively. Index creation can be turned off
with the create_default_indexes parameter to create_hypertable (default true).