### PR TITLE
Cleanup sql/timescaledb--*.sql files on `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,11 @@ check-sql-files:
 
 install: $(EXT_SQL_FILE)
 
+clean: clean-sql-files
+
+clean-sql-files:
+	@rm -f sql/$(EXTENSION)--*.sql
+
 package: clean $(EXT_SQL_FILE)
 	@mkdir -p package/lib
 	@mkdir -p package/extension


### PR DESCRIPTION
Old versions of the extension sql files could hang around
bloating package sizes if not caught.