### PR TITLE
Remove setup_timescaledb() and fix pg_dump/pg_restore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: c
 os: linux
 dist: trusty
 
-addons:
-  postgresql: "9.6"
-
 services:
   - docker
 
@@ -14,10 +11,15 @@ before_install:
   - sudo add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"
   - wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get install postgresql-server-dev-9.6
+  - sudo apt-get install postgresql-server-dev-9.6 postgresql-client-9.6
+  - sudo ln -sf /usr/lib/postgresql/9.6/bin/pg_dump /usr/bin/pg_dump
+  - sudo ln -sf /usr/lib/postgresql/9.6/bin/pg_restore /usr/bin/pg_restore
+  - pg_dump -V
+  - pg_restore -V
 
 install: make -f docker.mk build-image
 
 script: make -f docker.mk test
 
-after_failure: cat test/regression.diffs
+after_failure: 
+  - cat test/regression.diffs

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ before_install:
 install: make -f docker.mk build-image
 
 script: make -f docker.mk test
+
+after_failure: cat test/regression.diffs

--- a/README.md
+++ b/README.md
@@ -150,9 +150,6 @@ psql -U postgres -h localhost
 CREATE database tutorial;
 \c tutorial
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
-
--- Run initialization function
-SELECT setup_timescaledb();
 ```
 
 For convenience, this can also be done in one step by running a script from
@@ -265,6 +262,27 @@ actively working to resolve:
 - Custom user-created triggers on hypertables currently not allowed
 - `drop_chunks()` (see our [API Reference](docs/API.md)) is currently only
 supported for hypertables that are not partitioned by space.
+
+### Restoring a database from backup.
+
+A database with the timescaledb extension can be backed up using normal backup
+procedures (e.g. `pg\_dump`). However, when restoring the database the following
+procedure must be used.
+
+```sql
+CREATE DATABASE db_for_restore;
+ALTER DATABASE db_for_restore SET timescaledb.restoring='on';
+
+--execute the restore below:
+\! pg_restore -h localhost -U postgres -d single dump/single.sql
+
+--connect to the restored db;
+\c db_for_restore
+SELECT restore_timescaledb();
+ALTER DATABASE single SET timescaledb.restoring='off';
+```
+
+Note: You must use pg_dump and pg_restore versions 9.6.2 and above.
 
 ### More APIs
 For more information on TimescaleDB's APIs, check out our

--- a/docs/API.md
+++ b/docs/API.md
@@ -74,17 +74,6 @@ SELECT drop_chunks(interval '3 months', 'foo');
 
 ---
 
-### `setup_timescaledb()`
-
-Initializes a Postgres database to fully use TimescaleDB.
-
-**Sample usage**
-
-```sql
-SELECT setup_timescaledb();
-```
----
-
 ### `time_bucket()`
 
 This is a more powerful version of the standard postgres `date_trunc` function.

--- a/scripts/setup-db.sh
+++ b/scripts/setup-db.sh
@@ -15,8 +15,4 @@ CREATE DATABASE ${DB_NAME};
 \c ${DB_NAME}
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 
-\o /dev/null
-\echo 'Set up database...'
-select setup_timescaledb();
-\echo 'Success'
 EOF

--- a/sql/common/ddl_utils.sql
+++ b/sql/common/ddl_utils.sql
@@ -7,3 +7,9 @@ CREATE OR REPLACE FUNCTION ddl_is_drop_column(pg_ddl_command)
   RETURNS bool IMMUTABLE STRICT
   AS '$libdir/timescaledb' LANGUAGE C;
 
+CREATE OR REPLACE FUNCTION restore_timescaledb()
+    RETURNS VOID LANGUAGE SQL VOLATILE AS
+$BODY$
+    SELECT _timescaledb_internal.setup_meta();
+    SELECT _timescaledb_internal.setup_main(true);
+$BODY$;

--- a/sql/common/init.sql
+++ b/sql/common/init.sql
@@ -1,0 +1,13 @@
+DO $$
+DECLARE 
+    do_setup BOOLEAN;
+BEGIN 
+    SELECT current_setting('timescaledb.restoring', true) IS DISTINCT FROM 'on' INTO do_setup;
+
+    IF do_setup THEN
+        PERFORM _timescaledb_internal.setup_timescaledb();
+    END IF;
+END
+$$;
+
+

--- a/sql/load_order.txt
+++ b/sql/load_order.txt
@@ -49,3 +49,4 @@ sql/main/setup_main.sql
 sql/main/bookend.sql
 sql/common/permissions.sql
 sql/common/ddl_utils.sql
+sql/common/init.sql

--- a/sql/main/setup_main.sql
+++ b/sql/main/setup_main.sql
@@ -1,5 +1,5 @@
 -- Initializes a data node in the cluster.
-CREATE OR REPLACE FUNCTION _timescaledb_internal.setup_main()
+CREATE OR REPLACE FUNCTION _timescaledb_internal.setup_main(restore BOOLEAN = FALSE)
     RETURNS void LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE
@@ -138,6 +138,15 @@ BEGIN
     CREATE EVENT TRIGGER ddl_check_drop_command
        ON sql_drop
        EXECUTE PROCEDURE _timescaledb_internal.ddl_process_drop_table();
+
+    IF restore THEN
+        ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_create_index;
+        ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_alter_index;
+        ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_drop_index;
+        ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_create_column;
+        ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_create_trigger;
+        ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_check_drop_command;
+    END IF;
 
 END
 $BODY$

--- a/sql/meta/cluster.sql
+++ b/sql/meta/cluster.sql
@@ -83,7 +83,7 @@ EXCEPTION
 END
 $BODY$;
 
-CREATE OR REPLACE FUNCTION setup_timescaledb(
+CREATE OR REPLACE FUNCTION _timescaledb_internal.setup_timescaledb(
     database NAME = current_database(),
     username TEXT = current_user,
     password TEXT = NULL,

--- a/test/expected/agg_bookends.out
+++ b/test/expected/agg_bookends.out
@@ -6,12 +6,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 CREATE TABLE "btest"(time timestamp, time_alt timestamp, gp INTEGER, temp float, strid TEXT DEFAULT 'testing');
 SELECT create_hypertable('"btest"', 'time');
  create_hypertable 

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -7,12 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 \c single
 CREATE TABLE PUBLIC."one_Partition" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/expected/copy_from.out
+++ b/test/expected/copy_from.out
@@ -8,7 +8,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \c single
 CREATE TABLE PUBLIC."two_Partitions" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -6,12 +6,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 CREATE TABLE chunk_test(
         time       BIGINT,
         metric     INTEGER,

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -6,12 +6,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 create schema test_schema;
 create table test_schema.test_table(time bigint, temp float8, device_id text);
 \dt "test_schema".*

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 \ir include/ddl_ops_1.sql
 CREATE TABLE PUBLIC."Hypertable_1" (

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 -- Expect error when adding user again
 \set ON_ERROR_STOP 0

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 \ir include/ddl_ops_1.sql
 CREATE TABLE PUBLIC."Hypertable_1" (

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -8,7 +8,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \c single
 CREATE TABLE PUBLIC."two_Partitions" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 CREATE TABLE drop_test(time timestamp, temp float8, device text);
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
@@ -30,7 +29,7 @@ SELECT * FROM drop_test;
 (1 row)
 
 DROP EXTENSION timescaledb CASCADE;
-NOTICE:  drop cascades to 14 other objects
+NOTICE:  drop cascades to 8 other objects
 -- Querying the original table should not return any rows since all of
 -- them actually existed in chunks that are now gone
 SELECT * FROM drop_test;
@@ -45,12 +44,6 @@ CREATE EXTENSION timescaledb CASCADE;
 CREATE EXTENSION timescaledb CASCADE;
 ERROR:  extension "timescaledb" already exists
 \set ON_ERROR_STOP 1
-SELECT setup_timescaledb();
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 -- Make the table a hypertable again
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
  create_hypertable 

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -8,7 +8,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \c single
 CREATE TABLE PUBLIC."two_Partitions" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -7,12 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 \c single
 CREATE TABLE PUBLIC."two_Partitions" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -7,12 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 \c single
 CREATE TABLE PUBLIC."one_Partition" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -8,7 +8,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \c single
 CREATE TABLE PUBLIC."two_Partitions" (
   "timeCustom" BIGINT NOT NULL,
@@ -36,27 +35,61 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
 \o
+SELECT count(*)
+  FROM pg_depend
+ WHERE refclassid = 'pg_extension'::regclass
+     AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
+ count 
+-------
+   206
+(1 row)
+
 \c postgres
 \! pg_dump -h localhost -U postgres -Fc single > dump/single.sql
 \! dropdb -h localhost -U postgres single
-\! pg_restore -h localhost -U postgres -d postgres -C dump/single.sql
+\! createdb -h localhost -U postgres single
+ALTER DATABASE single SET timescaledb.restoring='on';
+\! pg_restore -h localhost -U postgres -d single dump/single.sql
 \c single
+SELECT restore_timescaledb();
+ restore_timescaledb 
+---------------------
+ 
+(1 row)
+
+ALTER DATABASE single SET timescaledb.restoring='off';
+--should be same as count above
+SELECT count(*)
+  FROM pg_depend
+ WHERE refclassid = 'pg_extension'::regclass
+     AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
+ count 
+-------
+   206
+(1 row)
+
+\c single
+--check simple ddl still works
+ALTER TABLE "two_Partitions" ADD COLUMN series_3 integer;
+INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1, series_3) VALUES
+(1357894000000000000, 'dev5', 1.5, 2, 4);
 SELECT * FROM "two_Partitions" order by "timeCustom", device_id;
-     timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
----------------------+-----------+----------+----------+----------+-------------
- 1257894000000000000 | dev1      |      1.5 |        1 |        2 | t
- 1257894000000000000 | dev1      |      1.5 |        2 |          | 
- 1257894000000000000 | dev2      |      1.5 |        2 |          | 
- 1257894000000000000 | dev2      |      1.5 |        1 |          | 
- 1257894000000001000 | dev1      |      2.5 |        3 |          | 
- 1257894001000000000 | dev1      |      3.5 |        4 |          | 
- 1257894002000000000 | dev1      |      2.5 |        3 |          | 
- 1257894002000000000 | dev1      |      5.5 |        6 |          | t
- 1257894002000000000 | dev1      |      5.5 |        7 |          | f
- 1257897600000000000 | dev1      |      4.5 |        5 |          | f
- 1257987600000000000 | dev1      |      1.5 |        2 |          | 
- 1257987600000000000 | dev1      |      1.5 |        1 |          | 
-(12 rows)
+     timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool | series_3 
+---------------------+-----------+----------+----------+----------+-------------+----------
+ 1257894000000000000 | dev1      |      1.5 |        1 |        2 | t           |         
+ 1257894000000000000 | dev1      |      1.5 |        2 |          |             |         
+ 1257894000000000000 | dev2      |      1.5 |        2 |          |             |         
+ 1257894000000000000 | dev2      |      1.5 |        1 |          |             |         
+ 1257894000000001000 | dev1      |      2.5 |        3 |          |             |         
+ 1257894001000000000 | dev1      |      3.5 |        4 |          |             |         
+ 1257894002000000000 | dev1      |      2.5 |        3 |          |             |         
+ 1257894002000000000 | dev1      |      5.5 |        6 |          | t           |         
+ 1257894002000000000 | dev1      |      5.5 |        7 |          | f           |         
+ 1257897600000000000 | dev1      |      4.5 |        5 |          | f           |         
+ 1257987600000000000 | dev1      |      1.5 |        2 |          |             |         
+ 1257987600000000000 | dev1      |      1.5 |        1 |          |             |         
+ 1357894000000000000 | dev5      |      1.5 |        2 |          |             |        4
+(13 rows)
 
 --query for the extension tables/sequences that will not be dumped by pg_dump (should be empty)
 SELECT objid::regclass, *

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -8,7 +8,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \c single
 CREATE TABLE PUBLIC."two_Partitions" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 \ir include/sql_query_results.sql
 CREATE TABLE PUBLIC.hyper_1 (

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 SET timescaledb.disable_optimizations= 'on';
 \ir include/sql_query_results.sql

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -1,14 +1,14 @@
 --make sure diff only has explain output not result output
 \! diff ../results/sql_query_results_optimized.out ../results/sql_query_results_unoptimized.out 
-11a12
+10a11
 > SET timescaledb.disable_optimizations= 'on';
-92,93c93,94
+91,92c92,93
 <                                               QUERY PLAN                                              
 < ------------------------------------------------------------------------------------------------------
 ---
 >                                    QUERY PLAN                                   
 > --------------------------------------------------------------------------------
-95,101c96,101
+94,100c95,100
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, _hyper_1_0_replica."time"))
 <          ->  Result
@@ -23,16 +23,16 @@
 >                Group Key: date_trunc('minute'::text, _hyper_1_0_replica."time")
 >                ->  Result
 >                      ->  Append
-103,104d102
+102,103d101
 <                      ->  Sort
 <                            Sort Key: (date_trunc('minute'::text, _hyper_1_1_0_partition."time")) DESC
-106,107c104,105
+105,106c103,104
 <                      ->  Index Scan using "1-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-135,141c133,138
+134,140c132,137
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, _hyper_1_0_replica."time"))
 <          ->  Result
@@ -47,10 +47,10 @@
 >                Group Key: date_trunc('minute'::text, _hyper_1_0_replica."time")
 >                ->  Result
 >                      ->  Append
-144,145d140
+143,144d139
 <                      ->  Sort
 <                            Sort Key: (date_trunc('minute'::text, _hyper_1_1_0_partition."time")) DESC
-148,150c143,145
+147,149c142,144
 <                      ->  Index Scan using "1-time_plain" on _hyper_1_1_0_1_data
 <                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 < (16 rows)
@@ -58,13 +58,13 @@
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 >                                  Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (13 rows)
-221,222c216,217
+220,221c215,216
 <                                                  QUERY PLAN                                                 
 < ------------------------------------------------------------------------------------------------------------
 ---
 >                                       QUERY PLAN                                      
 > --------------------------------------------------------------------------------------
-224,230c219,224
+223,229c218,223
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_0_replica."time"))
 <          ->  Result
@@ -79,22 +79,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, _hyper_1_0_replica."time")
 >                ->  Result
 >                      ->  Append
-232,233d225
+231,232d224
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_0_partition."time")) DESC
-235,236c227,228
+234,235c226,227
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-248,249c240,241
+247,248c239,240
 <                                                                            QUERY PLAN                                                                           
 < ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                                 QUERY PLAN                                                                
 > ------------------------------------------------------------------------------------------------------------------------------------------
-251,257c243,248
+250,256c242,247
 <    ->  GroupAggregate
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
@@ -109,22 +109,22 @@
 >                Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)
 >                ->  Result
 >                      ->  Append
-259,260d249
+258,259d248
 <                      ->  Sort
 <                            Sort Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_0_partition."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
-262,263c251,252
+261,262c250,251
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-275,276c264,265
+274,275c263,264
 <                                                               QUERY PLAN                                                              
 < --------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                    QUERY PLAN                                                   
 > ----------------------------------------------------------------------------------------------------------------
-278,284c267,272
+277,283c266,271
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)))
 <          ->  Result
@@ -139,22 +139,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval))
 >                ->  Result
 >                      ->  Append
-286,287d273
+285,286d272
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_0_partition."time" - '@ 30 secs'::interval))) DESC
-289,290c275,276
+288,289c274,275
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-302,303c288,289
+301,302c287,288
 <                                                                            QUERY PLAN                                                                           
 < ----------------------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                                 QUERY PLAN                                                                
 > ------------------------------------------------------------------------------------------------------------------------------------------
-305,311c291,296
+304,310c290,295
 <    ->  GroupAggregate
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
@@ -169,22 +169,22 @@
 >                Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_0_replica."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)
 >                ->  Result
 >                      ->  Append
-313,314d297
+312,313d296
 <                      ->  Sort
 <                            Sort Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_0_partition."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
-316,317c299,300
+315,316c298,299
 <                      ->  Index Scan using "7-time_plain" on _hyper_1_1_0_1_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_1_1_0_1_data
 > (10 rows)
-329,330c312,313
+328,329c311,312
 <                                                  QUERY PLAN                                                 
 < ------------------------------------------------------------------------------------------------------------
 ---
 >                                       QUERY PLAN                                      
 > --------------------------------------------------------------------------------------
-332,338c315,320
+331,337c314,319
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_0_replica."time"))
 <          ->  Result
@@ -199,22 +199,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, _hyper_2_0_replica."time")
 >                ->  Result
 >                      ->  Append
-340,341d321
+339,340d320
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_0_partition."time")) DESC
-343,344c323,324
+342,343c322,323
 <                      ->  Index Scan using "2-time_plain_tz" on _hyper_2_2_0_2_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_2_2_0_2_data
 > (10 rows)
-356,357c336,337
+355,356c335,336
 <                                                                 QUERY PLAN                                                                 
 < -------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                      QUERY PLAN                                                      
 > ---------------------------------------------------------------------------------------------------------------------
-359,365c339,344
+358,364c338,343
 <    ->  GroupAggregate
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_2_0_replica."time")::timestamp without time zone))
 <          ->  Result
@@ -229,22 +229,22 @@
 >                Group Key: time_bucket('@ 1 min'::interval, (_hyper_2_0_replica."time")::timestamp without time zone)
 >                ->  Result
 >                      ->  Append
-367,368d345
+366,367d344
 <                      ->  Sort
 <                            Sort Key: (time_bucket('@ 1 min'::interval, (_hyper_2_2_0_partition."time")::timestamp without time zone)) DESC
-370,371c347,348
+369,370c346,347
 <                      ->  Index Scan using "2-time_plain_tz" on _hyper_2_2_0_2_data
 < (13 rows)
 ---
 >                            ->  Seq Scan on _hyper_2_2_0_2_data
 > (10 rows)
-383,384c360,361
+382,383c359,360
 <                                        QUERY PLAN                                       
 < ----------------------------------------------------------------------------------------
 ---
 >                             QUERY PLAN                            
 > ------------------------------------------------------------------
-386,392c363,368
+385,391c362,367
 <    ->  GroupAggregate
 <          Group Key: (((_hyper_3_0_replica."time" / 10) * 10))
 <          ->  Result
@@ -259,10 +259,10 @@
 >                Group Key: ((_hyper_3_0_replica."time" / 10) * 10)
 >                ->  Result
 >                      ->  Append
-394,395d369
+393,394d368
 <                      ->  Sort
 <                            Sort Key: (((_hyper_3_3_0_partition."time" / 10) * 10)) DESC
-397,400c371,374
+396,399c370,373
 <                      ->  Index Scan using "3-time_plain_int" on _hyper_3_3_0_3_data
 <                      ->  Index Scan using "4-time_plain_int" on _hyper_3_3_0_4_data
 <                      ->  Index Scan using "5-time_plain_int" on _hyper_3_3_0_5_data
@@ -272,13 +272,13 @@
 >                            ->  Seq Scan on _hyper_3_3_0_4_data
 >                            ->  Seq Scan on _hyper_3_3_0_5_data
 > (12 rows)
-412,413c386,387
+411,412c385,386
 <                                              QUERY PLAN                                             
 < ----------------------------------------------------------------------------------------------------
 ---
 >                                   QUERY PLAN                                  
 > ------------------------------------------------------------------------------
-415,421c389,394
+414,420c388,393
 <    ->  GroupAggregate
 <          Group Key: (((((_hyper_3_0_replica."time" - 2) / 10) * 10) + 2))
 <          ->  Result
@@ -293,10 +293,10 @@
 >                Group Key: ((((_hyper_3_0_replica."time" - 2) / 10) * 10) + 2)
 >                ->  Result
 >                      ->  Append
-423,424d395
+422,423d394
 <                      ->  Sort
 <                            Sort Key: (((((_hyper_3_3_0_partition."time" - 2) / 10) * 10) + 2)) DESC
-426,429c397,400
+425,428c396,399
 <                      ->  Index Scan using "3-time_plain_int" on _hyper_3_3_0_3_data
 <                      ->  Index Scan using "4-time_plain_int" on _hyper_3_3_0_4_data
 <                      ->  Index Scan using "5-time_plain_int" on _hyper_3_3_0_5_data
@@ -306,13 +306,13 @@
 >                            ->  Seq Scan on _hyper_3_3_0_4_data
 >                            ->  Seq Scan on _hyper_3_3_0_5_data
 > (12 rows)
-480,481c451,452
+479,480c450,451
 <                                           QUERY PLAN                                           
 < -----------------------------------------------------------------------------------------------
 ---
 >                                            QUERY PLAN                                            
 > -------------------------------------------------------------------------------------------------
-483,487c454,460
+482,486c453,459
 <    ->  GroupAggregate
 <          Group Key: date_trunc('minute'::text, "time")
 <          ->  Index Scan using time_plain_plain_table on plain_table

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -6,12 +6,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
- setup_timescaledb 
--------------------
- 
-(1 row)
-
 \set ON_ERROR_STOP 0
 SET client_min_messages = ERROR;
 drop tablespace if exists tspace1;

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -7,7 +7,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \o
 -- Utility function for grouping/slotting time with a given interval.
 CREATE OR REPLACE FUNCTION date_group(

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -8,7 +8,6 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection
 \c single
 CREATE TABLE PUBLIC."one_Partition" (
   "timeCustom" BIGINT NOT NULL,

--- a/test/sql/drop_extension.sql
+++ b/test/sql/drop_extension.sql
@@ -23,8 +23,6 @@ CREATE EXTENSION timescaledb CASCADE;
 CREATE EXTENSION timescaledb CASCADE;
 \set ON_ERROR_STOP 1
 
-SELECT setup_timescaledb();
-
 -- Make the table a hypertable again
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
 

--- a/test/sql/include/create_single_db.sql
+++ b/test/sql/include/create_single_db.sql
@@ -5,4 +5,3 @@ CREATE DATABASE single;
 
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
-SELECT setup_timescaledb(hostname => 'fakehost'); -- fakehost makes sure there is no network connection

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -2,13 +2,35 @@
 \ir include/insert_two_partitions.sql
 \o
 
+SELECT count(*)
+  FROM pg_depend
+ WHERE refclassid = 'pg_extension'::regclass
+     AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
+
 \c postgres
 
 \! pg_dump -h localhost -U postgres -Fc single > dump/single.sql
 \! dropdb -h localhost -U postgres single
-\! pg_restore -h localhost -U postgres -d postgres -C dump/single.sql
+\! createdb -h localhost -U postgres single
+ALTER DATABASE single SET timescaledb.restoring='on';
+\! pg_restore -h localhost -U postgres -d single dump/single.sql
+\c single
+SELECT restore_timescaledb();
+ALTER DATABASE single SET timescaledb.restoring='off';
+
+--should be same as count above
+SELECT count(*)
+  FROM pg_depend
+ WHERE refclassid = 'pg_extension'::regclass
+     AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
+
 
 \c single
+--check simple ddl still works
+ALTER TABLE "two_Partitions" ADD COLUMN series_3 integer;
+INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1, series_3) VALUES
+(1357894000000000000, 'dev5', 1.5, 2, 4);
+
 SELECT * FROM "two_Partitions" order by "timeCustom", device_id;
 
 --query for the extension tables/sequences that will not be dumped by pg_dump (should be empty)


### PR DESCRIPTION
This PR removes the need to run setup_timescaledb. It also fixes
pg_dump and pg_restore. Previously, the database would restore in
a broken state because trigger functions were never attached to
meta tables (since setup_timescaledb() was not run). However, attaching
those triggers at extension creation also causes problems since the data
copy happens after extension creation but we don't want triggers fired
on the data restored (that could cause duplicate rows, for example).

The solution to this chicken-and-egg problem in this PR is to have
a special configuration (GUC) variable `timescaledb.restoring` that,
if 'on', would prevent the extension from attaching triggers at
extension creation. Then, after restoration, you'd call
restore_timescaledb() to attach the triggers and unset the GUC above.
This procedure is documented in the README as part of this PR.