### PR TITLE
Fix time interval field name in hypertable cache entry

### DIFF
--- a/src/catalog.h
+++ b/src/catalog.h
@@ -64,7 +64,7 @@ enum Anum_hypertable
 	Anum_hypertable_time_column_name,
 	Anum_hypertable_time_column_type,
 	Anum_hypertable_created_on,
-	Anum_hypertable_chunk_size_bytes,
+	Anum_hypertable_chunk_time_interval,
 	_Anum_hypertable_max,
 };
 

--- a/src/hypertable_cache.c
+++ b/src/hypertable_cache.c
@@ -108,7 +108,7 @@ hypertable_tuple_found(TupleInfo *ti, void *data)
 		DatumGetCString(DATUM_GET(values, Anum_hypertable_time_column_name)),
 			NAMEDATALEN);
 	he->time_column_type = DatumGetObjectId(DATUM_GET(values, Anum_hypertable_time_column_type));
-	he->chunk_size_bytes = DatumGetInt64(DATUM_GET(values, Anum_hypertable_chunk_size_bytes));
+	he->chunk_time_interval = DatumGetInt64(DATUM_GET(values, Anum_hypertable_chunk_time_interval));
 	he->num_replicas = DatumGetInt16(DATUM_GET(values, Anum_hypertable_replication_factor));
 
 	entry->hypertable = he;

--- a/src/hypertable_cache.h
+++ b/src/hypertable_cache.h
@@ -19,7 +19,7 @@ typedef struct Hypertable
 	char		time_column_name[NAMEDATALEN];
 	Oid			time_column_type;
 	int			num_epochs;
-	int64		chunk_size_bytes;
+	int64		chunk_time_interval;
 	int16		num_replicas;
 	/* Array of PartitionEpoch. Order by start_time */
 	PartitionEpoch *epochs[MAX_EPOCHS_PER_HYPERTABLE];


### PR DESCRIPTION
This change makes the naming of the time interval field in
the hypertable cache entry consistent with the table schema.