### PR TITLE
Fix timestamp test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 before_install:
-  - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build postgres:9.6.2-alpine
+  - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build postgres:9.6.3-alpine
 
 install:
   - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils && make -C /build install && chown -R postgres:postgres /build/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6.2
+FROM postgres:9.6.3
 
 MAINTAINER Timescale
 

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -145,11 +145,13 @@ FROM PUBLIC."testNs" GROUP BY time ORDER BY time ASC LIMIT 2;
 \set ON_ERROR_STOP 0
 SET timezone = 'UTC';
 ALTER DATABASE single SET timezone ='UTC';
--- Conversion to timestamp using Postgres built-in function taking double
+-- Conversion to timestamp using Postgres built-in function taking
+-- double. Gives inaccurate result on Postgres <= 9.6.2. Accurate on
+-- Postgres >= 9.6.3.
 SELECT to_timestamp(1486480176.236538);
             to_timestamp             
 -------------------------------------
- Tue Feb 07 15:09:36.236537 2017 UTC
+ Tue Feb 07 15:09:36.236538 2017 UTC
 (1 row)
 
 -- extension-specific version taking microsecond UNIX timestamp

--- a/test/sql/timestamp.sql
+++ b/test/sql/timestamp.sql
@@ -93,7 +93,9 @@ FROM PUBLIC."testNs" GROUP BY time ORDER BY time ASC LIMIT 2;
 SET timezone = 'UTC';
 ALTER DATABASE single SET timezone ='UTC';
 
--- Conversion to timestamp using Postgres built-in function taking double
+-- Conversion to timestamp using Postgres built-in function taking
+-- double. Gives inaccurate result on Postgres <= 9.6.2. Accurate on
+-- Postgres >= 9.6.3.
 SELECT to_timestamp(1486480176.236538);
 
 -- extension-specific version taking microsecond UNIX timestamp


### PR DESCRIPTION
The timestamp test broke with Postgres 9.6.3, because that version
contained an accuracy fix for the `to_timestamp()` function, giving
slightly different results for some timestamp values. This fixes the
timestamp test to expect the correct `to_timestamp()` output as of
version 9.6.3 of Postgres.