### PR TITLE
Add if_not_exists flag to create_hypertable()

### DIFF
--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -37,3 +37,15 @@ select create_hypertable('test_schema.test_1dim', 'time');
  test_schema | test_table | table | postgres
 (2 rows)
 
+select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true);
+NOTICE:  hypertable test_schema.test_1dim already exists, skipping
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+-- Should error when creating again without if_not_exists set to true
+\set ON_ERROR_STOP 0
+select create_hypertable('test_schema.test_1dim', 'time');
+ERROR:  hypertable test_schema.test_1dim already exists
+\set ON_ERROR_STOP 1

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -10,3 +10,11 @@ create table test_schema.test_1dim(time timestamp, temp float);
 select create_hypertable('test_schema.test_1dim', 'time');
 
 \dt "test_schema".*
+
+select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true);
+
+-- Should error when creating again without if_not_exists set to true
+\set ON_ERROR_STOP 0
+select create_hypertable('test_schema.test_1dim', 'time');
+\set ON_ERROR_STOP 1
+


### PR DESCRIPTION
Previously create_hypertable() would throw an error when called on
an already existing hypertable. This can now be skipped by setting
if_not_exists argument to true.