### PR TITLE
Fix bug with timescaledb.allow_install_without_preload GUC not working

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -5,7 +5,6 @@
 
 bool		guc_disable_optimizations = false;
 bool		guc_optimize_non_hypertables = false;
-bool		guc_allow_install_without_preload = false;
 bool		guc_restoring = false;
 
 
@@ -25,16 +24,6 @@ _guc_init(void)
 	DefineCustomBoolVariable("timescaledb.optimize_non_hypertables", "Apply timescale query optimization to plain tables",
 							 "Apply timescale query optimization to plain tables in addition to hypertables",
 							 &guc_optimize_non_hypertables,
-							 false,
-							 PGC_USERSET,
-							 0,
-							 NULL,
-							 NULL,
-							 NULL);
-
-	DefineCustomBoolVariable("timescaledb.allow_install_without_preload", "Allow installing timescaledb without preloading the library (DANGEROUS)",
-							 NULL,
-							 &guc_allow_install_without_preload,
 							 false,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -4,7 +4,6 @@
 
 extern bool guc_disable_optimizations;
 extern bool guc_optimize_non_hypertables;
-extern bool guc_allow_install_without_preload;
 
 void		_guc_init(void);
 void		_guc_fini(void);

--- a/src/init.c
+++ b/src/init.c
@@ -42,8 +42,12 @@ _PG_init(void)
 {
 	if (!process_shared_preload_libraries_in_progress)
 	{
+		/* cannot use GUC variable here since extension not yet loaded */
+		char	   *allow_install_without_preload = GetConfigOptionByName("timescaledb.allow_install_without_preload", NULL, true);
 
-		if (!guc_allow_install_without_preload)
+		if (allow_install_without_preload == NULL ||
+			strlen(allow_install_without_preload) != 2 ||
+			strncmp(allow_install_without_preload, "on", 2) != 0)
 		{
 			char	   *config_file = GetConfigOptionByName("config_file", NULL, false);
 


### PR DESCRIPTION
Can't use a GUC variable before extension is loaded.