### PR TITLE
Reference the correct column when scanning partition epochs

### DIFF
--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -171,7 +171,7 @@ partition_epoch_tuple_found(TupleInfo *ti, void *arg)
 
 	datum = heap_getattr(ti->tuple, Anum_partition_epoch_num_partitions, ti->desc, &is_null);
 	pctx->num_partitions = DatumGetInt16(datum);
-	datum = heap_getattr(ti->tuple, Anum_partition_partition_epoch_id, ti->desc, &is_null);
+	datum = heap_getattr(ti->tuple, Anum_partition_epoch_id, ti->desc, &is_null);
 	epoch_id = DatumGetInt32(datum);
 
 	pe = partition_epoch_create(epoch_id, pctx);

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -1,0 +1,68 @@
+\ir include/create_single_db.sql
+SET client_min_messages = WARNING;
+DROP DATABASE IF EXISTS single;
+SET client_min_messages = NOTICE;
+CREATE DATABASE single;
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+psql:include/create_single_db.sql:7: NOTICE:  installing required extension "postgres_fdw"
+SELECT * from _timescaledb_catalog.hypertable;
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | root_schema_name | root_table_name | replication_factor | placement | time_column_name | time_column_type | created_on | chunk_time_interval 
+----+-------------+------------+------------------------+-------------------------+------------------+-----------------+--------------------+-----------+------------------+------------------+------------+---------------------
+(0 rows)
+
+SELECT * from _timescaledb_catalog.partition_epoch;
+ id | hypertable_id | start_time | end_time | num_partitions | partitioning_func_schema | partitioning_func | partitioning_mod | partitioning_column 
+----+---------------+------------+----------+----------------+--------------------------+-------------------+------------------+---------------------
+(0 rows)
+
+CREATE TABLE should_drop (time timestamp, temp float8);
+SELECT create_hypertable('should_drop', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+-- Calling create hypertable again will increment hypertable ID
+-- although no new hypertable is created. Make sure we can handle this.
+SELECT create_hypertable('should_drop', 'time', if_not_exists => true);
+NOTICE:  hypertable should_drop already exists, skipping
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+SELECT * from _timescaledb_catalog.hypertable;
+ id | schema_name | table_name  | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name |      time_column_type       | created_on | chunk_time_interval 
+----+-------------+-------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+-----------------------------+------------+---------------------
+  1 | public      | should_drop | _timescaledb_internal  | _hyper_1                | _timescaledb_internal | _hyper_1_root   |                  1 | STICKY    | time             | timestamp without time zone | single     |       2592000000000
+(1 row)
+
+SELECT * from _timescaledb_catalog.partition_epoch;
+ id | hypertable_id | start_time | end_time | num_partitions | partitioning_func_schema | partitioning_func | partitioning_mod | partitioning_column 
+----+---------------+------------+----------+----------------+--------------------------+-------------------+------------------+---------------------
+  1 |             1 |            |          |              1 |                          |                   |            32768 | 
+(1 row)
+
+DROP TABLE should_drop;
+NOTICE:  drop cascades to 2 other objects
+CREATE TABLE should_drop (time timestamp, temp float8);
+SELECT create_hypertable('should_drop', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO should_drop VALUES (now(), 1.0);
+SELECT * from _timescaledb_catalog.hypertable;
+ id | schema_name | table_name  | associated_schema_name | associated_table_prefix |   root_schema_name    | root_table_name | replication_factor | placement | time_column_name |      time_column_type       | created_on | chunk_time_interval 
+----+-------------+-------------+------------------------+-------------------------+-----------------------+-----------------+--------------------+-----------+------------------+-----------------------------+------------+---------------------
+  3 | public      | should_drop | _timescaledb_internal  | _hyper_3                | _timescaledb_internal | _hyper_3_root   |                  1 | STICKY    | time             | timestamp without time zone | single     |       2592000000000
+(1 row)
+
+SELECT * from _timescaledb_catalog.partition_epoch;
+ id | hypertable_id | start_time | end_time | num_partitions | partitioning_func_schema | partitioning_func | partitioning_mod | partitioning_column 
+----+---------------+------------+----------+----------------+--------------------------+-------------------+------------------+---------------------
+  2 |             3 |            |          |              1 |                          |                   |            32768 | 
+(1 row)
+

--- a/test/sql/drop_hypertable.sql
+++ b/test/sql/drop_hypertable.sql
@@ -1,0 +1,22 @@
+\ir include/create_single_db.sql
+
+SELECT * from _timescaledb_catalog.hypertable;
+SELECT * from _timescaledb_catalog.partition_epoch;
+
+CREATE TABLE should_drop (time timestamp, temp float8);
+SELECT create_hypertable('should_drop', 'time');
+
+-- Calling create hypertable again will increment hypertable ID
+-- although no new hypertable is created. Make sure we can handle this.
+SELECT create_hypertable('should_drop', 'time', if_not_exists => true);
+SELECT * from _timescaledb_catalog.hypertable;
+SELECT * from _timescaledb_catalog.partition_epoch;
+DROP TABLE should_drop;
+
+CREATE TABLE should_drop (time timestamp, temp float8);
+SELECT create_hypertable('should_drop', 'time');
+
+INSERT INTO should_drop VALUES (now(), 1.0);
+SELECT * from _timescaledb_catalog.hypertable;
+SELECT * from _timescaledb_catalog.partition_epoch;
+


### PR DESCRIPTION
This fixes a bug that caused the wrong column to be referenced when
scanning the partition_epoch table. The bug did not usually manifest
itself because the referenced (hypertable) ID was typically
incremented in unison with the desired (partition epoch) ID.