### PR TITLE
Run tests on temp Postgres instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /timescaledb.so
 *.bak
 typedef.list
+/test/testcluster

--- a/docker.mk
+++ b/docker.mk
@@ -5,6 +5,7 @@ MAKE = make
 PGPORT = 5432
 TEST_PGPORT = 6543
 TEST_TABLESPACE_PATH = /tmp/tspace1
+TEST_INSTANCE_OPTS = # clear this setting when running against existing Docker instance
 
 build-image: Dockerfile
 	@docker build . -t $(IMAGE_NAME)

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -1,0 +1,2 @@
+timescaledb.allow_install_without_preload = 'on'
+shared_preload_libraries = 'timescaledb'

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -4,13 +4,20 @@ set -u
 set -e
 
 PG_REGRESS_PSQL=$1
-shift
 PSQL=${PSQL:-$PG_REGRESS_PSQL}
+TEST_PGUSER=${TEST_PGUSER:-postgres}
 TEST_TABLESPACE_PATH=${TEST_TABLESPACE_PATH:-/tmp/tspace1}
 
+shift
+
+# Setup directories required by tests
 cd test/sql
-PG_PROC_USER=$(ps u | awk '/postgres/ { print $1; exit }')
 mkdir -p ${TEST_TABLESPACE_PATH}
 mkdir -p dump
 
-exec ${PSQL} -v ON_ERROR_STOP=1 -v VERBOSITY=terse -v ECHO=all -v TEST_TABLESPACE_PATH=\'${TEST_TABLESPACE_PATH}\' $@
+# Hack to grant TEST_PGUSER superuser status so that we can
+# consistently run tests using the same user rather than the
+# current/local user
+${PSQL} $@ -v ECHO=none -c "ALTER USER ${TEST_PGUSER} WITH SUPERUSER;"
+
+exec ${PSQL} -U ${TEST_PGUSER} -v ON_ERROR_STOP=1 -v VERBOSITY=terse -v ECHO=all -v TEST_TABLESPACE_PATH=\'${TEST_TABLESPACE_PATH}\' $@


### PR DESCRIPTION
Tests are now run on a temporary Postgres instance, which is launched
by the `pg_regress` test runner. This allows running tests without
having an existing running instance with a matching configuration and
also obviates the need for preloading the TimescaleDB extension. As a
result, tests are simpler to setup and run, and are more reliable and
consistent.