### PR TITLE
Fix command-tag for COPY and INSERT

### DIFF
--- a/src/executor.c
+++ b/src/executor.c
@@ -1,10 +1,12 @@
 #include <postgres.h>
 #include <executor/executor.h>
+#include <access/xact.h>
 
 #include "executor.h"
 
 static ExecutorRun_hook_type prev_ExecutorRun_hook;
 static uint64 additional_tuples;
+static uint64 level = 0;
 
 void
 executor_add_number_tuples_processed(uint64 count)
@@ -18,17 +20,53 @@ executor_get_additional_tuples_processed()
 	return additional_tuples;
 }
 
+void
+executor_level_enter(void)
+{
+	if (0 == level)
+	{
+		additional_tuples = 0;
+	}
+	level++;
+}
+
+void
+executor_level_exit(void)
+{
+	level--;
+}
+
 static void
 timescaledb_ExecutorRun(QueryDesc *queryDesc,
 						ScanDirection direction,
 						uint64 count)
 {
-	additional_tuples = 0;
+	executor_level_enter();
+
 	if (prev_ExecutorRun_hook)
 		(*prev_ExecutorRun_hook) (queryDesc, direction, count);
 	else
 		standard_ExecutorRun(queryDesc, direction, count);
-	queryDesc->estate->es_processed += additional_tuples;
+
+	executor_level_exit();
+	if (0 == level)
+	{
+		queryDesc->estate->es_processed += additional_tuples;
+	}
+}
+
+static void
+executor_AtEOXact_abort(XactEvent event, void *arg)
+{
+	switch (event)
+	{
+		case XACT_EVENT_ABORT:
+		case XACT_EVENT_PARALLEL_ABORT:
+			level = 0;
+		default:
+			break;
+	}
+
 }
 
 void
@@ -36,10 +74,13 @@ _executor_init(void)
 {
 	prev_ExecutorRun_hook = ExecutorRun_hook;
 	ExecutorRun_hook = timescaledb_ExecutorRun;
+
+	RegisterXactCallback(executor_AtEOXact_abort, NULL);
 }
 
 void
 _executor_fini(void)
 {
 	ExecutorRun_hook = prev_ExecutorRun_hook;
+	UnregisterXactCallback(executor_AtEOXact_abort, NULL);
 }

--- a/src/executor.h
+++ b/src/executor.h
@@ -8,4 +8,6 @@ extern void _executor_fini(void);
 extern void executor_add_number_tuples_processed(uint64 count);
 extern uint64 executor_get_additional_tuples_processed(void);
 
+extern void executor_level_enter(void);
+extern void executor_level_exit(void);
 #endif   /* TIMESCALEDB_EXECUTOR_H */

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -79,7 +79,9 @@ timescaledb_ProcessUtility(Node *parsetree,
 		 */
 		uint64		processed;
 
+		executor_level_enter();
 		DoCopy((CopyStmt *) parsetree, queryString, &processed);
+		executor_level_exit();
 		processed += executor_get_additional_tuples_processed();
 		if (completionTag)
 			snprintf(completionTag, COMPLETION_TAG_BUFSIZE,

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -31,7 +31,7 @@ SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associ
 BEGIN;
 BEGIN
 \COPY "one_Partition" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
-COPY 3
+COPY 7
 COMMIT;
 COMMIT
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES

--- a/test/expected/copy_from.out
+++ b/test/expected/copy_from.out
@@ -23,6 +23,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+\set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -33,6 +34,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894002000000000, 'dev1', 2.5, 3);
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on
 \o
 COPY (SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id) TO STDOUT;
 1257894000000000000	dev1	1.5	1	2	t

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -23,6 +23,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+\set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -33,6 +34,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894002000000000, 'dev1', 2.5, 3);
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on
 \o
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -23,6 +23,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+\set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -33,6 +34,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894002000000000, 'dev1', 2.5, 3);
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on
 \o
 \d+ "_timescaledb_internal".*
 Index "_timescaledb_internal.1-two_Partitions_device_id_timeCustom_idx"

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -27,16 +27,23 @@ SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCust
  
 (1 row)
 
+\set QUIET off
 BEGIN;
+BEGIN
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
+COPY 7
 COMMIT;
+COMMIT
 INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257987600000000000, 'dev1', 1.5, 1),
 (1257987600000000000, 'dev1', 1.5, 2),
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
+INSERT 0 4
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+INSERT 0 1
+\set QUIET on
 \d+ "_timescaledb_internal".*
 Index "_timescaledb_internal.1-two_Partitions_device_id_timeCustom_idx"
    Column   |  Type  |  Definition  | Storage  
@@ -356,13 +363,17 @@ SELECT create_hypertable('error_test', 'time', 'device', 2);
  
 (1 row)
 
+\set QUIET off
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:20.1 2017', 21.3, 'dev1');
+INSERT 0 1
 \set ON_ERROR_STOP 0
 -- generate insert error 
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:22.3 2017', 21.1, NULL);
 ERROR:  null value in column "device" violates not-null constraint
 \set ON_ERROR_STOP 1
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:25.7 2017', 22.4, 'dev2');
+INSERT 0 1
+\set QUIET on
 SELECT * FROM error_test;
             time            | temp | device 
 ----------------------------+------+--------

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -31,7 +31,7 @@ SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associ
 BEGIN;
 BEGIN
 \COPY "one_Partition" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
-COPY 3
+COPY 7
 COMMIT;
 COMMIT
 INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -23,6 +23,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+\set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -33,6 +34,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894002000000000, 'dev1', 2.5, 3);
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on
 \o
 SELECT count(*)
   FROM pg_depend

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -23,6 +23,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+\set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -33,6 +34,7 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894002000000000, 'dev1', 2.5, 3);
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on
 \o
 SELECT * FROM PUBLIC."two_Partitions";
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 

--- a/test/sql/include/insert_two_partitions.sql
+++ b/test/sql/include/insert_two_partitions.sql
@@ -19,6 +19,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id
 
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
 
+\set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';
 COMMIT;
@@ -32,3 +33,4 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 
 INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
+\set QUIET on

--- a/test/sql/insert.sql
+++ b/test/sql/insert.sql
@@ -9,12 +9,14 @@ SELECT * FROM ONLY "two_Partitions";
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
 
+\set QUIET off
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:20.1 2017', 21.3, 'dev1');
 \set ON_ERROR_STOP 0
 -- generate insert error 
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:22.3 2017', 21.1, NULL);
 \set ON_ERROR_STOP 1
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:25.7 2017', 22.4, 'dev2');
+\set QUIET on
 SELECT * FROM error_test;
 
 --test character(9) partition keys since there were issues with padding causing partitioning errors


### PR DESCRIPTION
Previously the count returned by insert and copy was wrong because
the count was reset on every execute. But, often there is an execute
in the middle of an insert (i.e. to create a chunk). This fixes the
logic to reset the count only at the start of the top-level statement.