### PR TITLE
Provide API for adding hypertable dimensions

### DIFF
--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -79,7 +79,8 @@ CREATE TABLE _timescaledb_catalog.dimension (
     CHECK (
         (num_slices IS NULL AND interval_length IS NOT NULL) OR
         (num_slices IS NOT NULL AND interval_length IS NULL)
-    )
+    ),
+    UNIQUE (hypertable_id, column_name)
 );
 CREATE INDEX ON  _timescaledb_catalog.dimension(hypertable_id);
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension', '');

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -6,7 +6,7 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb;
 create schema test_schema;
-create table test_schema.test_table(time bigint, temp float8, device_id text);
+create table test_schema.test_table(time bigint, temp float8, device_id text, device_type text, location text, id int);
 \dt "test_schema".*
               List of relations
    Schema    |    Name    | Type  |  Owner   
@@ -20,6 +20,58 @@ select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2
  
 (1 row)
 
+--test adding one more closed dimension
+select add_dimension('test_schema.test_table', 'location', 2);
+ add_dimension 
+---------------
+ 
+(1 row)
+
+select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions 
+----+-------------+------------+------------------------+-------------------------+----------------
+  1 | test_schema | test_table | _timescaledb_internal  | _hyper_1                |              3
+(1 row)
+
+select * from _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-----------------------+-----------------
+  1 |             1 | time        | bigint      | t       |            |                          |                       |   2592000000000
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+  3 |             1 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+(3 rows)
+
+--test adding one more open dimension
+select add_dimension('test_schema.test_table', 'id', interval_length => 1000);
+ add_dimension 
+---------------
+ 
+(1 row)
+
+select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions 
+----+-------------+------------+------------------------+-------------------------+----------------
+  1 | test_schema | test_table | _timescaledb_internal  | _hyper_1                |              4
+(1 row)
+
+select * from _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-----------------------+-----------------
+  1 |             1 | time        | bigint      | t       |            |                          |                       |   2592000000000
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+  3 |             1 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+  4 |             1 | id          | integer     | t       |            |                          |                       |            1000
+(4 rows)
+
+\set ON_ERROR_STOP 0
+--adding the same dimension twice should afail
+select add_dimension('test_schema.test_table', 'location', 2);
+ERROR:  A dimension on column "location" already exists
+--adding a new dimension on a non-empty table should also fail
+insert into test_schema.test_table values (123456789, 23.8, 'blue', 'type1', 'nyc', 1);
+select add_dimension('test_schema.test_table', 'device_type', 2);
+ERROR:  Cannot add new dimension to a non-empty table
+\set ON_ERROR_STOP 1
 --test partitioning in only time dimension
 create table test_schema.test_1dim(time timestamp, temp float);
 select create_hypertable('test_schema.test_1dim', 'time');
@@ -49,7 +101,7 @@ select create_hypertable('test_schema.test_1dim', 'time');
 ERROR:  hypertable test_schema.test_1dim already exists
 \set ON_ERROR_STOP 1
 -- if_not_exist should also work with data in the hypertable
-insert into test_schema.test_1dim VALUES ('2004-10-19 10:23:54+02',1.0);
+insert into test_schema.test_1dim VALUES ('2004-10-19 10:23:54+02', 1.0);
 select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true);
 NOTICE:  hypertable test_schema.test_1dim already exists, skipping
  create_hypertable 

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -20,7 +20,7 @@ ERROR:  relation "public.Hypertable_1_mispelled" does not exist at character 33
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2);
 ERROR:  column "time_mispelled" does not exist
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'Device_id', 'Device_id', 2);
-ERROR:  illegal type for time column "Device_id": text
+ERROR:  illegal type for column "Device_id": text
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id_mispelled', 2);
 ERROR:  column "Device_id_mispelled" does not exist
 INSERT INTO PUBLIC."Hypertable_1" VALUES(1,'dev_1', 3); 

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -18,6 +18,7 @@ WHERE OID IN (
 ORDER BY proname;
          proname         
 -------------------------
+ add_dimension
  attach_tablespace
  create_hypertable
  drop_chunks
@@ -26,5 +27,5 @@ ORDER BY proname;
  restore_timescaledb
  set_chunk_time_interval
  time_bucket
-(8 rows)
+(9 rows)
 

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -295,3 +295,47 @@ SELECT "1dim" FROM "1dim";
  ("Fri Jan 20 09:00:59 2017",29.2)
 (4 rows)
 
+-- Create a three-dimensional table
+CREATE TABLE "3dim" (time timestamp, temp float, device text, location text);
+SELECT create_hypertable('"3dim"', 'time', 'device', 2);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+SELECT add_dimension('"3dim"', 'location', 2);
+ add_dimension 
+---------------
+ 
+(1 row)
+
+INSERT INTO "3dim" VALUES('2017-01-20T09:00:01', 22.5, 'blue', 'nyc');
+INSERT INTO "3dim" VALUES('2017-01-20T09:00:21', 21.2, 'brown', 'sthlm');
+INSERT INTO "3dim" VALUES('2017-01-20T09:00:47', 25.1, 'yellow', 'la');
+--show the constraints on the three-dimensional chunk
+\d+ _timescaledb_internal._hyper_3_6_chunk
+                       Table "_timescaledb_internal._hyper_3_6_chunk"
+  Column  |            Type             | Modifiers | Storage  | Stats target | Description 
+----------+-----------------------------+-----------+----------+--------------+-------------
+ time     | timestamp without time zone |           | plain    |              | 
+ temp     | double precision            |           | plain    |              | 
+ device   | text                        |           | extended |              | 
+ location | text                        |           | extended |              | 
+Indexes:
+    "22-3dim_time_idx" btree ("time" DESC)
+    "23-3dim_device_time_idx" btree (device, "time" DESC)
+Check constraints:
+    "constraint_10" CHECK (_timescaledb_internal.get_partition_for_key(location) >= 0 AND _timescaledb_internal.get_partition_for_key(location) < 1073741823)
+    "constraint_5" CHECK ("time" >= 'Sat Dec 24 16:00:00 2016'::timestamp without time zone AND "time" < 'Mon Jan 23 16:00:00 2017'::timestamp without time zone)
+    "constraint_9" CHECK (_timescaledb_internal.get_partition_for_key(device) >= 1073741823 AND _timescaledb_internal.get_partition_for_key(device) < 2147483647)
+Inherits: "3dim"
+
+--queries should work in three dimensions
+SELECT * FROM "3dim";
+           time           | temp | device | location 
+--------------------------+------+--------+----------
+ Fri Jan 20 09:00:01 2017 | 22.5 | blue   | nyc
+ Fri Jan 20 09:00:47 2017 | 25.1 | yellow | la
+ Fri Jan 20 09:00:21 2017 | 21.2 | brown  | sthlm
+(3 rows)
+

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -42,7 +42,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   108
+   110
 (1 row)
 
 \c postgres
@@ -66,7 +66,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   108
+   110
 (1 row)
 
 \c single

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -1,9 +1,29 @@
 \ir include/create_single_db.sql
 
 create schema test_schema;
-create table test_schema.test_table(time bigint, temp float8, device_id text);
+create table test_schema.test_table(time bigint, temp float8, device_id text, device_type text, location text, id int);
+
 \dt "test_schema".*
 select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2);
+
+--test adding one more closed dimension
+select add_dimension('test_schema.test_table', 'location', 2);
+select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
+select * from _timescaledb_catalog.dimension;
+
+--test adding one more open dimension
+select add_dimension('test_schema.test_table', 'id', interval_length => 1000);
+select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
+select * from _timescaledb_catalog.dimension;
+
+\set ON_ERROR_STOP 0
+--adding the same dimension twice should afail
+select add_dimension('test_schema.test_table', 'location', 2);
+
+--adding a new dimension on a non-empty table should also fail
+insert into test_schema.test_table values (123456789, 23.8, 'blue', 'type1', 'nyc', 1);
+select add_dimension('test_schema.test_table', 'device_type', 2);
+\set ON_ERROR_STOP 1
 
 --test partitioning in only time dimension
 create table test_schema.test_1dim(time timestamp, temp float);
@@ -19,11 +39,10 @@ select create_hypertable('test_schema.test_1dim', 'time');
 \set ON_ERROR_STOP 1
 
 -- if_not_exist should also work with data in the hypertable
-insert into test_schema.test_1dim VALUES ('2004-10-19 10:23:54+02',1.0);
+insert into test_schema.test_1dim VALUES ('2004-10-19 10:23:54+02', 1.0);
 select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true);
 
 -- Should error when creating again without if_not_exists set to true
 \set ON_ERROR_STOP 0
 select create_hypertable('test_schema.test_1dim', 'time');
 \set ON_ERROR_STOP 1
-

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -21,3 +21,17 @@ INSERT INTO "1dim" SELECT * FROM regular_table;
 SELECT * FROM "1dim";
 SELECT "1dim" FROM "1dim";
 
+-- Create a three-dimensional table
+CREATE TABLE "3dim" (time timestamp, temp float, device text, location text);
+SELECT create_hypertable('"3dim"', 'time', 'device', 2);
+SELECT add_dimension('"3dim"', 'location', 2);
+INSERT INTO "3dim" VALUES('2017-01-20T09:00:01', 22.5, 'blue', 'nyc');
+INSERT INTO "3dim" VALUES('2017-01-20T09:00:21', 21.2, 'brown', 'sthlm');
+INSERT INTO "3dim" VALUES('2017-01-20T09:00:47', 25.1, 'yellow', 'la');
+
+--show the constraints on the three-dimensional chunk
+\d+ _timescaledb_internal._hyper_3_6_chunk
+
+--queries should work in three dimensions
+SELECT * FROM "3dim";
+


### PR DESCRIPTION
A new public-facing API `add_dimension(table, column, ...)`
makes it possible to add additional dimensions (partitioning
columns) to a hypertable.

The code has also been refactored with a corresponding
internal function that is called by both `add_dimension()`
and `create_hypertable()`.