### PR TITLE
Remove unused functions

### DIFF
--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -7,26 +7,10 @@
 #include "chunk.h"
 
 static inline ChunkConstraint *
-chunk_constraint_from_form_data(Form_chunk_constraint fd)
-{
-	ChunkConstraint *cc;
-
-	cc = palloc0(sizeof(ChunkConstraint));
-	memcpy(&cc->fd, fd, sizeof(FormData_chunk_constraint));
-	return cc;
-}
-
-static inline ChunkConstraint *
 chunk_constraint_fill(ChunkConstraint *cc, HeapTuple tuple)
 {
 	memcpy(&cc->fd, GETSTRUCT(tuple), sizeof(FormData_chunk_constraint));
 	return cc;
-}
-
-static inline ChunkConstraint *
-chunk_constraint_from_tuple(HeapTuple tuple)
-{
-	return chunk_constraint_from_form_data((Form_chunk_constraint) GETSTRUCT(tuple));
 }
 
 static bool

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -39,17 +39,6 @@ hypercube_alloc(int16 num_dimensions)
 	return hc;
 }
 
-static inline void
-hypercube_free(Hypercube *hc)
-{
-	int			i;
-
-	for (i = 0; i < hc->num_slices; i++)
-		pfree(hc->slices[i]);
-
-	pfree(hc);
-}
-
 Hypercube *
 hypercube_copy(Hypercube *hc)
 {


### PR DESCRIPTION
Remove the following unused functions in order to quench compiler
warnings:

- chunk_constraint_from_form_data()
- chunk_constraint_from_tuple()
- hypercube_free()