### PR TITLE
Fix off-by-one error when creating aligned chunks

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -159,7 +159,9 @@ BEGIN
         -- There is a chunk that overlaps with new_range_start, cut
         -- new_range_start to begin where that chunk ends
         IF alignment_found THEN
-            RAISE EXCEPTION 'Should never happen: needed to cut an aligned dimension'
+            RAISE EXCEPTION 'Should never happen: needed to cut an aligned dimension.
+            Free_dimension %. Existing(end): %, New(start):%',
+            free_dimension_id, overlap_value, new_range_start
             USING ERRCODE = 'IO501';
         END IF;
         new_range_start := overlap_value;
@@ -176,7 +178,7 @@ BEGIN
     WHERE
     c.id = (
         SELECT _timescaledb_internal.chunk_id_get_by_dimensions(free_dimension_id || fixed_dimension_ids,
-                                                         new_range_end || fixed_dimension_values)
+                                                         new_range_end - 1 || fixed_dimension_values)
     )
     ORDER BY free_slice.range_start ASC
     LIMIT 1;
@@ -184,7 +186,9 @@ BEGIN
     IF FOUND THEN
         -- there is at least one table that starts inside, cut the end to match
         IF alignment_found THEN
-            RAISE EXCEPTION 'Should never happen: needed to cut an aligned dimension'
+            RAISE EXCEPTION 'Should never happen: needed to cut an aligned dimension.
+            Free_dimension %. Existing(start): %, New(end):%',
+            free_dimension_id, overlap_value, new_range_end
             USING ERRCODE = 'IO501';
         END IF;
         new_range_end := overlap_value;

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -133,3 +133,27 @@ SELECT * FROM _timescaledb_catalog.chunk c
   7 |             2 | _timescaledb_internal | _hyper_2_7_chunk |        7 |                 13 | 13 |            3 |          40 |        80 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
 (3 rows)
 
+    --check the cut-to-size with aligned dimensions code
+    INSERT INTO chunk_align_test VALUES (35, 1, 'dev1');
+    INSERT INTO chunk_align_test VALUES (35, 1, 'dev2');
+    INSERT INTO chunk_align_test VALUES (81, 1, 'dev1');
+    INSERT INTO chunk_align_test VALUES (81, 1, 'dev2');
+SELECT * FROM _timescaledb_catalog.chunk c
+    LEFT JOIN _timescaledb_catalog.chunk_constraint cc ON (c.id = cc.chunk_id)
+    LEFT JOIN _timescaledb_catalog.dimension_slice ds ON (ds.id = cc.dimension_slice_id)
+    LEFT JOIN _timescaledb_catalog.dimension d ON (d.id = ds.dimension_id)
+    LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+    WHERE h.schema_name = 'public' AND h.table_name = 'chunk_align_test'
+          AND d.column_name = 'time'
+    ORDER BY c.id, d.id;
+ id | hypertable_id |      schema_name      |    table_name     | chunk_id | dimension_slice_id | id | dimension_id | range_start | range_end | id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | id | schema_name |    table_name    | associated_schema_name | associated_table_prefix | num_dimensions 
+----+---------------+-----------------------+-------------------+----------+--------------------+----+--------------+-------------+-----------+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+----+-------------+------------------+------------------------+-------------------------+----------------
+  5 |             2 | _timescaledb_internal | _hyper_2_5_chunk  |        5 |                  9 |  9 |            3 |           0 |        10 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
+  6 |             2 | _timescaledb_internal | _hyper_2_6_chunk  |        6 |                  9 |  9 |            3 |           0 |        10 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
+  7 |             2 | _timescaledb_internal | _hyper_2_7_chunk  |        7 |                 13 | 13 |            3 |          40 |        80 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
+  8 |             2 | _timescaledb_internal | _hyper_2_8_chunk  |        8 |                 15 | 15 |            3 |          10 |        40 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
+  9 |             2 | _timescaledb_internal | _hyper_2_9_chunk  |        9 |                 15 | 15 |            3 |          10 |        40 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
+ 10 |             2 | _timescaledb_internal | _hyper_2_10_chunk |       10 |                 19 | 19 |            3 |          80 |       120 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
+ 11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |       11 |                 19 | 19 |            3 |          80 |       120 |  3 |             2 | time        | bigint      | t       |            |                          |                   |              40 |  2 | public      | chunk_align_test | _timescaledb_internal  | _hyper_2                |              2
+(7 rows)
+

--- a/test/sql/create_chunks.sql
+++ b/test/sql/create_chunks.sql
@@ -64,3 +64,18 @@ SELECT * FROM _timescaledb_catalog.chunk c
     WHERE h.schema_name = 'public' AND h.table_name = 'chunk_align_test'
           AND d.column_name = 'time'
     ORDER BY c.id, d.id;
+
+    --check the cut-to-size with aligned dimensions code
+    INSERT INTO chunk_align_test VALUES (35, 1, 'dev1');
+    INSERT INTO chunk_align_test VALUES (35, 1, 'dev2');
+    INSERT INTO chunk_align_test VALUES (81, 1, 'dev1');
+    INSERT INTO chunk_align_test VALUES (81, 1, 'dev2');
+SELECT * FROM _timescaledb_catalog.chunk c
+    LEFT JOIN _timescaledb_catalog.chunk_constraint cc ON (c.id = cc.chunk_id)
+    LEFT JOIN _timescaledb_catalog.dimension_slice ds ON (ds.id = cc.dimension_slice_id)
+    LEFT JOIN _timescaledb_catalog.dimension d ON (d.id = ds.dimension_id)
+    LEFT JOIN _timescaledb_catalog.hypertable h ON (d.hypertable_id = h.id)
+    WHERE h.schema_name = 'public' AND h.table_name = 'chunk_align_test'
+          AND d.column_name = 'time'
+    ORDER BY c.id, d.id;
+


### PR DESCRIPTION
It is not an error for range_end of a new chunk to be equal to
range_start of an existing chunk because range_end is exclusive.
Fix logic not to throw an error in that case.