### PR TITLE
Add function to get git version of code base.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ EXTENSION = timescaledb
 SQL_FILES = $(shell cat sql/load_order.txt)
 
 EXT_VERSION = $(shell cat timescaledb.control | grep 'default' | sed "s/^.*'\(.*\)'$\/\1/g")
+EXT_GIT_COMMIT := $(shell git describe --abbrev=4 --dirty --always --tags || echo $(EXT_GIT_COMMIT))
 EXT_SQL_FILE = sql/$(EXTENSION)--$(EXT_VERSION).sql
 
 DATA = $(EXT_SQL_FILE)
@@ -41,7 +42,8 @@ SRCS = \
 	src/insert_statement_state.c \
 	src/agg_bookend.c \
 	src/subspace_store.c \
-	src/guc.c
+	src/guc.c \
+	src/version.c
 
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
@@ -83,7 +85,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 EXTRA_CLEAN = $(EXT_SQL_FILE) $(DEPS)
 
 include $(PGXS)
-override CFLAGS += -DINCLUDE_PACKAGE_SUPPORT=0 -MMD
+override CFLAGS += -DINCLUDE_PACKAGE_SUPPORT=0 -MMD -DEXT_GIT_COMMIT=\"$(EXT_GIT_COMMIT)\"
 override pg_regress_clean_files = test/results/ test/regression.diffs test/regression.out tmp_check/ log/ $(TEST_CLUSTER)
 -include $(DEPS)
 

--- a/sql/load_order.txt
+++ b/sql/load_order.txt
@@ -22,3 +22,4 @@ sql/bookend.sql
 sql/time_bucket.sql
 sql/permissions.sql
 sql/init.sql
+sql/version.sql

--- a/sql/version.sql
+++ b/sql/version.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
+	AS '$libdir/timescaledb', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,21 @@
+#include "postgres.h"
+#include <string.h>
+#include "fmgr.h"
+
+const char* git_commit = EXT_GIT_COMMIT;
+
+PG_FUNCTION_INFO_V1(get_git_commit);
+
+Datum
+get_git_commit(PG_FUNCTION_ARGS) {
+	int32    var_size = VARHDRSZ + strlen(git_commit);
+	text     *version_text = (text *) palloc(var_size); 
+
+	SET_VARSIZE(version_text, var_size);
+
+	memcpy((void *) VARDATA(version_text),
+           (void *) git_commit,
+           var_size - VARHDRSZ);
+
+	PG_RETURN_TEXT_P(version_text);
+}

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -42,7 +42,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   110
+   111
 (1 row)
 
 \c postgres
@@ -66,7 +66,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   110
+   111
 (1 row)
 
 \c single

--- a/test/expected/version.out
+++ b/test/expected/version.out
@@ -1,0 +1,8 @@
+-- Just test that the function does not error out as the output
+-- will change.
+select count(*) from _timescaledb_internal.get_git_commit();
+ count 
+-------
+     1
+(1 row)
+

--- a/test/sql/version.sql
+++ b/test/sql/version.sql
@@ -1,0 +1,4 @@
+-- Just test that the function does not error out as the output
+-- will change.
+select count(*) from _timescaledb_internal.get_git_commit();
+


### PR DESCRIPTION
I found this useful when I compared different branches etc. to make sure what is running. Getting the git version from a shell command won't work when we build it in Docker but then I build with something like
```
docker build . -t timescaledb --build-arg EXT_VERSION_STRING=$(git describe --abbrev=4 --dirty --always --tags)
```