### PR TITLE
Add update script for PR #121

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,18 @@ dist: trusty
 services:
   - docker
 
-before_install:
-  - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build postgres:9.6.3-alpine
-
-install:
-  - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils && make -C /build install && chown -R postgres:postgres /build/"
-
-script:
-  - docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build installcheck TEST_INSTANCE_OPTS='--temp-instance=/tmp/pgdata --temp-config=/build/test/postgresql.conf'"
-
-after_failure:
-  - docker exec -it pgbuild cat /build/test/regression.diffs
-
-after_script:
-  - docker rm -f pgbuild
+jobs:
+  include:
+    - stage: test
+      before_install:
+        - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build postgres:9.6.3-alpine
+      install:
+        - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils && make -C /build install && chown -R postgres:postgres /build/"
+      script:
+        - docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build installcheck TEST_INSTANCE_OPTS='--temp-instance=/tmp/pgdata --temp-config=/build/test/postgresql.conf'"
+      after_failure:
+        - docker exec -it pgbuild cat /build/test/regression.diffs
+      after_script:
+        - docker rm -f pgbuild
+    - stage: test
+      script: PGTEST_TMPDIR=$TRAVIS_BUILD_DIR bash -x ./scripts/test_updates.sh

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -15,7 +15,7 @@ TAG_NAME=${TAG_NAME:-$GIT_BRANCH}
 docker rm -f $(docker ps -a -q -f name=${BUILD_CONTAINER_NAME} 2>/dev/null) 2>/dev/null
 
 # Run a Postgres container
-docker run -u postgres -d --name ${BUILD_CONTAINER_NAME} -v ${BASE_DIR}:/src postgres:${PG_IMAGE_TAG}
+docker run -d --name ${BUILD_CONTAINER_NAME} -v ${BASE_DIR}:/src postgres:${PG_IMAGE_TAG}
 
 # Install build dependencies
 docker exec -u root -it ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils && mkdir -p /build"

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -4,6 +4,8 @@ set -e
 set -o pipefail
 
 PGTEST_TMPDIR=${PGTEST_TMPDIR:-/tmp}
+CLEAN_DATA_DIR=${CLEAN_DATA_DIR:-$PGTEST_TMPDIR/pg_data_clean}
+UPDATED_DATA_DIR=${UPDATED_DATA_DIR:-$PGTEST_TMPDIR/pg_data_update}
 UPDATE_PG_PORT=${UPDATE_PG_PORT:-6432}
 CLEAN_PG_PORT=${CLEAN_PG_PORT:-6433}
 
@@ -14,7 +16,7 @@ set +e
 for i in {1..10}; do
   sleep 2
 
-  pg_isready -h localhost -p $1
+  pg_isready -h localhost -U postgres -p $1
 
   if [[ $? == 0 ]] ; then
     set -e
@@ -25,11 +27,11 @@ exit 1
 }
 
 docker rm -f timescaledb-orig timescaledb-updated timescaledb-clean || true
-rm -rf  ${PGTEST_TMPDIR}/pg_data ${PGTEST_TMPDIR}/pg_data_clean
+rm -rf  ${CLEAN_DATA_DIR} ${UPDATED_DATA_DIR}
 IMAGE_NAME=update_test TAG_NAME=latest bash scripts/docker-build.sh
 
-docker run -d --name timescaledb-clean -v /tmp/pg_data_clean:/var/lib/postgresql/data -p ${CLEAN_PG_PORT}:5432 update_test:latest
-docker run -d --name timescaledb-orig -v ${PGTEST_TMPDIR}/pg_data:/var/lib/postgresql/data -p ${UPDATE_PG_PORT}:5432 timescale/timescaledb:${UPDATE_FROM_TAG}
+docker run -d --name timescaledb-orig -v ${UPDATED_DATA_DIR}:/var/lib/postgresql/data -p ${UPDATE_PG_PORT}:5432 timescale/timescaledb:${UPDATE_FROM_TAG}
+docker run -d --name timescaledb-clean -v ${CLEAN_DATA_DIR}:/var/lib/postgresql/data -p ${CLEAN_PG_PORT}:5432 update_test:latest
 
 wait_for_pg ${UPDATE_PG_PORT}
 
@@ -37,7 +39,7 @@ echo "Executing setup script on 0.1.0"
 psql -h localhost -U postgres -p ${UPDATE_PG_PORT} -f test/sql/updates/setup.sql
 docker rm -vf timescaledb-orig
 
-docker run -d --name timescaledb-updated -v /tmp/pg_data:/var/lib/postgresql/data -p ${UPDATE_PG_PORT}:5432 update_test:latest
+docker run -d --name timescaledb-updated -v ${UPDATED_DATA_DIR}:/var/lib/postgresql/data -p ${UPDATE_PG_PORT}:5432 update_test:latest
 
 wait_for_pg ${UPDATE_PG_PORT}
 
@@ -54,13 +56,13 @@ echo "Restarting clean container"
 #below is needed so the clean container looks like updated, which has been restarted after the setup script
 #(especially needed for sequences which might otherwise be in different states -- e.g. some backends may have reserved batches)
 docker rm -vf timescaledb-clean
-docker run -d --name timescaledb-clean -v /tmp/pg_data_clean:/var/lib/postgresql/data -p ${CLEAN_PG_PORT}:5432 update_test:latest
+docker run -d --name timescaledb-clean -v ${CLEAN_DATA_DIR}:/var/lib/postgresql/data -p ${CLEAN_PG_PORT}:5432 update_test:latest
 wait_for_pg ${CLEAN_PG_PORT}
 
 echo "Testing"
-psql -X -v ECHO=ALL -h localhost -U postgres -d single -p ${UPDATE_PG_PORT} -f test/sql/updates/test-0.1.1.sql > /tmp/updated.out
-psql -X -v ECHO=ALL -h localhost -U postgres -d single -p ${CLEAN_PG_PORT} -f test/sql/updates/test-0.1.1.sql > /tmp/clean.out
+psql -X -v ECHO=ALL -h localhost -U postgres -d single -p ${UPDATE_PG_PORT} -f test/sql/updates/test-0.1.1.sql > ${PGTEST_TMPDIR}/updated.out
+psql -X -v ECHO=ALL -h localhost -U postgres -d single -p ${CLEAN_PG_PORT} -f test/sql/updates/test-0.1.1.sql > ${PGTEST_TMPDIR}/clean.out
 
-docker rm -f timescaledb-updated timescaledb-clean || rm -rf  ${PGTEST_TMPDIR}/pg_data ${PGTEST_TMPDIR}/pg_data_clean
+docker rm -f timescaledb-updated timescaledb-clean || rm -rf  ${CLEAN_DATA_DIR} ${UPDATED_DATA_DIR}
 
 diff ${PGTEST_TMPDIR}/clean.out ${PGTEST_TMPDIR}/updated.out | tee ${PGTEST_TMPDIR}/update_test.output

--- a/sql/updates/0.1.0--0.1.1-dev.sql
+++ b/sql/updates/0.1.0--0.1.1-dev.sql
@@ -1,3 +1,0 @@
-ALTER TABLE _timescaledb_catalog.hypertable ADD UNIQUE (id, schema_name);
-ALTER TABLE _timescaledb_catalog.hypertable_index DROP CONSTRAINT hypertable_index_hypertable_id_fkey;
-ALTER TABLE _timescaledb_catalog.hypertable_index ADD CONSTRAINT hypertable_index_hypertable_id_fkey FOREIGN KEY (hypertable_id, main_schema_name) REFERENCES _timescaledb_catalog.hypertable(id, schema_name) ON UPDATE CASCADE ON DELETE CASCADE;

--- a/sql/updates/README.md
+++ b/sql/updates/README.md
@@ -1,2 +1,9 @@
-Folder for update SQL-scripts named oldversion--newversion (0.1.0--0.1.1)
-It is assumed that there is only one file matching the newversion.
+Folder for update SQL-scripts named pre-oldversion--newversion or post-oldversion--newversion
+
+pre files are run before reloading the functions. These should include new
+tables, constraints, indexes, etc.
+
+post functions are run after reloading the functions. These include
+any entities depending on functions-- e.g. triggers.
+
+It is assumed that there is only one file for pre or post matching the newversion.

--- a/sql/updates/post-0.1.0--0.1.1-dev.sql
+++ b/sql/updates/post-0.1.0--0.1.1-dev.sql
@@ -1,0 +1,3 @@
+CREATE EVENT TRIGGER ddl_drop_trigger
+ON sql_drop
+EXECUTE PROCEDURE _timescaledb_internal.ddl_process_drop_trigger();

--- a/sql/updates/pre-0.1.0--0.1.1-dev.sql
+++ b/sql/updates/pre-0.1.0--0.1.1-dev.sql
@@ -1,0 +1,17 @@
+ALTER TABLE _timescaledb_catalog.hypertable ADD UNIQUE (id, schema_name);
+
+ALTER TABLE _timescaledb_catalog.hypertable_index
+DROP CONSTRAINT hypertable_index_hypertable_id_fkey,
+ADD CONSTRAINT hypertable_index_hypertable_id_fkey
+FOREIGN KEY (hypertable_id, main_schema_name)
+REFERENCES _timescaledb_catalog.hypertable(id, schema_name)
+ON UPDATE CASCADE
+ON DELETE CASCADE;
+
+ALTER TABLE _timescaledb_catalog.chunk_index
+DROP CONSTRAINT chunk_index_main_schema_name_fkey,
+ADD CONSTRAINT chunk_index_main_schema_name_fkey
+FOREIGN KEY (main_schema_name, main_index_name) 
+REFERENCES _timescaledb_catalog.hypertable_index(main_schema_name, main_index_name) 
+ON UPDATE CASCADE 
+ON DELETE CASCADE;

--- a/test/sql/updates/test-0.1.1.sql
+++ b/test/sql/updates/test-0.1.1.sql
@@ -1,2 +1,11 @@
-\d+ _timescaledb_catalog.hypertable;
-\d+ _timescaledb_catalog.hypertable_index;
+\d+ _timescaledb_catalog.*;
+\df+ _timescaledb_internal.*;
+\dy
+
+SELECT count(*)
+  FROM pg_depend
+ WHERE refclassid = 'pg_extension'::regclass
+     AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
+
+-- The list of tables configured to be dumped.
+SELECT unnest(extconfig)::regclass::text c from pg_extension where extname='timescaledb' ORDER BY c;


### PR DESCRIPTION
Also includes some update infrastructure changes. Main difference
is that sql/updates/ scripts are now split into pre- and post- files.
This is needed because table updates need to happen before reloading
functions (some functions checked for accessing right schema at
definition time). Meanwhile trigger updates need to happen after
since triggers must refer to valid functions at definition time.