### PR TITLE
Reduce local non-docker dependencies for update tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,6 @@ pgindent: typedef.list
 	pgindent --typedef=typedef.list
 
 manualupdate:
-	git diff origin/master $(MANUAL_UPDATE_FILES)
+	echo $(MANUAL_UPDATE_FILES)
 
 .PHONY: check-sql-files all


### PR DESCRIPTION
Get rid of dependencies on a local psql and stop mounting data volumes.