### PR TITLE
Add support for upserts (ON CONFLICT DO UPDATE)

### DIFF
--- a/src/chunk_dispatch.c
+++ b/src/chunk_dispatch.c
@@ -11,13 +11,14 @@
 #include "dimension.h"
 
 ChunkDispatch *
-chunk_dispatch_create(Hypertable *ht, EState *estate)
+chunk_dispatch_create(Hypertable *ht, EState *estate, Query *parse)
 {
 	ChunkDispatch *cp = palloc(sizeof(ChunkDispatch));
 
 	cp->hypertable = ht;
 	cp->estate = estate;
 	cp->hypertable_result_rel_info = NULL;
+	cp->parse = parse;
 	cp->cache = subspace_store_init(HYPERSPACE_NUM_DIMENSIONS(ht->space), estate->es_query_cxt);
 	return cp;
 }

--- a/src/chunk_dispatch.h
+++ b/src/chunk_dispatch.h
@@ -8,7 +8,11 @@
 #include "cache.h"
 #include "subspace_store.h"
 
-/* ChunkDispatch keeps info needed to dispatch tuples to chunks. */
+/*
+ * ChunkDispatch keeps cached state needed to dispatch tuples to chunks. It is
+ * separate from any plan and executor nodes, since it is used both for INSERT
+ * and COPY.
+*/
 typedef struct ChunkDispatch
 {
 	Hypertable *hypertable;
@@ -17,12 +21,13 @@ typedef struct ChunkDispatch
 	/* Keep a pointer to the original (hypertable's) ResultRelInfo since we will
 	 * reset the pointer in EState as we lookup new chunks. */
 	ResultRelInfo *hypertable_result_rel_info;
+	Query	   *parse;
 } ChunkDispatch;
 
 typedef struct Point Point;
 typedef struct ChunkInsertState ChunkInsertState;
 
-ChunkDispatch *chunk_dispatch_create(Hypertable *, EState *);
+ChunkDispatch *chunk_dispatch_create(Hypertable *, EState *, Query *);
 void		chunk_dispatch_destroy(ChunkDispatch *);
 ChunkInsertState *chunk_dispatch_get_chunk_insert_state(ChunkDispatch *, Point *);
 

--- a/src/chunk_dispatch_plan.h
+++ b/src/chunk_dispatch_plan.h
@@ -7,8 +7,10 @@
 typedef struct ChunkDispatchInfo
 {
 	Oid			hypertable_relid;
+	ModifyTable *mt;
+	Query	   *parse;
 } ChunkDispatchInfo;
 
-extern CustomScan *chunk_dispatch_plan_create(Plan *subplan, Oid hypertable_relid);
+extern CustomScan *chunk_dispatch_plan_create(ModifyTable *mt, Plan *subplan, Oid hypertable_relid, Query *parse);
 
 #endif   /* TIMESCALEDB_CHUNK_DISPATCH_PLAN_H */

--- a/src/chunk_dispatch_state.h
+++ b/src/chunk_dispatch_state.h
@@ -5,6 +5,7 @@
 #include <nodes/execnodes.h>
 
 typedef struct ChunkDispatch ChunkDispatch;
+typedef struct ChunkDispatchInfo ChunkDispatchInfo;
 typedef struct Cache Cache;
 
 /* State used for every tuple in an insert statement */
@@ -15,9 +16,22 @@ typedef struct ChunkDispatchState
 	PlanState  *subplan_state;
 	Cache	   *hypertable_cache;
 	Oid			hypertable_relid;
+
+	/*
+	 * Keep pointers to the original parsed Query and the ModifyTable plan
+	 * node. We need these to compute and update the arbiter indexes for each
+	 * chunk we INSERT into.
+	 */
+	Query	   *parse;
+	ModifyTable *mt;
+
+	/*
+	 * The chunk dispatch state. Keeps cached insert states (result relations)
+	 * for each chunk.
+	 */
 	ChunkDispatch *dispatch;
 } ChunkDispatchState;
 
-ChunkDispatchState *chunk_dispatch_state_create(Oid, Plan *);
+ChunkDispatchState *chunk_dispatch_state_create(ChunkDispatchInfo *, Plan *);
 
 #endif   /* TIMESCALEDB_CHUNK_DISPATCH_STATE_H */

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -12,6 +12,7 @@ typedef struct ChunkInsertState
 	Chunk	   *chunk;
 	Relation	rel;
 	ResultRelInfo *result_relation_info;
+	List	   *arbiter_indexes;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/src/copy.c
+++ b/src/copy.c
@@ -53,7 +53,7 @@ copy_chunk_state_create(Hypertable *ht, CopyState cstate)
 
 	ccstate = palloc(sizeof(CopyChunkState));
 	ccstate->estate = estate;
-	ccstate->dispatch = chunk_dispatch_create(ht, estate);
+	ccstate->dispatch = chunk_dispatch_create(ht, estate, NULL);
 	ccstate->cstate = cstate;
 	return ccstate;
 }

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -1,0 +1,122 @@
+CREATE TABLE upsert_test(time timestamp PRIMARY KEY, temp float, color text);
+SELECT create_hypertable('upsert_test', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 22.5, 'yellow') RETURNING *;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 22.5 | yellow
+(1 row)
+
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 23.8, 'yellow') ON CONFLICT (time)
+DO UPDATE SET temp = 23.8 RETURNING *;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 23.8 | yellow
+(1 row)
+
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 78.4, 'yellow') ON CONFLICT DO NOTHING;
+SELECT * FROM upsert_test;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 23.8 | yellow
+(1 row)
+
+-- Referencing constraints by name does not yet work on Hypertables. Check for proper error message.
+\set ON_ERROR_STOP 0
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 12.3, 'yellow') ON CONFLICT ON CONSTRAINT upsert_test_pkey
+DO UPDATE SET temp = 12.3 RETURNING time, temp, color;
+ERROR:  Hypertables do not support ON CONFLICT statements that reference constraints
+-- Test that update generates error on conflicts
+INSERT INTO upsert_test VALUES ('2017-01-21T09:00:01', 22.5, 'yellow') RETURNING *;
+           time           | temp | color  
+--------------------------+------+--------
+ Sat Jan 21 09:00:01 2017 | 22.5 | yellow
+(1 row)
+
+UPDATE upsert_test SET time = '2017-01-20T09:00:01';
+ERROR:  duplicate key value violates unique constraint "1-upsert_test_pkey"
+\set ON_ERROR_STOP 1
+-- Test with UNIQUE index on multiple columns instead of PRIMARY KEY constraint
+CREATE TABLE upsert_test_unique(time timestamp, temp float, color text);
+SELECT create_hypertable('upsert_test_unique', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+CREATE UNIQUE INDEX time_color_idx ON upsert_test_unique (time, color);
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 22.5, 'yellow') RETURNING *;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 22.5 | yellow
+(1 row)
+
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 21.2, 'brown');
+SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 22.5 | yellow
+ Fri Jan 20 09:00:01 2017 | 21.2 | brown
+(2 rows)
+
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 31.8, 'yellow') ON CONFLICT (time, color)
+DO UPDATE SET temp = 31.8;
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 54.3, 'yellow') ON CONFLICT DO NOTHING;
+SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 31.8 | yellow
+ Fri Jan 20 09:00:01 2017 | 21.2 | brown
+(2 rows)
+
+-- Test with multiple UNIQUE indexes
+CREATE TABLE upsert_test_multi_unique(time timestamp, temp float, color text);
+SELECT create_hypertable('upsert_test_multi_unique', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+CREATE UNIQUE INDEX multi_time_temp_idx ON upsert_test_multi_unique (time, temp);
+CREATE UNIQUE INDEX multi_time_color_idx ON upsert_test_multi_unique (time, color);
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'yellow');
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-21T09:00:01', 25.9, 'yellow');
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'brown');
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'purple') ON CONFLICT DO NOTHING;
+SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 25.9 | yellow
+ Fri Jan 20 09:00:01 2017 | 23.5 | brown
+ Sat Jan 21 09:00:01 2017 | 25.9 | yellow
+(3 rows)
+
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'blue') ON CONFLICT (time, temp)
+DO UPDATE SET color = 'blue';
+SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 23.5 | brown
+ Fri Jan 20 09:00:01 2017 | 25.9 | blue
+ Sat Jan 21 09:00:01 2017 | 25.9 | yellow
+(3 rows)
+
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-21T09:00:01', 45.7, 'yellow') ON CONFLICT (time, color)
+DO UPDATE SET temp = 45.7;
+SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 23.5 | brown
+ Fri Jan 20 09:00:01 2017 | 25.9 | blue
+ Sat Jan 21 09:00:01 2017 | 45.7 | yellow
+(3 rows)
+
+\set ON_ERROR_STOP 0
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'purple') ON CONFLICT (time, color)
+DO UPDATE set temp = 23.5;
+ERROR:  duplicate key value violates unique constraint "5-multi_time_temp_idx"
+\set ON_ERROR_STOP 1

--- a/test/sql/upsert.sql
+++ b/test/sql/upsert.sql
@@ -1,0 +1,50 @@
+CREATE TABLE upsert_test(time timestamp PRIMARY KEY, temp float, color text);
+SELECT create_hypertable('upsert_test', 'time');
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 22.5, 'yellow') RETURNING *;
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 23.8, 'yellow') ON CONFLICT (time)
+DO UPDATE SET temp = 23.8 RETURNING *;
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 78.4, 'yellow') ON CONFLICT DO NOTHING;
+SELECT * FROM upsert_test;
+
+-- Referencing constraints by name does not yet work on Hypertables. Check for proper error message.
+\set ON_ERROR_STOP 0
+INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 12.3, 'yellow') ON CONFLICT ON CONSTRAINT upsert_test_pkey
+DO UPDATE SET temp = 12.3 RETURNING time, temp, color;
+
+-- Test that update generates error on conflicts
+INSERT INTO upsert_test VALUES ('2017-01-21T09:00:01', 22.5, 'yellow') RETURNING *;
+UPDATE upsert_test SET time = '2017-01-20T09:00:01';
+\set ON_ERROR_STOP 1
+
+-- Test with UNIQUE index on multiple columns instead of PRIMARY KEY constraint
+CREATE TABLE upsert_test_unique(time timestamp, temp float, color text);
+SELECT create_hypertable('upsert_test_unique', 'time');
+CREATE UNIQUE INDEX time_color_idx ON upsert_test_unique (time, color);
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 22.5, 'yellow') RETURNING *;
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 21.2, 'brown');
+SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 31.8, 'yellow') ON CONFLICT (time, color)
+DO UPDATE SET temp = 31.8;
+INSERT INTO upsert_test_unique VALUES ('2017-01-20T09:00:01', 54.3, 'yellow') ON CONFLICT DO NOTHING;
+SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
+
+-- Test with multiple UNIQUE indexes
+CREATE TABLE upsert_test_multi_unique(time timestamp, temp float, color text);
+SELECT create_hypertable('upsert_test_multi_unique', 'time');
+CREATE UNIQUE INDEX multi_time_temp_idx ON upsert_test_multi_unique (time, temp);
+CREATE UNIQUE INDEX multi_time_color_idx ON upsert_test_multi_unique (time, color);
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'yellow');
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-21T09:00:01', 25.9, 'yellow');
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'brown');
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'purple') ON CONFLICT DO NOTHING;
+SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'blue') ON CONFLICT (time, temp)
+DO UPDATE SET color = 'blue';
+SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-21T09:00:01', 45.7, 'yellow') ON CONFLICT (time, color)
+DO UPDATE SET temp = 45.7;
+SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
+\set ON_ERROR_STOP 0
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'purple') ON CONFLICT (time, color)
+DO UPDATE set temp = 23.5;
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Upserts are now supported as long as there is a unique index that
includes all hypertable dimensions. Upserts using ON CONFLICT ON
CONSTRAINT statements are currently unsupported, although this should
be possible in the future.