### PR TITLE
Fix EXPLAIN and PREPAREd statements on INSERTs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,15 @@ SRCS = \
 	src/ddl_utils.c \
 	src/chunk_constraint.c \
 	src/partitioning.c \
+	src/planner_utils.c \
 	src/planner.c \
 	src/executor.c \
 	src/process_utility.c \
 	src/copy.c \
 	src/sort_transform.c \
+	src/hypertable_insert.c \
 	src/chunk_dispatch.c \
+	src/chunk_dispatch_info.c \
 	src/chunk_dispatch_state.c \
 	src/chunk_dispatch_plan.c \
 	src/chunk_insert_state.c \

--- a/src/chunk_dispatch.h
+++ b/src/chunk_dispatch.h
@@ -18,8 +18,11 @@ typedef struct ChunkDispatch
 	Hypertable *hypertable;
 	SubspaceStore *cache;
 	EState	   *estate;
-	/* Keep a pointer to the original (hypertable's) ResultRelInfo since we will
-	 * reset the pointer in EState as we lookup new chunks. */
+
+	/*
+	 * Keep a pointer to the original (hypertable's) ResultRelInfo since we
+	 * will reset the pointer in EState as we lookup new chunks.
+	 */
 	ResultRelInfo *hypertable_result_rel_info;
 	Query	   *parse;
 } ChunkDispatch;

--- a/src/chunk_dispatch_info.c
+++ b/src/chunk_dispatch_info.c
@@ -1,0 +1,96 @@
+#include <postgres.h>
+#include <nodes/readfuncs.h>
+
+#include "chunk_dispatch_info.h"
+
+static void
+chunk_dispatch_info_copy(struct ExtensibleNode *newnode,
+						 const struct ExtensibleNode *oldnode)
+{
+	ChunkDispatchInfo *newinfo = (ChunkDispatchInfo *) newnode;
+	const ChunkDispatchInfo *oldinfo = (const ChunkDispatchInfo *) oldnode;
+
+	newinfo->hypertable_relid = oldinfo->hypertable_relid;
+	newinfo->parse = copyObject(oldinfo->parse);
+}
+
+static bool
+chunk_dispatch_info_equal(const struct ExtensibleNode *an,
+						  const struct ExtensibleNode *bn)
+{
+	const ChunkDispatchInfo *a = (const ChunkDispatchInfo *) an;
+	const ChunkDispatchInfo *b = (const ChunkDispatchInfo *) bn;
+
+	return a->hypertable_relid == b->hypertable_relid &&
+		equal(a->parse, b->parse);
+}
+
+static void
+chunk_dispatch_info_out(struct StringInfoData *str,
+						const struct ExtensibleNode *node)
+{
+	const ChunkDispatchInfo *info = (const ChunkDispatchInfo *) node;
+
+	appendStringInfo(str, " :hypertableOid %d", info->hypertable_relid);
+	appendStringInfo(str, " :Query ");
+	outNode(str, info->parse);
+}
+
+static void
+chunk_dispatch_info_read(struct ExtensibleNode *node)
+{
+	ChunkDispatchInfo *info = (ChunkDispatchInfo *) node;
+	int			length;
+	char	   *token;
+
+	/* Skip :hypertableOid */
+	token = pg_strtok(&length);
+
+	/* Read OID */
+	token = pg_strtok(&length);
+
+	if (token == NULL)
+		elog(ERROR, "Missing hypertable relation ID");
+
+	info->hypertable_relid = strtol(token, NULL, 10);
+
+	/* Skip :Query */
+	token = pg_strtok(&length);
+
+	if (token == NULL)
+		elog(ERROR, "Missing Query node");
+
+	info->parse = stringToNode(token);
+}
+
+static ExtensibleNodeMethods chunk_dispatch_info_methods = {
+	.extnodename = "ChunkDispatchInfo",
+	.node_size = sizeof(ChunkDispatchInfo),
+	.nodeCopy = chunk_dispatch_info_copy,
+	.nodeEqual = chunk_dispatch_info_equal,
+	.nodeOut = chunk_dispatch_info_out,
+	.nodeRead = chunk_dispatch_info_read,
+};
+
+ChunkDispatchInfo *
+chunk_dispatch_info_create(Oid hypertable_relid, Query *parse)
+{
+	ChunkDispatchInfo *info = (ChunkDispatchInfo *) newNode(sizeof(ChunkDispatchInfo),
+															T_ExtensibleNode);
+
+	info->enode.extnodename = chunk_dispatch_info_methods.extnodename;
+	info->hypertable_relid = hypertable_relid;
+	info->parse = parse;
+	return info;
+}
+
+void
+_chunk_dispatch_info_init(void)
+{
+	RegisterExtensibleNodeMethods(&chunk_dispatch_info_methods);
+}
+
+void
+_chunk_dispatch_info_fini(void)
+{
+}

--- a/src/chunk_dispatch_info.h
+++ b/src/chunk_dispatch_info.h
@@ -1,0 +1,26 @@
+#ifndef TIMESCALEDB_CHUNK_DISPATCH_INFO_H
+#define TIMESCALEDB_CHUNK_DISPATCH_INFO_H
+
+#include <postgres.h>
+#include <nodes/parsenodes.h>
+#include <nodes/extensible.h>
+
+/*
+ * ChunkDispatchInfo holds plan info that needs to be passed on to the
+ * execution stage. Since it is part of the plan tree, it needs to be able
+ * support copyObject(), and therefore extends ExtensibleNode.
+ */
+typedef struct ChunkDispatchInfo
+{
+	ExtensibleNode enode;
+	/* Copied fields */
+	Oid			hypertable_relid;
+	Query	   *parse;
+} ChunkDispatchInfo;
+
+extern ChunkDispatchInfo *chunk_dispatch_info_create(Oid hypertable_relid, Query *parse);
+
+extern void _chunk_dispatch_info_init(void);
+extern void _chunk_dispatch_info_fini(void);
+
+#endif   /* TIMESCALEDB_CHUNK_DISPATCH_INFO_H */

--- a/src/chunk_dispatch_plan.c
+++ b/src/chunk_dispatch_plan.c
@@ -2,11 +2,13 @@
 #include <nodes/extensible.h>
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
+#include <nodes/readfuncs.h>
 #include <utils/rel.h>
 #include <catalog/pg_type.h>
 
 #include "chunk_dispatch_plan.h"
 #include "chunk_dispatch_state.h"
+#include "chunk_dispatch_info.h"
 
 /*
  * Create a ChunkDispatchState node from this plan. This is the full execution
@@ -40,14 +42,10 @@ static CustomScanMethods chunk_dispatch_plan_methods = {
  * node.
  */
 CustomScan *
-chunk_dispatch_plan_create(ModifyTable *mt, Plan *subplan, Oid hypertable_relid, Query *parse)
+chunk_dispatch_plan_create(Plan *subplan, Oid hypertable_relid, Query *parse)
 {
 	CustomScan *cscan = makeNode(CustomScan);
-	ChunkDispatchInfo *info = palloc(sizeof(ChunkDispatchInfo));
-
-	info->hypertable_relid = hypertable_relid;
-	info->mt = mt;
-	info->parse = parse;
+	ChunkDispatchInfo *info = chunk_dispatch_info_create(hypertable_relid, parse);
 
 	cscan->custom_private = list_make1(info);
 	cscan->methods = &chunk_dispatch_plan_methods;

--- a/src/chunk_dispatch_plan.h
+++ b/src/chunk_dispatch_plan.h
@@ -3,14 +3,9 @@
 
 #include <postgres.h>
 #include <nodes/plannodes.h>
+#include <nodes/parsenodes.h>
+#include <nodes/extensible.h>
 
-typedef struct ChunkDispatchInfo
-{
-	Oid			hypertable_relid;
-	ModifyTable *mt;
-	Query	   *parse;
-} ChunkDispatchInfo;
-
-extern CustomScan *chunk_dispatch_plan_create(ModifyTable *mt, Plan *subplan, Oid hypertable_relid, Query *parse);
+extern CustomScan *chunk_dispatch_plan_create(Plan *subplan, Oid hypertable_relid, Query *parse);
 
 #endif   /* TIMESCALEDB_CHUNK_DISPATCH_PLAN_H */

--- a/src/chunk_dispatch_state.h
+++ b/src/chunk_dispatch_state.h
@@ -3,6 +3,7 @@
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
+#include <nodes/parsenodes.h>
 
 typedef struct ChunkDispatch ChunkDispatch;
 typedef struct ChunkDispatchInfo ChunkDispatchInfo;
@@ -13,17 +14,16 @@ typedef struct ChunkDispatchState
 {
 	CustomScanState cscan_state;
 	Plan	   *subplan;
-	PlanState  *subplan_state;
 	Cache	   *hypertable_cache;
 	Oid			hypertable_relid;
 
 	/*
-	 * Keep pointers to the original parsed Query and the ModifyTable plan
-	 * node. We need these to compute and update the arbiter indexes for each
-	 * chunk we INSERT into.
+	 * Keep pointers to the original parsed Query and the ModifyTableState
+	 * plan node. We need these to compute and update the arbiter indexes for
+	 * each chunk we INSERT into.
 	 */
 	Query	   *parse;
-	ModifyTable *mt;
+	ModifyTableState *parent;
 
 	/*
 	 * The chunk dispatch state. Keeps cached insert states (result relations)
@@ -31,6 +31,8 @@ typedef struct ChunkDispatchState
 	 */
 	ChunkDispatch *dispatch;
 } ChunkDispatchState;
+
+#define CHUNK_DISPATCH_STATE_NAME "ChunkDispatchState"
 
 ChunkDispatchState *chunk_dispatch_state_create(ChunkDispatchInfo *, Plan *);
 

--- a/src/hypertable_insert.c
+++ b/src/hypertable_insert.c
@@ -1,0 +1,123 @@
+#include <postgres.h>
+#include <nodes/execnodes.h>
+#include <nodes/extensible.h>
+#include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
+#include <executor/nodeModifyTable.h>
+#include <utils/rel.h>
+#include <catalog/pg_type.h>
+
+#include "hypertable_insert.h"
+#include "chunk_dispatch_info.h"
+#include "chunk_dispatch_state.h"
+
+/*
+ * HypertableInsert (with corresponding executor node) is a plan node that
+ * implements INSERTs for hypertables. It is mostly a wrapper around the
+ * ModifyTable plan node that simply calls the wrapped ModifyTable plan without
+ * doing much else, apart from some initial state setup.
+ *
+ * The wrapping is needed to setup state in the execution phase, and give access
+ * to the ModifyTableState node to sub-plan states in the PlanState tree. For
+ * instance, the ChunkDispatchState node needs to set the arbiter index list in
+ * the ModifyTableState node whenever it inserts into a new chunk.
+ */
+
+
+static void
+hypertable_insert_begin(CustomScanState *node, EState *estate, int eflags)
+{
+	HypertableInsertState *state = (HypertableInsertState *) node;
+	PlanState  *ps = ExecInitNode(&state->mt->plan, estate, eflags);
+
+	node->custom_ps = list_make1(ps);
+
+	if (IsA(ps, ModifyTableState))
+	{
+		ModifyTableState *mtstate = (ModifyTableState *) ps;
+		int			i;
+
+		/*
+		 * Find all ChunkDispatchState subnodes and set their parent
+		 * ModifyTableState node
+		 */
+		for (i = 0; i < mtstate->mt_nplans; i++)
+		{
+			if (IsA(mtstate->mt_plans[i], CustomScanState))
+			{
+				CustomScanState *csstate = (CustomScanState *) mtstate->mt_plans[i];
+
+				if (strcmp(csstate->methods->CustomName, CHUNK_DISPATCH_STATE_NAME) == 0)
+				{
+					ChunkDispatchState *cdstate = (ChunkDispatchState *) mtstate->mt_plans[i];
+
+					cdstate->parent = mtstate;
+				}
+			}
+		}
+	}
+}
+
+static TupleTableSlot *
+hypertable_insert_exec(CustomScanState *node)
+{
+	return ExecProcNode(linitial(node->custom_ps));
+}
+
+static void
+hypertable_insert_end(CustomScanState *node)
+{
+	ExecEndNode(linitial(node->custom_ps));
+}
+
+static void
+hypertable_insert_rescan(CustomScanState *node)
+{
+	ExecReScan(linitial(node->custom_ps));
+}
+
+static CustomExecMethods hypertable_insert_state_methods = {
+	.CustomName = "HypertableInsertState",
+	.BeginCustomScan = hypertable_insert_begin,
+	.EndCustomScan = hypertable_insert_end,
+	.ExecCustomScan = hypertable_insert_exec,
+	.ReScanCustomScan = hypertable_insert_rescan,
+};
+
+static Node *
+hypertable_insert_state_create(CustomScan *cscan)
+{
+	HypertableInsertState *state;
+
+	state = (HypertableInsertState *) newNode(sizeof(HypertableInsertState), T_CustomScanState);
+	state->cscan_state.methods = &hypertable_insert_state_methods;
+	state->mt = (ModifyTable *) cscan->scan.plan.lefttree;
+
+	return (Node *) state;
+}
+
+static CustomScanMethods hypertable_insert_plan_methods = {
+	.CustomName = "HypertableInsert",
+	.CreateCustomScanState = hypertable_insert_state_create,
+};
+
+Plan *
+hypertable_insert_plan_create(ModifyTable *mt)
+{
+	CustomScan *cscan = makeNode(CustomScan);
+
+	cscan->methods = &hypertable_insert_plan_methods;
+	cscan->custom_plans = list_make1(mt);
+	cscan->scan.plan.lefttree = &mt->plan;
+	cscan->scan.scanrelid = 0;	/* This is not a real relation */
+
+	/* Copy costs, etc., from the original plan */
+	cscan->scan.plan.startup_cost = mt->plan.startup_cost;
+	cscan->scan.plan.total_cost = mt->plan.total_cost;
+	cscan->scan.plan.plan_rows = mt->plan.plan_rows;
+	cscan->scan.plan.plan_width = mt->plan.plan_width;
+	cscan->scan.plan.targetlist = mt->plan.targetlist;
+	cscan->custom_scan_tlist = NIL;
+
+	return &cscan->scan.plan;
+}

--- a/src/hypertable_insert.h
+++ b/src/hypertable_insert.h
@@ -1,0 +1,15 @@
+#ifndef TIMESCALEDB_HYPERTABLE_INSERT_H
+#define TIMESCALEDB_HYPERTABLE_INSERT_H
+
+#include <postgres.h>
+#include <nodes/execnodes.h>
+
+typedef struct HypertableInsertState
+{
+	CustomScanState cscan_state;
+	ModifyTable *mt;
+} HypertableInsertState;
+
+Plan	   *hypertable_insert_plan_create(ModifyTable *mt);
+
+#endif   /* TIMESCALEDB_HYPERTABLE_INSERT_H */

--- a/src/init.c
+++ b/src/init.c
@@ -19,6 +19,10 @@
 PG_MODULE_MAGIC;
 #endif
 
+
+extern void _chunk_dispatch_info_init(void);
+extern void _chunk_dispatch_info_fini(void);
+
 extern void _hypertable_cache_init(void);
 extern void _hypertable_cache_fini(void);
 
@@ -63,6 +67,7 @@ _PG_init(void)
 		}
 	}
 	elog(INFO, "timescaledb loaded");
+	_chunk_dispatch_info_init();
 	_hypertable_cache_init();
 	_cache_invalidate_init();
 	_planner_init();
@@ -84,4 +89,5 @@ _PG_fini(void)
 	_planner_fini();
 	_cache_invalidate_fini();
 	_hypertable_cache_fini();
+	_chunk_dispatch_info_fini();
 }

--- a/src/planner_utils.c
+++ b/src/planner_utils.c
@@ -1,0 +1,75 @@
+#include <postgres.h>
+#include <nodes/plannodes.h>
+#include <miscadmin.h>
+
+#include "planner_utils.h"
+
+static void plantree_walker(Plan **plan, void (*walker) (Plan **, void *), void *ctx);
+
+static inline void
+plantree_walk_subplans(List *plans, void (*walker) (Plan **, void *), void *ctx)
+{
+	ListCell   *lc;
+
+	if (plans == NIL)
+		return;
+
+	foreach(lc, plans)
+		plantree_walker((Plan **) &lfirst(lc), walker, ctx);
+}
+
+/* A plan tree walker. Similar to planstate_tree_walker in PostgreSQL's
+ * nodeFuncs.c, but this walks a Plan tree as opposed to a PlanState tree. */
+static void
+plantree_walker(Plan **planptr, void (*walker) (Plan **, void *), void *context)
+{
+	Plan	   *plan = *planptr;
+
+	if (plan == NULL)
+		return;
+
+	check_stack_depth();
+
+	/* special child plans */
+	switch (nodeTag(plan))
+	{
+		case T_ModifyTable:
+			plantree_walk_subplans(((ModifyTable *) plan)->plans, walker, context);
+			break;
+		case T_Append:
+			plantree_walk_subplans(((Append *) plan)->appendplans, walker, context);
+			break;
+		case T_MergeAppend:
+			plantree_walk_subplans(((MergeAppend *) plan)->mergeplans, walker, context);
+			break;
+		case T_BitmapAnd:
+			plantree_walk_subplans(((BitmapAnd *) plan)->bitmapplans, walker, context);
+			break;
+		case T_BitmapOr:
+			plantree_walk_subplans(((BitmapOr *) plan)->bitmapplans, walker, context);
+			break;
+		case T_SubqueryScan:
+			walker(&((SubqueryScan *) plan)->subplan, context);
+			break;
+		case T_CustomScan:
+			plantree_walk_subplans(((CustomScan *) plan)->custom_plans, walker, context);
+			break;
+		default:
+			break;
+	}
+
+	plantree_walker(&outerPlan(plan), walker, context);
+	plantree_walker(&innerPlan(plan), walker, context);
+	walker(planptr, context);
+}
+
+void
+planned_stmt_walker(PlannedStmt *stmt, void (*walker) (Plan **, void *), void *context)
+{
+	ListCell   *lc;
+
+	plantree_walker(&stmt->planTree, walker, context);
+
+	foreach(lc, stmt->subplans)
+		plantree_walker((Plan **) &lfirst(lc), walker, context);
+}

--- a/src/planner_utils.h
+++ b/src/planner_utils.h
@@ -1,0 +1,9 @@
+#ifndef TIMESCALEDB_PLANNER_UTILS_H
+#define TIMESCALEDB_PLANNER_UTILS_H
+
+#include <postgres.h>
+#include <nodes/plannodes.h>
+
+extern void planned_stmt_walker(PlannedStmt *stmt, void (*walker) (Plan **, void *), void *context);
+
+#endif   /* TIMESCALEDB_PLANNER_UTILS_H */

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -54,7 +54,8 @@ timescaledb_ProcessUtility(Node *parsetree,
 	}
 
 	/* Truncate a hypertable */
-	if (IsA(parsetree, TruncateStmt)) {
+	if (IsA(parsetree, TruncateStmt))
+	{
 		TruncateStmt *truncatestmt = (TruncateStmt *) parsetree;
 		ListCell   *cell;
 
@@ -67,7 +68,8 @@ timescaledb_ProcessUtility(Node *parsetree,
 				Cache	   *hcache = hypertable_cache_pin();
 				Hypertable *hentry = hypertable_cache_get_entry(hcache, relId);
 
-				if (hentry != NULL) {
+				if (hentry != NULL)
+				{
 					executor_level_enter();
 					spi_hypertable_truncate(hentry);
 					executor_level_exit();

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -246,14 +246,19 @@ SELECT * FROM "one_Partition" ORDER BY "timeCustom", device_id;
 (12 rows)
 
 --test that we can insert data into a 1-dimensional table (only time partitioning)
-CREATE TABLE "1dim"(time timestamp, temp float);
+CREATE TABLE "1dim"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim"', 'time');
  create_hypertable 
 -------------------
  
 (1 row)
 
-INSERT INTO "1dim" VALUES('2017-01-20T09:00:01', 22.5);
+INSERT INTO "1dim" VALUES('2017-01-20T09:00:01', 22.5) RETURNING *;
+           time           | temp 
+--------------------------+------
+ Fri Jan 20 09:00:01 2017 | 22.5
+(1 row)
+
 INSERT INTO "1dim" VALUES('2017-01-20T09:00:21', 21.2);
 INSERT INTO "1dim" VALUES('2017-01-20T09:00:47', 25.1);
 SELECT * FROM "1dim";
@@ -337,5 +342,72 @@ SELECT * FROM "3dim";
  Fri Jan 20 09:00:01 2017 | 22.5 | blue   | nyc
  Fri Jan 20 09:00:47 2017 | 25.1 | yellow | la
  Fri Jan 20 09:00:21 2017 | 21.2 | brown  | sthlm
+(3 rows)
+
+-- test that explain works
+EXPLAIN
+INSERT INTO "3dim" VALUES('2017-01-21T09:00:01', 32.9, 'green', 'nyc'),
+                         ('2017-01-21T09:00:47', 27.3, 'purple', 'la') RETURNING *;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)  (cost=0.00..0.03 rows=2 width=80)
+   ->  Insert on "3dim"  (cost=0.00..0.03 rows=2 width=80)
+         ->  Custom Scan (ChunkDispatch)  (cost=0.00..0.03 rows=2 width=80)
+               ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=2 width=80)
+(4 rows)
+
+EXPLAIN
+WITH "3dim_insert" AS (
+     INSERT INTO "3dim" VALUES('2017-01-21T09:01:44', 19.3, 'black', 'la') RETURNING time, temp
+), regular_insert AS (
+   INSERT INTO regular_table VALUES('2017-01-21T10:00:51', 14.3) RETURNING time, temp
+) INSERT INTO "1dim" (SELECT time, temp FROM "3dim_insert" UNION SELECT time, temp FROM regular_insert);
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)  (cost=0.09..0.12 rows=2 width=16)
+   ->  Insert on "1dim"  (cost=0.09..0.12 rows=2 width=16)
+         CTE 3dim_insert
+           ->  Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=80)
+                 ->  Insert on "3dim"  (cost=0.00..0.01 rows=1 width=80)
+                       ->  Custom Scan (ChunkDispatch)  (cost=0.00..0.01 rows=1 width=80)
+                             ->  Result  (cost=0.00..0.01 rows=1 width=80)
+         CTE regular_insert
+           ->  Insert on regular_table  (cost=0.00..0.01 rows=1 width=16)
+                 ->  Result  (cost=0.00..0.01 rows=1 width=16)
+         ->  Custom Scan (ChunkDispatch)  (cost=0.07..0.09 rows=2 width=16)
+               ->  Unique  (cost=0.07..0.09 rows=2 width=16)
+                     ->  Sort  (cost=0.07..0.08 rows=2 width=16)
+                           Sort Key: "3dim_insert"."time", "3dim_insert".temp
+                           ->  Append  (cost=0.00..0.06 rows=2 width=16)
+                                 ->  CTE Scan on "3dim_insert"  (cost=0.00..0.02 rows=1 width=16)
+                                 ->  CTE Scan on regular_insert  (cost=0.00..0.02 rows=1 width=16)
+(17 rows)
+
+-- test prepared statement INSERT
+PREPARE "1dim_plan" (timestamp, float) AS
+INSERT INTO "1dim" VALUES($1, $2) ON CONFLICT (time) DO NOTHING;
+EXECUTE "1dim_plan" ('2017-04-17 23:35', 31.4);
+EXECUTE "1dim_plan" ('2017-04-17 23:35', 32.6);
+-- test prepared statement with generic plan (forced when no parameters)
+PREPARE "1dim_plan_generic" AS
+INSERT INTO "1dim" VALUES('2017-05-18 17:24', 18.3);
+EXECUTE "1dim_plan_generic";
+SELECT * FROM "1dim" ORDER BY time;
+           time           | temp 
+--------------------------+------
+ Fri Jan 20 09:00:01 2017 | 22.5
+ Fri Jan 20 09:00:21 2017 | 21.2
+ Fri Jan 20 09:00:47 2017 | 25.1
+ Fri Jan 20 09:00:59 2017 | 29.2
+ Mon Apr 17 23:35:00 2017 | 31.4
+ Thu May 18 17:24:00 2017 | 18.3
+(6 rows)
+
+SELECT * FROM "3dim" ORDER BY (time, device);
+           time           | temp | device | location 
+--------------------------+------+--------+----------
+ Fri Jan 20 09:00:01 2017 | 22.5 | blue   | nyc
+ Fri Jan 20 09:00:21 2017 | 21.2 | brown  | sthlm
+ Fri Jan 20 09:00:47 2017 | 25.1 | yellow | la
 (3 rows)
 


### PR DESCRIPTION
This fixes an issue that caused EXPLAIN and PREPAREd statements to
fail on INSERTs. The plan modification on INSERTs passed on a plan
node to the execution stage. However, that plan node pointer becomes
invalid when the plan is copied, as happens with prepared statements
or EXPLAINs. The fix required another modification to the plan by
wrapping also the ModifyTable plan node. This wrapping is necessary to
access the plan state node (ModifyTableState) on execution. Having
access to the ModifyTableState node is necessary to set the correct
arbiter index list for ON CONFLICT statements.

This change also fixes the output of EXPLAIN to properly show the plan
tree, and performs some cleanups.