### PR TITLE
Release all cache pins when a transaction ends

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -42,6 +42,8 @@ extern MemoryContext cache_memory_ctx(Cache *cache);
 extern MemoryContext cache_switch_to_memory_context(Cache *cache);
 
 extern Cache *cache_pin(Cache *cache);
-extern void cache_release(Cache *cache);
+extern int	cache_release(Cache *cache);
+extern void _cache_init(void);
+extern void _cache_fini(void);
 
 #endif   /* TIMESCALEDB_CACHE_H */

--- a/src/init.c
+++ b/src/init.c
@@ -29,6 +29,9 @@ extern void _hypertable_cache_fini(void);
 extern void _cache_invalidate_init(void);
 extern void _cache_invalidate_fini(void);
 
+extern void _cache_init(void);
+extern void _cache_fini(void);
+
 extern void _planner_init(void);
 extern void _planner_fini(void);
 
@@ -68,6 +71,7 @@ _PG_init(void)
 	}
 	elog(INFO, "timescaledb loaded");
 	_chunk_dispatch_info_init();
+	_cache_init();
 	_hypertable_cache_init();
 	_cache_invalidate_init();
 	_planner_init();
@@ -89,5 +93,6 @@ _PG_fini(void)
 	_planner_fini();
 	_cache_invalidate_fini();
 	_hypertable_cache_fini();
+	_cache_fini();
 	_chunk_dispatch_info_fini();
 }


### PR DESCRIPTION
Currently, if a transaction ends (normally or abnormally) while a
cache is pinned, that cache will never be released, leading to a
memory leak. This change ensures that all taken cache pins are
released when a transaction ends by registering all pins in a list and
cleaning it up in a transaction end callback. This makes the use of
cache_release() optional. However, timely calls to cache_release() is
still encouraged since it is better to release memory as soon as
possible during long-running transactions.