### PR TITLE
Make VACUUM and REINDEX recurse to chunks

### DIFF
--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -2,6 +2,7 @@
 #define TIMESCALEDB_HYPERTABLE_H
 
 #include <postgres.h>
+#include <nodes/primnodes.h>
 
 #include "catalog.h"
 
@@ -21,5 +22,7 @@ typedef struct Hypertable
 
 extern Hypertable *hypertable_from_tuple(HeapTuple tuple);
 extern Chunk *hypertable_get_chunk(Hypertable *h, Point *point);
+extern Oid	hypertable_relid(RangeVar *rv);
+extern bool is_hypertable(Oid relid);
 
 #endif   /* TIMESCALEDB_HYPERTABLE_H */

--- a/src/hypertable_cache.c
+++ b/src/hypertable_cache.c
@@ -1,11 +1,5 @@
 #include <postgres.h>
-#include <access/relscan.h>
-#include <catalog/namespace.h>
 #include <utils/catcache.h>
-#include <utils/rel.h>
-#include <utils/fmgroids.h>
-#include <utils/tqual.h>
-#include <utils/acl.h>
 #include <utils/lsyscache.h>
 
 #include "hypertable_cache.h"

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2,7 +2,14 @@
 #include <nodes/parsenodes.h>
 #include <tcop/utility.h>
 #include <catalog/namespace.h>
+#include <catalog/pg_inherits_fn.h>
+#include <catalog/index.h>
 #include <commands/copy.h>
+#include <commands/vacuum.h>
+#include <commands/defrem.h>
+#include <utils/rel.h>
+#include <utils/lsyscache.h>
+#include <miscadmin.h>
 
 #include "utils.h"
 #include "hypertable_cache.h"
@@ -42,6 +49,7 @@ static void
 process_truncate(Node *parsetree)
 {
 	TruncateStmt *truncatestmt = (TruncateStmt *) parsetree;
+	Cache	   *hcache = hypertable_cache_pin();
 	ListCell   *cell;
 
 	foreach(cell, truncatestmt->relations)
@@ -50,18 +58,17 @@ process_truncate(Node *parsetree)
 
 		if (OidIsValid(relId))
 		{
-			Cache	   *hcache = hypertable_cache_pin();
-			Hypertable *hentry = hypertable_cache_get_entry(hcache, relId);
+			Hypertable *ht = hypertable_cache_get_entry(hcache, relId);
 
-			if (hentry != NULL)
+			if (ht != NULL)
 			{
 				executor_level_enter();
-				spi_hypertable_truncate(hentry);
+				spi_hypertable_truncate(ht);
 				executor_level_exit();
 			}
-			cache_release(hcache);
 		}
 	}
+	cache_release(hcache);
 }
 
 /* Change the schema of a hypertable */
@@ -69,23 +76,27 @@ static void
 process_alterobjectschema(Node *parsetree)
 {
 	AlterObjectSchemaStmt *alterstmt = (AlterObjectSchemaStmt *) parsetree;
-	Oid			relId = RangeVarGetRelid(alterstmt->relation, NoLock, true);
+	Oid			relid = RangeVarGetRelid(alterstmt->relation, NoLock, true);
+	Cache	   *hcache;
+	Hypertable *ht;
 
-	if (OidIsValid(relId))
+	if (!OidIsValid(relid) ||
+		alterstmt->objectType != OBJECT_TABLE)
+		return;
+
+	hcache = hypertable_cache_pin();
+	ht = hypertable_cache_get_entry(hcache, relid);
+
+	if (ht != NULL)
 	{
-		Cache	   *hcache = hypertable_cache_pin();
-		Hypertable *hentry = hypertable_cache_get_entry(hcache, relId);
-
-		if (hentry != NULL && alterstmt->objectType == OBJECT_TABLE)
-		{
-			executor_level_enter();
-			spi_hypertable_rename(hentry,
-								  alterstmt->newschema,
-								  NameStr(hentry->fd.table_name));
-			executor_level_exit();
-		}
-		cache_release(hcache);
+		executor_level_enter();
+		spi_hypertable_rename(ht,
+							  alterstmt->newschema,
+							  NameStr(ht->fd.table_name));
+		executor_level_exit();
 	}
+
+	cache_release(hcache);
 }
 
 /* Rename hypertable */
@@ -94,25 +105,29 @@ process_rename(Node *parsetree)
 {
 	RenameStmt *renamestmt = (RenameStmt *) parsetree;
 	Oid			relid = RangeVarGetRelid(renamestmt->relation, NoLock, true);
+	Cache	   *hcache;
+	Hypertable *ht;
 
-	if (OidIsValid(relid))
+	if (!OidIsValid(relid) ||
+		renamestmt->renameType != OBJECT_TABLE)
+		return;
+
+	hcache = hypertable_cache_pin();
+	ht = hypertable_cache_get_entry(hcache, relid);
+
+	if (ht != NULL)
 	{
-		Cache	   *hcache = hypertable_cache_pin();
-		Hypertable *hentry = hypertable_cache_get_entry(hcache, relid);
-
-		if (hentry != NULL && renamestmt->renameType == OBJECT_TABLE)
-		{
-			executor_level_enter();
-			spi_hypertable_rename(hentry,
-								  NameStr(hentry->fd.schema_name),
-								  renamestmt->newname);
-			executor_level_exit();
-		}
-		cache_release(hcache);
+		executor_level_enter();
+		spi_hypertable_rename(ht,
+							  NameStr(ht->fd.schema_name),
+							  renamestmt->newname);
+		executor_level_exit();
 	}
+
+	cache_release(hcache);
 }
 
-static void
+static bool
 process_copy(Node *parsetree, const char *query_string, char *completion_tag)
 {
 	CopyStmt   *stmt = (CopyStmt *) parsetree;
@@ -121,41 +136,180 @@ process_copy(Node *parsetree, const char *query_string, char *completion_tag)
 	 * Needed to add the appropriate number of tuples to the completion tag
 	 */
 	uint64		processed;
-	Hypertable *ht = NULL;
-	Cache	   *hcache = NULL;
+	Hypertable *ht;
+	Cache	   *hcache;
+	Oid			relid;
 
-	executor_level_enter();
+	if (!stmt->is_from)
+		return false;
 
-	if (stmt->is_from)
+	relid = RangeVarGetRelid(stmt->relation, NoLock, true);
+
+	if (!OidIsValid(relid))
+		return false;
+
+	hcache = hypertable_cache_pin();
+	ht = hypertable_cache_get_entry(hcache, relid);
+
+	if (ht == NULL)
 	{
-		Oid			relid = RangeVarGetRelid(stmt->relation, NoLock, true);
-
-		if (OidIsValid(relid))
-		{
-			hcache = hypertable_cache_pin();
-			ht = hypertable_cache_get_entry(hcache, relid);
-		}
+		cache_release(hcache);
+		return false;
 	}
 
-	if (stmt->is_from && ht != NULL)
-		timescaledb_DoCopy(stmt, query_string, &processed, ht);
-	else
-		DoCopy(stmt, query_string, &processed);
-
+	executor_level_enter();
+	timescaledb_DoCopy(stmt, query_string, &processed, ht);
 	executor_level_exit();
+
 	processed += executor_get_additional_tuples_processed();
 
 	if (completion_tag)
 		snprintf(completion_tag, COMPLETION_TAG_BUFSIZE,
 				 "COPY " UINT64_FORMAT, processed);
 
-	if (NULL != hcache)
-		cache_release(hcache);
+	cache_release(hcache);
+
+	return true;
+}
+
+typedef void (*process_chunk_t) (Oid chunk_relid, void *arg);
+
+/*
+ * Applies a function to each chunk of a hypertable.
+ *
+ * Returns the number of processed chunks, or -1 if the table was not a
+ * hypertable.
+ */
+static int
+foreach_chunk(RangeVar *rv, process_chunk_t process_chunk, void *arg)
+{
+	Oid			relid = hypertable_relid(rv);
+	List	   *chunks;
+	ListCell   *lc;
+	int			n = 0;
+
+	if (!OidIsValid(relid))
+		/* Not a hypertable */
+		return -1;
+
+	chunks = find_inheritance_children(relid, NoLock);
+
+	foreach(lc, chunks)
+	{
+		process_chunk(lfirst_oid(lc), arg);
+		n++;
+	}
+
+	return n;
+}
+
+typedef struct VacuumCtx
+{
+	VacuumStmt *stmt;
+	bool		is_toplevel;
+} VacuumCtx;
+
+/* Vacuums a single chunk */
+static void
+vacuum_chunk(Oid chunk_relid, void *arg)
+{
+	VacuumCtx  *ctx = (VacuumCtx *) arg;
+	char	   *relschema = get_namespace_name(get_rel_namespace(chunk_relid));
+	char	   *relname = get_rel_name(chunk_relid);
+
+	ctx->stmt->relation->relname = relname;
+	ctx->stmt->relation->schemaname = relschema;
+	ExecVacuum(ctx->stmt, ctx->is_toplevel);
+}
+
+/* Vacuums each chunk of a hypertable */
+static bool
+process_vacuum(Node *parsetree, ProcessUtilityContext context)
+{
+	VacuumStmt *stmt = (VacuumStmt *) parsetree;
+	VacuumCtx	ctx = {
+		.stmt = stmt,
+		.is_toplevel = (context == PROCESS_UTILITY_TOPLEVEL),
+	};
+
+	if (stmt->relation == NULL)
+		/* Vacuum is for all tables */
+		return false;
+
+	if (!OidIsValid(hypertable_relid(stmt->relation)))
+		return false;
+
+	PreventCommandDuringRecovery((stmt->options & VACOPT_VACUUM) ?
+								 "VACUUM" : "ANALYZE");
+
+	return foreach_chunk(stmt->relation, vacuum_chunk, &ctx) >= 0;
+}
+
+static void
+reindex_chunk(Oid chunk_relid, void *arg)
+{
+	ReindexStmt *stmt = (ReindexStmt *) arg;
+	char	   *relschema = get_namespace_name(get_rel_namespace(chunk_relid));
+	char	   *relname = get_rel_name(chunk_relid);
+
+	switch (stmt->kind)
+	{
+		case REINDEX_OBJECT_TABLE:
+			stmt->relation->relname = relname;
+			stmt->relation->schemaname = relschema;
+			ReindexTable(stmt->relation, stmt->options);
+			break;
+		case REINDEX_OBJECT_INDEX:
+			/* Not supported, a.t.m. See note in process_reindex(). */
+		default:
+			break;
+	}
+}
+
+/*
+ * Reindex a hypertable and all its chunks. Currently works only for REINDEX
+ * TABLE.
+ */
+static bool
+process_reindex(Node *parsetree)
+{
+	ReindexStmt *stmt = (ReindexStmt *) parsetree;
+	Oid			relid = RangeVarGetRelid(stmt->relation, NoLock, true);
+
+	switch (stmt->kind)
+	{
+		case REINDEX_OBJECT_TABLE:
+			if (!is_hypertable(relid))
+				return false;
+
+			PreventCommandDuringRecovery("REINDEX");
+
+			if (foreach_chunk(stmt->relation, reindex_chunk, stmt) >= 0)
+				return true;
+			break;
+		case REINDEX_OBJECT_INDEX:
+			if (!is_hypertable(IndexGetRelation(relid, true)))
+				return false;
+
+			/*
+			 * Recursing to chunks is currently not supported. Need to look up
+			 * all chunk indexes that corresponds to the hypertable's index.
+			 */
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("Reindexing of a specific index on a hypertable is currently unsupported."),
+					 errhint("As a workaround, it is possible to run REINDEX TABLE to reindex all "
+			  "indexes on a hypertable, including all indexes on chunks.")));
+			break;
+		default:
+			break;
+	}
+
+	return false;
 }
 
 
-/* Hook-intercept for ProcessUtility. Used to set COPY completion tag and */
-/* renaming of hypertables. */
+/* Hook-intercept for ProcessUtility. */
 static void
 timescaledb_ProcessUtility(Node *parsetree,
 						   const char *query_string,
@@ -182,8 +336,24 @@ timescaledb_ProcessUtility(Node *parsetree,
 			process_rename(parsetree);
 			break;
 		case T_CopyStmt:
-			process_copy(parsetree, query_string, completion_tag);
-			return;
+			if (process_copy(parsetree, query_string, completion_tag))
+				return;
+			break;
+		case T_VacuumStmt:
+			if (process_vacuum(parsetree, context))
+				return;
+			break;
+		case T_ReindexStmt:
+			if (process_reindex(parsetree))
+				return;
+			break;
+		case T_ClusterStmt:
+
+			/*
+			 * CLUSTER command on hypertables do not yet recurse to chunks.
+			 * This requires mapping a hypertable index to corresponding
+			 * indexes on each chunk.
+			 */
 		default:
 			break;
 	}

--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -1,0 +1,58 @@
+\ir include/create_single_db.sql
+SET client_min_messages = WARNING;
+DROP DATABASE IF EXISTS single;
+SET client_min_messages = NOTICE;
+CREATE DATABASE single;
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+CREATE TABLE reindex_test(time timestamp, temp float);
+CREATE UNIQUE INDEX reindex_test_time_unique_idx ON reindex_test(time);
+-- create hypertable with three chunks
+SELECT create_hypertable('reindex_test', 'time', chunk_time_interval => 2628000000000);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO reindex_test VALUES ('2017-01-20T09:00:01', 17.5),
+                                ('2017-01-21T09:00:01', 19.1),
+                                ('2017-04-20T09:00:01', 89.5),
+                                ('2017-04-21T09:00:01', 17.1),
+                                ('2017-06-20T09:00:01', 18.5),
+                                ('2017-06-21T09:00:01', 11.0);
+\d+ reindex_test
+                               Table "public.reindex_test"
+ Column |            Type             | Modifiers | Storage | Stats target | Description 
+--------+-----------------------------+-----------+---------+--------------+-------------
+ time   | timestamp without time zone |           | plain   |              | 
+ temp   | double precision            |           | plain   |              | 
+Indexes:
+    "reindex_test_time_unique_idx" UNIQUE, btree ("time")
+Child tables: _timescaledb_internal._hyper_1_1_chunk,
+              _timescaledb_internal._hyper_1_2_chunk,
+              _timescaledb_internal._hyper_1_3_chunk
+
+-- show reindexing
+REINDEX (VERBOSE) TABLE reindex_test;
+INFO:  index "1-reindex_test_time_unique_idx" was reindexed
+INFO:  index "2-reindex_test_time_unique_idx" was reindexed
+INFO:  index "3-reindex_test_time_unique_idx" was reindexed
+\set ON_ERROR_STOP 0
+-- this one currently doesn't recurse to chunks and instead gives an
+-- error
+REINDEX (VERBOSE) INDEX reindex_test_time_unique_idx;
+ERROR:  Reindexing of a specific index on a hypertable is currently unsupported.
+\set ON_ERROR_STOP 1
+-- show reindexing on a normal table
+CREATE TABLE reindex_norm(time timestamp, temp float);
+CREATE UNIQUE INDEX reindex_norm_time_unique_idx ON reindex_norm(time);
+INSERT INTO reindex_norm VALUES ('2017-01-20T09:00:01', 17.5),
+                                ('2017-01-21T09:00:01', 19.1),
+                                ('2017-04-20T09:00:01', 89.5),
+                                ('2017-04-21T09:00:01', 17.1),
+                                ('2017-06-20T09:00:01', 18.5),
+                                ('2017-06-21T09:00:01', 11.0);
+REINDEX (VERBOSE) TABLE reindex_norm;
+INFO:  index "reindex_norm_time_unique_idx" was reindexed
+REINDEX (VERBOSE) INDEX reindex_norm_time_unique_idx;
+INFO:  index "reindex_norm_time_unique_idx" was reindexed

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -1,3 +1,10 @@
+\ir include/create_single_db.sql
+SET client_min_messages = WARNING;
+DROP DATABASE IF EXISTS single;
+SET client_min_messages = NOTICE;
+CREATE DATABASE single;
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb;
 CREATE TABLE upsert_test(time timestamp PRIMARY KEY, temp float, color text);
 SELECT create_hypertable('upsert_test', 'time');
  create_hypertable 

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -1,0 +1,70 @@
+\ir include/create_single_db.sql
+SET client_min_messages = WARNING;
+DROP DATABASE IF EXISTS single;
+SET client_min_messages = NOTICE;
+CREATE DATABASE single;
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+CREATE TABLE vacuum_test(time timestamp, temp float);
+-- create hypertable with three chunks
+SELECT create_hypertable('vacuum_test', 'time', chunk_time_interval => 2628000000000);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO vacuum_test VALUES ('2017-01-20T09:00:01', 17.5),
+                               ('2017-01-21T09:00:01', 19.1),
+                               ('2017-04-20T09:00:01', 89.5),
+                               ('2017-04-21T09:00:01', 17.1),
+                               ('2017-06-20T09:00:01', 18.5),
+                               ('2017-06-21T09:00:01', 11.0);
+-- no stats
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk';
+ tablename | attname | histogram_bounds | n_distinct 
+-----------+---------+------------------+------------
+(0 rows)
+
+VACUUM (VERBOSE, ANALYZE) vacuum_test;
+INFO:  vacuuming "_timescaledb_internal._hyper_1_1_chunk"
+INFO:  index "1-vacuum_test_time_idx" now contains 2 row versions in 2 pages
+INFO:  "_hyper_1_1_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
+INFO:  analyzing "_timescaledb_internal._hyper_1_1_chunk"
+INFO:  "_hyper_1_1_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  vacuuming "_timescaledb_internal._hyper_1_2_chunk"
+INFO:  index "2-vacuum_test_time_idx" now contains 2 row versions in 2 pages
+INFO:  "_hyper_1_2_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
+INFO:  analyzing "_timescaledb_internal._hyper_1_2_chunk"
+INFO:  "_hyper_1_2_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  vacuuming "_timescaledb_internal._hyper_1_3_chunk"
+INFO:  index "3-vacuum_test_time_idx" now contains 2 row versions in 2 pages
+INFO:  "_hyper_1_3_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
+INFO:  analyzing "_timescaledb_internal._hyper_1_3_chunk"
+INFO:  "_hyper_1_3_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+-- stats should exist for all three chunks
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk';
+    tablename     | attname |                    histogram_bounds                     | n_distinct 
+------------------+---------+---------------------------------------------------------+------------
+ _hyper_1_1_chunk | time    | {"Fri Jan 20 09:00:01 2017","Sat Jan 21 09:00:01 2017"} |         -1
+ _hyper_1_1_chunk | temp    | {17.5,19.1}                                             |         -1
+ _hyper_1_2_chunk | time    | {"Thu Apr 20 09:00:01 2017","Fri Apr 21 09:00:01 2017"} |         -1
+ _hyper_1_2_chunk | temp    | {17.1,89.5}                                             |         -1
+ _hyper_1_3_chunk | time    | {"Tue Jun 20 09:00:01 2017","Wed Jun 21 09:00:01 2017"} |         -1
+ _hyper_1_3_chunk | temp    | {11,18.5}                                               |         -1
+(6 rows)
+
+-- Run vacuum on a normal (non-hypertable) table
+CREATE TABLE vacuum_norm(time timestamp, temp float);
+INSERT INTO vacuum_norm VALUES ('2017-01-20T09:00:01', 17.5),
+                               ('2017-01-21T09:00:01', 19.1),
+                               ('2017-04-20T09:00:01', 89.5),
+                               ('2017-04-21T09:00:01', 17.1),
+                               ('2017-06-20T09:00:01', 18.5),
+                               ('2017-06-21T09:00:01', 11.0);
+VACUUM (VERBOSE, ANALYZE) vacuum_norm;
+INFO:  vacuuming "public.vacuum_norm"
+INFO:  "vacuum_norm": found 0 removable, 6 nonremovable row versions in 1 out of 1 pages
+INFO:  analyzing "public.vacuum_norm"
+INFO:  "vacuum_norm": scanned 1 of 1 pages, containing 6 live rows and 0 dead rows; 6 rows in sample, 6 estimated total rows

--- a/test/sql/reindex.sql
+++ b/test/sql/reindex.sql
@@ -1,0 +1,39 @@
+\ir include/create_single_db.sql
+
+CREATE TABLE reindex_test(time timestamp, temp float);
+CREATE UNIQUE INDEX reindex_test_time_unique_idx ON reindex_test(time);
+
+-- create hypertable with three chunks
+SELECT create_hypertable('reindex_test', 'time', chunk_time_interval => 2628000000000);
+
+INSERT INTO reindex_test VALUES ('2017-01-20T09:00:01', 17.5),
+                                ('2017-01-21T09:00:01', 19.1),
+                                ('2017-04-20T09:00:01', 89.5),
+                                ('2017-04-21T09:00:01', 17.1),
+                                ('2017-06-20T09:00:01', 18.5),
+                                ('2017-06-21T09:00:01', 11.0);
+
+\d+ reindex_test
+
+-- show reindexing
+REINDEX (VERBOSE) TABLE reindex_test;
+
+\set ON_ERROR_STOP 0
+-- this one currently doesn't recurse to chunks and instead gives an
+-- error
+REINDEX (VERBOSE) INDEX reindex_test_time_unique_idx;
+\set ON_ERROR_STOP 1
+
+-- show reindexing on a normal table
+CREATE TABLE reindex_norm(time timestamp, temp float);
+CREATE UNIQUE INDEX reindex_norm_time_unique_idx ON reindex_norm(time);
+
+INSERT INTO reindex_norm VALUES ('2017-01-20T09:00:01', 17.5),
+                                ('2017-01-21T09:00:01', 19.1),
+                                ('2017-04-20T09:00:01', 89.5),
+                                ('2017-04-21T09:00:01', 17.1),
+                                ('2017-06-20T09:00:01', 18.5),
+                                ('2017-06-21T09:00:01', 11.0);
+
+REINDEX (VERBOSE) TABLE reindex_norm;
+REINDEX (VERBOSE) INDEX reindex_norm_time_unique_idx;

--- a/test/sql/upsert.sql
+++ b/test/sql/upsert.sql
@@ -1,3 +1,5 @@
+\ir include/create_single_db.sql
+
 CREATE TABLE upsert_test(time timestamp PRIMARY KEY, temp float, color text);
 SELECT create_hypertable('upsert_test', 'time');
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 22.5, 'yellow') RETURNING *;

--- a/test/sql/vacuum.sql
+++ b/test/sql/vacuum.sql
@@ -1,0 +1,35 @@
+\ir include/create_single_db.sql
+
+CREATE TABLE vacuum_test(time timestamp, temp float);
+
+-- create hypertable with three chunks
+SELECT create_hypertable('vacuum_test', 'time', chunk_time_interval => 2628000000000);
+
+INSERT INTO vacuum_test VALUES ('2017-01-20T09:00:01', 17.5),
+                               ('2017-01-21T09:00:01', 19.1),
+                               ('2017-04-20T09:00:01', 89.5),
+                               ('2017-04-21T09:00:01', 17.1),
+                               ('2017-06-20T09:00:01', 18.5),
+                               ('2017-06-21T09:00:01', 11.0);
+
+-- no stats
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk';
+
+VACUUM (VERBOSE, ANALYZE) vacuum_test;
+
+-- stats should exist for all three chunks
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk';
+
+-- Run vacuum on a normal (non-hypertable) table
+CREATE TABLE vacuum_norm(time timestamp, temp float);
+
+INSERT INTO vacuum_norm VALUES ('2017-01-20T09:00:01', 17.5),
+                               ('2017-01-21T09:00:01', 19.1),
+                               ('2017-04-20T09:00:01', 89.5),
+                               ('2017-04-21T09:00:01', 17.1),
+                               ('2017-06-20T09:00:01', 18.5),
+                               ('2017-06-21T09:00:01', 11.0);
+
+VACUUM (VERBOSE, ANALYZE) vacuum_norm;


### PR DESCRIPTION
Previously, when issued on hypertable, database maintenance
commands, like VACUUM and REINDEX, only affected the main
table and did not recurse to chunks.

This change fixes that issue, allowing database maintainers
to issue single commands on hypertables that affect all
the data stored in the hypertable.

These commands (VACUUM, REINDEX) only work at the table level
for hypertables. If issued at other levels, e.g., schema, or
database, the behavior is the same as in standard PostgreSQL
as all tables are covered by default.

REINDEX commands that specify a hypertable index do not
recurse as that requires mapping the hypertable
index to the corresponding index on the chunk. This might
be fixed in a future update.