### PR TITLE
Add support for negative values in dimension range

### DIFF
--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -89,8 +89,8 @@ SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_
 CREATE TABLE _timescaledb_catalog.dimension_slice (
     id            SERIAL   NOT NULL PRIMARY KEY,
     dimension_id  INTEGER  NOT NULL REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE,
-    range_start   BIGINT   NOT NULL CHECK (range_start >= 0),
-    range_end     BIGINT   NOT NULL CHECK (range_end >= 0),
+    range_start   BIGINT   NOT NULL,
+    range_end     BIGINT   NOT NULL,
     CHECK (range_start <= range_end),
     UNIQUE (dimension_id, range_start, range_end)
 );

--- a/sql/updates/pre-0.3.0--0.3.1-dev.sql
+++ b/sql/updates/pre-0.3.0--0.3.1-dev.sql
@@ -1,0 +1,3 @@
+ALTER TABLE _timescaledb_catalog.dimension_slice
+DROP CONSTRAINT dimension_slice_range_start_check,
+DROP CONSTRAINT dimension_slice_range_end_check;

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -300,6 +300,53 @@ SELECT "1dim" FROM "1dim";
  ("Fri Jan 20 09:00:59 2017",29.2)
 (4 rows)
 
+--test that we can insert pre-1970 dates
+CREATE TABLE "1dim_pre1970"(time timestamp PRIMARY KEY, temp float);
+SELECT create_hypertable('"1dim_pre1970"', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO "1dim_pre1970" VALUES('1969-11-20T09:00:00', 21.2);
+INSERT INTO "1dim_pre1970" VALUES('1969-12-20T09:00:00', 25.1);
+INSERT INTO "1dim_pre1970" VALUES('1970-01-20T09:00:00', 26.6);
+INSERT INTO "1dim_pre1970" VALUES('1969-02-20T09:00:00', 29.9);
+SELECT * FROM "1dim_pre1970";
+           time           | temp 
+--------------------------+------
+ Thu Nov 20 09:00:00 1969 | 21.2
+ Sat Dec 20 09:00:00 1969 | 25.1
+ Tue Jan 20 09:00:00 1970 | 26.6
+ Thu Feb 20 09:00:00 1969 | 29.9
+(4 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    
+----+---------------+-----------------------+------------------
+  1 |             1 | one_Partition         | _hyper_1_1_chunk
+  2 |             1 | one_Partition         | _hyper_1_2_chunk
+  3 |             1 | one_Partition         | _hyper_1_3_chunk
+  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk
+  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk
+  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk
+  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk
+  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk
+(8 rows)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice;
+ id | dimension_id |     range_start     |      range_end      
+----+--------------+---------------------+---------------------
+  1 |            1 | 1257892416000000000 | 1257895008000000000
+  2 |            1 | 1257897600000000000 | 1257900192000000000
+  3 |            1 | 1257985728000000000 | 1257988320000000000
+  4 |            2 |    1482624000000000 |    1485216000000000
+  5 |            3 |      -5184000000000 |      -2592000000000
+  6 |            3 |      -2592000000000 |                   0
+  7 |            3 |                   0 |       2592000000000
+  8 |            3 |     -28512000000000 |     -25920000000000
+(8 rows)
+
 -- Create a three-dimensional table
 CREATE TABLE "3dim" (time timestamp, temp float, device text, location text);
 SELECT create_hypertable('"3dim"', 'time', 'device', 2);
@@ -318,8 +365,8 @@ INSERT INTO "3dim" VALUES('2017-01-20T09:00:01', 22.5, 'blue', 'nyc');
 INSERT INTO "3dim" VALUES('2017-01-20T09:00:21', 21.2, 'brown', 'sthlm');
 INSERT INTO "3dim" VALUES('2017-01-20T09:00:47', 25.1, 'yellow', 'la');
 --show the constraints on the three-dimensional chunk
-\d+ _timescaledb_internal._hyper_3_6_chunk
-                       Table "_timescaledb_internal._hyper_3_6_chunk"
+\d+ _timescaledb_internal._hyper_4_10_chunk
+                      Table "_timescaledb_internal._hyper_4_10_chunk"
   Column  |            Type             | Modifiers | Storage  | Stats target | Description 
 ----------+-----------------------------+-----------+----------+--------------+-------------
  time     | timestamp without time zone |           | plain    |              | 
@@ -327,12 +374,12 @@ INSERT INTO "3dim" VALUES('2017-01-20T09:00:47', 25.1, 'yellow', 'la');
  device   | text                        |           | extended |              | 
  location | text                        |           | extended |              | 
 Indexes:
-    "22-3dim_time_idx" btree ("time" DESC)
-    "23-3dim_device_time_idx" btree (device, "time" DESC)
+    "26-3dim_time_idx" btree ("time" DESC)
+    "27-3dim_device_time_idx" btree (device, "time" DESC)
 Check constraints:
-    "constraint_10" CHECK (_timescaledb_internal.get_partition_for_key(location) >= 0 AND _timescaledb_internal.get_partition_for_key(location) < 1073741823)
-    "constraint_5" CHECK ("time" >= 'Sat Dec 24 16:00:00 2016'::timestamp without time zone AND "time" < 'Mon Jan 23 16:00:00 2017'::timestamp without time zone)
-    "constraint_9" CHECK (_timescaledb_internal.get_partition_for_key(device) >= 1073741823 AND _timescaledb_internal.get_partition_for_key(device) < 2147483647)
+    "constraint_13" CHECK (_timescaledb_internal.get_partition_for_key(device) >= 1073741823 AND _timescaledb_internal.get_partition_for_key(device) < 2147483647)
+    "constraint_14" CHECK (_timescaledb_internal.get_partition_for_key(location) >= 0 AND _timescaledb_internal.get_partition_for_key(location) < 1073741823)
+    "constraint_9" CHECK ("time" >= 'Sat Dec 24 16:00:00 2016'::timestamp without time zone AND "time" < 'Mon Jan 23 16:00:00 2017'::timestamp without time zone)
 Inherits: "3dim"
 
 --queries should work in three dimensions

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -21,6 +21,18 @@ INSERT INTO "1dim" SELECT * FROM regular_table;
 SELECT * FROM "1dim";
 SELECT "1dim" FROM "1dim";
 
+--test that we can insert pre-1970 dates
+CREATE TABLE "1dim_pre1970"(time timestamp PRIMARY KEY, temp float);
+SELECT create_hypertable('"1dim_pre1970"', 'time');
+INSERT INTO "1dim_pre1970" VALUES('1969-11-20T09:00:00', 21.2);
+INSERT INTO "1dim_pre1970" VALUES('1969-12-20T09:00:00', 25.1);
+INSERT INTO "1dim_pre1970" VALUES('1970-01-20T09:00:00', 26.6);
+INSERT INTO "1dim_pre1970" VALUES('1969-02-20T09:00:00', 29.9);
+SELECT * FROM "1dim_pre1970";
+SELECT * FROM _timescaledb_catalog.chunk;
+SELECT * FROM _timescaledb_catalog.dimension_slice;
+
+
 -- Create a three-dimensional table
 CREATE TABLE "3dim" (time timestamp, temp float, device text, location text);
 SELECT create_hypertable('"3dim"', 'time', 'device', 2);
@@ -30,7 +42,7 @@ INSERT INTO "3dim" VALUES('2017-01-20T09:00:21', 21.2, 'brown', 'sthlm');
 INSERT INTO "3dim" VALUES('2017-01-20T09:00:47', 25.1, 'yellow', 'la');
 
 --show the constraints on the three-dimensional chunk
-\d+ _timescaledb_internal._hyper_3_6_chunk
+\d+ _timescaledb_internal._hyper_4_10_chunk
 
 --queries should work in three dimensions
 SELECT * FROM "3dim";


### PR DESCRIPTION
Previously dimension_slice would only allow ranges to start and
end with values >= 0. However, this did not allow for timestamps
prior to 1970 because those times would be represented by negative
integers. With this PR we now support dates prior to 1970.

Addresses issue #153.