### PR TITLE
Improve handling of INTEGER timestamps

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     number_partitions       INTEGER = NULL,
     associated_schema_name  NAME = NULL,
     associated_table_prefix NAME = NULL,
-    chunk_time_interval     BIGINT =  _timescaledb_internal.interval_to_usec('1 month'),
+    chunk_time_interval     BIGINT = NULL,
     create_default_indexes  BOOLEAN = TRUE,
     if_not_exists           BOOLEAN = FALSE
 )
@@ -25,15 +25,18 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     SECURITY DEFINER SET search_path = ''
     AS
 $BODY$
+<<vars>>
 DECLARE
     hypertable_row   _timescaledb_catalog.hypertable;
-    table_name       NAME;
-    schema_name      NAME;
-    table_owner      NAME;
-    tablespace_oid   OID;
-    tablespace_name  NAME;
-    main_table_has_items BOOLEAN;
-    is_hypertable    BOOLEAN;
+    table_name                 NAME;
+    schema_name                NAME;
+    table_owner                NAME;
+    tablespace_oid             OID;
+    tablespace_name            NAME;
+    main_table_has_items       BOOLEAN;
+    is_hypertable              BOOLEAN;
+    chunk_time_interval_actual BIGINT;
+    time_type                  REGTYPE;
 BEGIN
     SELECT relname, nspname, reltablespace
     INTO STRICT table_name, schema_name, tablespace_oid
@@ -81,6 +84,31 @@ BEGIN
         USING ERRCODE = 'IO102';
     END IF;
 
+    -- We don't use INTO STRICT here because that error (no column) is surfaced later.
+    SELECT atttypid
+    INTO time_type
+    FROM pg_attribute
+    WHERE attrelid = main_table AND attname = time_column_name;
+
+    -- Timestamp types can use default value, integral should be an error if NULL
+    IF time_type IN ('TIMESTAMP', 'TIMESTAMPTZ') AND chunk_time_interval IS NULL THEN
+        chunk_time_interval_actual := _timescaledb_internal.interval_to_usec('1 month');
+    ELSIF time_type IN ('SMALLINT', 'INTEGER', 'BIGINT') AND chunk_time_interval IS NULL THEN
+        RAISE EXCEPTION 'chunk_time_interval needs to be explicitly set for types SMALLINT, INTEGER, and BIGINT'
+        USING ERRCODE = 'IO102';
+    ELSE
+        chunk_time_interval_actual := chunk_time_interval;
+    END IF;
+
+    -- Bounds check for integral timestamp types
+    IF time_type = 'INTEGER'::REGTYPE AND chunk_time_interval_actual > 2147483647 THEN
+        RAISE EXCEPTION 'chunk_time_interval is too large for type INTEGER (max: 2147483647)'
+        USING ERRCODE = 'IO102';
+    ELSIF time_type = 'SMALLINT'::REGTYPE AND chunk_time_interval_actual > 65535 THEN
+        RAISE EXCEPTION 'chunk_time_interval is too large for type SMALLINT (max: 65535)'
+        USING ERRCODE = 'IO102';
+    END IF;
+
     BEGIN
         SELECT *
         INTO hypertable_row
@@ -93,7 +121,7 @@ BEGIN
             number_partitions,
             associated_schema_name,
             associated_table_prefix,
-            chunk_time_interval,
+            chunk_time_interval_actual,
             tablespace_name
         );
     EXCEPTION

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -87,8 +87,7 @@ $BODY$
 DECLARE
     partitioning_func        _timescaledb_catalog.dimension.partitioning_func%TYPE = 'get_partition_for_key';
     partitioning_func_schema _timescaledb_catalog.dimension.partitioning_func_schema%TYPE = '_timescaledb_internal';
-    default_interval         BIGINT = _timescaledb_internal.interval_to_usec('1 month');
-    aligned BOOL;
+    aligned                  BOOL;
     column_type              REGTYPE;
     dimension_row            _timescaledb_catalog.dimension;
     table_has_items          BOOLEAN;
@@ -97,7 +96,6 @@ BEGIN
         RAISE EXCEPTION 'The number of slices/partitions or an interval must be specified'
         USING ERRCODE = 'IO101';
     END IF;
-
     EXECUTE format('SELECT TRUE FROM %s LIMIT 1', main_table) INTO table_has_items;
 
     IF table_has_items THEN

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -20,7 +20,7 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_0) 
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_1)  WHERE series_1 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
-SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition' );
+SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -111,13 +111,13 @@ CREATE TABLE "customSchema"."Hypertable_1" (
   sensor_4 NUMERIC NOT NULL DEFAULT 1
 );
 CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
 (1 row)
 
-SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -196,8 +196,8 @@ psql:include/ddl_ops_1.sql:60: ERROR:  Cannot create a unique index without the 
 UPDATE ONLY PUBLIC."Hypertable_1" SET time = 0 WHERE TRUE;
 DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 \set ON_ERROR_STOP 1
-CREATE TABLE my_ht (time bigint, val integer);
-SELECT * FROM create_hypertable('my_ht', 'time');
+CREATE TABLE my_ht (time BIGINT, val integer);
+SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -219,7 +219,7 @@ Indexes:
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 psql:include/ddl_ops_1.sql:73: ERROR:  column "val2" of relation "my_ht" already exists
 \set ON_ERROR_STOP 1
--- Should create 
+-- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 \d my_ht
      Table "public.my_ht"
@@ -279,7 +279,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -305,7 +305,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Device_id", "Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -331,7 +331,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -356,7 +356,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -380,7 +380,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  

--- a/test/expected/copy_from.out
+++ b/test/expected/copy_from.out
@@ -22,7 +22,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -6,7 +6,7 @@ CREATE DATABASE single;
 \c single
 CREATE EXTENSION IF NOT EXISTS timescaledb;
 create schema test_schema;
-create table test_schema.test_table(time bigint, temp float8, device_id text, device_type text, location text, id int);
+create table test_schema.test_table(time BIGINT, temp float8, device_id text, device_type text, location text, id int);
 \dt "test_schema".*
               List of relations
    Schema    |    Name    | Type  |  Owner   
@@ -14,7 +14,7 @@ create table test_schema.test_table(time bigint, temp float8, device_id text, de
  test_schema | test_table | table | postgres
 (1 row)
 
-select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2);
+select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -33,13 +33,13 @@ CREATE TABLE "customSchema"."Hypertable_1" (
   sensor_4 NUMERIC NOT NULL DEFAULT 1
 );
 CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
 (1 row)
 
-SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -102,8 +102,8 @@ psql:include/ddl_ops_1.sql:60: ERROR:  Cannot create a unique index without the 
 UPDATE ONLY PUBLIC."Hypertable_1" SET time = 0 WHERE TRUE;
 DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 \set ON_ERROR_STOP 1
-CREATE TABLE my_ht (time bigint, val integer);
-SELECT * FROM create_hypertable('my_ht', 'time');
+CREATE TABLE my_ht (time BIGINT, val integer);
+SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -125,7 +125,7 @@ Indexes:
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 psql:include/ddl_ops_1.sql:73: ERROR:  column "val2" of relation "my_ht" already exists
 \set ON_ERROR_STOP 1
--- Should create 
+-- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 \d my_ht
      Table "public.my_ht"
@@ -185,7 +185,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -211,7 +211,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Device_id", "Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -237,7 +237,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -262,7 +262,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -286,7 +286,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -15,25 +15,25 @@ CREATE TABLE PUBLIC."Hypertable_1" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
 \set ON_ERROR_STOP 0
-SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  relation "public.Hypertable_1_mispelled" does not exist at character 33
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  column "time_mispelled" does not exist
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'Device_id', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'Device_id', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  illegal type for column "Device_id": text
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id_mispelled', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id_mispelled', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  column "Device_id_mispelled" does not exist
-INSERT INTO PUBLIC."Hypertable_1" VALUES(1,'dev_1', 3); 
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2);
+INSERT INTO PUBLIC."Hypertable_1" VALUES(1,'dev_1', 3);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  the table being converted to a hypertable must be empty
 DELETE FROM  PUBLIC."Hypertable_1" ;
 \set ON_ERROR_STOP 1
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
 (1 row)
 
 \set ON_ERROR_STOP 0
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  hypertable public."Hypertable_1" already exists

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -33,13 +33,13 @@ CREATE TABLE "customSchema"."Hypertable_1" (
   sensor_4 NUMERIC NOT NULL DEFAULT 1
 );
 CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
 (1 row)
 
-SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -102,8 +102,8 @@ psql:include/ddl_ops_1.sql:60: ERROR:  Cannot create a unique index without the 
 UPDATE ONLY PUBLIC."Hypertable_1" SET time = 0 WHERE TRUE;
 DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 \set ON_ERROR_STOP 1
-CREATE TABLE my_ht (time bigint, val integer);
-SELECT * FROM create_hypertable('my_ht', 'time');
+CREATE TABLE my_ht (time BIGINT, val integer);
+SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -125,7 +125,7 @@ Indexes:
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 psql:include/ddl_ops_1.sql:73: ERROR:  column "val2" of relation "my_ht" already exists
 \set ON_ERROR_STOP 1
--- Should create 
+-- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 \d my_ht
      Table "public.my_ht"
@@ -185,7 +185,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -211,7 +211,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Device_id", "Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -237,7 +237,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -262,7 +262,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -286,7 +286,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -22,7 +22,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -22,7 +22,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -21,7 +21,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -20,7 +20,7 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_0) 
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_1)  WHERE series_1 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
-SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition' );
+SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  
@@ -410,4 +410,32 @@ SELECT * FROM "3dim" ORDER BY (time, device);
  Fri Jan 20 09:00:21 2017 | 21.2 | brown  | sthlm
  Fri Jan 20 09:00:47 2017 | 25.1 | yellow | la
 (3 rows)
+
+-- Test that large intervals and no interval fail for INTEGER
+\set ON_ERROR_STOP 0
+CREATE TABLE "inttime_err"(time INTEGER PRIMARY KEY, temp float);
+SELECT create_hypertable('"inttime_err"', 'time', chunk_time_interval=>2147483648);
+ERROR:  chunk_time_interval is too large for type INTEGER (max: 2147483647)
+SELECT create_hypertable('"inttime_err"', 'time');
+ERROR:  chunk_time_interval needs to be explicitly set for types SMALLINT, INTEGER, and BIGINT
+\set ON_ERROR_STOP 1
+SELECT create_hypertable('"inttime_err"', 'time', chunk_time_interval=>2147483647);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+-- Test that large intervals and no interval fail for SMALLINT
+\set ON_ERROR_STOP 0
+CREATE TABLE "smallinttime_err"(time SMALLINT PRIMARY KEY, temp float);
+SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>65536);
+ERROR:  chunk_time_interval is too large for type SMALLINT (max: 65535)
+SELECT create_hypertable('"smallinttime_err"', 'time');
+ERROR:  chunk_time_interval needs to be explicitly set for types SMALLINT, INTEGER, and BIGINT
+\set ON_ERROR_STOP 1
+SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>65535);
+ create_hypertable 
+-------------------
+ 
+(1 row)
 

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -22,7 +22,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -21,7 +21,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
  create_hypertable 
 -------------------
  

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -22,7 +22,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';

--- a/test/expected/truncate_hypertable.out
+++ b/test/expected/truncate_hypertable.out
@@ -22,7 +22,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_1)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set QUIET off
 BEGIN;
 \COPY public."two_Partitions" FROM 'data/ds1_dev1_1.tsv' NULL AS '';

--- a/test/expected/update.out
+++ b/test/expected/update.out
@@ -21,7 +21,7 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_0) 
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_1)  WHERE series_1 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
-SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition' );
+SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 --output command tags
 \set QUIET off
 BEGIN;

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -1,10 +1,10 @@
 \ir include/create_single_db.sql
 
 create schema test_schema;
-create table test_schema.test_table(time bigint, temp float8, device_id text, device_type text, location text, id int);
+create table test_schema.test_table(time BIGINT, temp float8, device_id text, device_type text, location text, id int);
 
 \dt "test_schema".*
-select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2);
+select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
 --test adding one more closed dimension
 select add_dimension('test_schema.test_table', 'location', 2);

--- a/test/sql/ddl_errors.sql
+++ b/test/sql/ddl_errors.sql
@@ -12,19 +12,19 @@ CREATE TABLE PUBLIC."Hypertable_1" (
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
 
 \set ON_ERROR_STOP 0
-SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2);
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2);
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'Device_id', 'Device_id', 2);
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id_mispelled', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'Device_id', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id_mispelled', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
-INSERT INTO PUBLIC."Hypertable_1" VALUES(1,'dev_1', 3); 
+INSERT INTO PUBLIC."Hypertable_1" VALUES(1,'dev_1', 3);
 
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
 DELETE FROM  PUBLIC."Hypertable_1" ;
 \set ON_ERROR_STOP 1
 
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
 \set ON_ERROR_STOP 0
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));

--- a/test/sql/include/ddl_ops_1.sql
+++ b/test/sql/include/ddl_ops_1.sql
@@ -26,9 +26,9 @@ CREATE TABLE "customSchema"."Hypertable_1" (
 );
 CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
 
-SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
-SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1);
+SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
 SELECT * FROM _timescaledb_catalog.hypertable;
 SELECT * FROM _timescaledb_catalog.hypertable_index;
@@ -63,8 +63,8 @@ DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 \set ON_ERROR_STOP 1
 
 
-CREATE TABLE my_ht (time bigint, val integer);
-SELECT * FROM create_hypertable('my_ht', 'time');
+CREATE TABLE my_ht (time BIGINT, val integer);
+SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 \d my_ht
 
@@ -73,7 +73,7 @@ ALTER TABLE my_ht ADD COLUMN val2 integer;
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 \set ON_ERROR_STOP 1
 
--- Should create 
+-- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 \d my_ht
 
@@ -97,7 +97,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \d+ "Hypertable_1_with_default_index_enabled"
 ROLLBACK;
 
@@ -109,7 +109,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Device_id", "Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \d+ "Hypertable_1_with_default_index_enabled"
 ROLLBACK;
 
@@ -121,7 +121,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \d+ "Hypertable_1_with_default_index_enabled"
 ROLLBACK;
 
@@ -132,7 +132,7 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time');
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \d+ "Hypertable_1_with_default_index_enabled"
 ROLLBACK;
 
@@ -143,6 +143,6 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   "Device_id" TEXT NOT NULL,
   sensor_1 NUMERIC NULL DEFAULT 1
 );
-SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE);
+SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \d+ "Hypertable_1_with_default_index_enabled"
 ROLLBACK;

--- a/test/sql/include/insert_single.sql
+++ b/test/sql/include/insert_single.sql
@@ -16,7 +16,7 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_1) 
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_2) WHERE series_2 IS NOT NULL;
 CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 
-SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition' );
+SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
 --output command tags
 \set QUIET off

--- a/test/sql/include/insert_two_partitions.sql
+++ b/test/sql/include/insert_two_partitions.sql
@@ -17,7 +17,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
 \set QUIET off
 BEGIN;

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -60,3 +60,19 @@ EXECUTE "1dim_plan_generic";
 
 SELECT * FROM "1dim" ORDER BY time;
 SELECT * FROM "3dim" ORDER BY (time, device);
+
+-- Test that large intervals and no interval fail for INTEGER
+\set ON_ERROR_STOP 0
+CREATE TABLE "inttime_err"(time INTEGER PRIMARY KEY, temp float);
+SELECT create_hypertable('"inttime_err"', 'time', chunk_time_interval=>2147483648);
+SELECT create_hypertable('"inttime_err"', 'time');
+\set ON_ERROR_STOP 1
+SELECT create_hypertable('"inttime_err"', 'time', chunk_time_interval=>2147483647);
+
+-- Test that large intervals and no interval fail for SMALLINT
+\set ON_ERROR_STOP 0
+CREATE TABLE "smallinttime_err"(time SMALLINT PRIMARY KEY, temp float);
+SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>65536);
+SELECT create_hypertable('"smallinttime_err"', 'time');
+\set ON_ERROR_STOP 1
+SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>65535);

--- a/test/sql/updates/setup.sql
+++ b/test/sql/updates/setup.sql
@@ -18,7 +18,7 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 
-SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2);
+SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 
 
 INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES


### PR DESCRIPTION
Previously the default chunk time in microseconds was too large
for an INTEGER field. If a user is using integer, they are using
seconds (since both milli and microsecond overflow), so now we
convert the default to the appropriate number in seconds.

Further, we check to make sure the chunk time interval is not too
large for INTEGER so as to avoid confusing problems later when the
user goes to insert.

Address issue #150