### PR TITLE
Reduce memory usage on long-running COPY operations

### DIFF
--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -56,8 +56,7 @@ create_chunk_result_relation_info(ChunkDispatch *dispatch, Relation rel, Index r
 	ResultRelInfo *rri,
 			   *rri_orig;
 
-	rri = palloc(sizeof(ResultRelInfo));
-	MemSet(rri, 0, sizeof(ResultRelInfo));
+	rri = palloc0(sizeof(ResultRelInfo));
 	NodeSetTag(rri, T_ResultRelInfo);
 
 	InitResultRelInfo(rri, rel, rti, 0);
@@ -163,4 +162,6 @@ chunk_insert_state_destroy(ChunkInsertState *state)
 
 	ExecCloseIndices(state->result_relation_info);
 	heap_close(state->rel, NoLock);
+	pfree(state->result_relation_info);
+	pfree(state);
 }

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -37,9 +37,9 @@ hypertable_get_chunk(Hypertable *h, Point *point)
 		MemoryContext old;
 
 		/*
-		 * chunk_find() must execute on the transaction memory context since
-		 * it allocates a lot of transient data. We don't want this allocated
-		 * on the cache's memory context.
+		 * chunk_find() must execute on a per-tuple memory context since it
+		 * allocates a lot of transient data. We don't want this allocated on
+		 * the cache's memory context.
 		 */
 		chunk = chunk_find(h->space, point);
 


### PR DESCRIPTION
This change ensures that the per-tuple exprcontext (on which per-tuple
state is allocated), is reset for every new tuple processed in a
long-running COPY transaction.