### PR TITLE
Fix append tests

### DIFF
--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -283,46 +283,54 @@ set enable_mergejoin = 'off';
 set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
-WHERE a.time > now() - interval '3 hours' AND j.time > now() - interval '3 hours';
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
+WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Nested Loop
    Join Filter: (a.colorid = j.colorid)
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: append_test
          ->  Append
-               ->  Bitmap Heap Scan on _hyper_1_1_chunk a_1
-                     Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-                     ->  Bitmap Index Scan on "1-append_test_time_idx"
-                           Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Heap Scan on _hyper_1_2_chunk a_2
-                     Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-                     ->  Bitmap Index Scan on "2-append_test_time_idx"
-                           Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Heap Scan on _hyper_1_3_chunk a_3
-                     Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-                     ->  Bitmap Index Scan on "3-append_test_time_idx"
-                           Index Cond: ("time" > (now() - '@ 3 hours'::interval))
+               ->  Index Scan using "3-append_test_time_idx" on _hyper_1_3_chunk a_1
+                     Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: join_test
          ->  Append
-               ->  Bitmap Heap Scan on _hyper_2_4_chunk j_1
-                     Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-                     ->  Bitmap Index Scan on "4-join_test_time_idx"
-                           Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Heap Scan on _hyper_2_5_chunk j_2
-                     Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-                     ->  Bitmap Index Scan on "5-join_test_time_idx"
-                           Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Heap Scan on _hyper_2_6_chunk j_3
-                     Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-                     ->  Bitmap Index Scan on "6-join_test_time_idx"
-                           Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-(32 rows)
+               ->  Index Scan using "4-join_test_time_idx" on _hyper_2_4_chunk j_1
+                     Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+               ->  Index Scan using "5-join_test_time_idx" on _hyper_2_5_chunk j_2
+                     Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+               ->  Index Scan using "6-join_test_time_idx" on _hyper_2_6_chunk j_3
+                     Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+(16 rows)
 
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
-WHERE a.time > now() - interval '3 hours' AND j.time > now() - interval '3 hours';
+WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
            time           | temp | colorid |           time           | temp | colorid 
 --------------------------+------+---------+--------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3 | Tue Aug 22 09:18:22 2017 | 23.1 |       3

--- a/test/expected/append_unoptimized.out
+++ b/test/expected/append_unoptimized.out
@@ -299,46 +299,56 @@ set enable_mergejoin = 'off';
 set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
-WHERE a.time > now() - interval '3 hours' AND j.time > now() - interval '3 hours';
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
+WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Nested Loop
    Join Filter: (a.colorid = j.colorid)
    ->  Append
          ->  Seq Scan on append_test a
-               Filter: ("time" > (now() - '@ 3 hours'::interval))
-         ->  Bitmap Heap Scan on _hyper_1_1_chunk a_1
-               Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Index Scan on "1-append_test_time_idx"
-                     Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-         ->  Bitmap Heap Scan on _hyper_1_2_chunk a_2
-               Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Index Scan on "2-append_test_time_idx"
-                     Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-         ->  Bitmap Heap Scan on _hyper_1_3_chunk a_3
-               Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Index Scan on "3-append_test_time_idx"
-                     Index Cond: ("time" > (now() - '@ 3 hours'::interval))
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Index Scan using "1-append_test_time_idx" on _hyper_1_1_chunk a_1
+               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Index Scan using "2-append_test_time_idx" on _hyper_1_2_chunk a_2
+               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Index Scan using "3-append_test_time_idx" on _hyper_1_3_chunk a_3
+               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Append
          ->  Seq Scan on join_test j
-               Filter: ("time" > (now() - '@ 3 hours'::interval))
-         ->  Bitmap Heap Scan on _hyper_2_4_chunk j_1
-               Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Index Scan on "4-join_test_time_idx"
-                     Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-         ->  Bitmap Heap Scan on _hyper_2_5_chunk j_2
-               Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Index Scan on "5-join_test_time_idx"
-                     Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-         ->  Bitmap Heap Scan on _hyper_2_6_chunk j_3
-               Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-               ->  Bitmap Index Scan on "6-join_test_time_idx"
-                     Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-(32 rows)
+               Filter: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Index Scan using "4-join_test_time_idx" on _hyper_2_4_chunk j_1
+               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Index Scan using "5-join_test_time_idx" on _hyper_2_5_chunk j_2
+               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+         ->  Index Scan using "6-join_test_time_idx" on _hyper_2_6_chunk j_3
+               Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+(20 rows)
 
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
-WHERE a.time > now() - interval '3 hours' AND j.time > now() - interval '3 hours';
+WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
            time           | temp | colorid |           time           | temp | colorid 
 --------------------------+------+---------+--------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3 | Tue Aug 22 09:18:22 2017 | 23.1 |       3

--- a/test/expected/append_x_diff.out
+++ b/test/expected/append_x_diff.out
@@ -129,71 +129,47 @@
 < (14 rows)
 ---
 > (11 rows)
-303,304c287,288
-<                                  QUERY PLAN                                 
-< ----------------------------------------------------------------------------
+311,312c295,298
+<                                   QUERY PLAN                                   
+< -------------------------------------------------------------------------------
 ---
->                                     QUERY PLAN                                    
-> ----------------------------------------------------------------------------------
-307,336c291,320
+> psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+>                                      QUERY PLAN                                      
+> -------------------------------------------------------------------------------------
+315,333c301,315
 <    ->  Append
 <          ->  Seq Scan on append_test a
-<                Filter: ("time" > (now() - '@ 3 hours'::interval))
-<          ->  Bitmap Heap Scan on _hyper_1_1_chunk a_1
-<                Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-<                ->  Bitmap Index Scan on "1-append_test_time_idx"
-<                      Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-<          ->  Bitmap Heap Scan on _hyper_1_2_chunk a_2
-<                Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-<                ->  Bitmap Index Scan on "2-append_test_time_idx"
-<                      Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-<          ->  Bitmap Heap Scan on _hyper_1_3_chunk a_3
-<                Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-<                ->  Bitmap Index Scan on "3-append_test_time_idx"
-<                      Index Cond: ("time" > (now() - '@ 3 hours'::interval))
+<                Filter: ("time" > (now_s() - '@ 3 hours'::interval))
+<          ->  Index Scan using "1-append_test_time_idx" on _hyper_1_1_chunk a_1
+<                Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+<          ->  Index Scan using "2-append_test_time_idx" on _hyper_1_2_chunk a_2
+<                Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+<          ->  Index Scan using "3-append_test_time_idx" on _hyper_1_3_chunk a_3
+<                Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
 <    ->  Append
 <          ->  Seq Scan on join_test j
-<                Filter: ("time" > (now() - '@ 3 hours'::interval))
-<          ->  Bitmap Heap Scan on _hyper_2_4_chunk j_1
-<                Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-<                ->  Bitmap Index Scan on "4-join_test_time_idx"
-<                      Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-<          ->  Bitmap Heap Scan on _hyper_2_5_chunk j_2
-<                Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-<                ->  Bitmap Index Scan on "5-join_test_time_idx"
-<                      Index Cond: ("time" > (now() - '@ 3 hours'::interval))
-<          ->  Bitmap Heap Scan on _hyper_2_6_chunk j_3
-<                Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
-<                ->  Bitmap Index Scan on "6-join_test_time_idx"
-<                      Index Cond: ("time" > (now() - '@ 3 hours'::interval))
+<                Filter: ("time" > (now_s() - '@ 3 hours'::interval))
+<          ->  Index Scan using "4-join_test_time_idx" on _hyper_2_4_chunk j_1
+<                Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+<          ->  Index Scan using "5-join_test_time_idx" on _hyper_2_5_chunk j_2
+<                Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+<          ->  Index Scan using "6-join_test_time_idx" on _hyper_2_6_chunk j_3
+<                Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+< (20 rows)
 ---
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: append_test
 >          ->  Append
->                ->  Bitmap Heap Scan on _hyper_1_1_chunk a_1
->                      Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
->                      ->  Bitmap Index Scan on "1-append_test_time_idx"
->                            Index Cond: ("time" > (now() - '@ 3 hours'::interval))
->                ->  Bitmap Heap Scan on _hyper_1_2_chunk a_2
->                      Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
->                      ->  Bitmap Index Scan on "2-append_test_time_idx"
->                            Index Cond: ("time" > (now() - '@ 3 hours'::interval))
->                ->  Bitmap Heap Scan on _hyper_1_3_chunk a_3
->                      Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
->                      ->  Bitmap Index Scan on "3-append_test_time_idx"
->                            Index Cond: ("time" > (now() - '@ 3 hours'::interval))
+>                ->  Index Scan using "3-append_test_time_idx" on _hyper_1_3_chunk a_1
+>                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: join_test
 >          ->  Append
->                ->  Bitmap Heap Scan on _hyper_2_4_chunk j_1
->                      Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
->                      ->  Bitmap Index Scan on "4-join_test_time_idx"
->                            Index Cond: ("time" > (now() - '@ 3 hours'::interval))
->                ->  Bitmap Heap Scan on _hyper_2_5_chunk j_2
->                      Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
->                      ->  Bitmap Index Scan on "5-join_test_time_idx"
->                            Index Cond: ("time" > (now() - '@ 3 hours'::interval))
->                ->  Bitmap Heap Scan on _hyper_2_6_chunk j_3
->                      Recheck Cond: ("time" > (now() - '@ 3 hours'::interval))
->                      ->  Bitmap Index Scan on "6-join_test_time_idx"
->                            Index Cond: ("time" > (now() - '@ 3 hours'::interval))
+>                ->  Index Scan using "4-join_test_time_idx" on _hyper_2_4_chunk j_1
+>                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+>                ->  Index Scan using "5-join_test_time_idx" on _hyper_2_5_chunk j_2
+>                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+>                ->  Index Scan using "6-join_test_time_idx" on _hyper_2_6_chunk j_3
+>                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
+> (16 rows)

--- a/test/sql/include/append.sql
+++ b/test/sql/include/append.sql
@@ -128,8 +128,8 @@ set enable_material = 'off';
 
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
-WHERE a.time > now() - interval '3 hours' AND j.time > now() - interval '3 hours';
+WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
 
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
-WHERE a.time > now() - interval '3 hours' AND j.time > now() - interval '3 hours';
+WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';


### PR DESCRIPTION
One of the append tests accidentally used the PostgreSQL now()
function instead of a mocked now_s() function. This caused
tests to eventually fail. This change corrects that mistake.