### PR TITLE
Fix semantics of time_bucket on DATE input

### DIFF
--- a/sql/time_bucket.sql
+++ b/sql/time_bucket.sql
@@ -7,6 +7,10 @@ CREATE OR REPLACE FUNCTION public.time_bucket(bucket_width INTERVAL, ts TIMESTAM
 CREATE OR REPLACE FUNCTION public.time_bucket(bucket_width INTERVAL, ts TIMESTAMPTZ) RETURNS TIMESTAMPTZ
 	AS '$libdir/timescaledb', 'timestamptz_bucket' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+--bucketing on date should not do any timezone conversion
+CREATE OR REPLACE FUNCTION public.time_bucket(bucket_width INTERVAL, ts DATE) RETURNS DATE
+	AS '$libdir/timescaledb', 'date_bucket' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
 -- If an interval is given as the third argument, the bucket alignment is offset by the interval.
 CREATE OR REPLACE FUNCTION public.time_bucket(bucket_width INTERVAL, ts TIMESTAMP, "offset" INTERVAL)
     RETURNS TIMESTAMP LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
@@ -19,6 +23,13 @@ CREATE OR REPLACE FUNCTION public.time_bucket(bucket_width INTERVAL, ts TIMESTAM
 $BODY$
     SELECT public.time_bucket(bucket_width, ts-"offset")+"offset";
 $BODY$;
+
+CREATE OR REPLACE FUNCTION public.time_bucket(bucket_width INTERVAL, ts DATE, "offset" INTERVAL)
+    RETURNS DATE LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+$BODY$
+    SELECT (public.time_bucket(bucket_width, ts-"offset")+"offset")::date;
+$BODY$;
+
 
 CREATE OR REPLACE FUNCTION public.time_bucket(bucket_width BIGINT, ts BIGINT)
     RETURNS BIGINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -43,7 +43,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   124
+   126
 (1 row)
 
 \c postgres
@@ -67,7 +67,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   124
+   126
 (1 row)
 
 \c single

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -239,6 +239,11 @@ SELECT timestamp '294247-01-01 23:59:59.999999' + interval '1 us';
 
 SELECT _timescaledb_internal.to_unix_microseconds(timestamp '294247-01-01 23:59:59.999999' + interval '1 us');
 ERROR:  timestamp out of range
+--no time_bucketing of dates not by integer # of days
+SELECT time_bucket('1 hour', DATE '2012-01-01');
+ERROR:  interval must not have sub-day precision
+SELECT time_bucket('25 hour', DATE '2012-01-01');
+ERROR:  interval must be a multiple of a day
 \set ON_ERROR_STOP 1
 SELECT time_bucket(INTERVAL '1 day', TIMESTAMP '2011-01-02 01:01:01');
        time_bucket        
@@ -561,5 +566,46 @@ FROM unnest(ARRAY[
    98 |          98
   107 |          98
   108 |         108
+(4 rows)
+
+SELECT time, time_bucket(INTERVAL '1 day', time::date)
+FROM unnest(ARRAY[
+    date '2017-11-05',
+    date '2017-11-06'
+    ]) AS time;
+    time    | time_bucket 
+------------+-------------
+ 11-05-2017 | 11-05-2017
+ 11-06-2017 | 11-06-2017
+(2 rows)
+
+SELECT time, time_bucket(INTERVAL '4 day', time::date)
+FROM unnest(ARRAY[
+    date '2017-11-02',
+    date '2017-11-03',
+    date '2017-11-06',
+    date '2017-11-07'
+    ]) AS time;
+    time    | time_bucket 
+------------+-------------
+ 11-02-2017 | 10-30-2017
+ 11-03-2017 | 11-03-2017
+ 11-06-2017 | 11-03-2017
+ 11-07-2017 | 11-07-2017
+(4 rows)
+
+SELECT time, time_bucket(INTERVAL '4 day', time::date, INTERVAL '2 day')
+FROM unnest(ARRAY[
+    date '2017-11-04',
+    date '2017-11-05',
+    date '2017-11-08',
+    date '2017-11-09'
+    ]) AS time;
+    time    | time_bucket 
+------------+-------------
+ 11-04-2017 | 11-01-2017
+ 11-05-2017 | 11-05-2017
+ 11-08-2017 | 11-05-2017
+ 11-09-2017 | 11-09-2017
 (4 rows)
 

--- a/test/sql/timestamp.sql
+++ b/test/sql/timestamp.sql
@@ -144,6 +144,11 @@ SELECT _timescaledb_internal.to_unix_microseconds('294247-01-01 23:59:59.999999'
 SELECT timestamp '294247-01-01 23:59:59.999999' + interval '1 us';
 SELECT _timescaledb_internal.to_unix_microseconds(timestamp '294247-01-01 23:59:59.999999' + interval '1 us');
 
+--no time_bucketing of dates not by integer # of days
+
+SELECT time_bucket('1 hour', DATE '2012-01-01');
+SELECT time_bucket('25 hour', DATE '2012-01-01');
+
 \set ON_ERROR_STOP 1
 
 SELECT time_bucket(INTERVAL '1 day', TIMESTAMP '2011-01-02 01:01:01');
@@ -328,3 +333,26 @@ FROM unnest(ARRAY[
      '107',
      '108'
     ]::int[]) AS time;
+
+
+SELECT time, time_bucket(INTERVAL '1 day', time::date)
+FROM unnest(ARRAY[
+    date '2017-11-05',
+    date '2017-11-06'
+    ]) AS time;
+
+SELECT time, time_bucket(INTERVAL '4 day', time::date)
+FROM unnest(ARRAY[
+    date '2017-11-02',
+    date '2017-11-03',
+    date '2017-11-06',
+    date '2017-11-07'
+    ]) AS time;
+
+SELECT time, time_bucket(INTERVAL '4 day', time::date, INTERVAL '2 day')
+FROM unnest(ARRAY[
+    date '2017-11-04',
+    date '2017-11-05',
+    date '2017-11-08',
+    date '2017-11-09'
+    ]) AS time;


### PR DESCRIPTION
Previously, date was auto-cast to timestamptz when time_bucket was
called. This led to weird behavior with regards to timezones and
the return value was a timestamptz. This PR makes time_bucket return
a DATE on DATE input and avoids all timezone conversions.