### PR TITLE
Fix failure when constraint-aware append excludes all chunks

### DIFF
--- a/src/constraint_aware_append.h
+++ b/src/constraint_aware_append.h
@@ -14,6 +14,7 @@ typedef struct ConstraintAwareAppendState
 {
 	CustomScanState csstate;
 	Plan	   *subplan;
+	Size		num_append_subplans;
 } ConstraintAwareAppendState;
 
 typedef struct Hypertable Hypertable;

--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -47,17 +47,42 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
                                ('2017-05-22T09:18:22', 36.2, 2),
                                ('2017-05-22T09:18:23', 15.2, 2),
                                ('2017-08-22T09:18:22', 34.1, 3);
+-- query should exclude all chunks with optimization on
+EXPLAIN (costs off)
+SELECT * FROM append_test WHERE time > now_s() + '1 month';
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: append_test
+   ->  Append
+(3 rows)
+
+SELECT * FROM append_test WHERE time > now_s() + '1 month';
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+ time | temp | colorid 
+------+------+---------
+(0 rows)
+
 -- when optimized, the plan should be a constraint-aware append and
 -- cover only one chunk. It should be a backward index scan due to
 -- descending index on time. Should also skip the main table, since it
 -- cannot hold tuples
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -69,12 +94,12 @@ psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -85,11 +110,11 @@ psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Limit
@@ -104,12 +129,12 @@ psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -121,8 +146,8 @@ psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:67: NOTICE:  Immutable function now_i() called!
-psql:include/append.sql:67: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -160,11 +185,11 @@ ORDER BY time;
 
 SELECT * FROM append_test WHERE time > now_v() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -176,12 +201,12 @@ PREPARE query_opt AS
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time;
 EXECUTE query_opt;
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -189,7 +214,7 @@ psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
 
 EXPLAIN (costs off)
 EXECUTE query_opt;
-psql:include/append.sql:89: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:94: NOTICE:  Stable function now_s() called!
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -205,13 +230,13 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
             t             | avg  
 --------------------------+------
  Sun Jan 01 00:00:00 2017 | 28.5
@@ -223,11 +248,11 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Sort
@@ -250,7 +275,7 @@ PREPARE query_param AS
 SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 EXPLAIN (costs off)
 EXECUTE query_param(now_s() - interval '2 months');
-psql:include/append.sql:111: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:116: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -284,16 +309,16 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
  Nested Loop
@@ -317,20 +342,20 @@ psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
            time           | temp | colorid |           time           | temp | colorid 
 --------------------------+------+---------+--------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3 | Tue Aug 22 09:18:22 2017 | 23.1 |       3

--- a/test/expected/append_unoptimized.out
+++ b/test/expected/append_unoptimized.out
@@ -47,16 +47,48 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
                                ('2017-05-22T09:18:22', 36.2, 2),
                                ('2017-05-22T09:18:23', 15.2, 2),
                                ('2017-08-22T09:18:22', 34.1, 3);
+-- query should exclude all chunks with optimization on
+EXPLAIN (costs off)
+SELECT * FROM append_test WHERE time > now_s() + '1 month';
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Append
+   ->  Seq Scan on append_test
+         Filter: ("time" > (now_s() + '@ 1 mon'::interval))
+   ->  Index Scan using "1-append_test_time_idx" on _hyper_1_1_chunk
+         Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+   ->  Index Scan using "2-append_test_time_idx" on _hyper_1_2_chunk
+         Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+   ->  Index Scan using "3-append_test_time_idx" on _hyper_1_3_chunk
+         Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+(9 rows)
+
+SELECT * FROM append_test WHERE time > now_s() + '1 month';
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+ time | temp | colorid 
+------+------+---------
+(0 rows)
+
 -- when optimized, the plan should be a constraint-aware append and
 -- cover only one chunk. It should be a backward index scan due to
 -- descending index on time. Should also skip the main table, since it
 -- cannot hold tuples
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
                              QUERY PLAN                              
 ---------------------------------------------------------------------
  Append
@@ -72,13 +104,13 @@ psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -89,10 +121,10 @@ psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Limit
@@ -111,14 +143,14 @@ psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -130,8 +162,8 @@ psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:67: NOTICE:  Immutable function now_i() called!
-psql:include/append.sql:67: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -169,11 +201,11 @@ ORDER BY time;
 
 SELECT * FROM append_test WHERE time > now_v() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:78: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -185,14 +217,14 @@ PREPARE query_opt AS
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time;
 EXECUTE query_opt;
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -219,13 +251,13 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:95: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
             t             | avg  
 --------------------------+------
  Sun Jan 01 00:00:00 2017 | 28.5
@@ -237,10 +269,10 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
                                       QUERY PLAN                                       
 ---------------------------------------------------------------------------------------
  Sort
@@ -266,7 +298,7 @@ PREPARE query_param AS
 SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 EXPLAIN (costs off)
 EXECUTE query_param(now_s() - interval '2 months');
-psql:include/append.sql:111: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:116: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -300,14 +332,14 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
  Nested Loop
@@ -335,20 +367,20 @@ psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
            time           | temp | colorid |           time           | temp | colorid 
 --------------------------+------+---------+--------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3 | Tue Aug 22 09:18:22 2017 | 23.1 |       3

--- a/test/expected/append_x_diff.out
+++ b/test/expected/append_x_diff.out
@@ -4,7 +4,31 @@
 < \set DISABLE_OPTIMIZATIONS on
 ---
 > \set DISABLE_OPTIMIZATIONS off
-60,71c60,68
+57,68c57,63
+<                              QUERY PLAN                              
+< ---------------------------------------------------------------------
+<  Append
+<    ->  Seq Scan on append_test
+<          Filter: ("time" > (now_s() + '@ 1 mon'::interval))
+<    ->  Index Scan using "1-append_test_time_idx" on _hyper_1_1_chunk
+<          Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+<    ->  Index Scan using "2-append_test_time_idx" on _hyper_1_2_chunk
+<          Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+<    ->  Index Scan using "3-append_test_time_idx" on _hyper_1_3_chunk
+<          Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+< (9 rows)
+---
+> psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
+>              QUERY PLAN              
+> -------------------------------------
+>  Custom Scan (ConstraintAwareAppend)
+>    Hypertable: append_test
+>    ->  Append
+> (3 rows)
+76,77d70
+< psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+< psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
+92,103c85,93
 <                              QUERY PLAN                              
 < ---------------------------------------------------------------------
 <  Append
@@ -18,7 +42,7 @@
 <          Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 < (9 rows)
 ---
-> psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
 >                                 QUERY PLAN                                 
 > ---------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
@@ -27,16 +51,16 @@
 >          ->  Index Scan using "3-append_test_time_idx" on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (5 rows)
-81d77
-< psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
-96,97c92,94
+113d102
+< psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+128,129c117,119
 <                                      QUERY PLAN                                     
 < ------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:56: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
 >                                         QUERY PLAN                                        
 > ------------------------------------------------------------------------------------------
-99,109c96,102
+131,141c121,127
 <    ->  Merge Append
 <          Sort Key: append_test."time"
 <          ->  Index Scan Backward using append_test_time_idx on append_test
@@ -56,16 +80,16 @@
 >                ->  Index Scan Backward using "3-append_test_time_idx" on _hyper_1_3_chunk
 >                      Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (7 rows)
-120,121d112
-< psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-155,156c146,147
+152,153d137
+< psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+< psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+187,188c171,172
 <                             QUERY PLAN                             
 < -------------------------------------------------------------------
 ---
 >                                QUERY PLAN                                
 > -------------------------------------------------------------------------
-159,167c150,158
+191,199c175,183
 <    ->  Append
 <          ->  Seq Scan on append_test
 <                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
@@ -85,10 +109,10 @@
 >                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
 >                ->  Seq Scan on _hyper_1_3_chunk
 >                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-194,195d184
-< psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:86: NOTICE:  Stable function now_s() called!
-203,215c192,201
+226,227d209
+< psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+< psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+235,247c217,226
 <                                   QUERY PLAN                                  
 < ------------------------------------------------------------------------------
 <  Merge Append
@@ -103,7 +127,7 @@
 <          Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 < (10 rows)
 ---
-> psql:include/append.sql:89: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:94: NOTICE:  Stable function now_s() called!
 >                                      QUERY PLAN                                     
 > ------------------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
@@ -113,31 +137,31 @@
 >          ->  Index Scan Backward using "3-append_test_time_idx" on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (6 rows)
-243a230
-> psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-250c237,238
+275a255
+> psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+282c262,263
 <          ->  Result
 ---
 >          ->  Custom Scan (ConstraintAwareAppend)
 >                Hypertable: append_test
-252,255d239
+284,287d264
 <                      ->  Seq Scan on append_test
 <                            Filter: ("time" > (now_s() - '@ 4 mons'::interval))
 <                      ->  Index Scan using "1-append_test_time_idx" on _hyper_1_1_chunk
 <                            Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-260c244
+292c269
 < (14 rows)
 ---
 > (11 rows)
-311,312c295,298
+343,344c320,323
 <                                   QUERY PLAN                                   
 < -------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:131: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
 >                                      QUERY PLAN                                      
 > -------------------------------------------------------------------------------------
-315,333c301,315
+347,365c326,340
 <    ->  Append
 <          ->  Seq Scan on append_test a
 <                Filter: ("time" > (now_s() - '@ 3 hours'::interval))

--- a/test/sql/include/append.sql
+++ b/test/sql/include/append.sql
@@ -39,6 +39,11 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
                                ('2017-05-22T09:18:23', 15.2, 2),
                                ('2017-08-22T09:18:22', 34.1, 3);
 
+-- query should exclude all chunks with optimization on
+EXPLAIN (costs off)
+SELECT * FROM append_test WHERE time > now_s() + '1 month';
+SELECT * FROM append_test WHERE time > now_s() + '1 month';
+
 -- when optimized, the plan should be a constraint-aware append and
 -- cover only one chunk. It should be a backward index scan due to
 -- descending index on time. Should also skip the main table, since it


### PR DESCRIPTION
This change fixes a bug that occurs when a constraint-aware append
plan excludes all chunks at execution time. Append nodes do not handle
the case when all subplans are pruned and the append node's subplan
list is empty. To avoid a failure in that case, the constraint-aware
plan node will shortcut the execution of the query and never call the
append node.