### PR TITLE
Fix possible segfault in planner

### DIFF
--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -379,14 +379,18 @@ WHERE time < to_timestamp(900)
 GROUP BY t 
 ORDER BY t DESC 
 LIMIT 2;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Limit
-   ->  GroupAggregate
-         Group Key: date_trunc('minute'::text, "time")
-         ->  Index Scan using time_plain_plain_table on plain_table
-               Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(5 rows)
+   ->  Sort
+         Sort Key: (date_trunc('minute'::text, "time")) DESC
+         ->  HashAggregate
+               Group Key: date_trunc('minute'::text, "time")
+               ->  Bitmap Heap Scan on plain_table
+                     Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+                     ->  Bitmap Index Scan on time_plain_plain_table
+                           Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(9 rows)
 
 SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
 FROM plain_table 

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -229,35 +229,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-382,383c396,397
+417,418c431,432
 <                                           QUERY PLAN                                           
 < -----------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-385,389c399,407
-<    ->  GroupAggregate
-<          Group Key: date_trunc('minute'::text, "time")
-<          ->  Index Scan using time_plain_plain_table on plain_table
-<                Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-< (5 rows)
----
->    ->  Sort
->          Sort Key: (date_trunc('minute'::text, "time")) DESC
->          ->  HashAggregate
->                Group Key: date_trunc('minute'::text, "time")
->                ->  Bitmap Heap Scan on plain_table
->                      Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
->                      ->  Bitmap Index Scan on time_plain_plain_table
->                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-> (9 rows)
-413,414c431,432
-<                                           QUERY PLAN                                           
-< -----------------------------------------------------------------------------------------------
----
->                                                 QUERY PLAN                                                 
-> -----------------------------------------------------------------------------------------------------------
-416,420c434,442
+420,424c434,442
 <    ->  GroupAggregate
 <          Group Key: date_trunc('minute'::text, "time")
 <          ->  Index Scan using time_plain_plain_table on plain_table


### PR DESCRIPTION
Previously, the planner had a global context that kept a reference to
the hypertable cache. The reference counting system in that global
context was unsafe and could lead to a segfault. This PR gets rid
of that context and makes the whole system a lot safer.

Fixes #184