### PR TITLE
Remove triggers from chunk and chunk_constraint

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -245,14 +245,20 @@ $BODY$;
 
 -- Drops a hypertable
 CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_hypertable(
-    schema_name NAME,
-    table_name  NAME
+    hypertable_id INT,
+    is_cascade BOOLEAN
 )
-    RETURNS VOID LANGUAGE SQL VOLATILE AS
+    RETURNS VOID LANGUAGE PLPGSQL VOLATILE AS
 $BODY$
+BEGIN 
+    PERFORM _timescaledb_internal.drop_chunk(c.id, is_cascade)
+    FROM _timescaledb_catalog.hypertable h
+    INNER JOIN _timescaledb_catalog.chunk c ON (c.hypertable_id = h.id)
+    WHERE h.id = drop_hypertable.hypertable_id;
+
     DELETE FROM _timescaledb_catalog.hypertable h
-    WHERE h.schema_name = drop_hypertable.schema_name AND
-          h.table_name = drop_hypertable.table_name
+    WHERE h.id = drop_hypertable.hypertable_id;
+END
 $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.dimension_get_time(
@@ -275,21 +281,18 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_chunks_older_than(
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE AS
 $BODY$
-DECLARE
 BEGIN
-    EXECUTE format(
-        $$
-        DELETE FROM _timescaledb_catalog.chunk c
-        USING _timescaledb_catalog.hypertable h,
-        _timescaledb_internal.dimension_get_time(h.id) time_dimension,
-        _timescaledb_catalog.dimension_slice ds,
-        _timescaledb_catalog.chunk_constraint cc
-        WHERE h.id = c.hypertable_id AND ds.dimension_id = time_dimension.id AND cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id
-        AND ds.range_end <= %1$L
-        AND (%2$L IS NULL OR h.schema_name = %2$L)
-        AND (%3$L IS NULL OR h.table_name = %3$L)
-        $$, older_than_time, schema_name, table_name
-    );
+    PERFORM _timescaledb_internal.drop_chunk(c.id, false)
+    FROM _timescaledb_catalog.chunk c
+    INNER JOIN _timescaledb_catalog.hypertable h ON (h.id = c.hypertable_id)
+    INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+    INNER JOIN _timescaledb_catalog.dimension_slice ds
+        ON (ds.dimension_id =  time_dimension.id)
+    INNER JOIN _timescaledb_catalog.chunk_constraint cc
+        ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+    WHERE ds.range_end <= older_than_time
+    AND (drop_chunks_older_than.schema_name IS NULL OR h.schema_name = drop_chunks_older_than.schema_name)
+    AND (drop_chunks_older_than.table_name IS NULL OR h.table_name = drop_chunks_older_than.table_name);
 END
 $BODY$;
 
@@ -508,8 +511,8 @@ BEGIN
     WHERE ht.schema_name = truncate_hypertable.schema_name
     AND ht.table_name = truncate_hypertable.table_name;
 
-    DELETE FROM _timescaledb_catalog.chunk
+    PERFORM  _timescaledb_internal.drop_chunk(c.id, FALSE)
+    FROM _timescaledb_catalog.chunk c
     WHERE hypertable_id = hypertable_row.id;
-
 END
 $BODY$;

--- a/sql/ddl_triggers.sql
+++ b/sql/ddl_triggers.sql
@@ -160,22 +160,7 @@ BEGIN
 END
 $BODY$;
 
--- Handles drop table command
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_process_drop_table()
-        RETURNS event_trigger LANGUAGE plpgsql AS $BODY$
-DECLARE
-    obj record;
-BEGIN
-    FOR obj IN SELECT * FROM pg_event_trigger_dropped_objects()
-    LOOP
-        IF tg_tag = 'DROP TABLE' AND  _timescaledb_internal.is_main_table(obj.schema_name, obj.object_name) THEN
-            PERFORM _timescaledb_internal.drop_hypertable(obj.schema_name, obj.object_name);
-        END IF;
-    END LOOP;
-END
-$BODY$;
-
- CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_change_owner(main_table OID, new_table_owner NAME)
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_change_owner(main_table OID, new_table_owner NAME)
     RETURNS void LANGUAGE plpgsql
     SECURITY DEFINER SET search_path = ''
     AS

--- a/sql/functions_load_order.txt
+++ b/sql/functions_load_order.txt
@@ -1,8 +1,8 @@
 sql/errors.sql
+sql/chunk.sql
 sql/ddl_internal.sql
 sql/util_time.sql
 sql/util_internal_table_ddl.sql
-sql/chunk.sql
 sql/chunk_trigger.sql
 sql/chunk_constraint.sql
 sql/hypertable_triggers.sql

--- a/sql/setup_main.sql
+++ b/sql/setup_main.sql
@@ -14,18 +14,6 @@ BEGIN
     AFTER INSERT OR UPDATE OR DELETE ON _timescaledb_catalog.chunk_index
     FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.on_change_chunk_index();
 
-    DROP TRIGGER IF EXISTS trigger_main_on_change_chunk
-    ON _timescaledb_catalog.chunk;
-    CREATE TRIGGER trigger_main_on_change_chunk
-    AFTER UPDATE OR DELETE OR INSERT ON _timescaledb_catalog.chunk
-    FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.on_change_chunk();
-
-    DROP TRIGGER IF EXISTS trigger_main_on_change_chunk_constraint
-    ON _timescaledb_catalog.chunk_constraint;
-    CREATE TRIGGER trigger_main_on_change_chunk_constraint
-    AFTER UPDATE OR DELETE OR INSERT ON _timescaledb_catalog.chunk_constraint
-    FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.on_change_chunk_constraint();
-
     -- no DELETE: it would be a no-op
     DROP TRIGGER IF EXISTS trigger_1_main_on_change_hypertable
     ON _timescaledb_catalog.hypertable;
@@ -73,17 +61,12 @@ BEGIN
        ON sql_drop
        EXECUTE PROCEDURE _timescaledb_internal.ddl_process_drop_trigger();
 
-    CREATE EVENT TRIGGER ddl_check_drop_command
-       ON sql_drop
-       EXECUTE PROCEDURE _timescaledb_internal.ddl_process_drop_table();
-
     IF restore THEN
         ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_create_index;
         ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_alter_index;
         ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_drop_index;
         ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_create_trigger;
         ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_drop_trigger;
-        ALTER EXTENSION timescaledb ADD EVENT TRIGGER ddl_check_drop_command;
     END IF;
 
 END

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -105,7 +105,7 @@ SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_
 -- 'schema_name' and 'table_name'.
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.chunk (
     id              SERIAL  NOT NULL    PRIMARY KEY,
-    hypertable_id   INT     NOT NULL    REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE,
+    hypertable_id   INT     NOT NULL    REFERENCES _timescaledb_catalog.hypertable(id),
     schema_name     NAME    NOT NULL,
     table_name      NAME    NOT NULL,
     UNIQUE (schema_name, table_name)
@@ -118,8 +118,8 @@ SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_
 -- constraint associated with a chunk will also be a table constraint
 -- on the chunk's data table.
 CREATE TABLE _timescaledb_catalog.chunk_constraint (
-    chunk_id            INTEGER  NOT NULL REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE,
-    dimension_slice_id  INTEGER  NULL REFERENCES _timescaledb_catalog.dimension_slice(id) ON DELETE CASCADE,
+    chunk_id            INTEGER  NOT NULL REFERENCES _timescaledb_catalog.chunk(id),
+    dimension_slice_id  INTEGER  NULL REFERENCES _timescaledb_catalog.dimension_slice(id),
     constraint_name     NAME NOT NULL,
     hypertable_constraint_name NAME NULL,
     PRIMARY KEY(chunk_id, constraint_name)

--- a/sql/tablespace.sql
+++ b/sql/tablespace.sql
@@ -3,7 +3,7 @@
 -- the chunk's hypertable, if any.
 CREATE OR REPLACE FUNCTION _timescaledb_internal.select_tablespace(
     hypertable_id INTEGER,
-    chunk_id      INTEGER
+    chunk_dimension_slice_ids      INTEGER[]
 )
     RETURNS NAME LANGUAGE PLPGSQL VOLATILE AS
 $BODY$
@@ -18,7 +18,7 @@ DECLARE
         WHERE (t.hypertable_id = select_tablespace.hypertable_id)
         ORDER BY id DESC
     );
-    dimension_slices INT[];
+    hypertable_dimension_slices INT[];
     partitioning_func TEXT;
 BEGIN
 
@@ -38,28 +38,42 @@ BEGIN
     INTO dimension_id, partitioning_func;
 
     -- Find all dimension slices for the chosen dimension
-    dimension_slices := ARRAY(
+    hypertable_dimension_slices := ARRAY(
         SELECT s.id FROM _timescaledb_catalog.dimension_slice s
         WHERE (s.dimension_id = main_block.dimension_id)
+        ORDER BY s.id
     );
-
-    -- Find the chunk's dimension slice for the chosen dimension
-    SELECT s.id FROM _timescaledb_catalog.dimension_slice s
-    INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = s.id)
-    INNER JOIN _timescaledb_catalog.chunk c ON (cc.chunk_id = c.id)
-    WHERE (s.dimension_id = main_block.dimension_id)
-    AND (c.id = select_tablespace.chunk_id)
-    INTO STRICT chunk_slice_id;
 
     -- Find the array index of the chunk's dimension slice
     SELECT i
-    FROM generate_subscripts(dimension_slices, 1) AS i
-    WHERE dimension_slices[i] = chunk_slice_id
+    FROM generate_subscripts(hypertable_dimension_slices, 1) AS i
+    WHERE hypertable_dimension_slices[i] = ANY(chunk_dimension_slice_ids)
     INTO STRICT chunk_slice_index;
 
     -- Use the chunk's dimension slice index to pick a tablespace in
     -- the tablespaces array
     RETURN tablespaces[chunk_slice_index % array_length(tablespaces, 1) + 1];
+END
+$BODY$;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.select_tablespace(
+    hypertable_id INTEGER,
+    chunk_id      INTEGER
+)
+    RETURNS NAME LANGUAGE PLPGSQL VOLATILE AS
+$BODY$
+DECLARE
+    chunk_dimension_slice_ids INTEGER[];
+BEGIN
+    -- Find the chunk's dimension slice ids
+    chunk_dimension_slice_ids = ARRAY (
+        SELECT s.id FROM _timescaledb_catalog.dimension_slice s
+        INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = s.id)
+        INNER JOIN _timescaledb_catalog.chunk c ON (cc.chunk_id = c.id)
+        WHERE (c.id = select_tablespace.chunk_id)
+    );
+
+    RETURN _timescaledb_internal.select_tablespace(hypertable_id, chunk_dimension_slice_ids);
 END
 $BODY$;
 

--- a/sql/updates/post-0.4.1--0.4.2-dev.sql
+++ b/sql/updates/post-0.4.1--0.4.2-dev.sql
@@ -1,7 +1,3 @@
-CREATE TRIGGER trigger_main_on_change_chunk_constraint
-AFTER UPDATE OR DELETE OR INSERT ON _timescaledb_catalog.chunk_constraint
-FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.on_change_chunk_constraint();
-
 SELECT _timescaledb_internal.add_constraint(h.id, c.oid)
 FROM _timescaledb_catalog.hypertable h
 INNER JOIN pg_constraint c ON (c.conrelid = format('%I.%I', h.schema_name, h.table_name)::regclass);
@@ -11,3 +7,30 @@ WHERE EXISTS (
  SELECT 1 FROM pg_constraint WHERE conindid = format('%I.%I', hi.main_schema_name, hi.main_index_name)::regclass
 );
 
+ALTER TABLE _timescaledb_catalog.chunk
+DROP CONSTRAINT chunk_hypertable_id_fkey,
+ADD CONSTRAINT chunk_hypertable_id_fkey
+  FOREIGN KEY (hypertable_id) 
+  REFERENCES _timescaledb_catalog.hypertable(id);
+
+ALTER TABLE _timescaledb_catalog.chunk_constraint
+DROP CONSTRAINT chunk_constraint_chunk_id_fkey,
+ADD CONSTRAINT chunk_constraint_chunk_id_fkey
+  FOREIGN KEY (chunk_id) 
+  REFERENCES _timescaledb_catalog.chunk(id);
+
+ALTER TABLE _timescaledb_catalog.chunk_constraint
+DROP CONSTRAINT chunk_constraint_dimension_slice_id_fkey,
+ADD CONSTRAINT chunk_constraint_dimension_slice_id_fkey
+  FOREIGN KEY (dimension_slice_id) 
+  REFERENCES _timescaledb_catalog.dimension_slice(id);
+
+
+DROP EVENT TRIGGER ddl_check_drop_command;
+
+DROP TRIGGER trigger_main_on_change_chunk ON _timescaledb_catalog.chunk;
+
+DROP FUNCTION _timescaledb_internal.chunk_create_table(int);
+DROP FUNCTION _timescaledb_internal.ddl_process_drop_table();
+DROP FUNCTION _timescaledb_internal.on_change_chunk();
+DROP FUNCTION _timescaledb_internal.drop_hypertable(name, name);

--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -18,7 +18,8 @@ SET client_min_messages = WARNING -- suppress NOTICE on IF EXISTS
 ;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_create_table(
-    chunk_id INT
+    chunk_id INT,
+    tablespace_name NAME
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE AS
 $BODY$
@@ -26,7 +27,6 @@ DECLARE
     chunk_row _timescaledb_catalog.chunk;
     hypertable_row _timescaledb_catalog.hypertable;
     tablespace_clause TEXT := '';
-    tablespace_name NAME;
     table_owner     NAME;
     tablespace_oid  OID;
 BEGIN
@@ -38,8 +38,6 @@ BEGIN
     FROM _timescaledb_catalog.hypertable
     WHERE id = chunk_row.hypertable_id;
 
-    tablespace_name := _timescaledb_internal.select_tablespace(chunk_row.hypertable_id,
-                                                               chunk_row.id);
     SELECT t.oid
     INTO tablespace_oid
     FROM pg_catalog.pg_tablespace t

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -77,6 +77,10 @@ const static InternalFunctionDef internal_function_definitions[_MAX_INTERNAL_FUN
 	[DDL_DROP_CONSTRAINT] = {
 		.name = "drop_constraint",
 		.args = 2,
+	},
+	[DDL_DROP_HYPERTABLE] = {
+		.name = "drop_hypertable",
+		.args = 2
 	}
 };
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -28,11 +28,18 @@ enum CatalogTable
 	_MAX_CATALOG_TABLES,
 };
 
+#define CatalogInternalCall1(func, datum1) \
+	OidFunctionCall1(catalog_get_internal_function_id(catalog_get(), func), datum1);
+#define CatalogInternalCall2(func, datum1, datum2) \
+	OidFunctionCall2(catalog_get_internal_function_id(catalog_get(), func), datum1, datum2);
+
+
 typedef enum InternalFunction
 {
 	DDL_CHANGE_OWNER = 0,
 	DDL_ADD_CONSTRAINT,
 	DDL_DROP_CONSTRAINT,
+	DDL_DROP_HYPERTABLE,
 	_MAX_INTERNAL_FUNCTIONS,
 } InternalFunction;
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -269,6 +269,47 @@ reindex_chunk(Oid chunk_relid, void *arg)
 	}
 }
 
+static bool
+process_drop(Node *parsetree)
+{
+	DropStmt   *stmt = (DropStmt *) parsetree;
+	ListCell   *cell1;
+	Cache	   *hcache = NULL;
+	bool		handled = false;
+
+	if (stmt->removeType != OBJECT_TABLE)
+	{
+		return false;
+	}
+
+	hcache = hypertable_cache_pin();
+
+	foreach(cell1, stmt->objects)
+	{
+		List	   *object = lfirst(cell1);
+		Oid			relid = RangeVarGetRelid(makeRangeVarFromNameList(object), NoLock, true);
+
+		if (OidIsValid(relid))
+		{
+			Hypertable *ht;
+
+			ht = hypertable_cache_get_entry(hcache, relid);
+			if (NULL != ht)
+			{
+				if (list_length(stmt->objects) != 1)
+				{
+					elog(ERROR, "Cannot drop a hypertable along with other objects");
+				}
+				CatalogInternalCall2(DDL_DROP_HYPERTABLE, Int32GetDatum(ht->fd.id), BoolGetDatum(stmt->behavior == DROP_CASCADE));
+				handled = true;
+			}
+		}
+	}
+
+	cache_release(hcache);
+	return handled;
+}
+
 /*
  * Reindex a hypertable and all its chunks. Currently works only for REINDEX
  * TABLE.
@@ -318,16 +359,15 @@ process_altertable_change_owner(Hypertable *ht, AlterTableCmd *cmd, Oid relid)
 
 	Assert(IsA(cmd->newowner, RoleSpec));
 	role = (RoleSpec *) cmd->newowner;
-	OidFunctionCall2(catalog_get_internal_function_id(catalog_get(), DDL_CHANGE_OWNER),
-				   ObjectIdGetDatum(relid), CStringGetDatum(role->rolename));
+
+	CatalogInternalCall2(DDL_CHANGE_OWNER, ObjectIdGetDatum(relid), CStringGetDatum(role->rolename));
 }
 
 static void
-process_altertable_add_constraint(Hypertable *ht, const char* constraint_name)
+process_altertable_add_constraint(Hypertable *ht, const char *constraint_name)
 {
 	Assert(constraint_name != NULL);
-	OidFunctionCall2(catalog_get_internal_function_id(catalog_get(), DDL_ADD_CONSTRAINT),
-				 Int32GetDatum(ht->fd.id), CStringGetDatum(constraint_name));
+	CatalogInternalCall2(DDL_ADD_CONSTRAINT, Int32GetDatum(ht->fd.id), CStringGetDatum(constraint_name));
 }
 
 
@@ -338,8 +378,7 @@ process_altertable_drop_constraint(Hypertable *ht, AlterTableCmd *cmd, Oid relid
 
 	constraint_name = cmd->name;
 	Assert(constraint_name != NULL);
-	OidFunctionCall2(catalog_get_internal_function_id(catalog_get(), DDL_DROP_CONSTRAINT),
-				 Int32GetDatum(ht->fd.id), CStringGetDatum(constraint_name));
+	CatalogInternalCall2(DDL_DROP_CONSTRAINT, Int32GetDatum(ht->fd.id), CStringGetDatum(constraint_name));
 }
 
 
@@ -375,12 +414,14 @@ process_altertable(Node *parsetree)
 				break;
 			case AT_AddIndex:
 				{
-					Assert(IsA(cmd->def, IndexStmt));
 					IndexStmt  *stmt = (IndexStmt *) cmd->def;
+
+					Assert(IsA(cmd->def, IndexStmt));
 
 					Assert(stmt->isconstraint);
 					process_altertable_add_constraint(ht, stmt->idxname);
 				}
+
 				/*
 				 * AddConstraint sometimes transformed to AddIndex if Index is
 				 * involved. different path than CREATE INDEX.
@@ -388,8 +429,9 @@ process_altertable(Node *parsetree)
 			case AT_AddConstraint:
 			case AT_AddConstraintRecurse:
 				{
-					Assert(IsA(cmd->def, Constraint));
 					Constraint *stmt = (Constraint *) cmd->def;
+
+					Assert(IsA(cmd->def, Constraint));
 
 					process_altertable_add_constraint(ht, stmt->conname);
 				}
@@ -438,6 +480,16 @@ timescaledb_ProcessUtility(Node *parsetree,
 			break;
 		case T_RenameStmt:
 			process_rename(parsetree);
+			break;
+		case T_DropStmt:
+
+			/*
+			 * Drop associated metadata/chunks but also continue on to drop
+			 * the main table. Because chunks are deleted before the main
+			 * table is dropped, the drop respects CASCADE in the expected
+			 * way.
+			 */
+			process_drop(parsetree);
 			break;
 		case T_CopyStmt:
 			if (process_copy(parsetree, query_string, completion_tag))

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -106,7 +106,6 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
 (12 rows)
 
 SELECT _timescaledb_internal.drop_chunks_older_than(2);
-NOTICE:  index "1-drop_chunk_test1_time_idx" does not exist, skipping
  drop_chunks_older_than 
 ------------------------
  
@@ -150,7 +149,6 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
 (10 rows)
 
 SELECT _timescaledb_internal.drop_chunks_older_than(3, 'drop_chunk_test1');
-NOTICE:  index "2-drop_chunk_test1_time_idx" does not exist, skipping
  drop_chunks_older_than 
 ------------------------
  

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -23,6 +23,48 @@ SELECT create_hypertable('should_drop', 'time');
  
 (1 row)
 
+CREATE TABLE hyper_with_dependencies (time timestamp, temp float8);
+SELECT create_hypertable('hyper_with_dependencies', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+CREATE VIEW dependent_view AS SELECT * FROM hyper_with_dependencies;
+INSERT INTO hyper_with_dependencies VALUES (now(), 1.0);
+\set ON_ERROR_STOP 0
+DROP TABLE hyper_with_dependencies;
+ERROR:  cannot drop table hyper_with_dependencies because other objects depend on it
+\set ON_ERROR_STOP 1
+DROP TABLE hyper_with_dependencies CASCADE;
+NOTICE:  drop cascades to view dependent_view
+\dv
+      List of relations
+ Schema | Name | Type | Owner 
+--------+------+------+-------
+(0 rows)
+
+CREATE TABLE chunk_with_dependencies (time timestamp, temp float8);
+SELECT create_hypertable('chunk_with_dependencies', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO chunk_with_dependencies VALUES (now(), 1.0);
+CREATE VIEW dependent_view_chunk AS SELECT * FROM _timescaledb_internal._hyper_3_2_chunk;
+\set ON_ERROR_STOP 0
+DROP TABLE chunk_with_dependencies;
+ERROR:  cannot drop table _timescaledb_internal._hyper_3_2_chunk because other objects depend on it
+\set ON_ERROR_STOP 1
+DROP TABLE chunk_with_dependencies CASCADE;
+NOTICE:  drop cascades to view dependent_view_chunk
+\dv
+      List of relations
+ Schema | Name | Type | Owner 
+--------+------+------+-------
+(0 rows)
+
 -- Calling create hypertable again will increment hypertable ID
 -- although no new hypertable is created. Make sure we can handle this.
 SELECT create_hypertable('should_drop', 'time', if_not_exists => true);
@@ -56,12 +98,12 @@ INSERT INTO should_drop VALUES (now(), 1.0);
 SELECT * from _timescaledb_catalog.hypertable;
  id | schema_name | table_name  | associated_schema_name | associated_table_prefix | num_dimensions 
 ----+-------------+-------------+------------------------+-------------------------+----------------
-  2 | public      | should_drop | _timescaledb_internal  | _hyper_2                |              1
+  4 | public      | should_drop | _timescaledb_internal  | _hyper_4                |              1
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
 ----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------
-  2 |             2 | time        | timestamp without time zone | t       |            |                          |                   |   2592000000000
+  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |   2592000000000
 (1 row)
 

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -407,36 +407,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
   1 | newschema   | newname    | _timescaledb_internal  | _hyper_1                |              2
 (1 row)
 
-DROP TABLE "newschema"."newname" CASCADE;
-NOTICE:  drop cascades to 4 other objects
-NOTICE:  index "1-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
-NOTICE:  index "2-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
-NOTICE:  index "3-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
-NOTICE:  index "4-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
-NOTICE:  index "5-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
-NOTICE:  index "6-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
-NOTICE:  index "7-two_Partitions_timeCustom_idx" does not exist, skipping
-NOTICE:  index "10-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
-NOTICE:  index "11-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
-NOTICE:  index "12-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
-NOTICE:  index "13-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
-NOTICE:  index "14-two_Partitions_timeCustom_idx" does not exist, skipping
-NOTICE:  index "8-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
-NOTICE:  index "9-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
-NOTICE:  index "15-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
-NOTICE:  index "16-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
-NOTICE:  index "17-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
-NOTICE:  index "18-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
-NOTICE:  index "19-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
-NOTICE:  index "20-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
-NOTICE:  index "21-two_Partitions_timeCustom_idx" does not exist, skipping
-NOTICE:  index "22-two_Partitions_device_id_timeCustom_idx" does not exist, skipping
-NOTICE:  index "23-two_Partitions_timeCustom_series_0_idx" does not exist, skipping
-NOTICE:  index "24-two_Partitions_timeCustom_series_1_idx" does not exist, skipping
-NOTICE:  index "25-two_Partitions_timeCustom_series_2_idx" does not exist, skipping
-NOTICE:  index "26-two_Partitions_timeCustom_series_bool_idx" does not exist, skipping
-NOTICE:  index "27-two_Partitions_timeCustom_device_id_idx" does not exist, skipping
-NOTICE:  index "28-two_Partitions_timeCustom_idx" does not exist, skipping
+DROP TABLE "newschema"."newname";
 SELECT * FROM _timescaledb_catalog.hypertable;
  id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions 
 ----+-------------+------------+------------------------+-------------------------+----------------

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -43,7 +43,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   135
+   134
 (1 row)
 
 \c postgres
@@ -67,7 +67,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   135
+   134
 (1 row)
 
 \c single

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -92,14 +92,6 @@ INNER JOIN _timescaledb_catalog.chunk ch ON (ch.table_name = c.relname);
 
 --cleanup
 DROP TABLE tspace_1dim CASCADE;
-NOTICE:  drop cascades to 2 other objects
-NOTICE:  index "5-tspace_1dim_time_idx" does not exist, skipping
-NOTICE:  index "6-tspace_1dim_time_idx" does not exist, skipping
 DROP TABLE tspace_2dim CASCADE;
-NOTICE:  drop cascades to 2 other objects
-NOTICE:  index "1-tspace_2dim_time_idx" does not exist, skipping
-NOTICE:  index "2-tspace_2dim_device_time_idx" does not exist, skipping
-NOTICE:  index "3-tspace_2dim_time_idx" does not exist, skipping
-NOTICE:  index "4-tspace_2dim_device_time_idx" does not exist, skipping
 DROP TABLESPACE tablespace1;
 DROP TABLESPACE tablespace2;

--- a/test/sql/drop_hypertable.sql
+++ b/test/sql/drop_hypertable.sql
@@ -6,6 +6,32 @@ SELECT * from _timescaledb_catalog.dimension;
 CREATE TABLE should_drop (time timestamp, temp float8);
 SELECT create_hypertable('should_drop', 'time');
 
+CREATE TABLE hyper_with_dependencies (time timestamp, temp float8);
+SELECT create_hypertable('hyper_with_dependencies', 'time');
+
+CREATE VIEW dependent_view AS SELECT * FROM hyper_with_dependencies;
+
+INSERT INTO hyper_with_dependencies VALUES (now(), 1.0);
+
+\set ON_ERROR_STOP 0
+DROP TABLE hyper_with_dependencies;
+\set ON_ERROR_STOP 1
+DROP TABLE hyper_with_dependencies CASCADE;
+\dv
+
+CREATE TABLE chunk_with_dependencies (time timestamp, temp float8);
+SELECT create_hypertable('chunk_with_dependencies', 'time');
+
+INSERT INTO chunk_with_dependencies VALUES (now(), 1.0);
+
+CREATE VIEW dependent_view_chunk AS SELECT * FROM _timescaledb_internal._hyper_3_2_chunk;
+
+\set ON_ERROR_STOP 0
+DROP TABLE chunk_with_dependencies;
+\set ON_ERROR_STOP 1
+DROP TABLE chunk_with_dependencies CASCADE;
+\dv
+
 -- Calling create hypertable again will increment hypertable ID
 -- although no new hypertable is created. Make sure we can handle this.
 SELECT create_hypertable('should_drop', 'time', if_not_exists => true);

--- a/test/sql/drop_rename_hypertable.sql
+++ b/test/sql/drop_rename_hypertable.sql
@@ -21,7 +21,7 @@ SELECT * FROM _timescaledb_catalog.hypertable_index WHERE main_schema_name <> 'n
 SELECT * FROM _timescaledb_catalog.chunk_index WHERE main_schema_name <> 'newschema';
 
 SELECT * FROM _timescaledb_catalog.hypertable;
-DROP TABLE "newschema"."newname" CASCADE;
+DROP TABLE "newschema"."newname";
 
 SELECT * FROM _timescaledb_catalog.hypertable;
 \dt  "public".*


### PR DESCRIPTION
Streamline code and remove triggers from chunk and
chunk_constraint. Lots of additional cleanup. Also removes need to CASCADE
hypertable drops (fixes #88).