### PR TITLE
Improve the size utils functions.

### DIFF
--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -13,10 +13,6 @@
 -- index_bytes        - Disc space used by indexes
 -- toast_bytes        - Disc space of toast tables
 -- total_bytes        - Total disk space used by the specified table, including all indexes and TOAST data
--- table_size         - Pretty output of table_bytes
--- index_bytes        - Pretty output of index_bytes
--- toast_bytes        - Pretty output of toast_bytes
--- total_size         - Pretty output of total_bytes
 
 CREATE OR REPLACE FUNCTION hypertable_relation_size(
     main_table              REGCLASS
@@ -24,12 +20,8 @@ CREATE OR REPLACE FUNCTION hypertable_relation_size(
 RETURNS TABLE (table_bytes BIGINT,
                index_bytes BIGINT,
                toast_bytes BIGINT,
-               total_bytes BIGINT,
-               table_size  TEXT,
-               index_size  TEXT,
-               toast_size  TEXT,
-               total_size  TEXT) LANGUAGE PLPGSQL VOLATILE
-               SECURITY DEFINER SET search_path = ''
+               total_bytes BIGINT
+               ) LANGUAGE PLPGSQL STABLE
                AS
 $BODY$
 DECLARE
@@ -47,11 +39,7 @@ BEGIN
         SELECT table_bytes,
                index_bytes,
                toast_bytes,
-               total_bytes,
-               pg_size_pretty(table_bytes) as table,
-               pg_size_pretty(index_bytes) as index,
-               pg_size_pretty(toast_bytes) as toast,
-               pg_size_pretty(total_bytes) as total
+               total_bytes
                FROM (
                SELECT *, total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes FROM (
                       SELECT
@@ -78,6 +66,85 @@ BEGIN
 END;
 $BODY$;
 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.range_value_to_pretty(
+    time_value      BIGINT,
+    column_type     REGTYPE
+)
+    RETURNS TEXT LANGUAGE PLPGSQL STABLE AS
+$BODY$
+DECLARE
+BEGIN
+    IF time_value IS NULL THEN
+        RETURN format('%L', NULL);
+    END IF;
+    CASE column_type
+      WHEN 'BIGINT'::regtype, 'INTEGER'::regtype, 'SMALLINT'::regtype THEN
+        RETURN format('%L', time_value); -- scale determined by user.
+      WHEN 'TIMESTAMP'::regtype, 'TIMESTAMPTZ'::regtype THEN
+        -- assume time_value is in microsec
+        RETURN format('%1$L', _timescaledb_internal.to_timestamp(time_value)); -- microseconds
+      WHEN 'DATE'::regtype THEN
+        RETURN format('%L', timezone('UTC',_timescaledb_internal.to_timestamp(time_value))::date);
+      ELSE
+        RETURN time_value;
+    END CASE;
+END
+$BODY$;
+
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.partitioning_column_to_pretty(
+    d   _timescaledb_catalog.dimension
+)
+    RETURNS TEXT LANGUAGE PLPGSQL STABLE AS
+$BODY$
+DECLARE
+BEGIN
+        IF d.partitioning_func IS NULL THEN
+           RETURN d.column_name;
+        ELSE
+           RETURN d.partitioning_func_schema || '.' || d.partitioning_func
+                  || '(' || d.column_name || ')';
+        END IF;
+END
+$BODY$;
+
+
+-- Get relation size of hypertable
+-- like pg_relation_size(hypertable)
+-- (https://www.postgresql.org/docs/9.6/static/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE)
+--
+-- main_table - hypertable to get size of
+--
+-- Returns:
+-- table_size         - Pretty output of table_bytes
+-- index_bytes        - Pretty output of index_bytes
+-- toast_bytes        - Pretty output of toast_bytes
+-- total_size         - Pretty output of total_bytes
+
+CREATE OR REPLACE FUNCTION hypertable_relation_size_pretty(
+    main_table              REGCLASS
+)
+RETURNS TABLE (table_size  TEXT,
+               index_size  TEXT,
+               toast_size  TEXT,
+               total_size  TEXT) LANGUAGE PLPGSQL STABLE
+               AS
+$BODY$
+DECLARE
+        table_name       NAME;
+        schema_name      NAME;
+BEGIN
+        RETURN QUERY
+        SELECT pg_size_pretty(table_bytes) as table,
+               pg_size_pretty(index_bytes) as index,
+               pg_size_pretty(toast_bytes) as toast,
+               pg_size_pretty(total_bytes) as total
+               FROM hypertable_relation_size(main_table);
+
+END;
+$BODY$;
+
+
 -- Get relation size of the chunks of an hypertable
 -- like pg_relation_size
 -- (https://www.postgresql.org/docs/9.6/static/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE)
@@ -85,36 +152,31 @@ $BODY$;
 -- main_table - hypertable to get size of
 --
 -- Returns:
--- chunk_id          - Timescaledb id of a chunk
--- chunk_table       - Table used for the chunk
--- dimensions        - Partitioning dimension names
--- ranges            - Partition ranges for each dimension of the chunk
--- table_bytes       - Disk space used by main_table
--- index_bytes       - Disk space used by indexes
--- toast_bytes       - Disc space of toast tables
--- total_bytes       - Disk space used in total
--- table_size        - Pretty output of table_bytes
--- index_size        - Pretty output of index_bytes
--- toast_size        - Pretty output of toast_bytes
--- total_size        - Pretty output of total_bytes
+-- chunk_id                      - Timescaledb id of a chunk
+-- chunk_table                   - Table used for the chunk
+-- partitioning_columns          - Partitioning column names
+-- partitioning_column_types     - Type of partitioning columns
+-- partitioning_hash_functions   - Hash functions of partitioning columns
+-- ranges                        - Partition ranges for each dimension of the chunk
+-- table_bytes                   - Disk space used by main_table
+-- index_bytes                   - Disk space used by indexes
+-- toast_bytes                   - Disc space of toast tables
+-- total_bytes                   - Disk space used in total
 
 CREATE OR REPLACE FUNCTION chunk_relation_size(
     main_table              REGCLASS
 )
 RETURNS TABLE (chunk_id INT,
                chunk_table TEXT,
-               dimensions NAME[],
+               partitioning_columns NAME[],
+               partitioning_column_types REGTYPE[],
+               partitioning_hash_functions TEXT[],
                ranges int8range[],
                table_bytes BIGINT,
                index_bytes BIGINT,
                toast_bytes BIGINT,
-               total_bytes BIGINT,
-               table_size  TEXT,
-               index_size  TEXT,
-               toast_size  TEXT,
-               total_size  TEXT)
-               LANGUAGE PLPGSQL VOLATILE
-               SECURITY DEFINER SET search_path = ''
+               total_bytes BIGINT)
+               LANGUAGE PLPGSQL STABLE
                AS
 $BODY$
 DECLARE
@@ -132,16 +194,14 @@ BEGIN
 
         SELECT chunk_id,
         chunk_table,
-        dimensions,
+        partitioning_columns,
+        partitioning_column_types,
+        partitioning_hash_functions,
         ranges,
         table_bytes,
         index_bytes,
         toast_bytes,
-        total_bytes,
-        pg_size_pretty(table_bytes) AS table,
-        pg_size_pretty(index_bytes) AS index,
-        pg_size_pretty(toast_bytes) AS toast,
-        pg_size_pretty(total_bytes) AS total
+        total_bytes
         FROM (
         SELECT *,
               total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes
@@ -151,10 +211,11 @@ BEGIN
                pg_total_relation_size('"' || c.schema_name || '"."' || c.table_name || '"') AS total_bytes,
                pg_indexes_size('"' || c.schema_name || '"."' || c.table_name || '"') AS index_bytes,
                pg_total_relation_size(reltoastrelid) AS toast_bytes,
-               array_agg(d.column_name ORDER BY d.column_name DESC) as dimensions,
-               array_agg(int8range(range_start, range_end) ORDER BY d.column_name DESC) as ranges
+               array_agg(d.column_name ORDER BY d.interval_length, d.column_name ASC) as partitioning_columns,
+               array_agg(d.column_type ORDER BY d.interval_length, d.column_name ASC) as partitioning_column_types,
+               array_agg(d.partitioning_func_schema || '.' || d.partitioning_func ORDER BY d.interval_length, d.column_name ASC) as partitioning_hash_functions,
+               array_agg(int8range(range_start, range_end) ORDER BY d.interval_length, d.column_name ASC) as ranges
                FROM
-
                _timescaledb_catalog.hypertable h,
                _timescaledb_catalog.chunk c,
                _timescaledb_catalog.chunk_constraint cc,
@@ -181,6 +242,108 @@ BEGIN
 END;
 $BODY$;
 
+-- Get relation size of the chunks of an hypertable
+-- like pg_relation_size
+-- (https://www.postgresql.org/docs/9.6/static/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE)
+--
+-- main_table - hypertable to get size of
+--
+-- Returns:
+-- chunk_id                      - Timescaledb id of a chunk
+-- chunk_table                   - Table used for the chunk
+-- partitioning_columns          - Partitioning column names
+-- partitioning_column_types     - Type of partitioning columns
+-- partitioning_hash_functions   - Hash functions of partitioning columns
+-- ranges                        - Partition ranges for each dimension of the chunk
+-- table_size                    - Pretty output of table_bytes
+-- index_size                    - Pretty output of index_bytes
+-- toast_size                    - Pretty output of toast_bytes
+-- total_size                    - Pretty output of total_bytes
+
+
+CREATE OR REPLACE FUNCTION chunk_relation_size_pretty(
+    main_table              REGCLASS
+)
+RETURNS TABLE (chunk_id INT,
+               chunk_table TEXT,
+               partitioning_columns NAME[],
+               partitioning_column_types REGTYPE[],
+               partitioning_hash_functions TEXT[],
+               ranges TEXT[],
+               table_size  TEXT,
+               index_size  TEXT,
+               toast_size  TEXT,
+               total_size  TEXT
+               )
+               LANGUAGE PLPGSQL STABLE
+               AS
+$BODY$
+DECLARE
+        table_name       NAME;
+        schema_name      NAME;
+BEGIN
+        SELECT relname, nspname
+        INTO STRICT table_name, schema_name
+        FROM pg_class c
+        INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
+        WHERE c.OID = main_table;
+
+        RETURN QUERY EXECUTE format(
+        $$
+
+        SELECT chunk_id,
+        chunk_table,
+        partitioning_columns,
+        partitioning_column_types,
+        partitioning_functions,
+        ranges,
+        pg_size_pretty(table_bytes) AS table,
+        pg_size_pretty(index_bytes) AS index,
+        pg_size_pretty(toast_bytes) AS toast,
+        pg_size_pretty(total_bytes) AS total
+        FROM (
+        SELECT *,
+              total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes
+              FROM (
+               SELECT c.id as chunk_id,
+               '"' || c.schema_name || '"."' || c.table_name || '"' as chunk_table,
+               pg_total_relation_size('"' || c.schema_name || '"."' || c.table_name || '"') AS total_bytes,
+               pg_indexes_size('"' || c.schema_name || '"."' || c.table_name || '"') AS index_bytes,
+               pg_total_relation_size(reltoastrelid) AS toast_bytes,
+               array_agg(d.column_name ORDER BY d.interval_length, d.column_name ASC) as partitioning_columns,
+               array_agg(d.column_type ORDER BY d.interval_length, d.column_name ASC) as partitioning_column_types,
+               array_agg(d.partitioning_func_schema || '.' || d.partitioning_func ORDER BY d.interval_length, d.column_name ASC) as partitioning_functions,
+               array_agg('[' || _timescaledb_internal.range_value_to_pretty(range_start, column_type) ||
+                         ',' ||
+                         _timescaledb_internal.range_value_to_pretty(range_end, column_type) || ')' ORDER BY d.interval_length, d.column_name ASC) as ranges
+               FROM
+               _timescaledb_catalog.hypertable h,
+               _timescaledb_catalog.chunk c,
+               _timescaledb_catalog.chunk_constraint cc,
+               _timescaledb_catalog.dimension d,
+               _timescaledb_catalog.dimension_slice ds,
+               pg_class pgc,
+               pg_namespace pns
+               WHERE h.schema_name = %L
+                     AND h.table_name = %L
+                     AND pgc.relname = h.table_name
+                     AND pns.oid = pgc.relnamespace
+                     AND pns.nspname = h.schema_name
+                     AND relkind = 'r'
+                     AND c.hypertable_id = h.id
+                     AND c.id = cc.chunk_id
+                     AND cc.dimension_slice_id = ds.id
+                     AND ds.dimension_id = d.id
+               GROUP BY c.id, pgc.reltoastrelid, pgc.oid ORDER BY c.id
+               ) sub1
+        ) sub2;
+        $$,
+        schema_name, table_name);
+
+END;
+$BODY$;
+
+
 -- Get sizes of indexes on a hypertable
 --
 -- main_table - hypertable to get index sizes of
@@ -188,15 +351,13 @@ $BODY$;
 -- Returns:
 -- index_name           - index on hyper table
 -- total_bytes          - size of index on disk
--- total_size           - pretty output of total_bytes
 
 CREATE OR REPLACE FUNCTION indexes_relation_size(
     main_table              REGCLASS
 )
 RETURNS TABLE (index_name TEXT,
-               total_bytes BIGINT,
-               total_size  TEXT) LANGUAGE PLPGSQL VOLATILE
-               SECURITY DEFINER SET search_path = ''
+               total_bytes BIGINT)
+               LANGUAGE PLPGSQL STABLE
                AS
 $BODY$
 DECLARE
@@ -212,8 +373,7 @@ BEGIN
         RETURN QUERY EXECUTE format(
         $$
         SELECT hi.main_schema_name || '.' || hi.main_index_name,
-               sum(pg_relation_size('"' || ci.schema_name || '"."' || ci.index_name || '"'))::bigint,
-               pg_size_pretty(sum(pg_relation_size('"' || ci.schema_name || '"."' || ci.index_name || '"')))
+               sum(pg_relation_size('"' || ci.schema_name || '"."' || ci.index_name || '"'))::bigint
         FROM
         _timescaledb_catalog.hypertable h,
         _timescaledb_catalog.hypertable_index hi,
@@ -227,5 +387,29 @@ BEGIN
         $$,
         schema_name, table_name);
 
+END;
+$BODY$;
+
+
+-- Get sizes of indexes on a hypertable
+--
+-- main_table - hypertable to get index sizes of
+--
+-- Returns:
+-- index_name           - index on hyper table
+-- total_size           - pretty output of total_bytes
+
+CREATE OR REPLACE FUNCTION indexes_relation_size_pretty(
+    main_table              REGCLASS
+)
+RETURNS TABLE (index_name_ TEXT,
+               total_size  TEXT) LANGUAGE PLPGSQL STABLE
+               AS
+$BODY$
+BEGIN
+        RETURN QUERY
+        SELECT index_name,
+               pg_size_pretty(total_bytes)
+        FROM indexes_relation_size(main_table);
 END;
 $BODY$;

--- a/sql/updates/pre-0.4.2--0.5.0-dev.sql
+++ b/sql/updates/pre-0.4.2--0.5.0-dev.sql
@@ -39,3 +39,7 @@ DROP FUNCTION _timescaledb_internal.rename_hypertable(name, name, text, text);
 ALTER EXTENSION timescaledb
 DROP FUNCTION create_hypertable(REGCLASS, NAME, NAME,INTEGER,NAME,NAME,BIGINT,BOOLEAN, BOOLEAN);
 DROP FUNCTION create_hypertable(REGCLASS, NAME, NAME,INTEGER,NAME,NAME,BIGINT,BOOLEAN, BOOLEAN);
+
+DROP FUNCTION IF EXISTS hypertable_relation_size(regclass);
+DROP FUNCTION IF EXISTS chunk_relation_size(regclass);
+DROP FUNCTION IF EXISTS indexes_relation_size(regclass);

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -17,20 +17,23 @@ WHERE OID IN (
     deptype = 'e' and classid = 'pg_catalog.pg_proc'::regclass
 ) AND pronamespace = 'public'::regnamespace
 ORDER BY proname;
-         proname          
---------------------------
+             proname             
+---------------------------------
  add_dimension
  attach_tablespace
  chunk_relation_size
+ chunk_relation_size_pretty
  create_hypertable
  drop_chunks
  first
  histogram
  hypertable_relation_size
+ hypertable_relation_size_pretty
  indexes_relation_size
+ indexes_relation_size_pretty
  last
  restore_timescaledb
  set_chunk_time_interval
  time_bucket
-(13 rows)
+(16 rows)
 

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -43,7 +43,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   127
+   132
 (1 row)
 
 \c postgres
@@ -67,7 +67,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   127
+   132
 (1 row)
 
 \c single

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -46,29 +46,102 @@ INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 INSERT 0 1
 \set QUIET on
 SELECT * FROM hypertable_relation_size('"public"."two_Partitions"');
- table_bytes | index_bytes | toast_bytes | total_bytes | table_size | index_size | toast_size | total_size 
--------------+-------------+-------------+-------------+------------+------------+------------+------------
-       32768 |      417792 |       32768 |      483328 | 32 kB      | 408 kB     | 32 kB      | 472 kB
+ table_bytes | index_bytes | toast_bytes | total_bytes 
+-------------+-------------+-------------+-------------
+       32768 |      417792 |       32768 |      483328
+(1 row)
+
+SELECT * FROM hypertable_relation_size_pretty('"public"."two_Partitions"');
+ table_size | index_size | toast_size | total_size 
+------------+------------+------------+------------
+ 32 kB      | 408 kB     | 32 kB      | 472 kB
 (1 row)
 
 SELECT * FROM chunk_relation_size('"public"."two_Partitions"');
- chunk_id |                chunk_table                 |       dimensions       |                                 ranges                                  | table_bytes | index_bytes | toast_bytes | total_bytes | table_size | index_size | toast_size | total_size 
-----------+--------------------------------------------+------------------------+-------------------------------------------------------------------------+-------------+-------------+-------------+-------------+------------+------------+------------+------------
-        1 | "_timescaledb_internal"."_hyper_1_1_chunk" | {timeCustom,device_id} | {"[1257892416000000000,1257895008000000000)","[1073741823,2147483647)"} |        8192 |      114688 |        8192 |      131072 | 8192 bytes | 112 kB     | 8192 bytes | 128 kB
-        2 | "_timescaledb_internal"."_hyper_1_2_chunk" | {timeCustom,device_id} | {"[1257897600000000000,1257900192000000000)","[1073741823,2147483647)"} |        8192 |      106496 |        8192 |      122880 | 8192 bytes | 104 kB     | 8192 bytes | 120 kB
-        3 | "_timescaledb_internal"."_hyper_1_3_chunk" | {timeCustom,device_id} | {"[1257985728000000000,1257988320000000000)","[1073741823,2147483647)"} |        8192 |       98304 |        8192 |      114688 | 8192 bytes | 96 kB      | 8192 bytes | 112 kB
-        4 | "_timescaledb_internal"."_hyper_1_4_chunk" | {timeCustom,device_id} | {"[1257892416000000000,1257895008000000000)","[0,1073741823)"}          |        8192 |       98304 |        8192 |      114688 | 8192 bytes | 96 kB      | 8192 bytes | 112 kB
+ chunk_id |                chunk_table                 |  partitioning_columns  | partitioning_column_types |            partitioning_hash_functions             |                                 ranges                                  | table_bytes | index_bytes | toast_bytes | total_bytes 
+----------+--------------------------------------------+------------------------+---------------------------+----------------------------------------------------+-------------------------------------------------------------------------+-------------+-------------+-------------+-------------
+        1 | "_timescaledb_internal"."_hyper_1_1_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1257892416000000000,1257895008000000000)","[1073741823,2147483647)"} |        8192 |      114688 |        8192 |      131072
+        2 | "_timescaledb_internal"."_hyper_1_2_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1257897600000000000,1257900192000000000)","[1073741823,2147483647)"} |        8192 |      106496 |        8192 |      122880
+        3 | "_timescaledb_internal"."_hyper_1_3_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1257985728000000000,1257988320000000000)","[1073741823,2147483647)"} |        8192 |       98304 |        8192 |      114688
+        4 | "_timescaledb_internal"."_hyper_1_4_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1257892416000000000,1257895008000000000)","[0,1073741823)"}          |        8192 |       98304 |        8192 |      114688
+(4 rows)
+
+SELECT * FROM chunk_relation_size_pretty('"public"."two_Partitions"');
+ chunk_id |                chunk_table                 |  partitioning_columns  | partitioning_column_types |            partitioning_hash_functions             |                                   ranges                                    | table_size | index_size | toast_size | total_size 
+----------+--------------------------------------------+------------------------+---------------------------+----------------------------------------------------+-----------------------------------------------------------------------------+------------+------------+------------+------------
+        1 | "_timescaledb_internal"."_hyper_1_1_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"['1257892416000000000','1257895008000000000')","[1073741823,2147483647)"} | 8192 bytes | 112 kB     | 8192 bytes | 128 kB
+        2 | "_timescaledb_internal"."_hyper_1_2_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"['1257897600000000000','1257900192000000000')","[1073741823,2147483647)"} | 8192 bytes | 104 kB     | 8192 bytes | 120 kB
+        3 | "_timescaledb_internal"."_hyper_1_3_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"['1257985728000000000','1257988320000000000')","[1073741823,2147483647)"} | 8192 bytes | 96 kB      | 8192 bytes | 112 kB
+        4 | "_timescaledb_internal"."_hyper_1_4_chunk" | {timeCustom,device_id} | {bigint,text}             | {NULL,_timescaledb_internal.get_partition_for_key} | {"['1257892416000000000','1257895008000000000')","[0,1073741823)"}          | 8192 bytes | 96 kB      | 8192 bytes | 112 kB
 (4 rows)
 
 SELECT * FROM indexes_relation_size('"public"."two_Partitions"');
-                    index_name                    | total_bytes | total_size 
---------------------------------------------------+-------------+------------
- public.two_Partitions_device_id_timeCustom_idx   |       65536 | 64 kB
- public.two_Partitions_timeCustom_device_id_idx   |       65536 | 64 kB
- public.two_Partitions_timeCustom_idx             |       65536 | 64 kB
- public.two_Partitions_timeCustom_series_0_idx    |       65536 | 64 kB
- public.two_Partitions_timeCustom_series_1_idx    |       65536 | 64 kB
- public.two_Partitions_timeCustom_series_2_idx    |       40960 | 40 kB
- public.two_Partitions_timeCustom_series_bool_idx |       49152 | 48 kB
+                    index_name                    | total_bytes 
+--------------------------------------------------+-------------
+ public.two_Partitions_device_id_timeCustom_idx   |       65536
+ public.two_Partitions_timeCustom_device_id_idx   |       65536
+ public.two_Partitions_timeCustom_idx             |       65536
+ public.two_Partitions_timeCustom_series_0_idx    |       65536
+ public.two_Partitions_timeCustom_series_1_idx    |       65536
+ public.two_Partitions_timeCustom_series_2_idx    |       40960
+ public.two_Partitions_timeCustom_series_bool_idx |       49152
 (7 rows)
+
+SELECT * FROM indexes_relation_size_pretty('"public"."two_Partitions"');
+                   index_name_                    | total_size 
+--------------------------------------------------+------------
+ public.two_Partitions_device_id_timeCustom_idx   | 64 kB
+ public.two_Partitions_timeCustom_device_id_idx   | 64 kB
+ public.two_Partitions_timeCustom_idx             | 64 kB
+ public.two_Partitions_timeCustom_series_0_idx    | 64 kB
+ public.two_Partitions_timeCustom_series_1_idx    | 64 kB
+ public.two_Partitions_timeCustom_series_2_idx    | 40 kB
+ public.two_Partitions_timeCustom_series_bool_idx | 48 kB
+(7 rows)
+
+CREATE TABLE timestamp_partitioned(time TIMESTAMP, value TEXT);
+SELECT * FROM create_hypertable('timestamp_partitioned', 'time', 'value', 2);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO timestamp_partitioned VALUES('2004-10-19 10:23:54', '10');
+INSERT INTO timestamp_partitioned VALUES('2004-12-19 10:23:54', '30');
+SELECT * FROM chunk_relation_size('timestamp_partitioned');
+ chunk_id |                chunk_table                 | partitioning_columns |      partitioning_column_types       |            partitioning_hash_functions             |                              ranges                               | table_bytes | index_bytes | toast_bytes | total_bytes 
+----------+--------------------------------------------+----------------------+--------------------------------------+----------------------------------------------------+-------------------------------------------------------------------+-------------+-------------+-------------+-------------
+        5 | "_timescaledb_internal"."_hyper_2_5_chunk" | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1096416000000000,1099008000000000)","[1073741823,2147483647)"} |        8192 |       32768 |        8192 |       49152
+        6 | "_timescaledb_internal"."_hyper_2_6_chunk" | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1101600000000000,1104192000000000)","[1073741823,2147483647)"} |        8192 |       32768 |        8192 |       49152
+(2 rows)
+
+SELECT * FROM chunk_relation_size_pretty('timestamp_partitioned');
+ chunk_id |                chunk_table                 | partitioning_columns |      partitioning_column_types       |            partitioning_hash_functions             |                                            ranges                                             | table_size | index_size | toast_size | total_size 
+----------+--------------------------------------------+----------------------+--------------------------------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+------------+------------+------------+------------
+        5 | "_timescaledb_internal"."_hyper_2_5_chunk" | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_for_key} | {"['Tue Sep 28 17:00:00 2004 PDT','Thu Oct 28 17:00:00 2004 PDT')","[1073741823,2147483647)"} | 8192 bytes | 32 kB      | 8192 bytes | 48 kB
+        6 | "_timescaledb_internal"."_hyper_2_6_chunk" | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_for_key} | {"['Sat Nov 27 16:00:00 2004 PST','Mon Dec 27 16:00:00 2004 PST')","[1073741823,2147483647)"} | 8192 bytes | 32 kB      | 8192 bytes | 48 kB
+(2 rows)
+
+CREATE TABLE timestamp_partitioned_2(time TIMESTAMP, value CHAR(9));
+SELECT * FROM create_hypertable('timestamp_partitioned_2', 'time', 'value', 2);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO timestamp_partitioned_2 VALUES('2004-10-19 10:23:54', '10');
+INSERT INTO timestamp_partitioned_2 VALUES('2004-12-19 10:23:54', '30');
+SELECT * FROM chunk_relation_size('timestamp_partitioned_2');
+ chunk_id |                chunk_table                 | partitioning_columns |         partitioning_column_types         |            partitioning_hash_functions             |                              ranges                               | table_bytes | index_bytes | toast_bytes | total_bytes 
+----------+--------------------------------------------+----------------------+-------------------------------------------+----------------------------------------------------+-------------------------------------------------------------------+-------------+-------------+-------------+-------------
+        7 | "_timescaledb_internal"."_hyper_3_7_chunk" | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1096416000000000,1099008000000000)","[1073741823,2147483647)"} |        8192 |       32768 |             |       40960
+        8 | "_timescaledb_internal"."_hyper_3_8_chunk" | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_for_key} | {"[1101600000000000,1104192000000000)","[1073741823,2147483647)"} |        8192 |       32768 |             |       40960
+(2 rows)
+
+SELECT * FROM chunk_relation_size_pretty('timestamp_partitioned_2');
+ chunk_id |                chunk_table                 | partitioning_columns |         partitioning_column_types         |            partitioning_hash_functions             |                                            ranges                                             | table_size | index_size | toast_size | total_size 
+----------+--------------------------------------------+----------------------+-------------------------------------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+------------+------------+------------+------------
+        7 | "_timescaledb_internal"."_hyper_3_7_chunk" | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_for_key} | {"['Tue Sep 28 17:00:00 2004 PDT','Thu Oct 28 17:00:00 2004 PDT')","[1073741823,2147483647)"} | 8192 bytes | 32 kB      |            | 40 kB
+        8 | "_timescaledb_internal"."_hyper_3_8_chunk" | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_for_key} | {"['Sat Nov 27 16:00:00 2004 PST','Mon Dec 27 16:00:00 2004 PST')","[1073741823,2147483647)"} | 8192 bytes | 32 kB      |            | 40 kB
+(2 rows)
 

--- a/test/sql/size_utils.sql
+++ b/test/sql/size_utils.sql
@@ -1,6 +1,25 @@
 \ir include/insert_two_partitions.sql
 
 SELECT * FROM hypertable_relation_size('"public"."two_Partitions"');
+SELECT * FROM hypertable_relation_size_pretty('"public"."two_Partitions"');
 SELECT * FROM chunk_relation_size('"public"."two_Partitions"');
+SELECT * FROM chunk_relation_size_pretty('"public"."two_Partitions"');
 SELECT * FROM indexes_relation_size('"public"."two_Partitions"');
+SELECT * FROM indexes_relation_size_pretty('"public"."two_Partitions"');
 
+CREATE TABLE timestamp_partitioned(time TIMESTAMP, value TEXT);
+SELECT * FROM create_hypertable('timestamp_partitioned', 'time', 'value', 2);
+
+INSERT INTO timestamp_partitioned VALUES('2004-10-19 10:23:54', '10');
+INSERT INTO timestamp_partitioned VALUES('2004-12-19 10:23:54', '30');
+SELECT * FROM chunk_relation_size('timestamp_partitioned');
+SELECT * FROM chunk_relation_size_pretty('timestamp_partitioned');
+
+
+CREATE TABLE timestamp_partitioned_2(time TIMESTAMP, value CHAR(9));
+SELECT * FROM create_hypertable('timestamp_partitioned_2', 'time', 'value', 2);
+
+INSERT INTO timestamp_partitioned_2 VALUES('2004-10-19 10:23:54', '10');
+INSERT INTO timestamp_partitioned_2 VALUES('2004-12-19 10:23:54', '30');
+SELECT * FROM chunk_relation_size('timestamp_partitioned_2');
+SELECT * FROM chunk_relation_size_pretty('timestamp_partitioned_2');


### PR DESCRIPTION
The hypertable, chunk, and index size functions are
now split into main function and a corresponding ´pretty´
function. In chunk_relation_size_pretty() the ranges are
now converted into a human readable form.