### PR TITLE
Add backup/restore scripts for single hypertables

### DIFF
--- a/scripts/ts_dump.sh
+++ b/scripts/ts_dump.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This script is used for backing up a single hypertable into an easy-to-restore
+# tarball. The tarball contains two files: (1) a .sql file for recreating the
+# hypertable and its indices and (2) a .csv file containing the data as CSV.
+#
+# Because pg_dump/pg_restore dump all of TimescaleDB's internal tables when
+# used, this script is useful if you want a backup that can be restored
+# regardless of TimescaleDB version running, or as part of a process where you
+# do not want to always backup all your hypertables at once.
+
+
+if [[ -z "$1" || -z "$2" ]]; then
+    echo "Usage: $0 hypertable output_name [pg_dump CONNECTION OPTIONS]"
+    echo "    hypertable  - Hypertable to backup"
+    echo "    output_name - Output files will be stored in an archive named [output_name].tar.gz"
+    echo "    "
+    echo "Any connection options for pg_dump/psql (e.g. -d database, -U username) should be listed at the end"
+    exit 1
+fi
+
+HYPERTABLE=$1
+PREFIX=$2
+
+shift 2
+set -e
+echo "Backing up schema as $PREFIX-schema.sql..."
+pg_dump $@ --schema-only -t $HYPERTABLE -f $PREFIX-schema.sql
+echo "--" >> $PREFIX-schema.sql
+echo "-- Restore to hypertable" >> $PREFIX-schema.sql
+echo "--" >> $PREFIX-schema.sql
+psql $@ -qAtX -c "SELECT _timescaledb_internal.get_create_command('$HYPERTABLE');" >> $PREFIX-schema.sql
+
+echo "Backing up data as $PREFIX-data.csv..."
+psql $@ -c "\COPY (SELECT * FROM $HYPERTABLE) TO $PREFIX-data.csv DELIMITER ',' CSV"
+
+echo "Archiving and removing previous files..."
+tar -czvf $PREFIX.tar.gz $PREFIX-data.csv $PREFIX-schema.sql
+rm $PREFIX-data.csv
+rm $PREFIX-schema.sql

--- a/scripts/ts_restore.sh
+++ b/scripts/ts_restore.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This script is used for restoring a hypertable from a tarball made with
+# ts_dump.sh. It unarchives the tarball, producing a schema file and data file,
+# which are then restore separately.
+
+
+if [[ -z "$1" || -z "$2" ]]; then
+    echo "Usage: $0 hypertable tarfile_name"
+    echo "    hypertable   - Hypertable to restore"
+    echo "    tarfile_name - Name of the tarball created by ts_dump.sh to restore"
+    echo "    "
+    echo "Any connection options for pg_restore/psql (e.g. -d database, -U username) should be listed at the end"
+    exit 1
+
+fi
+
+HYPERTABLE=$1
+TARFILE=$2
+PREFIX="${TARFILE/.tar.gz/}"
+shift 2
+echo "Unarchiving tarball..."
+tar xvzf $TARFILE
+
+echo "Restoring hypertable's schema..."
+psql -q -v "ON_ERROR_STOP=1" $@ < $PREFIX-schema.sql
+if [ $? -ne 0 ]; then
+    echo "Restoring schema failed, exiting."
+    rm $PREFIX-data.csv
+    rm $PREFIX-schema.sql
+    exit $?
+fi
+
+echo "Restoring hypertable's data..."
+psql $@ -v "ON_ERROR_STOP=1" -c "\COPY $HYPERTABLE FROM $PREFIX-data.csv DELIMITER ',' CSV"
+if [ $? -ne 0 ]; then
+    echo "Restoring data failed, exiting."
+fi
+
+rm $PREFIX-data.csv
+rm $PREFIX-schema.sql

--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -142,3 +142,69 @@ BEGIN
     END LOOP;
 END
 $BODY$;
+
+-- Outputs the create_hypertable command to recreate the given hypertable.
+--
+-- This is currently used internally for our single hypertable backup tool
+-- so that it knows how to restore the hypertable without user intervention.
+--
+-- It only works for hypertables with up to 2 dimensions.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.get_create_command(
+    table_name NAME
+)
+    RETURNS TEXT LANGUAGE PLPGSQL VOLATILE AS
+$BODY$
+DECLARE
+    h_id             INTEGER;
+    schema_name      NAME;
+    time_column      NAME;
+    time_interval    BIGINT;
+    space_column     NAME;
+    space_partitions INTEGER;
+    dimension_cnt    INTEGER;
+    dimension_row    record;
+    ret              TEXT;
+BEGIN
+    SELECT h.id, h.schema_name
+    FROM _timescaledb_catalog.hypertable AS h
+    WHERE h.table_name = get_create_command.table_name
+    INTO h_id, schema_name;
+
+    IF h_id IS NULL THEN
+        RAISE EXCEPTION 'hypertable % not found', table_name
+        USING ERRCODE = 'IO101';
+    END IF;
+
+    SELECT COUNT(*)
+    FROM _timescaledb_catalog.dimension d
+    WHERE d.hypertable_id = h_id
+    INTO STRICT dimension_cnt;
+
+    IF dimension_cnt > 2 THEN
+        RAISE EXCEPTION 'get_create_command only supports hypertables with up to 2 dimensions'
+        USING ERRCODE = 'IO101';
+    END IF;
+
+    FOR dimension_row IN
+        SELECT *
+        FROM _timescaledb_catalog.dimension d
+        WHERE d.hypertable_id = h_id
+        LOOP
+        IF dimension_row.interval_length IS NOT NULL THEN
+            time_column := dimension_row.column_name;
+            time_interval := dimension_row.interval_length;
+        ELSIF dimension_row.num_slices IS NOT NULL THEN
+            space_column := dimension_row.column_name;
+            space_partitions := dimension_row.num_slices;
+        END IF;
+    END LOOP;
+
+    ret := format($$SELECT create_hypertable('%I.%I', '%I'$$, schema_name, table_name, time_column);
+    IF space_column IS NOT NULL THEN
+        ret := ret || format($$, '%I', %s$$, space_column, space_partitions);
+    END IF;
+    ret := ret || format($$, chunk_time_interval => %s, create_default_indexes=>FALSE);$$, time_interval);
+
+    RETURN ret;
+END
+$BODY$;

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -8,6 +8,11 @@ CREATE EXTENSION IF NOT EXISTS timescaledb;
 SET timescaledb.disable_optimizations = :DISABLE_OPTIMIZATIONS;
 create schema test_schema;
 create table test_schema.test_table(time BIGINT, temp float8, device_id text, device_type text, location text, id int, id2 int);
+\set ON_ERROR_STOP 0
+-- get_create_command should fail since hypertable isn't made yet
+SELECT * FROM _timescaledb_internal.get_create_command('test_table');
+ERROR:  hypertable test_table not found
+\set ON_ERROR_STOP 1
 \dt "test_schema".*
               List of relations
    Schema    |    Name    | Type  |  Owner   
@@ -19,6 +24,12 @@ select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2
  create_hypertable 
 -------------------
  
+(1 row)
+
+SELECT * FROM _timescaledb_internal.get_create_command('test_table');
+                                                                 get_create_command                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_table', '"time"', 'device_id', 2, chunk_time_interval => 2592000000000, create_default_indexes=>FALSE);
 (1 row)
 
 --test adding one more closed dimension
@@ -42,6 +53,11 @@ select * from _timescaledb_catalog.dimension;
   3 |             1 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
 (3 rows)
 
+\set ON_ERROR_STOP 0
+-- get_create_command only works on tables w/ 1 or 2 dimensions
+SELECT * FROM _timescaledb_internal.get_create_command('test_table');
+ERROR:  get_create_command only supports hypertables with up to 2 dimensions
+\set ON_ERROR_STOP 1
 --test adding one more open dimension
 select add_dimension('test_schema.test_table', 'id', interval_length => 1000);
  add_dimension 
@@ -82,6 +98,12 @@ select create_hypertable('test_schema.test_1dim', 'time');
  create_hypertable 
 -------------------
  
+(1 row)
+
+SELECT * FROM _timescaledb_internal.get_create_command('test_1dim');
+                                                        get_create_command                                                         
+-----------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_1dim', '"time"', chunk_time_interval => 2592000000000, create_default_indexes=>FALSE);
 (1 row)
 
 \dt "test_schema".*

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -43,7 +43,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   120
+   121
 (1 row)
 
 \c postgres
@@ -67,7 +67,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   120
+   121
 (1 row)
 
 \c single


### PR DESCRIPTION
Using pg_dump/pg_restore for a database with hypertables will back
up all internal tables too, which is sometimes not desired. These
scripts allow one to backup regular PostgreSQL tables separately
and then pick and choose which hypertables to backup and restore.
This also provides a forward-compatible way of backing up and
restoring hypertables, since data is dumped to CSV and restored
by re-creating and re-inserting the data.