### PR TITLE
Forbid relocating extension after install.

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -79,12 +79,16 @@ static void
 process_alterobjectschema(Node *parsetree)
 {
 	AlterObjectSchemaStmt *alterstmt = (AlterObjectSchemaStmt *) parsetree;
-	Oid			relid = RangeVarGetRelid(alterstmt->relation, NoLock, true);
+	Oid			relid;
 	Cache	   *hcache;
 	Hypertable *ht;
 
-	if (!OidIsValid(relid) ||
-		alterstmt->objectType != OBJECT_TABLE)
+	if (alterstmt->objectType != OBJECT_TABLE)
+		return;
+
+	relid = RangeVarGetRelid(alterstmt->relation, NoLock, true);
+
+	if (!OidIsValid(relid))
 		return;
 
 	hcache = hypertable_cache_pin();

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -1,0 +1,33 @@
+SET client_min_messages = WARNING;
+DROP DATABASE IF EXISTS single;
+SET client_min_messages = NOTICE;
+CREATE DATABASE single;
+\c single
+CREATE SCHEMA "testSchema0";
+CREATE EXTENSION IF NOT EXISTS timescaledb SCHEMA "testSchema0";
+SET timescaledb.disable_optimizations = :DISABLE_OPTIMIZATIONS;
+CREATE TABLE test(time timestamp, temp float8, device text);
+SELECT "testSchema0".create_hypertable('test', 'time', 'device', 2);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.hypertable;
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions 
+----+-------------+------------+------------------------+-------------------------+----------------
+  1 | public      | test       | _timescaledb_internal  | _hyper_1                |              2
+(1 row)
+
+INSERT INTO test VALUES('Mon Mar 20 09:17:00.936242 2017', 23.4, 'dev1');
+SELECT * FROM test;
+              time               | temp | device 
+---------------------------------+------+--------
+ Mon Mar 20 09:17:00.936242 2017 | 23.4 | dev1
+(1 row)
+
+CREATE SCHEMA "testSchema";
+\set ON_ERROR_STOP 0
+ALTER EXTENSION timescaledb SET SCHEMA "testSchema";
+ERROR:  extension "timescaledb" does not support SET SCHEMA
+\set ON_ERROR_STOP 1

--- a/test/sql/relocate_extension.sql
+++ b/test/sql/relocate_extension.sql
@@ -1,0 +1,23 @@
+SET client_min_messages = WARNING;
+DROP DATABASE IF EXISTS single;
+SET client_min_messages = NOTICE;
+CREATE DATABASE single;
+
+\c single
+CREATE SCHEMA "testSchema0";
+CREATE EXTENSION IF NOT EXISTS timescaledb SCHEMA "testSchema0";
+SET timescaledb.disable_optimizations = :DISABLE_OPTIMIZATIONS;
+
+
+CREATE TABLE test(time timestamp, temp float8, device text);
+
+SELECT "testSchema0".create_hypertable('test', 'time', 'device', 2);
+SELECT * FROM _timescaledb_catalog.hypertable;
+INSERT INTO test VALUES('Mon Mar 20 09:17:00.936242 2017', 23.4, 'dev1');
+SELECT * FROM test;
+
+CREATE SCHEMA "testSchema";
+
+\set ON_ERROR_STOP 0
+ALTER EXTENSION timescaledb SET SCHEMA "testSchema";
+\set ON_ERROR_STOP 1

--- a/timescaledb.control
+++ b/timescaledb.control
@@ -2,4 +2,6 @@
 comment = 'Enables scalable inserts and complex queries for time-series data'
 default_version = '0.5.0-dev'
 module_pathname = '$libdir/timescaledb'
-relocatable = true
+#extension cannot be relocatable once installed because it uses multiple schemas and that is forbidden by PG.
+#(though this extension is relocatable during installation).
+relocatable = false


### PR DESCRIPTION
Unfortunately, Postgres forbids relocating the "public api" schema
of extensions that use multiple schemas after initial installation.
This PR marks the extension as not relocatable and tests relocation
during initial install.