### PR TITLE
Block adding constraints using an existing index

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -721,6 +721,12 @@ process_altertable(Node *parsetree)
 
 					Assert(IsA(cmd->def, Constraint));
 
+					if (stmt->indexname != NULL)
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("Hypertables currently does not support adding "
+								  "a constraint using an existing index.")));
+
 					process_altertable_add_constraint(ht, stmt->conname);
 				}
 

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -117,6 +117,14 @@ ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE (time);
 ERROR:  could not create unique index "4_3_hyper_unique_time_key"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_unique WHERE device_id = 'dev3';
+-- Try adding constraint using existing index
+CREATE UNIQUE INDEX ON hyper_unique (time);
+\set ON_ERROR_STOP 0
+ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE USING INDEX hyper_unique_time_idx;
+NOTICE:  ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "hyper_unique_time_idx" to "hyper_unique_time_key"
+ERROR:  Hypertables currently does not support adding a constraint using an existing index.
+\set ON_ERROR_STOP 1
+DROP INDEX hyper_unique_time_idx;
 --now can create
 ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE (time);
 \d+ _timescaledb_internal._hyper_2_4_chunk
@@ -273,12 +281,12 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000001, 'dev3', 11);
 --can't add fk because of dev3 row
 \set ON_ERROR_STOP 0
-ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey 
+ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (device_id) REFERENCES devices(device_id);
 ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_13_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_fk WHERE device_id = 'dev3';
-ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey 
+ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (device_id) REFERENCES devices(device_id);
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
@@ -311,7 +319,7 @@ CREATE TABLE referrer2 (
    time BIGINT NOT NULL
 );
 \set ON_ERROR_STOP 0
-ALTER TABLE referrer2 ADD CONSTRAINT hyper_fk_device_id_fkey 
+ALTER TABLE referrer2 ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (time) REFERENCES  hyper_for_ref(time);
 ERROR:  Foreign keys to hypertables are not supported.
 \set ON_ERROR_STOP 1

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -63,13 +63,21 @@ ALTER TABLE hyper_unique DROP CONSTRAINT hyper_unique_time_key;
 INSERT INTO hyper_unique(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev3', 11);
 
-
 --shouldn't be able to create constraint
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE (time);
 \set ON_ERROR_STOP 1
 
 DELETE FROM hyper_unique WHERE device_id = 'dev3';
+
+-- Try adding constraint using existing index
+CREATE UNIQUE INDEX ON hyper_unique (time);
+
+\set ON_ERROR_STOP 0
+ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE USING INDEX hyper_unique_time_idx;
+\set ON_ERROR_STOP 1
+
+DROP INDEX hyper_unique_time_idx;
 
 --now can create
 ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE (time);
@@ -190,13 +198,13 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 
 --can't add fk because of dev3 row
 \set ON_ERROR_STOP 0
-ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey 
+ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (device_id) REFERENCES devices(device_id);
 \set ON_ERROR_STOP 1
 
 DELETE FROM hyper_fk WHERE device_id = 'dev3';
 
-ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey 
+ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (device_id) REFERENCES devices(device_id);
 
 \set ON_ERROR_STOP 0
@@ -230,7 +238,7 @@ CREATE TABLE referrer2 (
 );
 
 \set ON_ERROR_STOP 0
-ALTER TABLE referrer2 ADD CONSTRAINT hyper_fk_device_id_fkey 
+ALTER TABLE referrer2 ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (time) REFERENCES  hyper_for_ref(time);
 \set ON_ERROR_STOP 1
 


### PR DESCRIPTION
Adding a constraint using an existing index changes the existing
index's name as a side effect (PostgreSQL wants the index name to
match the constraint name). This creates a mismatch between the
index's name and our metadata in the chunk_index table. Further, since
the name change happens as a result of an internal command (and not
via DDL command that we can capture) there is currently no way to sync
up this information.