### PR TITLE
Move logic from process utility hook to object access hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ SRCS = \
 	src/cache.c \
 	src/cache_invalidate.c \
 	src/process_utility.c \
+	src/object_access.c \
 	src/trigger.c \
 	src/chunk.c \
 	src/scanner.c \

--- a/src/init.c
+++ b/src/init.c
@@ -7,6 +7,7 @@
 
 #include "executor.h"
 #include "guc.h"
+#include "object_access.h"
 
 #define MIN_SUPPORTED_VERSION_STR "9.6"
 #define MIN_SUPPORTED_VERSION_NUM 90600
@@ -76,6 +77,7 @@ _PG_init(void)
 	_cache_invalidate_init();
 	_planner_init();
 	_executor_init();
+	_object_access_init();
 	_process_utility_init();
 	_guc_init();
 }
@@ -89,6 +91,7 @@ _PG_fini(void)
 	 */
 	_guc_fini();
 	_process_utility_fini();
+	_object_access_fini();
 	_executor_fini();
 	_planner_fini();
 	_cache_invalidate_fini();

--- a/src/object_access.c
+++ b/src/object_access.c
@@ -1,0 +1,144 @@
+#include <postgres.h>
+#include <catalog/objectaccess.h>
+#include <catalog/objectaddress.h>
+#include <catalog/pg_class.h>
+#include <access/sysattr.h>
+#include <access/genam.h>
+#include <access/htup_details.h>
+#include <utils/fmgroids.h>
+#include <utils/tqual.h>
+#include <utils/lsyscache.h>
+#include <utils/builtins.h>
+
+#include "object_access.h"
+#include "hypertable.h"
+#include "hypertable_cache.h"
+#include "catalog.h"
+#include "extension.h"
+
+#define rename_hypertable(old_schema_name, old_table_name, new_schema_name, new_table_name)		\
+	CatalogInternalCall4(DDL_RENAME_HYPERTABLE,							\
+						 DirectFunctionCall1(namein, CStringGetDatum(old_schema_name)), \
+						 NameGetDatum(&old_table_name), \
+						 DirectFunctionCall1(namein, CStringGetDatum(new_schema_name)), \
+						 NameGetDatum(&new_table_name))
+
+
+static object_access_hook_type prev_object_hook;
+
+static HeapTuple
+get_object_by_oid(Relation catalog, Oid objectId, Snapshot snapshot)
+{
+	HeapTuple	tuple;
+	Oid			classId = RelationGetRelid(catalog);
+
+	Oid			oidIndexId = get_object_oid_index(classId);
+	SysScanDesc scan;
+	ScanKeyData skey;
+
+	Assert(OidIsValid(oidIndexId));
+
+	ScanKeyInit(&skey,
+				ObjectIdAttributeNumber,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(objectId));
+
+	scan = systable_beginscan(catalog, oidIndexId, true,
+							  snapshot, 1, &skey);
+	tuple = systable_getnext(scan);
+	if (!HeapTupleIsValid(tuple))
+	{
+		systable_endscan(scan);
+		return NULL;
+	}
+	tuple = heap_copytuple(tuple);
+
+	systable_endscan(scan);
+
+	return tuple;
+}
+
+
+static void
+alter_table(Oid relid)
+{
+	if (!OidIsValid(relid))
+		return;
+
+	if (is_hypertable(relid))
+	{
+		Relation	rel = heap_open(RelationRelationId, AccessShareLock);
+		HeapTuple	oldtup = get_object_by_oid(rel, relid, NULL);
+		HeapTuple	newtup = get_object_by_oid(rel, relid, SnapshotSelf);
+		Form_pg_class old = (Form_pg_class) GETSTRUCT(oldtup);
+		Form_pg_class new = (Form_pg_class) GETSTRUCT(newtup);
+
+		if (strncmp(NameStr(old->relname), NameStr(new->relname), NAMEDATALEN) ||
+			old->relnamespace != new->relnamespace)
+		{
+			const char *old_ns = get_namespace_name(old->relnamespace);
+			const char *new_ns = get_namespace_name(new->relnamespace);
+
+			rename_hypertable(old_ns, old->relname, new_ns, new->relname);
+		}
+
+		heap_close(rel, AccessShareLock);
+	}
+}
+
+
+static void
+object_access_alter_hook(Oid classId,
+						 Oid objectId,
+						 int subId,
+						 void *arg)
+{
+	switch (classId)
+	{
+		case RelationRelationId:
+			alter_table(objectId);
+			break;
+		default:
+			break;
+
+	}
+}
+
+static
+void
+timescaledb_object_access(ObjectAccessType access,
+						  Oid classId,
+						  Oid objectId,
+						  int subId,
+						  void *arg)
+{
+	if (prev_object_hook != NULL)
+	{
+		prev_object_hook(access, classId, objectId, subId, arg);
+	}
+
+	if (!extension_is_loaded())
+		return;
+
+	switch (access)
+	{
+		case OAT_POST_ALTER:
+			object_access_alter_hook(classId, objectId, subId, arg);
+			break;
+		default:
+			break;
+	}
+}
+
+void
+_object_access_init(void)
+{
+	prev_object_hook = object_access_hook;
+	object_access_hook = timescaledb_object_access;
+}
+
+void
+_object_access_fini(void)
+{
+	object_access_hook = prev_object_hook;
+}

--- a/src/object_access.h
+++ b/src/object_access.h
@@ -1,0 +1,9 @@
+#ifndef TIMESCALEDB_OBJECT_ACCESS_H
+#define TIMESCALEDB_OBJECT_ACCESS_H
+
+#include <postgres.h>
+
+extern void _object_access_init(void);
+extern void _object_access_fini(void);
+
+#endif   /* TIMESCALEDB_OBJECT_ACCESS_H */

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -34,6 +34,8 @@ partitioning_info_set_textfunc_fmgr(PartitioningInfo *pi, Oid relid)
 
 	pi->column_attnum = get_attnum(relid, pi->column);
 	type_id = get_atttype(relid, pi->column_attnum);
+	if (!OidIsValid(type_id))
+		return;
 
 	/*
 	 * First look for an explicit cast type. Needed since the output of for

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -135,7 +135,7 @@ ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE (time);
  device_id | text    | not null  | extended |              | 
  sensor_1  | numeric | default 1 | main     |              | 
 Indexes:
-    "4_4_hyper_unique_time_key" UNIQUE CONSTRAINT, btree ("time")
+    "4_6_hyper_unique_time_key" UNIQUE CONSTRAINT, btree ("time")
 Check constraints:
     "constraint_4" CHECK ("time" >= '1257987700000000000'::bigint AND "time" < '1257987700000000010'::bigint)
     "hyper_unique_sensor_1_check" CHECK (sensor_1 > 10::numeric)
@@ -150,7 +150,7 @@ ERROR:  relation "hyper_unique_time_key" already exists
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_unique(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  duplicate key value violates unique constraint "4_4_hyper_unique_time_key"
+ERROR:  duplicate key value violates unique constraint "4_6_hyper_unique_time_key"
 \set ON_ERROR_STOP 1
 --cannot create unique constraint on non-partition column
 \set ON_ERROR_STOP 0
@@ -174,7 +174,7 @@ INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  duplicate key value violates unique constraint "6_6_hyper_pk_pkey"
+ERROR:  duplicate key value violates unique constraint "6_8_hyper_pk_pkey"
 \set ON_ERROR_STOP 1
 --should have unique constraint not just unique index
 \d+ _timescaledb_internal._hyper_3_6_chunk
@@ -185,7 +185,7 @@ ERROR:  duplicate key value violates unique constraint "6_6_hyper_pk_pkey"
  device_id | text    | not null  | extended |              | 
  sensor_1  | numeric | default 1 | main     |              | 
 Indexes:
-    "6_6_hyper_pk_pkey" PRIMARY KEY, btree ("time")
+    "6_8_hyper_pk_pkey" PRIMARY KEY, btree ("time")
 Check constraints:
     "constraint_6" CHECK ("time" >= '1257987700000000000'::bigint AND "time" < '1257987700000000010'::bigint)
     "hyper_pk_sensor_1_check" CHECK (sensor_1 > 10::numeric)
@@ -210,7 +210,7 @@ INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 --shouldn't be able to create pk
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_pk ADD CONSTRAINT hyper_pk_pkey PRIMARY KEY (time);
-ERROR:  could not create unique index "6_7_hyper_pk_pkey"
+ERROR:  could not create unique index "6_9_hyper_pk_pkey"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_pk WHERE device_id = 'dev3';
 --cannot create pk constraint on non-partition column
@@ -228,7 +228,7 @@ ALTER TABLE hyper_pk ADD CONSTRAINT hyper_pk_pkey PRIMARY KEY (time);
  device_id | text    | not null  | extended |              | 
  sensor_1  | numeric | default 1 | main     |              | 
 Indexes:
-    "6_8_hyper_pk_pkey" PRIMARY KEY, btree ("time")
+    "6_10_hyper_pk_pkey" PRIMARY KEY, btree ("time")
 Check constraints:
     "constraint_6" CHECK ("time" >= '1257987700000000000'::bigint AND "time" < '1257987700000000010'::bigint)
     "hyper_pk_sensor_1_check" CHECK (sensor_1 > 10::numeric)
@@ -243,7 +243,7 @@ ERROR:  relation "hyper_pk_pkey" already exists
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  duplicate key value violates unique constraint "6_8_hyper_pk_pkey"
+ERROR:  duplicate key value violates unique constraint "6_10_hyper_pk_pkey"
 \set ON_ERROR_STOP 1
 ----------------------- FOREIGN KEY  ------------------
 CREATE TABLE devices(
@@ -265,7 +265,7 @@ SELECT * FROM create_hypertable('hyper_fk', 'time', chunk_time_interval => 10);
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  insert or update on table "_hyper_4_7_chunk" violates foreign key constraint "7_10_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_7_chunk" violates foreign key constraint "7_12_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 INSERT INTO devices VALUES ('dev2');
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
@@ -273,7 +273,7 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 --delete should fail
 \set ON_ERROR_STOP 0
 DELETE FROM devices;
-ERROR:  update or delete on table "devices" violates foreign key constraint "8_12_hyper_fk_device_id_fkey" on table "_hyper_4_8_chunk"
+ERROR:  update or delete on table "devices" violates foreign key constraint "8_14_hyper_fk_device_id_fkey" on table "_hyper_4_8_chunk"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_fk DROP CONSTRAINT hyper_fk_device_id_fkey;
 --should now be able to add non-fk rows
@@ -283,7 +283,7 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (device_id) REFERENCES devices(device_id);
-ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_13_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_15_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_fk WHERE device_id = 'dev3';
 ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
@@ -291,7 +291,7 @@ FOREIGN KEY (device_id) REFERENCES devices(device_id);
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000002, 'dev3', 11);
-ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_14_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_16_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 ----------------------- FOREIGN KEY INTO A HYPERTABLE  ------------------
 --FOREIGN KEY references into a hypertable are currently broken.
@@ -344,7 +344,7 @@ INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_15_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_18_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_ex DROP CONSTRAINT hyper_ex_time_device_id_excl;
 --can now add
@@ -357,7 +357,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
         time WITH =, device_id WITH =
     ) WHERE (not canceled)
 ;
-ERROR:  could not create exclusion constraint "9_17_hyper_ex_time_device_id_excl"
+ERROR:  could not create exclusion constraint "9_19_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_ex WHERE sensor_1 = 12;
 ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
@@ -368,7 +368,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_18_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_20_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 --cannot add exclusion constraint without partition key.
 CREATE TABLE hyper_ex_invalid (
@@ -383,4 +383,39 @@ CREATE TABLE hyper_ex_invalid (
 \set ON_ERROR_STOP 0
 SELECT * FROM create_hypertable('hyper_ex_invalid', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  Cannot create a unique index without the column: time (used in partitioning)
+\set ON_ERROR_STOP 1
+---alter without constraint names ---
+CREATE TABLE hyper_unique_default_name (
+  time BIGINT NOT NULL,
+  device_id TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
+);
+SELECT * FROM create_hypertable('hyper_unique_default_name', 'time', chunk_time_interval => 10);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO hyper_unique_default_name(time, device_id,sensor_1) VALUES
+(1257987700000000000, 'dev2', 11);
+ALTER TABLE hyper_unique_default_name ADD UNIQUE (time);
+\d+ hyper_unique_default_name
+                Table "public.hyper_unique_default_name"
+  Column   |  Type   | Modifiers | Storage  | Stats target | Description 
+-----------+---------+-----------+----------+--------------+-------------
+ time      | bigint  | not null  | plain    |              | 
+ device_id | text    | not null  | extended |              | 
+ sensor_1  | numeric | default 1 | main     |              | 
+Indexes:
+    "hyper_unique_default_name_time_key" UNIQUE CONSTRAINT, btree ("time")
+    "hyper_unique_default_name_time_idx" btree ("time" DESC)
+Check constraints:
+    "hyper_unique_default_name_sensor_1_check" CHECK (sensor_1 > 10::numeric)
+Child tables: _timescaledb_internal._hyper_8_10_chunk
+
+--uniquness violation fails
+\set ON_ERROR_STOP 0
+INSERT INTO hyper_unique_default_name(time, device_id,sensor_1) VALUES
+(1257987700000000000, 'dev2', 11);
+ERROR:  duplicate key value violates unique constraint "10_21_hyper_unique_default_name_time_key"
 \set ON_ERROR_STOP 1

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -307,3 +307,28 @@ CREATE TABLE hyper_ex_invalid (
 \set ON_ERROR_STOP 0
 SELECT * FROM create_hypertable('hyper_ex_invalid', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set ON_ERROR_STOP 1
+
+---alter without constraint names ---
+
+CREATE TABLE hyper_unique_default_name (
+  time BIGINT NOT NULL,
+  device_id TEXT NOT NULL,
+  sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
+);
+
+
+SELECT * FROM create_hypertable('hyper_unique_default_name', 'time', chunk_time_interval => 10);
+
+INSERT INTO hyper_unique_default_name(time, device_id,sensor_1) VALUES
+(1257987700000000000, 'dev2', 11);
+
+ALTER TABLE hyper_unique_default_name ADD UNIQUE (time);
+
+\d+ hyper_unique_default_name
+--uniquness violation fails
+\set ON_ERROR_STOP 0
+INSERT INTO hyper_unique_default_name(time, device_id,sensor_1) VALUES
+(1257987700000000000, 'dev2', 11);
+\set ON_ERROR_STOP 1
+
+


### PR DESCRIPTION
The object access hook is always called when catalog objects are
changed. This is a much safer way of intercepting changes than the
processUtility hooks since in the latter there may be multiple paths
by which an object can change and there is more risk to missing a path.
This change and the following commits making similar changes thus makes
the code much more robust.