### PR TITLE
Block adding constraints without a constraint name

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -739,6 +739,12 @@ process_altertable(Node *parsetree)
 								 errmsg("Hypertables currently does not support adding "
 								  "a constraint using an existing index.")));
 
+					if (stmt->conname == NULL)
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("Adding a constraint to a hypertable without a "
+									  "constraint name is not supported.")));
+
 					process_altertable_add_constraint(ht, stmt->conname);
 				}
 

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -117,12 +117,15 @@ ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE (time);
 ERROR:  could not create unique index "4_3_hyper_unique_time_key"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_unique WHERE device_id = 'dev3';
--- Try adding constraint using existing index
 CREATE UNIQUE INDEX ON hyper_unique (time);
 \set ON_ERROR_STOP 0
+-- Try adding constraint using existing index
 ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE USING INDEX hyper_unique_time_idx;
 NOTICE:  ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "hyper_unique_time_idx" to "hyper_unique_time_key"
 ERROR:  Hypertables currently does not support adding a constraint using an existing index.
+-- Try to add constraint without a name
+ALTER TABLE hyper_unique ADD UNIQUE (time);
+ERROR:  Adding a constraint to a hypertable without a constraint name is not supported.
 \set ON_ERROR_STOP 1
 DROP INDEX hyper_unique_time_idx;
 --now can create

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -70,11 +70,15 @@ ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE (time);
 
 DELETE FROM hyper_unique WHERE device_id = 'dev3';
 
--- Try adding constraint using existing index
+
 CREATE UNIQUE INDEX ON hyper_unique (time);
 
 \set ON_ERROR_STOP 0
+-- Try adding constraint using existing index
 ALTER TABLE hyper_unique ADD CONSTRAINT hyper_unique_time_key UNIQUE USING INDEX hyper_unique_time_idx;
+
+-- Try to add constraint without a name
+ALTER TABLE hyper_unique ADD UNIQUE (time);
 \set ON_ERROR_STOP 1
 
 DROP INDEX hyper_unique_time_idx;


### PR DESCRIPTION
The current approach of handling alter table commands does not allow
getting the result of the command; for instance, the object address of
a created constraint on a hypertable. Thus there is no way to get the
auto-generated name of a constraint, which is needed when the
corresponding constraints are created on the hypertable's chunks.

Therefore, this change blocks the ability to create constraints
without an explicit name. When a better approach to handling alter
table is deviced, it is possible to remove this restriction.