### PR TITLE
Fix constraint validation on regular tables

### DIFF
--- a/test/expected/create_table.out
+++ b/test/expected/create_table.out
@@ -1,0 +1,23 @@
+\ir include/create_single_db.sql
+SET client_min_messages = WARNING;
+DROP DATABASE IF EXISTS single;
+SET client_min_messages = NOTICE;
+CREATE DATABASE single;
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+SET timescaledb.disable_optimizations = :DISABLE_OPTIMIZATIONS;
+-- Test that we can verify constraints on regular tables
+CREATE TABLE test_hyper_pk(time TIMESTAMPTZ PRIMARY KEY, temp FLOAT, device INT);
+CREATE TABLE test_pk(device INT PRIMARY KEY);
+CREATE TABLE test_like(LIKE test_pk);
+SELECT create_hypertable('test_hyper_pk', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- Foreign key constraints that reference hypertables are currently unsupported
+CREATE TABLE test_fk(time TIMESTAMPTZ REFERENCES test_hyper_pk(time));
+ERROR:  Foreign keys to hypertables are not supported.
+\set ON_ERROR_STOP 1

--- a/test/sql/create_table.sql
+++ b/test/sql/create_table.sql
@@ -1,0 +1,13 @@
+\ir include/create_single_db.sql
+
+-- Test that we can verify constraints on regular tables
+CREATE TABLE test_hyper_pk(time TIMESTAMPTZ PRIMARY KEY, temp FLOAT, device INT);
+CREATE TABLE test_pk(device INT PRIMARY KEY);
+CREATE TABLE test_like(LIKE test_pk);
+
+SELECT create_hypertable('test_hyper_pk', 'time');
+
+\set ON_ERROR_STOP 0
+-- Foreign key constraints that reference hypertables are currently unsupported
+CREATE TABLE test_fk(time TIMESTAMPTZ REFERENCES test_hyper_pk(time));
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Constraints on regular PostgreSQL tables need to be validatated so
that they don't have a foreign key constraint that references a
hypertable, as this is not yet supported. This change fixes a bug in
this validation caused by not checking for the proper node types when
parsing a CreateStmt node. The CreateStmt is now also parsed in the
DDL end hook, instead of the processUtility hook, which ensures that
the CreateStmt node has been run through parse analysis. The parse
analysis changes the contents of the node to be more consistent across
different CREATE statements. For instance, a CREATE LIKE statement
will look more similar to a regular CREATE statement after parse
analysis.