### PR TITLE
Fix INSERT on hypertables using sub-selects with aggregates

### DIFF
--- a/src/chunk_dispatch_plan.c
+++ b/src/chunk_dispatch_plan.c
@@ -5,6 +5,7 @@
 #include <nodes/readfuncs.h>
 #include <utils/rel.h>
 #include <catalog/pg_type.h>
+#include <rewrite/rewriteManip.h>
 
 #include "chunk_dispatch_plan.h"
 #include "chunk_dispatch_state.h"
@@ -27,6 +28,84 @@ static CustomScanMethods chunk_dispatch_plan_methods = {
 	.CreateCustomScanState = create_chunk_dispatch_state,
 };
 
+/*
+ * Build a target list for a CustomScan node.
+ *
+ * The CustomScan node needs to provide a modified target list in case of
+ * subplan nodes that have target lists with expressions that involve, e.g.,
+ * aggregates. Such target lists need a matching parent node type (e.g., a
+ * target list with an AggDef needs a Agg node parent). If we simply use the
+ * subplan's target list on a CustomScan parent node, there might be a mismatch.
+ *
+ * The code here is similar to ExecCheckPlanOutput() in nodeModifyTable.c in the
+ * PostgreSQL source code, but here we construct a modified target list for the
+ * CustomScan node instead of simply just checking validity.
+ *
+ */
+static List *
+build_customscan_targetlist(Relation rel, List *targetlist)
+{
+	TupleDesc	tupdesc = RelationGetDescr(rel);
+	List	   *new_targetlist = NIL;
+	ListCell   *lc;
+	int			attno = 0;
+
+	foreach(lc, targetlist)
+	{
+		TargetEntry *te = lfirst(lc);
+		Form_pg_attribute attr;
+		Expr	   *expr;
+
+		/* Ignore junk items */
+		if (te->resjunk)
+			continue;
+
+		if (attno >= tupdesc->natts)
+			ereport(ERROR,
+					(errcode(ERRCODE_DATATYPE_MISMATCH),
+					 errmsg("table row type and query-specified row type do not match"),
+					 errdetail("Query has too many columns.")));
+
+		attr = tupdesc->attrs[attno++];
+
+		if (attr->attisdropped)
+			expr = &makeConst(INT4OID,
+							  -1,
+							  InvalidOid,
+							  sizeof(int32),
+							  (Datum) 0,
+							  true,
+							  true)->xpr;
+		else
+
+			/*
+			 * According to nodes/primnodes.h, the INDEX_VAR Var type is
+			 * abused in CustomScan nodes to reference custom scan tuple
+			 * types.
+			 */
+			expr = &makeVar(INDEX_VAR,
+							attno,
+							exprType((Node *) te->expr),
+							exprTypmod((Node *) te->expr),
+							exprCollation((Node *) te->expr),
+							0)->xpr;
+
+		new_targetlist = lappend(new_targetlist,
+								 makeTargetEntry(expr,
+												 attno,
+												 NULL,
+												 te->resjunk));
+	}
+
+	if (attno != tupdesc->natts)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+		  errmsg("table row type and query-specified row type do not match"),
+				 errdetail("Query has too few columns.")));
+
+	return new_targetlist;
+}
+
 /* Create a chunk dispatch plan node in the form of a CustomScan node. The
  * purpose of this plan node is to dispatch (route) tuples to the correct chunk
  * in a hypertable.
@@ -42,10 +121,11 @@ static CustomScanMethods chunk_dispatch_plan_methods = {
  * node.
  */
 CustomScan *
-chunk_dispatch_plan_create(Plan *subplan, Oid hypertable_relid, Query *parse)
+chunk_dispatch_plan_create(Plan *subplan, Index hypertable_rti, Oid hypertable_relid, Query *parse)
 {
 	CustomScan *cscan = makeNode(CustomScan);
 	ChunkDispatchInfo *info = chunk_dispatch_info_create(hypertable_relid, parse);
+	Relation	rel;
 
 	cscan->custom_private = list_make1(info);
 	cscan->methods = &chunk_dispatch_plan_methods;
@@ -60,11 +140,20 @@ chunk_dispatch_plan_create(Plan *subplan, Oid hypertable_relid, Query *parse)
 	cscan->scan.plan.plan_width = subplan->plan_width;
 
 	/*
-	 * Copy target list from parent table. This should work since hypertables
-	 * mandate that chunks have identical column definitions
+	 * Create a modified target list for the CustomScan based on the subplan's
+	 * original target list
 	 */
-	cscan->scan.plan.targetlist = subplan->targetlist;
-	cscan->custom_scan_tlist = NIL;
+	rel = relation_open(hypertable_relid, AccessShareLock);
+	cscan->scan.plan.targetlist = build_customscan_targetlist(rel, subplan->targetlist);
+	RelationClose(rel);
+
+	/*
+	 * We need to set a custom_scan_tlist for EXPLAIN (verbose). But this
+	 * target list needs to reference the proper rangetable entry so we must
+	 * replace all INDEX_VAR attnos with the hypertable's rangetable index.
+	 */
+	cscan->custom_scan_tlist = copyObject(cscan->scan.plan.targetlist);
+	ChangeVarNodes((Node *) cscan->custom_scan_tlist, INDEX_VAR, hypertable_rti, 0);
 
 	return cscan;
 }

--- a/src/chunk_dispatch_plan.h
+++ b/src/chunk_dispatch_plan.h
@@ -6,6 +6,6 @@
 #include <nodes/parsenodes.h>
 #include <nodes/extensible.h>
 
-extern CustomScan *chunk_dispatch_plan_create(Plan *subplan, Oid hypertable_relid, Query *parse);
+extern CustomScan *chunk_dispatch_plan_create(Plan *subplan, Index hypertable_rti, Oid hypertable_relid, Query *parse);
 
 #endif   /* TIMESCALEDB_CHUNK_DISPATCH_PLAN_H */

--- a/src/planner.c
+++ b/src/planner.c
@@ -382,7 +382,8 @@ modifytable_plan_walker(Plan **planptr, void *pctx)
 			 */
 			forboth(lc_plan, mt->plans, lc_rel, mt->resultRelations)
 			{
-				RangeTblEntry *rte = rt_fetch(lfirst_int(lc_rel), ctx->rtable);
+				Index		rti = lfirst_int(lc_rel);
+				RangeTblEntry *rte = rt_fetch(rti, ctx->rtable);
 				Hypertable *ht = hypertable_cache_get_entry(ctx->hcache, rte->relid);
 
 				if (ht != NULL)
@@ -394,7 +395,7 @@ modifytable_plan_walker(Plan **planptr, void *pctx)
 					 * We replace the plan with our custom chunk dispatch
 					 * plan.
 					 */
-					*subplan_ptr = chunk_dispatch_plan_create(subplan, rte->relid, ctx->parse);
+					*subplan_ptr = chunk_dispatch_plan_create(subplan, rti, rte->relid, ctx->parse);
 					hypertable_found = true;
 				}
 			}

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -368,7 +368,7 @@ SELECT create_hypertable('error_test', 'time', 'device', 2);
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:20.1 2017', 21.3, 'dev1');
 INSERT 0 1
 \set ON_ERROR_STOP 0
--- generate insert error 
+-- generate insert error
 INSERT INTO error_test VALUES ('Mon Mar 20 09:18:22.3 2017', 21.1, NULL);
 ERROR:  null value in column "device" violates not-null constraint
 \set ON_ERROR_STOP 1
@@ -450,4 +450,407 @@ SELECT * FROM date_col_test WHERE time > '2001-01-01';
  02-01-2001 |   98 | dev1
  03-02-2001 |   98 | dev1
 (2 rows)
+
+CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+EXPLAIN (verbose on, costs off)
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on public.many_partitions_test_1m
+         ->  Custom Scan (ChunkDispatch)
+               Output: many_partitions_test_1m."time", many_partitions_test_1m.temp, many_partitions_test_1m.device
+               ->  HashAggregate
+                     Output: (time_bucket('@ 1 min'::interval, many_partitions_test."time")), avg(many_partitions_test.temp), many_partitions_test.device
+                     Group Key: time_bucket('@ 1 min'::interval, many_partitions_test."time"), many_partitions_test.device
+                     ->  Result
+                           Output: time_bucket('@ 1 min'::interval, many_partitions_test."time"), many_partitions_test.device, many_partitions_test.temp
+                           ->  Append
+                                 ->  Seq Scan on public.many_partitions_test
+                                       Output: many_partitions_test."time", many_partitions_test.temp, many_partitions_test.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_9_chunk
+                                       Output: _hyper_4_9_chunk."time", _hyper_4_9_chunk.temp, _hyper_4_9_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_10_chunk
+                                       Output: _hyper_4_10_chunk."time", _hyper_4_10_chunk.temp, _hyper_4_10_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_11_chunk
+                                       Output: _hyper_4_11_chunk."time", _hyper_4_11_chunk.temp, _hyper_4_11_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_12_chunk
+                                       Output: _hyper_4_12_chunk."time", _hyper_4_12_chunk.temp, _hyper_4_12_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_13_chunk
+                                       Output: _hyper_4_13_chunk."time", _hyper_4_13_chunk.temp, _hyper_4_13_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_14_chunk
+                                       Output: _hyper_4_14_chunk."time", _hyper_4_14_chunk.temp, _hyper_4_14_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_15_chunk
+                                       Output: _hyper_4_15_chunk."time", _hyper_4_15_chunk.temp, _hyper_4_15_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_16_chunk
+                                       Output: _hyper_4_16_chunk."time", _hyper_4_16_chunk.temp, _hyper_4_16_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_17_chunk
+                                       Output: _hyper_4_17_chunk."time", _hyper_4_17_chunk.temp, _hyper_4_17_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_18_chunk
+                                       Output: _hyper_4_18_chunk."time", _hyper_4_18_chunk.temp, _hyper_4_18_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_19_chunk
+                                       Output: _hyper_4_19_chunk."time", _hyper_4_19_chunk.temp, _hyper_4_19_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_20_chunk
+                                       Output: _hyper_4_20_chunk."time", _hyper_4_20_chunk.temp, _hyper_4_20_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_21_chunk
+                                       Output: _hyper_4_21_chunk."time", _hyper_4_21_chunk.temp, _hyper_4_21_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_22_chunk
+                                       Output: _hyper_4_22_chunk."time", _hyper_4_22_chunk.temp, _hyper_4_22_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_23_chunk
+                                       Output: _hyper_4_23_chunk."time", _hyper_4_23_chunk.temp, _hyper_4_23_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_24_chunk
+                                       Output: _hyper_4_24_chunk."time", _hyper_4_24_chunk.temp, _hyper_4_24_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_25_chunk
+                                       Output: _hyper_4_25_chunk."time", _hyper_4_25_chunk.temp, _hyper_4_25_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_26_chunk
+                                       Output: _hyper_4_26_chunk."time", _hyper_4_26_chunk.temp, _hyper_4_26_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_27_chunk
+                                       Output: _hyper_4_27_chunk."time", _hyper_4_27_chunk.temp, _hyper_4_27_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_28_chunk
+                                       Output: _hyper_4_28_chunk."time", _hyper_4_28_chunk.temp, _hyper_4_28_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_29_chunk
+                                       Output: _hyper_4_29_chunk."time", _hyper_4_29_chunk.temp, _hyper_4_29_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_30_chunk
+                                       Output: _hyper_4_30_chunk."time", _hyper_4_30_chunk.temp, _hyper_4_30_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_31_chunk
+                                       Output: _hyper_4_31_chunk."time", _hyper_4_31_chunk.temp, _hyper_4_31_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_32_chunk
+                                       Output: _hyper_4_32_chunk."time", _hyper_4_32_chunk.temp, _hyper_4_32_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_33_chunk
+                                       Output: _hyper_4_33_chunk."time", _hyper_4_33_chunk.temp, _hyper_4_33_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_34_chunk
+                                       Output: _hyper_4_34_chunk."time", _hyper_4_34_chunk.temp, _hyper_4_34_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_35_chunk
+                                       Output: _hyper_4_35_chunk."time", _hyper_4_35_chunk.temp, _hyper_4_35_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_36_chunk
+                                       Output: _hyper_4_36_chunk."time", _hyper_4_36_chunk.temp, _hyper_4_36_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_37_chunk
+                                       Output: _hyper_4_37_chunk."time", _hyper_4_37_chunk.temp, _hyper_4_37_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_38_chunk
+                                       Output: _hyper_4_38_chunk."time", _hyper_4_38_chunk.temp, _hyper_4_38_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_39_chunk
+                                       Output: _hyper_4_39_chunk."time", _hyper_4_39_chunk.temp, _hyper_4_39_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_40_chunk
+                                       Output: _hyper_4_40_chunk."time", _hyper_4_40_chunk.temp, _hyper_4_40_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_41_chunk
+                                       Output: _hyper_4_41_chunk."time", _hyper_4_41_chunk.temp, _hyper_4_41_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_42_chunk
+                                       Output: _hyper_4_42_chunk."time", _hyper_4_42_chunk.temp, _hyper_4_42_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_43_chunk
+                                       Output: _hyper_4_43_chunk."time", _hyper_4_43_chunk.temp, _hyper_4_43_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_44_chunk
+                                       Output: _hyper_4_44_chunk."time", _hyper_4_44_chunk.temp, _hyper_4_44_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_45_chunk
+                                       Output: _hyper_4_45_chunk."time", _hyper_4_45_chunk.temp, _hyper_4_45_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_46_chunk
+                                       Output: _hyper_4_46_chunk."time", _hyper_4_46_chunk.temp, _hyper_4_46_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_47_chunk
+                                       Output: _hyper_4_47_chunk."time", _hyper_4_47_chunk.temp, _hyper_4_47_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_48_chunk
+                                       Output: _hyper_4_48_chunk."time", _hyper_4_48_chunk.temp, _hyper_4_48_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_49_chunk
+                                       Output: _hyper_4_49_chunk."time", _hyper_4_49_chunk.temp, _hyper_4_49_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_50_chunk
+                                       Output: _hyper_4_50_chunk."time", _hyper_4_50_chunk.temp, _hyper_4_50_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_51_chunk
+                                       Output: _hyper_4_51_chunk."time", _hyper_4_51_chunk.temp, _hyper_4_51_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_52_chunk
+                                       Output: _hyper_4_52_chunk."time", _hyper_4_52_chunk.temp, _hyper_4_52_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_53_chunk
+                                       Output: _hyper_4_53_chunk."time", _hyper_4_53_chunk.temp, _hyper_4_53_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_54_chunk
+                                       Output: _hyper_4_54_chunk."time", _hyper_4_54_chunk.temp, _hyper_4_54_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_55_chunk
+                                       Output: _hyper_4_55_chunk."time", _hyper_4_55_chunk.temp, _hyper_4_55_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_56_chunk
+                                       Output: _hyper_4_56_chunk."time", _hyper_4_56_chunk.temp, _hyper_4_56_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_57_chunk
+                                       Output: _hyper_4_57_chunk."time", _hyper_4_57_chunk.temp, _hyper_4_57_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_58_chunk
+                                       Output: _hyper_4_58_chunk."time", _hyper_4_58_chunk.temp, _hyper_4_58_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_59_chunk
+                                       Output: _hyper_4_59_chunk."time", _hyper_4_59_chunk.temp, _hyper_4_59_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_60_chunk
+                                       Output: _hyper_4_60_chunk."time", _hyper_4_60_chunk.temp, _hyper_4_60_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_61_chunk
+                                       Output: _hyper_4_61_chunk."time", _hyper_4_61_chunk.temp, _hyper_4_61_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_62_chunk
+                                       Output: _hyper_4_62_chunk."time", _hyper_4_62_chunk.temp, _hyper_4_62_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_63_chunk
+                                       Output: _hyper_4_63_chunk."time", _hyper_4_63_chunk.temp, _hyper_4_63_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_64_chunk
+                                       Output: _hyper_4_64_chunk."time", _hyper_4_64_chunk.temp, _hyper_4_64_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_65_chunk
+                                       Output: _hyper_4_65_chunk."time", _hyper_4_65_chunk.temp, _hyper_4_65_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_66_chunk
+                                       Output: _hyper_4_66_chunk."time", _hyper_4_66_chunk.temp, _hyper_4_66_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_67_chunk
+                                       Output: _hyper_4_67_chunk."time", _hyper_4_67_chunk.temp, _hyper_4_67_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_68_chunk
+                                       Output: _hyper_4_68_chunk."time", _hyper_4_68_chunk.temp, _hyper_4_68_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_69_chunk
+                                       Output: _hyper_4_69_chunk."time", _hyper_4_69_chunk.temp, _hyper_4_69_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_70_chunk
+                                       Output: _hyper_4_70_chunk."time", _hyper_4_70_chunk.temp, _hyper_4_70_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_71_chunk
+                                       Output: _hyper_4_71_chunk."time", _hyper_4_71_chunk.temp, _hyper_4_71_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_72_chunk
+                                       Output: _hyper_4_72_chunk."time", _hyper_4_72_chunk.temp, _hyper_4_72_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_73_chunk
+                                       Output: _hyper_4_73_chunk."time", _hyper_4_73_chunk.temp, _hyper_4_73_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_74_chunk
+                                       Output: _hyper_4_74_chunk."time", _hyper_4_74_chunk.temp, _hyper_4_74_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_75_chunk
+                                       Output: _hyper_4_75_chunk."time", _hyper_4_75_chunk.temp, _hyper_4_75_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_76_chunk
+                                       Output: _hyper_4_76_chunk."time", _hyper_4_76_chunk.temp, _hyper_4_76_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_77_chunk
+                                       Output: _hyper_4_77_chunk."time", _hyper_4_77_chunk.temp, _hyper_4_77_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_78_chunk
+                                       Output: _hyper_4_78_chunk."time", _hyper_4_78_chunk.temp, _hyper_4_78_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_79_chunk
+                                       Output: _hyper_4_79_chunk."time", _hyper_4_79_chunk.temp, _hyper_4_79_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_80_chunk
+                                       Output: _hyper_4_80_chunk."time", _hyper_4_80_chunk.temp, _hyper_4_80_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_81_chunk
+                                       Output: _hyper_4_81_chunk."time", _hyper_4_81_chunk.temp, _hyper_4_81_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_82_chunk
+                                       Output: _hyper_4_82_chunk."time", _hyper_4_82_chunk.temp, _hyper_4_82_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_83_chunk
+                                       Output: _hyper_4_83_chunk."time", _hyper_4_83_chunk.temp, _hyper_4_83_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_84_chunk
+                                       Output: _hyper_4_84_chunk."time", _hyper_4_84_chunk.temp, _hyper_4_84_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_85_chunk
+                                       Output: _hyper_4_85_chunk."time", _hyper_4_85_chunk.temp, _hyper_4_85_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_86_chunk
+                                       Output: _hyper_4_86_chunk."time", _hyper_4_86_chunk.temp, _hyper_4_86_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_87_chunk
+                                       Output: _hyper_4_87_chunk."time", _hyper_4_87_chunk.temp, _hyper_4_87_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_88_chunk
+                                       Output: _hyper_4_88_chunk."time", _hyper_4_88_chunk.temp, _hyper_4_88_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_89_chunk
+                                       Output: _hyper_4_89_chunk."time", _hyper_4_89_chunk.temp, _hyper_4_89_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_90_chunk
+                                       Output: _hyper_4_90_chunk."time", _hyper_4_90_chunk.temp, _hyper_4_90_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_91_chunk
+                                       Output: _hyper_4_91_chunk."time", _hyper_4_91_chunk.temp, _hyper_4_91_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_92_chunk
+                                       Output: _hyper_4_92_chunk."time", _hyper_4_92_chunk.temp, _hyper_4_92_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_93_chunk
+                                       Output: _hyper_4_93_chunk."time", _hyper_4_93_chunk.temp, _hyper_4_93_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_94_chunk
+                                       Output: _hyper_4_94_chunk."time", _hyper_4_94_chunk.temp, _hyper_4_94_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_95_chunk
+                                       Output: _hyper_4_95_chunk."time", _hyper_4_95_chunk.temp, _hyper_4_95_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_96_chunk
+                                       Output: _hyper_4_96_chunk."time", _hyper_4_96_chunk.temp, _hyper_4_96_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_97_chunk
+                                       Output: _hyper_4_97_chunk."time", _hyper_4_97_chunk.temp, _hyper_4_97_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_98_chunk
+                                       Output: _hyper_4_98_chunk."time", _hyper_4_98_chunk.temp, _hyper_4_98_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_99_chunk
+                                       Output: _hyper_4_99_chunk."time", _hyper_4_99_chunk.temp, _hyper_4_99_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_100_chunk
+                                       Output: _hyper_4_100_chunk."time", _hyper_4_100_chunk.temp, _hyper_4_100_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_101_chunk
+                                       Output: _hyper_4_101_chunk."time", _hyper_4_101_chunk.temp, _hyper_4_101_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_102_chunk
+                                       Output: _hyper_4_102_chunk."time", _hyper_4_102_chunk.temp, _hyper_4_102_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_103_chunk
+                                       Output: _hyper_4_103_chunk."time", _hyper_4_103_chunk.temp, _hyper_4_103_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_104_chunk
+                                       Output: _hyper_4_104_chunk."time", _hyper_4_104_chunk.temp, _hyper_4_104_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_105_chunk
+                                       Output: _hyper_4_105_chunk."time", _hyper_4_105_chunk.temp, _hyper_4_105_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_106_chunk
+                                       Output: _hyper_4_106_chunk."time", _hyper_4_106_chunk.temp, _hyper_4_106_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_107_chunk
+                                       Output: _hyper_4_107_chunk."time", _hyper_4_107_chunk.temp, _hyper_4_107_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_108_chunk
+                                       Output: _hyper_4_108_chunk."time", _hyper_4_108_chunk.temp, _hyper_4_108_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_109_chunk
+                                       Output: _hyper_4_109_chunk."time", _hyper_4_109_chunk.temp, _hyper_4_109_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_110_chunk
+                                       Output: _hyper_4_110_chunk."time", _hyper_4_110_chunk.temp, _hyper_4_110_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_111_chunk
+                                       Output: _hyper_4_111_chunk."time", _hyper_4_111_chunk.temp, _hyper_4_111_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_112_chunk
+                                       Output: _hyper_4_112_chunk."time", _hyper_4_112_chunk.temp, _hyper_4_112_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_113_chunk
+                                       Output: _hyper_4_113_chunk."time", _hyper_4_113_chunk.temp, _hyper_4_113_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_114_chunk
+                                       Output: _hyper_4_114_chunk."time", _hyper_4_114_chunk.temp, _hyper_4_114_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_115_chunk
+                                       Output: _hyper_4_115_chunk."time", _hyper_4_115_chunk.temp, _hyper_4_115_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_116_chunk
+                                       Output: _hyper_4_116_chunk."time", _hyper_4_116_chunk.temp, _hyper_4_116_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_117_chunk
+                                       Output: _hyper_4_117_chunk."time", _hyper_4_117_chunk.temp, _hyper_4_117_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_118_chunk
+                                       Output: _hyper_4_118_chunk."time", _hyper_4_118_chunk.temp, _hyper_4_118_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_119_chunk
+                                       Output: _hyper_4_119_chunk."time", _hyper_4_119_chunk.temp, _hyper_4_119_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_120_chunk
+                                       Output: _hyper_4_120_chunk."time", _hyper_4_120_chunk.temp, _hyper_4_120_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_121_chunk
+                                       Output: _hyper_4_121_chunk."time", _hyper_4_121_chunk.temp, _hyper_4_121_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_122_chunk
+                                       Output: _hyper_4_122_chunk."time", _hyper_4_122_chunk.temp, _hyper_4_122_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_123_chunk
+                                       Output: _hyper_4_123_chunk."time", _hyper_4_123_chunk.temp, _hyper_4_123_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_124_chunk
+                                       Output: _hyper_4_124_chunk."time", _hyper_4_124_chunk.temp, _hyper_4_124_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_125_chunk
+                                       Output: _hyper_4_125_chunk."time", _hyper_4_125_chunk.temp, _hyper_4_125_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_126_chunk
+                                       Output: _hyper_4_126_chunk."time", _hyper_4_126_chunk.temp, _hyper_4_126_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_127_chunk
+                                       Output: _hyper_4_127_chunk."time", _hyper_4_127_chunk.temp, _hyper_4_127_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_128_chunk
+                                       Output: _hyper_4_128_chunk."time", _hyper_4_128_chunk.temp, _hyper_4_128_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_129_chunk
+                                       Output: _hyper_4_129_chunk."time", _hyper_4_129_chunk.temp, _hyper_4_129_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_130_chunk
+                                       Output: _hyper_4_130_chunk."time", _hyper_4_130_chunk.temp, _hyper_4_130_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_131_chunk
+                                       Output: _hyper_4_131_chunk."time", _hyper_4_131_chunk.temp, _hyper_4_131_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_132_chunk
+                                       Output: _hyper_4_132_chunk."time", _hyper_4_132_chunk.temp, _hyper_4_132_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_133_chunk
+                                       Output: _hyper_4_133_chunk."time", _hyper_4_133_chunk.temp, _hyper_4_133_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_134_chunk
+                                       Output: _hyper_4_134_chunk."time", _hyper_4_134_chunk.temp, _hyper_4_134_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_135_chunk
+                                       Output: _hyper_4_135_chunk."time", _hyper_4_135_chunk.temp, _hyper_4_135_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_136_chunk
+                                       Output: _hyper_4_136_chunk."time", _hyper_4_136_chunk.temp, _hyper_4_136_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_137_chunk
+                                       Output: _hyper_4_137_chunk."time", _hyper_4_137_chunk.temp, _hyper_4_137_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_138_chunk
+                                       Output: _hyper_4_138_chunk."time", _hyper_4_138_chunk.temp, _hyper_4_138_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_139_chunk
+                                       Output: _hyper_4_139_chunk."time", _hyper_4_139_chunk.temp, _hyper_4_139_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_140_chunk
+                                       Output: _hyper_4_140_chunk."time", _hyper_4_140_chunk.temp, _hyper_4_140_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_141_chunk
+                                       Output: _hyper_4_141_chunk."time", _hyper_4_141_chunk.temp, _hyper_4_141_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_142_chunk
+                                       Output: _hyper_4_142_chunk."time", _hyper_4_142_chunk.temp, _hyper_4_142_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_143_chunk
+                                       Output: _hyper_4_143_chunk."time", _hyper_4_143_chunk.temp, _hyper_4_143_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_144_chunk
+                                       Output: _hyper_4_144_chunk."time", _hyper_4_144_chunk.temp, _hyper_4_144_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_145_chunk
+                                       Output: _hyper_4_145_chunk."time", _hyper_4_145_chunk.temp, _hyper_4_145_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_146_chunk
+                                       Output: _hyper_4_146_chunk."time", _hyper_4_146_chunk.temp, _hyper_4_146_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_147_chunk
+                                       Output: _hyper_4_147_chunk."time", _hyper_4_147_chunk.temp, _hyper_4_147_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_148_chunk
+                                       Output: _hyper_4_148_chunk."time", _hyper_4_148_chunk.temp, _hyper_4_148_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_149_chunk
+                                       Output: _hyper_4_149_chunk."time", _hyper_4_149_chunk.temp, _hyper_4_149_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_150_chunk
+                                       Output: _hyper_4_150_chunk."time", _hyper_4_150_chunk.temp, _hyper_4_150_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_151_chunk
+                                       Output: _hyper_4_151_chunk."time", _hyper_4_151_chunk.temp, _hyper_4_151_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_152_chunk
+                                       Output: _hyper_4_152_chunk."time", _hyper_4_152_chunk.temp, _hyper_4_152_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_153_chunk
+                                       Output: _hyper_4_153_chunk."time", _hyper_4_153_chunk.temp, _hyper_4_153_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_154_chunk
+                                       Output: _hyper_4_154_chunk."time", _hyper_4_154_chunk.temp, _hyper_4_154_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_155_chunk
+                                       Output: _hyper_4_155_chunk."time", _hyper_4_155_chunk.temp, _hyper_4_155_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_156_chunk
+                                       Output: _hyper_4_156_chunk."time", _hyper_4_156_chunk.temp, _hyper_4_156_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_157_chunk
+                                       Output: _hyper_4_157_chunk."time", _hyper_4_157_chunk.temp, _hyper_4_157_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_158_chunk
+                                       Output: _hyper_4_158_chunk."time", _hyper_4_158_chunk.temp, _hyper_4_158_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_159_chunk
+                                       Output: _hyper_4_159_chunk."time", _hyper_4_159_chunk.temp, _hyper_4_159_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_160_chunk
+                                       Output: _hyper_4_160_chunk."time", _hyper_4_160_chunk.temp, _hyper_4_160_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_161_chunk
+                                       Output: _hyper_4_161_chunk."time", _hyper_4_161_chunk.temp, _hyper_4_161_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_162_chunk
+                                       Output: _hyper_4_162_chunk."time", _hyper_4_162_chunk.temp, _hyper_4_162_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_163_chunk
+                                       Output: _hyper_4_163_chunk."time", _hyper_4_163_chunk.temp, _hyper_4_163_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_164_chunk
+                                       Output: _hyper_4_164_chunk."time", _hyper_4_164_chunk.temp, _hyper_4_164_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_165_chunk
+                                       Output: _hyper_4_165_chunk."time", _hyper_4_165_chunk.temp, _hyper_4_165_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_166_chunk
+                                       Output: _hyper_4_166_chunk."time", _hyper_4_166_chunk.temp, _hyper_4_166_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_167_chunk
+                                       Output: _hyper_4_167_chunk."time", _hyper_4_167_chunk.temp, _hyper_4_167_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_168_chunk
+                                       Output: _hyper_4_168_chunk."time", _hyper_4_168_chunk.temp, _hyper_4_168_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_169_chunk
+                                       Output: _hyper_4_169_chunk."time", _hyper_4_169_chunk.temp, _hyper_4_169_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_170_chunk
+                                       Output: _hyper_4_170_chunk."time", _hyper_4_170_chunk.temp, _hyper_4_170_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_171_chunk
+                                       Output: _hyper_4_171_chunk."time", _hyper_4_171_chunk.temp, _hyper_4_171_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_172_chunk
+                                       Output: _hyper_4_172_chunk."time", _hyper_4_172_chunk.temp, _hyper_4_172_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_173_chunk
+                                       Output: _hyper_4_173_chunk."time", _hyper_4_173_chunk.temp, _hyper_4_173_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_174_chunk
+                                       Output: _hyper_4_174_chunk."time", _hyper_4_174_chunk.temp, _hyper_4_174_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_175_chunk
+                                       Output: _hyper_4_175_chunk."time", _hyper_4_175_chunk.temp, _hyper_4_175_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_176_chunk
+                                       Output: _hyper_4_176_chunk."time", _hyper_4_176_chunk.temp, _hyper_4_176_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_177_chunk
+                                       Output: _hyper_4_177_chunk."time", _hyper_4_177_chunk.temp, _hyper_4_177_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_178_chunk
+                                       Output: _hyper_4_178_chunk."time", _hyper_4_178_chunk.temp, _hyper_4_178_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_179_chunk
+                                       Output: _hyper_4_179_chunk."time", _hyper_4_179_chunk.temp, _hyper_4_179_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_180_chunk
+                                       Output: _hyper_4_180_chunk."time", _hyper_4_180_chunk.temp, _hyper_4_180_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_181_chunk
+                                       Output: _hyper_4_181_chunk."time", _hyper_4_181_chunk.temp, _hyper_4_181_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_182_chunk
+                                       Output: _hyper_4_182_chunk."time", _hyper_4_182_chunk.temp, _hyper_4_182_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_183_chunk
+                                       Output: _hyper_4_183_chunk."time", _hyper_4_183_chunk.temp, _hyper_4_183_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_184_chunk
+                                       Output: _hyper_4_184_chunk."time", _hyper_4_184_chunk.temp, _hyper_4_184_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_185_chunk
+                                       Output: _hyper_4_185_chunk."time", _hyper_4_185_chunk.temp, _hyper_4_185_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_4_186_chunk
+                                       Output: _hyper_4_186_chunk."time", _hyper_4_186_chunk.temp, _hyper_4_186_chunk.device
+(368 rows)
+
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
+           time           | temp | device 
+--------------------------+------+--------
+ Wed Dec 31 16:00:00 1969 |    1 | 1
+ Wed Dec 31 16:00:00 1969 |   10 | 10
+ Wed Dec 31 16:00:00 1969 |   11 | 11
+ Wed Dec 31 16:00:00 1969 |   12 | 12
+ Wed Dec 31 16:00:00 1969 |   13 | 13
+ Wed Dec 31 16:00:00 1969 |   14 | 14
+ Wed Dec 31 16:00:00 1969 |   15 | 15
+ Wed Dec 31 16:00:00 1969 |   16 | 16
+ Wed Dec 31 16:00:00 1969 |   17 | 17
+ Wed Dec 31 16:00:00 1969 |   18 | 18
+(10 rows)
 


### PR DESCRIPTION
When inserting into a hypertable using a sub-select clause that
involves an aggregate, the insert fails with the error "Aggref found
in non-Agg plan node". This happens because the target list from the
aggregate sub-select expects an aggregate parent node and we simply
reuse the target list when modifying the insert plan with new
CustomScan plan nodes.

This change creates a modified target list to use with the CustomScan
node that avoids this issue.