### PR TITLE
Fix pgindent issues due to windows-related changes

### DIFF
--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -61,6 +61,7 @@ inval_cache_callback(Datum arg, Oid relid)
 }
 
 PGDLLEXPORT Datum invalidate_relcache_trigger(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(invalidate_relcache_trigger);
 
 /*
@@ -103,6 +104,7 @@ invalidate_relcache_trigger(PG_FUNCTION_ARGS)
 }
 
 PGDLLEXPORT Datum invalidate_relcache(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(invalidate_relcache);
 
 /*

--- a/src/compat.c
+++ b/src/compat.c
@@ -4,6 +4,7 @@
 /* Old functions that are no longer used but are needed for compatibiliy when
  * updating the extension. */
 PGDLLEXPORT Datum insert_main_table_trigger(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(insert_main_table_trigger);
 
 Datum
@@ -14,6 +15,7 @@ insert_main_table_trigger(PG_FUNCTION_ARGS)
 }
 
 PGDLLEXPORT Datum insert_main_table_trigger_after(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(insert_main_table_trigger_after);
 
 Datum
@@ -24,6 +26,7 @@ insert_main_table_trigger_after(PG_FUNCTION_ARGS)
 }
 
 PGDLLEXPORT Datum ddl_is_change_owner(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(ddl_is_change_owner);
 
 Datum
@@ -34,6 +37,7 @@ ddl_is_change_owner(PG_FUNCTION_ARGS)
 }
 
 PGDLLEXPORT Datum ddl_change_owner_to(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(ddl_change_owner_to);
 
 Datum

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -150,6 +150,7 @@ calculate_open_range_default(Dimension *dim, int64 value)
 }
 
 PGDLLEXPORT Datum dimension_calculate_open_range_default(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(dimension_calculate_open_range_default);
 
 /*
@@ -196,6 +197,7 @@ calculate_closed_range_default(Dimension *dim, int64 value)
 }
 
 PGDLLEXPORT Datum dimension_calculate_closed_range_default(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(dimension_calculate_closed_range_default);
 
 /*

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -96,6 +96,7 @@ partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDes
 
 /* _timescaledb_catalog.get_partition_for_key(key TEXT) RETURNS INT */
 PGDLLEXPORT Datum get_partition_for_key(PG_FUNCTION_ARGS);
+
 PG_FUNCTION_INFO_V1(get_partition_for_key);
 
 Datum


### PR DESCRIPTION
Files that have been modified with the PGDLLEXPORT macro
are no longer pgindent formatted. This change fixes these
pgindent issues.