### PR TITLE
Quench a number of type mismatch warnings

### DIFF
--- a/src/catalog.c
+++ b/src/catalog.c
@@ -26,7 +26,7 @@ static const char *catalog_table_names[_MAX_CATALOG_TABLES] = {
 
 typedef struct TableIndexDef
 {
-	size_t		length;
+	int			length;
 	char	  **names;
 } TableIndexDef;
 
@@ -86,7 +86,7 @@ static const char *catalog_table_serial_id_names[_MAX_CATALOG_TABLES] = {
 typedef struct InternalFunctionDef
 {
 	char	   *name;
-	size_t		args;
+	int			args;
 } InternalFunctionDef;
 
 const static InternalFunctionDef internal_function_definitions[_MAX_INTERNAL_FUNCTIONS] = {
@@ -247,15 +247,17 @@ catalog_get(void)
 													catalog.cache_schema_id);
 
 	catalog.internal_schema_id = get_namespace_oid(INTERNAL_SCHEMA_NAME, false);
+
 	for (i = 0; i < _MAX_INTERNAL_FUNCTIONS; i++)
 	{
 		InternalFunctionDef def = internal_function_definitions[i];
 		FuncCandidateList funclist =
-		FuncnameGetCandidates(list_make2(makeString(INTERNAL_SCHEMA_NAME), makeString(def.name)),
+		FuncnameGetCandidates(list_make2(makeString(INTERNAL_SCHEMA_NAME),
+										 makeString(def.name)),
 							  def.args, NULL, false, false, false);
 
 		if (funclist == NULL || funclist->next)
-			elog(ERROR, "Oid lookup failed for the function %s with %lu args", def.name, def.args);
+			elog(ERROR, "Oid lookup failed for the function %s with %d args", def.name, def.args);
 
 		catalog.functions[i].function_id = funclist->oid;
 	}

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -682,7 +682,7 @@ chunk_copy(Chunk *chunk)
 static Chunk *
 chunk_scan_internal(int indexid,
 					ScanKeyData scankey[],
-					Size nkeys,
+					int nkeys,
 					int16 num_constraints,
 					bool fail_if_not_found)
 {

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -68,7 +68,7 @@ dimension_vec_tuple_found(TupleInfo *ti, void *data)
 
 static int
 dimension_slice_scan_limit_internal(ScanKeyData *scankey,
-									Size num_scankeys,
+									int num_scankeys,
 									tuple_found_func on_tuple_found,
 									void *scandata,
 									int limit)

--- a/src/extension.c
+++ b/src/extension.c
@@ -181,15 +181,17 @@ extension_is_loaded(void)
 		extension_update_state();
 	}
 
-	if (creating_extension && OidIsValid(get_extension_oid(EXTENSION_NAME, true)) && get_extension_oid(EXTENSION_NAME, true) == CurrentExtensionObject)
+	/*
+	 * Turn off extension during upgrade scripts. This is necessary so that,
+	 * for example, the catalog does not go looking for things that aren't yet
+	 * there.
+	 */
+	if (creating_extension)
 	{
-		/* turn off extension during upgrade scripts */
+		Oid			extension_oid = get_extension_oid(EXTENSION_NAME, true);
 
-		/*
-		 * This is necessary so that, for example, the catalog does not go
-		 * looking for things that aren't yet there.
-		 */
-		return false;
+		if (OidIsValid(extension_oid) && extension_oid == CurrentExtensionObject)
+			return false;
 	}
 
 	switch (extstate)

--- a/src/histogram.c
+++ b/src/histogram.c
@@ -40,13 +40,14 @@ hist_sfunc(PG_FUNCTION_ARGS)
 	MemoryContext aggcontext;
 	bytea	   *state = (PG_ARGISNULL(0) ? NULL : PG_GETARG_BYTEA_P(0));
 	Datum	   *hist;
-
-	double		val = PG_GETARG_FLOAT8(1);
-	double		min = PG_GETARG_FLOAT8(2);
-	double		max = PG_GETARG_FLOAT8(3);
-	int			nbuckets = PG_GETARG_INT32(4);
-
-	int			bucket = DirectFunctionCall4(width_bucket_float8, val, min, max, nbuckets);
+	Datum		val_datum = PG_GETARG_DATUM(1);
+	Datum		min_datum = PG_GETARG_DATUM(2);
+	Datum		max_datum = PG_GETARG_DATUM(3);
+	Datum		nbuckets_datum = PG_GETARG_DATUM(4);
+	double		min = DatumGetFloat8(min_datum);
+	double		max = DatumGetFloat8(max_datum);
+	int			nbuckets = DatumGetInt32(nbuckets_datum);
+	int32		bucket = DatumGetInt32(DirectFunctionCall4(width_bucket_float8, val_datum, min_datum, max_datum, nbuckets_datum));
 
 	if (!AggCheckCallContext(fcinfo, &aggcontext))
 	{

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -108,8 +108,8 @@ get_partition_for_key(PG_FUNCTION_ARGS)
 
 	data = PG_GETARG_VARLENA_PP(0);
 
-	hash_u = hash_any((unsigned char *) VARDATA_ANY(data),
-					  VARSIZE_ANY_EXHDR(data));
+	hash_u = DatumGetUInt32(hash_any((unsigned char *) VARDATA_ANY(data),
+									 VARSIZE_ANY_EXHDR(data)));
 
 	res = (int32) (hash_u & 0x7fffffff);		/* Only positive numbers */
 

--- a/src/version.c
+++ b/src/version.c
@@ -11,7 +11,7 @@ PG_FUNCTION_INFO_V1(get_git_commit);
 Datum
 get_git_commit(PG_FUNCTION_ARGS)
 {
-	int32		var_size = VARHDRSZ + strlen(git_commit);
+	size_t		var_size = VARHDRSZ + strlen(git_commit);
 	text	   *version_text = (text *) palloc(var_size);
 
 	SET_VARSIZE(version_text, var_size);


### PR DESCRIPTION
These changes will fix a number of warnings generated by some
compilers and platforms (most notably on Windows) that mostly relate
to assigning values to variables with mismatching types.

A number of datum functions were also called without actually passing
datums or assigning return values to datums. Those are now passed
datums instead of raw data types.