### PR TITLE
Add reindex_chunk function

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -565,3 +565,11 @@ BEGIN
     END LOOP;
 END
 $BODY$;
+
+
+--documentation of these function located in chunk_index.h
+CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_index_clone(chunk_index_oid OID) RETURNS OID
+AS '$libdir/timescaledb', 'chunk_index_clone' LANGUAGE C VOLATILE STRICT;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_index_replace(chunk_index_oid_old OID, chunk_index_oid_new OID) RETURNS VOID
+AS '$libdir/timescaledb', 'chunk_index_replace' LANGUAGE C VOLATILE STRICT;

--- a/sql/util_time.sql
+++ b/sql/util_time.sql
@@ -101,3 +101,6 @@ BEGIN
     END IF;
 END
 $BODY$;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.time_to_internal(time_element anyelement, time_type REGTYPE) RETURNS BIGINT
+	AS '$libdir/timescaledb', 'time_to_internal' LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -27,6 +27,7 @@ typedef struct Chunk
 {
 	FormData_chunk fd;
 	Oid			table_id;
+	Oid			hypertable_relid;
 
 	/*
 	 * The hypercube defines the chunks position in the N-dimensional space.

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -11,6 +11,7 @@
 #include "subspace_store.h"
 #include "hypertable_cache.h"
 #include "trigger.h"
+#include "scanner.h"
 
 Hypertable *
 hypertable_from_tuple(HeapTuple tuple)

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -218,3 +218,25 @@ scanner_scan(ScannerCtx *ctx)
 
 	return ictx.tinfo.count;
 }
+
+bool
+scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type)
+{
+	int			num_found = scanner_scan(ctx);
+
+	ctx->limit = 2;
+
+	switch (num_found)
+	{
+		case 0:
+			if (fail_if_not_found)
+			{
+				elog(ERROR, "%s not found", item_type);
+			}
+			return false;
+		case 1:
+			return true;
+		default:
+			elog(ERROR, "More than one %s found.", item_type);
+	}
+}

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -83,5 +83,7 @@ typedef struct ScannerCtx
 /* Performs an index scan or heap scan and returns the number of matching
  * tuples. */
 int			scanner_scan(ScannerCtx *ctx);
+bool		scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type);
+
 
 #endif   /* TIMESCALEDB_SCANNER_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -140,6 +140,25 @@ pg_unix_microseconds_to_timestamp(PG_FUNCTION_ARGS)
 	PG_RETURN_TIMESTAMPTZ(timestamp);
 }
 
+PG_FUNCTION_INFO_V1(time_to_internal);
+
+Datum
+time_to_internal(PG_FUNCTION_ARGS)
+{
+	Datum		val;
+	Oid			type;
+	int64		res;
+
+	if (PG_ARGISNULL(0))
+		PG_RETURN_NULL();
+
+	val = PG_GETARG_DATUM(0);
+	type = PG_GETARG_OID(1);
+
+	res = time_value_to_internal(val, type);
+	PG_RETURN_INT64(res);
+}
+
 
 /*	*/
 int64
@@ -159,7 +178,10 @@ time_value_to_internal(Datum time_val, Oid type)
 	}
 	if (type == TIMESTAMPOID)
 	{
-		/* for timestamps, ignore timezones, make believe the timestamp is at UTC */
+		/*
+		 * for timestamps, ignore timezones, make believe the timestamp is at
+		 * UTC
+		 */
 		Datum		res = DirectFunctionCall1(pg_timestamp_to_unix_microseconds, time_val);
 
 		return DatumGetInt64(res);

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -49,7 +49,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   115
+   118
 (1 row)
 
 SELECT * FROM test.show_columns('public."two_Partitions"');
@@ -235,7 +235,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   115
+   118
 (1 row)
 
 --main table and chunk schemas should be the same

--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -1,8 +1,7 @@
-CREATE TABLE reindex_test(time timestamp, temp float);
+CREATE TABLE reindex_test(time timestamp, temp float, PRIMARY KEY(time, temp));
 CREATE UNIQUE INDEX reindex_test_time_unique_idx ON reindex_test(time);
 -- create hypertable with three chunks
 SELECT create_hypertable('reindex_test', 'time', chunk_time_interval => 2628000000000);
-NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
  create_hypertable 
 -------------------
  
@@ -18,7 +17,7 @@ SELECT * FROM test.show_columns('reindex_test');
  Column |            Type             | Nullable 
 --------+-----------------------------+----------
  time   | timestamp without time zone | t
- temp   | double precision            | f
+ temp   | double precision            | t
 (2 rows)
 
 SELECT * FROM test.show_subtables('reindex_test');
@@ -34,10 +33,15 @@ SELECT * FROM test.show_subtables('reindex_test');
 -- show reindexing
 REINDEX (VERBOSE) TABLE reindex_test;
 INFO:  index "_hyper_1_1_chunk_reindex_test_time_unique_idx" was reindexed
+INFO:  index "1_1_reindex_test_pkey" was reindexed
 INFO:  index "_hyper_1_2_chunk_reindex_test_time_unique_idx" was reindexed
+INFO:  index "2_2_reindex_test_pkey" was reindexed
 INFO:  index "_hyper_1_3_chunk_reindex_test_time_unique_idx" was reindexed
+INFO:  index "3_3_reindex_test_pkey" was reindexed
 INFO:  index "_hyper_1_4_chunk_reindex_test_time_unique_idx" was reindexed
+INFO:  index "4_4_reindex_test_pkey" was reindexed
 INFO:  index "_hyper_1_5_chunk_reindex_test_time_unique_idx" was reindexed
+INFO:  index "5_5_reindex_test_pkey" was reindexed
 \set ON_ERROR_STOP 0
 -- this one currently doesn't recurse to chunks and instead gives an
 -- error
@@ -57,3 +61,63 @@ REINDEX (VERBOSE) TABLE reindex_norm;
 INFO:  index "reindex_norm_time_unique_idx" was reindexed
 REINDEX (VERBOSE) INDEX reindex_norm_time_unique_idx;
 INFO:  index "reindex_norm_time_unique_idx" was reindexed
+SELECT * FROM test.show_constraintsp('_timescaledb_internal.%');
+                 Table                  |      Constraint       | Type |   Columns   |                     Index                     |                                                                     Expr                                                                     
+----------------------------------------+-----------------------+------+-------------+-----------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk | 1_1_reindex_test_pkey | p    | {time,temp} | _timescaledb_internal."1_1_reindex_test_pkey" | 
+ _timescaledb_internal._hyper_1_1_chunk | constraint_1          | c    | {time}      | -                                             | (("time" >= 'Thu Jan 19 10:00:00 2017'::timestamp without time zone) AND ("time" < 'Sat Feb 18 20:00:00 2017'::timestamp without time zone))
+ _timescaledb_internal._hyper_1_2_chunk | 2_2_reindex_test_pkey | p    | {time,temp} | _timescaledb_internal."2_2_reindex_test_pkey" | 
+ _timescaledb_internal._hyper_1_2_chunk | constraint_2          | c    | {time}      | -                                             | (("time" >= 'Tue Mar 21 06:00:00 2017'::timestamp without time zone) AND ("time" < 'Thu Apr 20 16:00:00 2017'::timestamp without time zone))
+ _timescaledb_internal._hyper_1_3_chunk | 3_3_reindex_test_pkey | p    | {time,temp} | _timescaledb_internal."3_3_reindex_test_pkey" | 
+ _timescaledb_internal._hyper_1_3_chunk | constraint_3          | c    | {time}      | -                                             | (("time" >= 'Thu Apr 20 16:00:00 2017'::timestamp without time zone) AND ("time" < 'Sun May 21 02:00:00 2017'::timestamp without time zone))
+ _timescaledb_internal._hyper_1_4_chunk | 4_4_reindex_test_pkey | p    | {time,temp} | _timescaledb_internal."4_4_reindex_test_pkey" | 
+ _timescaledb_internal._hyper_1_4_chunk | constraint_4          | c    | {time}      | -                                             | (("time" >= 'Sun May 21 02:00:00 2017'::timestamp without time zone) AND ("time" < 'Tue Jun 20 12:00:00 2017'::timestamp without time zone))
+ _timescaledb_internal._hyper_1_5_chunk | 5_5_reindex_test_pkey | p    | {time,temp} | _timescaledb_internal."5_5_reindex_test_pkey" | 
+ _timescaledb_internal._hyper_1_5_chunk | constraint_5          | c    | {time}      | -                                             | (("time" >= 'Tue Jun 20 12:00:00 2017'::timestamp without time zone) AND ("time" < 'Thu Jul 20 22:00:00 2017'::timestamp without time zone))
+(10 rows)
+
+SELECT * FROM reindex_norm;
+           time           | temp 
+--------------------------+------
+ Fri Jan 20 09:00:01 2017 | 17.5
+ Sat Jan 21 09:00:01 2017 | 19.1
+ Thu Apr 20 09:00:01 2017 | 89.5
+ Fri Apr 21 09:00:01 2017 | 17.1
+ Tue Jun 20 09:00:01 2017 | 18.5
+ Wed Jun 21 09:00:01 2017 |   11
+(6 rows)
+
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
+                                Index                                |   Columns   | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------------------+-------------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      | t      | f       | f         | 
+ _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} | t      | t       | f         | 
+(2 rows)
+
+SELECT * FROM _timescaledb_internal.chunk_index_clone('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass);
+ chunk_index_clone 
+-------------------
+             31375
+(1 row)
+
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
+                                Index                                |   Columns   | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------------------+-------------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      | t      | f       | f         | 
+ _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} | t      | t       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk_1_1_reindex_test_pkey        | {time,temp} | t      | t       | f         | 
+(3 rows)
+
+SELECT * FROM _timescaledb_internal.chunk_index_replace('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass, '_timescaledb_internal."_hyper_1_1_chunk_1_1_reindex_test_pkey"'::regclass);
+ chunk_index_replace 
+---------------------
+ 
+(1 row)
+
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
+                                Index                                |   Columns   | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------------------+-------------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      | t      | f       | f         | 
+ _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} | t      | t       | f         | 
+(2 rows)
+

--- a/test/sql/reindex.sql
+++ b/test/sql/reindex.sql
@@ -1,4 +1,4 @@
-CREATE TABLE reindex_test(time timestamp, temp float);
+CREATE TABLE reindex_test(time timestamp, temp float, PRIMARY KEY(time, temp));
 CREATE UNIQUE INDEX reindex_test_time_unique_idx ON reindex_test(time);
 
 -- create hypertable with three chunks
@@ -36,3 +36,13 @@ INSERT INTO reindex_norm VALUES ('2017-01-20T09:00:01', 17.5),
 
 REINDEX (VERBOSE) TABLE reindex_norm;
 REINDEX (VERBOSE) INDEX reindex_norm_time_unique_idx;
+
+SELECT * FROM test.show_constraintsp('_timescaledb_internal.%');
+SELECT * FROM reindex_norm;
+
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
+SELECT * FROM _timescaledb_internal.chunk_index_clone('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass);
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
+SELECT * FROM _timescaledb_internal.chunk_index_replace('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass, '_timescaledb_internal."_hyper_1_1_chunk_1_1_reindex_test_pkey"'::regclass);
+
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');


### PR DESCRIPTION
reindex_chunk allows you to reindex the indexes of only certain chunks,
filtering by time. This is a common use case because a user may
want to reindex chunks after they are no longer getting new data once.

reindex_create also has a recreate option which will not use REINDEX
but will rather CREATE INDEX a new index and then
DROP INDEX / RENAME new_index to old_name. This approach has advantages
in terms of blocking reads for a much shorter period of time. However,
it does more work and will use more disk space during the operation.