### PR TITLE
Fix bug with extension starting too early.

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -6,6 +6,7 @@
 #include <catalog/namespace.h>
 #include <utils/lsyscache.h>
 #include <utils/inval.h>
+#include <miscadmin.h>
 
 #include "catalog.h"
 #include "extension.h"
@@ -82,7 +83,12 @@ extension_exists()
 static enum ExtensionState
 extension_new_state()
 {
-	if (!IsTransactionState())
+	/*
+	 * NormalProcessingMode necessary to avoid accessing cache before its
+	 * ready (which may result in an infinite loop). More concretely we need
+	 * RelationCacheInitializePhase3 to have been already called.
+	 */
+	if (!IsNormalProcessingMode() || !IsTransactionState())
 		return EXTENSION_STATE_UNKNOWN;
 
 	if (proxy_table_exists())

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -884,7 +884,7 @@ process_index_end(Node *parsetree, CollectedCommand *cmd)
 		switch (cmd->type)
 		{
 			case SCT_Simple:
-				info.obj =  cmd->d.simple.address;
+				info.obj = cmd->d.simple.address;
 				break;
 			default:
 				elog(ERROR,


### PR DESCRIPTION
Extension_new_state() was sometimes using the pg cache before it
was fully initialized. This commit adds a check to make sure that
does not happen.