### PR TITLE
Remove previous CIS definition from file copy procedure

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -82,6 +82,7 @@ timescaledb_CopyFrom(CopyState cstate, Relation main_rel, List *range_table, Hyp
 	ExprContext *econtext;
 	TupleTableSlot *myslot;
 	MemoryContext oldcontext = CurrentMemoryContext;
+	ChunkInsertState *prev_cis = NULL;
 
 	ErrorContextCallback errcallback;
 	CommandId	mycid = GetCurrentCommandId(true);
@@ -218,8 +219,7 @@ timescaledb_CopyFrom(CopyState cstate, Relation main_rel, List *range_table, Hyp
 		Oid			loaded_oid = InvalidOid;
 		Point	   *point;
 		ChunkDispatch *dispatch = ccstate->dispatch;
-		ChunkInsertState *cis,
-				   *prev_cis = NULL;
+		ChunkInsertState *cis;
 
 		CHECK_FOR_INTERRUPTS();
 


### PR DESCRIPTION
- Remove definition of the previous chunk insert state as it does not change from NULL (is reassigned to null in loop)