### PR TITLE
Allow setting partitioning function

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -9,7 +9,9 @@
 -- associated_schema_name - (Optional) Schema for internal hypertable tables
 -- associated_table_prefix - (Optional) Prefix for internal hypertable table names
 -- chunk_time_interval - (Optional) Initial time interval for a chunk
--- create_default_indexes - (Optional) Whether or not to create the default indexes.
+-- create_default_indexes - (Optional) Whether or not to create the default indexes
+-- if_not_exists - (Optional) Do not fail if table is already a hypertable
+-- partitioning_func - (Optional) The partitioning function to use for spatial partitioning
 CREATE OR REPLACE FUNCTION  create_hypertable(
     main_table              REGCLASS,
     time_column_name        NAME,
@@ -19,7 +21,8 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     associated_table_prefix NAME = NULL,
     chunk_time_interval     anyelement = NULL::bigint,
     create_default_indexes  BOOLEAN = TRUE,
-    if_not_exists           BOOLEAN = FALSE
+    if_not_exists           BOOLEAN = FALSE,
+    partitioning_func       REGPROC = NULL
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE
     SECURITY DEFINER SET search_path = ''
@@ -102,7 +105,8 @@ BEGIN
             associated_schema_name,
             associated_table_prefix,
             chunk_time_interval_actual,
-            tablespace_name
+            tablespace_name,
+            partitioning_func
         );
     EXCEPTION
         WHEN unique_violation THEN
@@ -128,7 +132,8 @@ CREATE OR REPLACE FUNCTION  add_dimension(
     main_table              REGCLASS,
     column_name             NAME,
     number_partitions       INTEGER = NULL,
-    interval_length         BIGINT = NULL
+    interval_length         BIGINT = NULL,
+    partitioning_func       REGPROC = NULL
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE
     SECURITY DEFINER SET search_path = ''
@@ -162,7 +167,8 @@ BEGIN
                                                 hypertable_row,
                                                 column_name,
                                                 number_partitions,
-                                                interval_length);
+                                                interval_length,
+                                                partitioning_func);
 END
 $BODY$;
 

--- a/sql/updates/pre-0.6.0--0.7.0-dev.sql
+++ b/sql/updates/pre-0.6.0--0.7.0-dev.sql
@@ -24,3 +24,9 @@ INNER JOIN pg_constraint pg_hypertable_con ON (
 INNER JOIN pg_class pg_hypertable_index_class ON (
     pg_hypertable_con.conindid = pg_hypertable_index_class.oid
 );
+
+-- Upgrade support for setting partitioning function
+DROP FUNCTION create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean);
+DROP FUNCTION add_dimension(regclass,name,integer,bigint);
+DROP FUNCTION _timescaledb_internal.create_hypertable_row(regclass,name,name,name,name,integer,name,name,bigint,name);
+DROP FUNCTION _timescaledb_internal.add_dimension(regclass,_timescaledb_catalog.hypertable,name,integer,bigint,boolean);

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -1,22 +1,11 @@
 CREATE TABLE part_legacy(time timestamptz, temp float, device int);
-SELECT create_hypertable('part_legacy', 'time', 'device', 2);
+SELECT create_hypertable('part_legacy', 'time', 'device', 2, partitioning_func => '_timescaledb_internal.get_partition_for_key');
  create_hypertable 
 -------------------
  
 (1 row)
 
-SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                    |   2592000000000
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash |                
-(2 rows)
-
-\c single :ROLE_SUPERUSER
-UPDATE _timescaledb_catalog.dimension SET partitioning_func = 'get_partition_for_key'
-WHERE partitioning_func IS NOT NULL;
-\c single :ROLE_DEFAULT_PERM_USER
--- Show updated partitioning function
+-- Show legacy partitioning function is used
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
 ----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------
@@ -143,7 +132,7 @@ SELECT create_hypertable('part_new_convert1', 'time', 'temp', 2);
 
 INSERT INTO part_new_convert1 VALUES ('2017-03-22T09:18:23', 1.0, 2);
 \set ON_ERROR_STOP 0
--- Changing the type of a hash-partitioned column should be unsupported
+-- Changing the type of a hash-partitioned column should not be supported
 ALTER TABLE part_new_convert1 ALTER COLUMN temp TYPE numeric;
 ERROR:  Cannot change the type of a hash-partitioned column
 \set ON_ERROR_STOP 1
@@ -163,4 +152,35 @@ Check constraints:
     "constraint_7" CHECK ("time" >= 'Wed Feb 22 16:00:00 2017'::timestamp without time zone AND "time" < 'Fri Mar 24 17:00:00 2017'::timestamp without time zone)
     "constraint_8" CHECK (_timescaledb_internal.get_partition_hash(temp) >= 0 AND _timescaledb_internal.get_partition_hash(temp) < 1073741823)
 Inherits: part_new_convert1
+
+CREATE TABLE part_add_dim(time timestamptz, temp float8, device int, location int);
+SELECT create_hypertable('part_add_dim', 'time', 'temp', 2);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => 'bad_func');
+ERROR:  function "bad_func" does not exist at character 74
+\set ON_ERROR_STOP 1
+SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => '_timescaledb_internal.get_partition_for_key');
+ add_dimension 
+---------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |   2592000000000
+  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |   2592000000000
+  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
+  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
+  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |   2592000000000
+  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |   2592000000000
+  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
+  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+(9 rows)
 


### PR DESCRIPTION
Users might want to implement their own partitioning function
or use the legacy one included with TimescaleDB. This change
adds support for setting the partitioning function in
create_hypertable() and add_dimension().