### PR TITLE
Fix column type change on plain tables

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1074,7 +1074,7 @@ process_altertable_end_index(Node *parsetree, CollectedCommand *cmd)
 }
 
 static void
-process_altertable_start(Node *parsetree)
+process_altertable_start_table(Node *parsetree)
 {
 	AlterTableStmt *stmt = (AlterTableStmt *) parsetree;
 	Oid			relid = AlterTableLookupRelation(stmt, NoLock);
@@ -1122,7 +1122,9 @@ process_altertable_start(Node *parsetree)
 				break;
 			case AT_AlterColumnType:
 				Assert(IsA(cmd->def, ColumnDef));
-				process_alter_column_type_start(ht, cmd);
+
+				if (ht != NULL)
+					process_alter_column_type_start(ht, cmd);
 				break;
 			default:
 				break;
@@ -1130,6 +1132,21 @@ process_altertable_start(Node *parsetree)
 	}
 
 	cache_release(hcache);
+}
+
+static void
+process_altertable_start(Node *parsetree)
+{
+	AlterTableStmt *stmt = (AlterTableStmt *) parsetree;
+
+	switch (stmt->relkind)
+	{
+		case OBJECT_TABLE:
+			process_altertable_start_table(parsetree);
+			break;
+		default:
+			break;
+	}
 }
 
 static void
@@ -1270,7 +1287,6 @@ process_altertable_end(Node *parsetree, CollectedCommand *cmd)
 			break;
 	}
 }
-
 
 static void
 create_trigger_chunk(Hypertable *ht, Oid chunk_relid, void *arg)

--- a/test/expected/plain.out
+++ b/test/expected/plain.out
@@ -6,6 +6,7 @@ CREATE TABLE regular_table(time timestamp, temp float8, tag text, color integer)
 -- Renaming indexes should work
 CREATE INDEX time_color_idx ON regular_table(time, color);
 ALTER INDEX time_color_idx RENAME TO time_color_idx2;
+ALTER TABLE regular_table ALTER COLUMN color TYPE bigint;
 \d+ regular_table
                                Table "public.regular_table"
  Column |            Type             | Modifiers | Storage  | Stats target | Description 
@@ -13,7 +14,7 @@ ALTER INDEX time_color_idx RENAME TO time_color_idx2;
  time   | timestamp without time zone |           | plain    |              | 
  temp   | double precision            |           | plain    |              | 
  tag    | text                        |           | extended |              | 
- color  | integer                     |           | plain    |              | 
+ color  | bigint                      |           | plain    |              | 
 Indexes:
     "time_color_idx2" btree ("time", color)
 

--- a/test/sql/plain.sql
+++ b/test/sql/plain.sql
@@ -8,6 +8,7 @@ CREATE TABLE regular_table(time timestamp, temp float8, tag text, color integer)
 -- Renaming indexes should work
 CREATE INDEX time_color_idx ON regular_table(time, color);
 ALTER INDEX time_color_idx RENAME TO time_color_idx2;
+ALTER TABLE regular_table ALTER COLUMN color TYPE bigint;
 
 \d+ regular_table
 


### PR DESCRIPTION
A recent change blocked changing types of space-partitioned hypertable
columns. However, this blocking should not apply to regular tables,
which otherwise causes a crash. This change fixes this issue by
properly checking that the the table is a hypertable.