### PR TITLE
Chunk insert state optimizations

### DIFF
--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -235,8 +235,6 @@ chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 	state->mctx = cis_context;
 	state->chunk = chunk;
 	state->rel = rel;
-	state->rti = rti;
-	state->estate = dispatch->estate;
 	state->result_relation_info = create_chunk_result_relation_info(dispatch, rel, rti);
 
 	if (state->result_relation_info->ri_RelationDesc->rd_rel->relhasindex &&

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -17,8 +17,6 @@ typedef struct ChunkInsertState
 	List	   *arbiter_indexes;
 	TupleConversionMap *tup_conv_map;
 	TupleTableSlot *slot;
-	Index		rti;
-	EState	   *estate;
 	MemoryContext mctx;
 } ChunkInsertState;
 

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -17,6 +17,8 @@ typedef struct ChunkInsertState
 	List	   *arbiter_indexes;
 	TupleConversionMap *tup_conv_map;
 	TupleTableSlot *slot;
+	Index		rti;
+	EState	   *estate;
 	MemoryContext mctx;
 } ChunkInsertState;
 

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -73,10 +73,8 @@ subspace_store_add(SubspaceStore *store, const Hypercube *hc,
 			vec = last->storage;
 		}
 
-		if (vec->num_slices > 0)
-		{
-			Assert(vec->slices[0]->fd.dimension_id == target->fd.dimension_id);
-		}
+		Assert(0 == vec->num_slices ||
+			   vec->slices[0]->fd.dimension_id == target->fd.dimension_id);
 
 		match = dimension_vec_find_slice(vec, target->fd.range_start);
 
@@ -90,7 +88,7 @@ subspace_store_add(SubspaceStore *store, const Hypercube *hc,
 				 * At dimension 0 only keep one slice. This is an optimization
 				 * to prevent this store from growing too large.
 				 */
-				Assert(vec->num_slices = 1);
+				Assert(1 == vec->num_slices);
 				dimension_vec_remove_slice(vecptr, 0);
 			}
 			copy = dimension_slice_copy(target);


### PR DESCRIPTION
This PR comprises three commits that optimize or fix bugs in the chunk insert state code.

1. Limit the size of the range table on INSERT
2. Do not convert tuples to chunk format unless needed
3. Fix assertions in subspace store