### PR TITLE
Use per-chunk memory context for cached chunks

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -371,6 +371,15 @@ chunk_tuple_found(TupleInfo *ti, void *arg)
 	return false;
 }
 
+void
+chunk_free(Chunk *chunk)
+{
+	if (NULL != chunk->cube)
+		hypercube_free(chunk->cube);
+
+	pfree(chunk);
+}
+
 /* Fill in a chunk stub. The stub data structure needs the chunk ID and constraints set.
  * The rest of the fields will be filled in from the table data. */
 static Chunk *

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -68,6 +68,7 @@ typedef struct ChunkScanEntry
 extern Chunk *chunk_create_from_tuple(HeapTuple tuple, int16 num_constraints);
 extern Chunk *chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
 extern Chunk *chunk_create_stub(int32 id, int16 num_constraints);
+extern void chunk_free(Chunk *chunk);
 extern bool chunk_add_constraint(Chunk *chunk, ChunkConstraint *constraint);
 extern bool chunk_add_constraint_from_tuple(Chunk *chunk, HeapTuple constraint_tuple);
 extern Chunk *chunk_find(Hyperspace *hs, Point *p);

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -249,7 +249,6 @@ chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 	MemoryContextSwitchTo(cis_context);
 	state = palloc0(sizeof(ChunkInsertState));
 	state->mctx = cis_context;
-	state->chunk = chunk;
 	state->rel = rel;
 	state->result_relation_info = create_chunk_result_relation_info(dispatch, rel, rti);
 

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -11,7 +11,6 @@
 
 typedef struct ChunkInsertState
 {
-	Chunk	   *chunk;
 	Relation	rel;
 	ResultRelInfo *result_relation_info;
 	List	   *arbiter_indexes;

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -23,6 +23,17 @@ hypercube_alloc(int16 num_dimensions)
 	return hc;
 }
 
+void
+hypercube_free(Hypercube *hc)
+{
+	int			i;
+
+	for (i = 0; i < hc->num_slices; i++)
+		dimension_slice_free(hc->slices[i]);
+
+	pfree(hc);
+}
+
 #if defined(USE_ASSERT_CHECKING)
 static inline bool
 hypercube_is_sorted(Hypercube *hc)

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -23,6 +23,7 @@ typedef struct Hypercube
 
 
 extern Hypercube *hypercube_alloc(int16 num_dimensions);
+extern void hypercube_free(Hypercube *hc);
 extern void hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
 extern Hypercube *hypercube_from_constraints(ChunkConstraint constraints[], int16 num_constraints);
 extern Hypercube *hypercube_calculate_from_point(Hyperspace *hs, Point *p);


### PR DESCRIPTION
The chunk cache needs to free chunk memory as
it evicts chunks from the cache. This was previously
done by pfree:ing the chunk memory, but this didn't
account for sub-allocated objects, like the chunk's
hypercube. This lead to some chunk objects remaining
in the cache's memory context, thus inflating memory
usage, although the objects were no longer associated
with a chunk.

This change adds a per-chunk memory context in the cache
that allows all chunk memory to be easily freed when
the cache entry is evicted or when the chunk cache
is destroyed.