### PR TITLE
Fix EXPLAIN for ConstraintAware and MergeAppend

### DIFF
--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -52,7 +52,7 @@ psql:include/append.sql:44: NOTICE:  Stable function now_s() called!
 -------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: append_test
-   ->  Append
+   Chunks left after exclusion: 0
 (3 rows)
 
 SELECT * FROM append_test WHERE time > now_s() + '1 month';
@@ -65,34 +65,52 @@ psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
 ------+------+---------
 (0 rows)
 
+--query should exclude all chunks and be a MergeAppend
+EXPLAIN (costs off)
+SELECT * FROM append_test WHERE time > now_s() + '1 month'
+ORDER BY time DESC limit 1;
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+                QUERY PLAN                 
+-------------------------------------------
+ Limit
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: append_test
+         Chunks left after exclusion: 0
+(4 rows)
+
 -- when optimized, the plan should be a constraint-aware append and
 -- cover only one chunk. It should be a backward index scan due to
 -- descending index on time. Should also skip the main table, since it
 -- cannot hold tuples
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: append_test
+   Chunks left after exclusion: 1
    ->  Append
          ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(5 rows)
+(6 rows)
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -103,31 +121,32 @@ psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: append_test
+         Chunks left after exclusion: 1
          ->  Merge Append
                Sort Key: _hyper_1_3_chunk."time"
                ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                      Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(7 rows)
+(8 rows)
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -139,8 +158,8 @@ psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
-psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:77: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:77: NOTICE:  Immutable function now_i() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -167,6 +186,7 @@ ORDER BY time;
    Sort Key: append_test."time"
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: append_test
+         Chunks left after exclusion: 3
          ->  Append
                ->  Seq Scan on _hyper_1_1_chunk
                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
@@ -174,15 +194,15 @@ ORDER BY time;
                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
                ->  Seq Scan on _hyper_1_3_chunk
                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-(11 rows)
+(12 rows)
 
 SELECT * FROM append_test WHERE time > now_v() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -194,12 +214,12 @@ PREPARE query_opt AS
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time;
 EXECUTE query_opt;
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -207,29 +227,30 @@ psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
 
 EXPLAIN (costs off)
 EXECUTE query_opt;
-psql:include/append.sql:94: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: append_test
+   Chunks left after exclusion: 1
    ->  Merge Append
          Sort Key: _hyper_1_3_chunk."time"
          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(6 rows)
+(7 rows)
 
 -- aggregates should produce same output
 SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
             t             | avg  
 --------------------------+------
  Sun Jan 01 00:00:00 2017 | 28.5
@@ -241,11 +262,11 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -254,12 +275,13 @@ psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
          Group Key: date_trunc('year'::text, append_test."time")
          ->  Custom Scan (ConstraintAwareAppend)
                Hypertable: append_test
+               Chunks left after exclusion: 2
                ->  Append
                      ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
                            Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
                      ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                            Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(11 rows)
+(12 rows)
 
 -- a parameterized query can safely constify params, so won't be
 -- optimized by constraint-aware append since regular constraint
@@ -268,7 +290,7 @@ PREPARE query_param AS
 SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 EXPLAIN (costs off)
 EXECUTE query_param(now_s() - interval '2 months');
-psql:include/append.sql:116: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:121: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -285,7 +307,7 @@ psql:include/append.sql:116: NOTICE:  Stable function now_s() called!
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamp, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:121: NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+psql:include/append.sql:126: NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
  create_hypertable 
 -------------------
  
@@ -303,27 +325,29 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Nested Loop
    Join Filter: (a.colorid = j.colorid)
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: append_test
+         Chunks left after exclusion: 1
          ->  Append
                ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk a_1
                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: join_test
+         Chunks left after exclusion: 3
          ->  Append
                ->  Index Scan using _hyper_2_4_chunk_join_test_time_idx on _hyper_2_4_chunk j_1
                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
@@ -331,25 +355,25 @@ psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
                ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_3
                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
-(16 rows)
+(18 rows)
 
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
            time           | temp | colorid |           time           | temp | colorid 
 --------------------------+------+---------+--------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3 | Tue Aug 22 09:18:22 2017 | 23.1 |       3

--- a/test/expected/append_unoptimized.out
+++ b/test/expected/append_unoptimized.out
@@ -72,16 +72,39 @@ psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
 ------+------+---------
 (0 rows)
 
+--query should exclude all chunks and be a MergeAppend
+EXPLAIN (costs off)
+SELECT * FROM append_test WHERE time > now_s() + '1 month'
+ORDER BY time DESC limit 1;
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit
+   ->  Merge Append
+         Sort Key: append_test."time" DESC
+         ->  Index Scan using append_test_time_idx on append_test
+               Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+         ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
+               Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+         ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
+               Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
+               Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+(11 rows)
+
 -- when optimized, the plan should be a constraint-aware append and
 -- cover only one chunk. It should be a backward index scan due to
 -- descending index on time. Should also skip the main table, since it
 -- cannot hold tuples
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
  Append
@@ -97,13 +120,13 @@ psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -114,10 +137,10 @@ psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit
@@ -136,14 +159,14 @@ psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -155,8 +178,8 @@ psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
-psql:include/append.sql:72: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:77: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:77: NOTICE:  Immutable function now_i() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -194,11 +217,11 @@ ORDER BY time;
 
 SELECT * FROM append_test WHERE time > now_v() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:83: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:88: NOTICE:  Volatile function now_v() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -210,14 +233,14 @@ PREPARE query_opt AS
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time;
 EXECUTE query_opt;
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
            time           | temp | colorid 
 --------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3
@@ -244,13 +267,13 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:100: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:105: NOTICE:  Stable function now_s() called!
             t             | avg  
 --------------------------+------
  Sun Jan 01 00:00:00 2017 | 28.5
@@ -262,10 +285,10 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -291,7 +314,7 @@ PREPARE query_param AS
 SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 EXPLAIN (costs off)
 EXECUTE query_param(now_s() - interval '2 months');
-psql:include/append.sql:116: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:121: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -308,7 +331,7 @@ psql:include/append.sql:116: NOTICE:  Stable function now_s() called!
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamp, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:121: NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+psql:include/append.sql:126: NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
  create_hypertable 
 -------------------
  
@@ -326,14 +349,14 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Nested Loop
@@ -361,20 +384,20 @@ psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:140: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:145: NOTICE:  Stable function now_s() called!
            time           | temp | colorid |           time           | temp | colorid 
 --------------------------+------+---------+--------------------------+------+---------
  Tue Aug 22 09:18:22 2017 | 34.1 |       3 | Tue Aug 22 09:18:22 2017 | 23.1 |       3

--- a/test/expected/append_x_diff.out
+++ b/test/expected/append_x_diff.out
@@ -23,12 +23,36 @@
 > -------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
 >    Hypertable: append_test
->    ->  Append
+>    Chunks left after exclusion: 0
 > (3 rows)
 69,70d63
 < psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
 < psql:include/append.sql:45: NOTICE:  Stable function now_s() called!
-85,96c78,86
+83,84c76,78
+<                                        QUERY PLAN                                       
+< ----------------------------------------------------------------------------------------
+---
+> psql:include/append.sql:50: NOTICE:  Stable function now_s() called!
+>                 QUERY PLAN                 
+> -------------------------------------------
+86,96c80,83
+<    ->  Merge Append
+<          Sort Key: append_test."time" DESC
+<          ->  Index Scan using append_test_time_idx on append_test
+<                Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+<          ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
+<                Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+<          ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
+<                Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+<          ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
+<                Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
+< (11 rows)
+---
+>    ->  Custom Scan (ConstraintAwareAppend)
+>          Hypertable: append_test
+>          Chunks left after exclusion: 0
+> (4 rows)
+108,119c95,104
 <                                     QUERY PLAN                                    
 < ----------------------------------------------------------------------------------
 <  Append
@@ -42,25 +66,26 @@
 <          Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 < (9 rows)
 ---
-> psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:57: NOTICE:  Stable function now_s() called!
 >                                        QUERY PLAN                                       
 > ----------------------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
 >    Hypertable: append_test
+>    Chunks left after exclusion: 1
 >    ->  Append
 >          ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-> (5 rows)
-106d95
-< psql:include/append.sql:55: NOTICE:  Stable function now_s() called!
-121,122c110,112
+> (6 rows)
+129d113
+< psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+144,145c128,130
 <                                            QUERY PLAN                                            
 < -------------------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:61: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:66: NOTICE:  Stable function now_s() called!
 >                                               QUERY PLAN                                               
 > -------------------------------------------------------------------------------------------------------
-124,134c114,120
+147,157c132,139
 <    ->  Merge Append
 <          Sort Key: append_test."time"
 <          ->  Index Scan Backward using append_test_time_idx on append_test
@@ -75,21 +100,22 @@
 ---
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: append_test
+>          Chunks left after exclusion: 1
 >          ->  Merge Append
 >                Sort Key: _hyper_1_3_chunk."time"
 >                ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                      Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-> (7 rows)
-145,146d130
-< psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:65: NOTICE:  Stable function now_s() called!
-180,181c164,165
+> (8 rows)
+168,169d149
+< psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+< psql:include/append.sql:70: NOTICE:  Stable function now_s() called!
+203,204c183,184
 <                             QUERY PLAN                             
 < -------------------------------------------------------------------
 ---
 >                                QUERY PLAN                                
 > -------------------------------------------------------------------------
-184,192c168,176
+207,216c187,197
 <    ->  Append
 <          ->  Seq Scan on append_test
 <                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
@@ -99,9 +125,11 @@
 <                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
 <          ->  Seq Scan on _hyper_1_3_chunk
 <                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
+< (11 rows)
 ---
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: append_test
+>          Chunks left after exclusion: 3
 >          ->  Append
 >                ->  Seq Scan on _hyper_1_1_chunk
 >                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
@@ -109,10 +137,11 @@
 >                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
 >                ->  Seq Scan on _hyper_1_3_chunk
 >                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-219,220d202
-< psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:91: NOTICE:  Stable function now_s() called!
-228,240c210,219
+> (12 rows)
+242,243d222
+< psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+< psql:include/append.sql:96: NOTICE:  Stable function now_s() called!
+251,263c230,240
 <                                         QUERY PLAN                                         
 < -------------------------------------------------------------------------------------------
 <  Merge Append
@@ -127,41 +156,43 @@
 <          Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 < (10 rows)
 ---
-> psql:include/append.sql:94: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
 >                                            QUERY PLAN                                            
 > -------------------------------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
 >    Hypertable: append_test
+>    Chunks left after exclusion: 1
 >    ->  Merge Append
 >          Sort Key: _hyper_1_3_chunk."time"
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-> (6 rows)
-268a248
-> psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
-275c255,256
+> (7 rows)
+291a269
+> psql:include/append.sql:112: NOTICE:  Stable function now_s() called!
+298c276,278
 <          ->  Result
 ---
 >          ->  Custom Scan (ConstraintAwareAppend)
 >                Hypertable: append_test
-277,280d257
+>                Chunks left after exclusion: 2
+300,303d279
 <                      ->  Seq Scan on append_test
 <                            Filter: ("time" > (now_s() - '@ 4 mons'::interval))
 <                      ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
 <                            Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-285c262
+308c284
 < (14 rows)
 ---
-> (11 rows)
-337,338c314,317
+> (12 rows)
+360,361c336,339
 <                                          QUERY PLAN                                         
 < --------------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:136: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:141: NOTICE:  Stable function now_s() called!
 >                                             QUERY PLAN                                            
 > --------------------------------------------------------------------------------------------------
-341,359c320,334
+364,382c342,358
 <    ->  Append
 <          ->  Seq Scan on append_test a
 <                Filter: ("time" > (now_s() - '@ 3 hours'::interval))
@@ -184,11 +215,13 @@
 ---
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: append_test
+>          Chunks left after exclusion: 1
 >          ->  Append
 >                ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk a_1
 >                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: join_test
+>          Chunks left after exclusion: 3
 >          ->  Append
 >                ->  Index Scan using _hyper_2_4_chunk_join_test_time_idx on _hyper_2_4_chunk j_1
 >                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
@@ -196,4 +229,4 @@
 >                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
 >                ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_3
 >                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
-> (16 rows)
+> (18 rows)

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -163,11 +163,12 @@ LIMIT 2;
          Group Key: (date_trunc('minute'::text, hyper_1."time"))
          ->  Custom Scan (ConstraintAwareAppend)
                Hypertable: hyper_1
+               Chunks left after exclusion: 1
                ->  Merge Append
                      Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
                      ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(9 rows)
+(10 rows)
 
 SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
 FROM hyper_1 

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -80,16 +80,17 @@
 ---
 >                                                       QUERY PLAN                                                       
 > -----------------------------------------------------------------------------------------------------------------------
-162,170c164,176
+162,171c164,176
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, hyper_1."time"))
 <          ->  Custom Scan (ConstraintAwareAppend)
 <                Hypertable: hyper_1
+<                Chunks left after exclusion: 1
 <                ->  Merge Append
 <                      Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
 <                      ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
 <                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-< (9 rows)
+< (10 rows)
 ---
 >    ->  Sort
 >          Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
@@ -104,13 +105,13 @@
 >                                  ->  Bitmap Index Scan on _hyper_1_1_chunk_time_plain
 >                                        Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (13 rows)
-239,240c245,246
+240,241c245,246
 <                                         QUERY PLAN                                        
 < ------------------------------------------------------------------------------------------
 ---
 >                                    QUERY PLAN                                    
 > ---------------------------------------------------------------------------------
-244,249c250,256
+245,250c250,256
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, hyper_1."time")) DESC
@@ -125,13 +126,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-261,262c268,269
+262,263c268,269
 <                                                                 QUERY PLAN                                                                 
 < -------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-266,271c273,279
+267,272c273,279
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: ((time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
@@ -146,13 +147,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-283,284c291,292
+284,285c291,292
 <                                                    QUERY PLAN                                                    
 < -----------------------------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-288,293c296,302
+289,294c296,302
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval))) DESC
@@ -167,13 +168,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-305,306c314,315
+306,307c314,315
 <                                                                 QUERY PLAN                                                                 
 < -------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-310,315c319,325
+311,316c319,325
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: ((time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
@@ -188,13 +189,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-327,328c337,338
+328,329c337,338
 <                                          QUERY PLAN                                          
 < ---------------------------------------------------------------------------------------------
 ---
 >                                      QUERY PLAN                                     
 > ------------------------------------------------------------------------------------
-332,337c342,348
+333,338c342,348
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, hyper_1_tz."time")) DESC
@@ -209,13 +210,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-349,350c360,361
+350,351c360,361
 <                                                        QUERY PLAN                                                        
 < -------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                     QUERY PLAN                                                     
 > -------------------------------------------------------------------------------------------------------------------
-354,359c365,371
+355,360c365,371
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, (hyper_1_tz."time")::timestamp without time zone)) DESC
@@ -230,13 +231,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-371,372c383,384
+372,373c383,384
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                            QUERY PLAN                            
 > -----------------------------------------------------------------
-376,383c388,396
+377,384c388,396
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (((hyper_1_int."time" / 10) * 10)) DESC
@@ -255,13 +256,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-395,396c408,409
+396,397c408,409
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                                  QUERY PLAN                                  
 > -----------------------------------------------------------------------------
-400,407c413,421
+401,408c413,421
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (((((hyper_1_int."time" - 2) / 10) * 10) + 2)) DESC
@@ -280,13 +281,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-460,461c474,475
+461,462c474,475
 <                                           QUERY PLAN                                           
 < -----------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-463,467c477,485
+464,468c477,485
 <    ->  GroupAggregate
 <          Group Key: date_trunc('minute'::text, "time")
 <          ->  Index Scan using time_plain_plain_table on plain_table

--- a/test/sql/include/append.sql
+++ b/test/sql/include/append.sql
@@ -44,6 +44,11 @@ EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() + '1 month';
 SELECT * FROM append_test WHERE time > now_s() + '1 month';
 
+--query should exclude all chunks and be a MergeAppend
+EXPLAIN (costs off)
+SELECT * FROM append_test WHERE time > now_s() + '1 month'
+ORDER BY time DESC limit 1;
+
 -- when optimized, the plan should be a constraint-aware append and
 -- cover only one chunk. It should be a backward index scan due to
 -- descending index on time. Should also skip the main table, since it


### PR DESCRIPTION
This fixes a bug with an explain for ConstraintAware plans
when all chunks were excluded and a MergeAppend was used.
The problem was that the EXPLAIN output for MergeAppend nodes
expected at least one child to print the sorting column info.
When all chunks were excluded there are no children. This
PR removes all child execution states from the ConstraintAware
node when all chunks are excluded.