### PR TITLE
Recurse CLUSTER command to chunks

### DIFF
--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -7,6 +7,13 @@
 typedef struct Chunk Chunk;
 typedef struct Hypertable Hypertable;
 
+typedef struct ChunkIndexMapping
+{
+	Oid			chunkoid;
+	Oid			parent_indexoid;
+	Oid			indexoid;
+} ChunkIndexMapping;
+
 extern void chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid, int32 chunk_id, Oid chunkrelid);
 extern Oid	chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid, int32 hypertable_id, Oid hypertable_indexrelid);
 extern int	chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool should_drop);
@@ -15,4 +22,7 @@ extern int	chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *ne
 extern int	chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *newname);
 extern int	chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, const char *tablespace);
 extern void chunk_index_create_from_constraint(int32 hypertable_id, Oid hypertable_constaint, int32 chunk_id, Oid chunk_constraint);
+extern List *chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid);
+extern void chunk_index_mark_clustered(Oid chunkrelid, Oid indexrelid);
+
 #endif   /* TIMESCALEDB_CHUNK_INDEX_H */

--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -1,0 +1,94 @@
+CREATE TABLE cluster_test(time timestamptz, temp float, location int);
+SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => interval '1 day');
+NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+-- Show default indexes
+SELECT * FROM test.show_indexes('cluster_test');
+         Index         | Columns | Unique | Primary | Exclusion | Tablespace 
+-----------------------+---------+--------+---------+-----------+------------
+ cluster_test_time_idx | {time}  | f      | f       | f         | 
+(1 row)
+
+-- Create two chunks
+INSERT INTO cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1),
+       ('2017-01-21T09:00:01', 21.3, 2);
+-- Run cluster
+CLUSTER VERBOSE cluster_test USING cluster_test_time_idx;
+INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using index scan on "_hyper_1_2_chunk_cluster_test_time_idx"
+INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using index scan on "_hyper_1_1_chunk_cluster_test_time_idx"
+INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "public.cluster_test" using sequential scan and sort
+INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
+-- Create a third chunk
+INSERT INTO cluster_test VALUES ('2017-01-22T09:00:01', 19.5, 3);
+-- Show clustered indexes
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true;
+                          indexrelid                          | indisclustered 
+--------------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx | t
+ _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx | t
+ cluster_test_time_idx                                        | t
+(3 rows)
+
+-- Recluster just our table
+CLUSTER VERBOSE cluster_test;
+INFO:  clustering "_timescaledb_internal._hyper_1_3_chunk" using index scan on "_hyper_1_3_chunk_cluster_test_time_idx"
+INFO:  "_hyper_1_3_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
+INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
+INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "public.cluster_test" using sequential scan and sort
+INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
+-- Show clustered indexes, including new chunk
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true;
+                          indexrelid                          | indisclustered 
+--------------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx | t
+ _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx | t
+ cluster_test_time_idx                                        | t
+ _timescaledb_internal._hyper_1_3_chunk_cluster_test_time_idx | t
+(4 rows)
+
+-- Recluster all tables (although will only be our test table)
+CLUSTER VERBOSE;
+INFO:  clustering "_timescaledb_internal._hyper_1_3_chunk" using sequential scan and sort
+INFO:  "_hyper_1_3_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "public.cluster_test" using sequential scan and sort
+INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
+INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
+INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
+INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+-- Change the clustered index
+CREATE INDEX ON cluster_test (time, location);
+CLUSTER VERBOSE cluster_test using cluster_test_time_location_idx;
+INFO:  clustering "_timescaledb_internal._hyper_1_3_chunk" using sequential scan and sort
+INFO:  "_hyper_1_3_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
+INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
+INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "public.cluster_test" using sequential scan and sort
+INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
+-- Show updated clustered indexes
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true;
+                        indexrelid                        | indisclustered 
+----------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_3_chunk_time_location_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_time_location_idx | t
+ _timescaledb_internal._hyper_1_1_chunk_time_location_idx | t
+ cluster_test_time_location_idx                           | t
+(4 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_FILES
   append_unoptimized.sql
   append_x_diff.sql
   chunks.sql
+  cluster.sql
   constraint.sql
   copy_from.sql
   create_chunks.sql

--- a/test/sql/cluster.sql
+++ b/test/sql/cluster.sql
@@ -1,0 +1,42 @@
+CREATE TABLE cluster_test(time timestamptz, temp float, location int);
+
+SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => interval '1 day');
+
+-- Show default indexes
+SELECT * FROM test.show_indexes('cluster_test');
+
+-- Create two chunks
+INSERT INTO cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1),
+       ('2017-01-21T09:00:01', 21.3, 2);
+
+-- Run cluster
+CLUSTER VERBOSE cluster_test USING cluster_test_time_idx;
+
+-- Create a third chunk
+INSERT INTO cluster_test VALUES ('2017-01-22T09:00:01', 19.5, 3);
+
+-- Show clustered indexes
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true;
+
+-- Recluster just our table
+CLUSTER VERBOSE cluster_test;
+
+-- Show clustered indexes, including new chunk
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true;
+
+-- Recluster all tables (although will only be our test table)
+CLUSTER VERBOSE;
+
+-- Change the clustered index
+CREATE INDEX ON cluster_test (time, location);
+
+CLUSTER VERBOSE cluster_test using cluster_test_time_location_idx;
+
+-- Show updated clustered indexes
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true;


### PR DESCRIPTION
Clustering a table means reordering it according to an index.
This operation requires an exclusive lock and extensive
processing time. On large hypertables with many chunks, CLUSTER
risks blocking a lot of operations by holding locks for a long time.
This is alleviated by processing each chunk in a new transaction,
ensuring locks are only held on one chunk at a time.