### PR TITLE
Change DATE partitioning to be completely tz-independent

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -172,7 +172,7 @@ time_value_to_internal(Datum time_val, Oid type)
 	}
 	if (type == DATEOID)
 	{
-		Datum		tz = DirectFunctionCall1(date_timestamptz, time_val);
+		Datum		tz = DirectFunctionCall1(date_timestamp, time_val);
 		Datum		res = DirectFunctionCall1(pg_timestamp_to_unix_microseconds, tz);
 
 		return DatumGetInt64(res);

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -399,3 +399,15 @@ SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>6553
  
 (1 row)
 
+--make sure date inserts work even when the timezone changes the 
+CREATE TABLE hyper_date(time date, temp float);
+SELECT create_hypertable('"hyper_date"', 'time');
+NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+SET timezone=+1;
+INSERT INTO "hyper_date" VALUES('2011-01-26', 22.5);
+RESET timezone;

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -110,3 +110,10 @@ SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>6553
 SELECT create_hypertable('"smallinttime_err"', 'time');
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>65535);
+
+--make sure date inserts work even when the timezone changes the 
+CREATE TABLE hyper_date(time date, temp float);
+SELECT create_hypertable('"hyper_date"', 'time');
+SET timezone=+1;
+INSERT INTO "hyper_date" VALUES('2011-01-26', 22.5);
+RESET timezone;


### PR DESCRIPTION
The insert logic in time_value_to_internal was not tz independent,
causing problems with date in some timezones. This is now fixed.

Fixes #306.