### PR TITLE
Run standard PostgreSQL tests with TimescaleDB loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,23 @@ os:
 services:
   - docker
 env:
-  - PG_VERSION=9.6.5
-  - PG_VERSION=10.0
-
+  # PG_VERSION (docker) and PG_GIT_TAG (Git) should be the same
+  - PG_VERSION=9.6.5 PG_GIT_TAG=REL9_6_5
+  - PG_VERSION=10.0 PG_GIT_TAG=REL_10_0
 before_install:
-  - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build postgres:${PG_VERSION}-alpine
+  # We need the PostgreSQL source for running the standard PostgreSQL
+  # regression tests
+  - git clone --branch ${PG_GIT_TAG} --depth 1 https://github.com/postgres/postgres.git /tmp/postgres
+  - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres postgres:${PG_VERSION}-alpine
 install:
-  - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake && mkdir -p /build/debug && cd /build/debug && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug && make install && chown -R postgres:postgres /build/"
+  - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake bison flex && mkdir -p /build/debug"
+  # We only need to build the regress stuff
+  - docker exec -it pgbuild /bin/sh -c "cd /postgres && ./configure --enable-debug --enable-cassert --without-readline --without-zlib && make -C /postgres/src/test/regress"
+  - docker exec -it pgbuild /bin/sh -c "cd /build/debug && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug -DPG_SOURCE_DIR=/postgres && make install && chown -R postgres:postgres /build/"
 script:
-  - docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug installcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
+  - docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug installcheck pginstallcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 after_failure:
-  - docker exec -it pgbuild cat /build/debug/test/regression.diffs
+  - docker exec -it pgbuild cat /build/debug/test/regression.diffs /build/debug/test/pgtest/regressions.diffs
 after_script:
   - docker rm -f pgbuild
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,13 +167,13 @@ if (PG_SOURCE_DIR)
   message(STATUS "Found PostgreSQL source in ${PG_SOURCE_DIR}")
 endif (PG_SOURCE_DIR)
 
+add_subdirectory(sql)
+add_subdirectory(src)
+
 if (UNIX)
   add_subdirectory(test)
   add_subdirectory(scripts)
 endif (UNIX)
-
-add_subdirectory(sql)
-add_subdirectory(src)
 
 set(EXT_CONTROL_FILE ${PROJECT_NAME}.control)
 configure_file(${EXT_CONTROL_FILE}.in ${EXT_CONTROL_FILE})

--- a/sql/bookend.sql
+++ b/sql/bookend.sql
@@ -1,37 +1,37 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.first_sfunc(internal, anyelement, "any")
 RETURNS internal
 AS '$libdir/timescaledb', 'first_sfunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.first_combinefunc(internal, internal)
 RETURNS internal
 AS '$libdir/timescaledb', 'first_combinefunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.last_sfunc(internal, anyelement, "any")
 RETURNS internal
 AS '$libdir/timescaledb', 'last_sfunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.last_combinefunc(internal, internal)
 RETURNS internal
 AS '$libdir/timescaledb', 'last_combinefunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.bookend_finalfunc(internal, anyelement, "any")
 RETURNS anyelement
 AS '$libdir/timescaledb', 'bookend_finalfunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.bookend_serializefunc(internal)
 RETURNS bytea
 AS '$libdir/timescaledb', 'bookend_serializefunc'
-LANGUAGE C IMMUTABLE STRICT;
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.bookend_deserializefunc(bytea, internal)
 RETURNS internal
 AS '$libdir/timescaledb', 'bookend_deserializefunc'
-LANGUAGE C IMMUTABLE STRICT;
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 --This aggregate returns the "first" element of the first argument when ordered by the second argument.
 --Ex. first(temp, time) returns the temp value for the row with the lowest time

--- a/sql/bookend.sql
+++ b/sql/bookend.sql
@@ -26,12 +26,12 @@ LANGUAGE C IMMUTABLE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.bookend_serializefunc(internal)
 RETURNS bytea
 AS '$libdir/timescaledb', 'bookend_serializefunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.bookend_deserializefunc(bytea, internal)
 RETURNS internal
 AS '$libdir/timescaledb', 'bookend_deserializefunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE STRICT;
 
 --This aggregate returns the "first" element of the first argument when ordered by the second argument.
 --Ex. first(temp, time) returns the temp value for the row with the lowest time
@@ -60,5 +60,3 @@ CREATE AGGREGATE last(anyelement, "any") (
     FINALFUNC = _timescaledb_internal.bookend_finalfunc,
     FINALFUNC_EXTRA
 );
-
-

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -538,7 +538,7 @@ END
 $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.verify_hypertable_indexes(hypertable REGCLASS) RETURNS VOID
-AS '$libdir/timescaledb', 'indexing_verify_hypertable_indexes' LANGUAGE C IMMUTABLE STRICT;
+AS '$libdir/timescaledb', 'indexing_verify_hypertable_indexes' LANGUAGE C STRICT;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_change_owner(main_table OID, new_table_owner NAME)
     RETURNS void LANGUAGE plpgsql

--- a/sql/ddl_triggers.sql
+++ b/sql/ddl_triggers.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
-AS '$libdir/timescaledb', 'timescaledb_ddl_command_end' LANGUAGE C IMMUTABLE STRICT;
+AS '$libdir/timescaledb', 'timescaledb_ddl_command_end' LANGUAGE C;
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_command_end;
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end

--- a/sql/histogram.sql
+++ b/sql/histogram.sql
@@ -1,27 +1,27 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_sfunc (state INTERNAL, val DOUBLE PRECISION, MIN DOUBLE PRECISION, MAX DOUBLE PRECISION, nbuckets INTEGER)
 RETURNS INTERNAL
 AS '$libdir/timescaledb', 'hist_sfunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_combinefunc(state1 INTERNAL, state2 INTERNAL)
 RETURNS INTERNAL
 AS '$libdir/timescaledb', 'hist_combinefunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_serializefunc(INTERNAL)
 RETURNS bytea
 AS '$libdir/timescaledb', 'hist_serializefunc'
-LANGUAGE C IMMUTABLE STRICT;
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_deserializefunc(bytea, INTERNAL)
 RETURNS INTERNAL
 AS '$libdir/timescaledb', 'hist_deserializefunc'
-LANGUAGE C IMMUTABLE STRICT;
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_finalfunc(state INTERNAL, val DOUBLE PRECISION, MIN DOUBLE PRECISION, MAX DOUBLE PRECISION, nbuckets INTEGER)
 RETURNS INTEGER[]
 AS '$libdir/timescaledb', 'hist_finalfunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 -- Tell Postgres how to use the new function
 DROP AGGREGATE IF EXISTS histogram (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, INTEGER);

--- a/sql/histogram.sql
+++ b/sql/histogram.sql
@@ -11,12 +11,12 @@ LANGUAGE C IMMUTABLE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_serializefunc(INTERNAL)
 RETURNS bytea
 AS '$libdir/timescaledb', 'hist_serializefunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_deserializefunc(bytea, INTERNAL)
 RETURNS INTERNAL
 AS '$libdir/timescaledb', 'hist_deserializefunc'
-LANGUAGE C IMMUTABLE;
+LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_finalfunc(state INTERNAL, val DOUBLE PRECISION, MIN DOUBLE PRECISION, MAX DOUBLE PRECISION, nbuckets INTEGER)
 RETURNS INTEGER[]

--- a/sql/partitioning.sql
+++ b/sql/partitioning.sql
@@ -1,8 +1,8 @@
 -- Deprecated partition hash function
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_partition_for_key(val anyelement)
     RETURNS int
-    AS '$libdir/timescaledb', 'get_partition_for_key' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'get_partition_for_key' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_partition_hash(val anyelement)
     RETURNS int
-    AS '$libdir/timescaledb', 'get_partition_hash' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'get_partition_hash' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -77,7 +77,7 @@ $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.dimension_is_finite(
     val      BIGINT
 )
-    RETURNS BOOLEAN LANGUAGE SQL IMMUTABLE AS
+    RETURNS BOOLEAN LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
 $BODY$
     --end values of bigint reserved for infinite
     SELECT val > (-9223372036854775808)::bigint AND val < 9223372036854775807::bigint
@@ -249,4 +249,4 @@ END
 $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.validate_triggers(main_table REGCLASS) RETURNS VOID
-    AS '$libdir/timescaledb', 'hypertable_validate_triggers' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'hypertable_validate_triggers' LANGUAGE C STRICT;

--- a/sql/util_time.sql
+++ b/sql/util_time.sql
@@ -1,15 +1,15 @@
 -- This file contains utilities for time conversion.
 CREATE OR REPLACE FUNCTION _timescaledb_internal.to_microseconds(ts TIMESTAMPTZ) RETURNS BIGINT
-	AS '$libdir/timescaledb', 'pg_timestamp_to_microseconds' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'pg_timestamp_to_microseconds' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.to_unix_microseconds(ts TIMESTAMPTZ) RETURNS BIGINT
-	AS '$libdir/timescaledb', 'pg_timestamp_to_unix_microseconds' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'pg_timestamp_to_unix_microseconds' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.to_timestamp(unixtime_us BIGINT) RETURNS TIMESTAMPTZ
-	AS '$libdir/timescaledb', 'pg_unix_microseconds_to_timestamp' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'pg_unix_microseconds_to_timestamp' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.to_timestamp_pg(postgres_us BIGINT) RETURNS TIMESTAMPTZ
-	AS '$libdir/timescaledb', 'pg_microseconds_to_timestamp' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'pg_microseconds_to_timestamp' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 
 -- Time can be represented in a hypertable as an int* (bigint/integer/smallint) or as a timestamp type (
@@ -45,7 +45,7 @@ $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.interval_to_usec(
        chunk_interval INTERVAL
 )
-RETURNS BIGINT LANGUAGE SQL IMMUTABLE AS
+RETURNS BIGINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
 $BODY$
     SELECT (int_sec * 1000000)::bigint from extract(epoch from chunk_interval) as int_sec;
 $BODY$;
@@ -56,7 +56,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.time_interval_specification_to_
     default_value INTERVAL,
     field_name TEXT
 )
-RETURNS BIGINT LANGUAGE PLPGSQL IMMUTABLE AS
+RETURNS BIGINT LANGUAGE PLPGSQL AS
 $BODY$
 BEGIN
     IF time_type IN ('TIMESTAMP', 'TIMESTAMPTZ', 'DATE') THEN

--- a/sql/version.sql
+++ b/sql/version.sql
@@ -1,2 +1,2 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
-	AS '$libdir/timescaledb', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
+    AS '$libdir/timescaledb', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,28 +11,42 @@ set(TEST_ROLE_DEFAULT_PERM_USER default_perm_user)
 set(TEST_ROLE_DEFAULT_PERM_USER_2 default_perm_user_2)
 
 # Basic connection info for test instance
-set(TEST_PGPORT_LOCAL 5432)
-set(TEST_PGPORT_TEMP_INSTANCE 1432)
-set(TEST_PGHOST localhost)
-set(TEST_PGUSER ${TEST_ROLE_DEFAULT_PERM_USER})
-set(TEST_DBNAME single)
+set(TEST_PGPORT_LOCAL 5432 CACHE STRING "The port of a running PostgreSQL instance")
+set(TEST_PGHOST localhost CACHE STRING "The hostname of a running PostgreSQL instance")
+set(TEST_PGUSER ${TEST_ROLE_DEFAULT_PERM_USER} CACHE STRING "The PostgreSQL test user")
+set(TEST_DBNAME single CACHE STRING "The database name to use for tests")
+set(TEST_PGPORT_TEMP_INSTANCE 15432 CACHE STRING "The port to run a temporary test PostgreSQL instance on")
+set(TEST_SCHEDULE ${CMAKE_CURRENT_BINARY_DIR}/test_schedule CACHE STRING "The test schedule to run")
 set(TEST_INPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(TEST_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(TEST_CLUSTER ${TEST_OUTPUT_DIR}/testcluster)
-set(TEST_SCHEDULE ${CMAKE_CURRENT_BINARY_DIR}/test_schedule)
 
 add_subdirectory(sql)
 
-set(PG_REGRESS_OPTS_COMMON
-  --create-role=${TEST_ROLE_SUPERUSER},${TEST_ROLE_DEFAULT_PERM_USER},${TEST_ROLE_DEFAULT_PERM_USER_2}
-  --dbname=${TEST_DBNAME}
-  --outputdir=${TEST_OUTPUT_DIR}
-  --launcher=${TEST_INPUT_DIR}/runner.sh
+set(PG_REGRESS_OPTS_BASE
+  --user=${TEST_PGUSER}
   --host=${TEST_PGHOST}
   --load-language=plpgsql
-  --dlpath=${PROJECT_BINARY_DIR}/src
-  --inputdir=${TEST_INPUT_DIR})
-SET(PG_REGRESS_ENV
+  --dlpath=${PROJECT_BINARY_DIR}/src)
+
+set(PG_REGRESS_OPTS_EXTRA
+  --create-role=${TEST_ROLE_SUPERUSER},${TEST_ROLE_DEFAULT_PERM_USER},${TEST_ROLE_DEFAULT_PERM_USER_2}
+  --dbname=${TEST_DBNAME}
+  --launcher=${TEST_INPUT_DIR}/runner.sh)
+
+set(PG_REGRESS_OPTS_INOUT
+  --inputdir=${TEST_INPUT_DIR}
+  --outputdir=${TEST_OUTPUT_DIR})
+
+set(PG_REGRESS_OPTS_TEMP_INSTANCE
+  --port=${TEST_PGPORT_TEMP_INSTANCE}
+  --temp-instance=${TEST_CLUSTER}
+  --temp-config=${TEST_OUTPUT_DIR}/postgresql.conf)
+
+set(PG_REGRESS_OPTS_LOCAL_INSTANCE
+  --port=${TEST_PGPORT_LOCAL})
+
+set(PG_REGRESS_ENV
   TEST_PGUSER=${TEST_PGUSER}
   TEST_ROLE_SUPERUSER=${TEST_ROLE_SUPERUSER}
   TEST_ROLE_DEFAULT_PERM_USER=${TEST_ROLE_DEFAULT_PERM_USER}
@@ -43,29 +57,30 @@ SET(PG_REGRESS_ENV
   TEST_SCHEDULE=${TEST_SCHEDULE}
   PG_REGRESS=${PG_REGRESS})
 
-set(PG_REGRESS_OPTS_TEMP_INSTANCE
-  --user=${TEST_PGUSER}
-  --port=${TEST_PGPORT_TEMP_INSTANCE}
-  --temp-instance=${TEST_CLUSTER}
-  --temp-config=${TEST_OUTPUT_DIR}/postgresql.conf
-  ${PG_REGRESS_OPTS_COMMON})
-
-set(PG_REGRESS_OPTS_LOCAL
-  --user=postgres
-  --port=${TEST_PGPORT_LOCAL}
-  ${PG_REGRESS_OPTS_COMMON})
-
-file(MAKE_DIRECTORY ${TEST_OUTPUT_DIR})
 file(WRITE ${TEST_OUTPUT_DIR}/postgresql.conf "shared_preload_libraries=timescaledb")
 
 # installcheck starts up new temporary instances for testing code
 add_custom_target(installcheck
-  COMMAND ${CMAKE_COMMAND} -E env ${PG_REGRESS_ENV}
-  ${CMAKE_CURRENT_SOURCE_DIR}/pg_regress.sh ${PG_REGRESS_OPTS_TEMP_INSTANCE}
+  COMMAND ${CMAKE_COMMAND} -E env
+  ${PG_REGRESS_ENV}
+  ${CMAKE_CURRENT_SOURCE_DIR}/pg_regress.sh
+  ${PG_REGRESS_OPTS_BASE}
+  ${PG_REGRESS_OPTS_EXTRA}
+  ${PG_REGRESS_OPTS_INOUT}
+  ${PG_REGRESS_OPTS_TEMP_INSTANCE}
   USES_TERMINAL)
 
 # installchecklocal tests against an existing postgres instance
 add_custom_target(installchecklocal
-  COMMAND ${CMAKE_COMMAND} -E env ${PG_REGRESS_ENV}
-  ${CMAKE_CURRENT_SOURCE_DIR}/pg_regress.sh ${PG_REGRESS_OPTS_LOCAL}
+  COMMAND ${CMAKE_COMMAND} -E env
+  ${PG_REGRESS_ENV}
+  ${CMAKE_CURRENT_SOURCE_DIR}/pg_regress.sh
+  ${PG_REGRESS_OPTS_BASE}
+  ${PG_REGRESS_OPTS_EXTRA}
+  ${PG_REGRESS_OPTS_INOUT}
+  ${PG_REGRESS_OPTS_LOCAL_INSTANCE}
   USES_TERMINAL)
+
+if (PG_SOURCE_DIR)
+  add_subdirectory(pgtest)
+endif (PG_SOURCE_DIR)

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -1,0 +1,62 @@
+set(PG_REGRESS_DIR
+  ${PG_SOURCE_DIR}/src/test/regress
+  CACHE PATH
+  "Path to PostgreSQL's regress directory")
+
+# Copy the input and output files from PostgreSQL's test suite. The
+# test suite generates some SQL scripts and output files from template
+# source files and require directories to be colocated
+file(COPY
+  ${PG_REGRESS_DIR}/data
+  ${PG_REGRESS_DIR}/input
+  ${PG_REGRESS_DIR}/output
+  ${PG_REGRESS_DIR}/sql
+  ${PG_REGRESS_DIR}/expected
+  DESTINATION
+  ${CMAKE_CURRENT_BINARY_DIR})
+
+file(READ
+  ${PG_REGRESS_DIR}/serial_schedule
+  PG_TEST_SCHEDULE)
+
+# Tests to ignore
+set(PG_IGNORE_TESTS
+  tablespace
+  opr_sanity
+  sanity_check)
+
+# Modify the test schedule to ignore some tests
+foreach(IGNORE_TEST ${PG_IGNORE_TESTS})
+  string(REPLACE
+    "test: ${IGNORE_TEST}" "ignore: ${IGNORE_TEST}\ntest: ${IGNORE_TEST}"
+    PG_TEST_SCHEDULE
+    ${PG_TEST_SCHEDULE})
+endforeach(IGNORE_TEST)
+
+# Write the final test schedule
+file(WRITE
+  ${CMAKE_CURRENT_BINARY_DIR}/serial_schedule
+  ${PG_TEST_SCHEDULE})
+
+# Need --dlpath set to PostgreSQL's test directory so that the tests
+# can load libraries there
+set(PG_REGRESS_OPTS_PGTEST
+  --schedule=${CMAKE_CURRENT_BINARY_DIR}/serial_schedule
+  --load-extension=timescaledb
+  --dlpath=${PG_REGRESS_DIR})
+
+add_custom_target(pginstallcheck
+  COMMAND
+  ${PG_REGRESS}
+  ${PG_REGRESS_OPTS_BASE}
+  ${PG_REGRESS_OPTS_PGTEST}
+  ${PG_REGRESS_OPTS_TEMP_INSTANCE}
+  USES_TERMINAL)
+
+add_custom_target(pginstallchecklocal
+  COMMAND
+  ${PG_REGRESS}
+  ${PG_REGRESS_OPTS_BASE}
+  ${PG_REGRESS_OPTS_PGTEST}
+  ${PG_REGRESS_OPTS_LOCAL_INSTANCE}
+  USES_TERMINAL)

--- a/test/pgtest/README.md
+++ b/test/pgtest/README.md
@@ -1,0 +1,29 @@
+# PostgreSQL tests for TimescaleDB
+
+The CMake configuration within this directory makes it possible to run
+the standard PostgreSQL test suite with the TimescaleDB extension
+loaded. This is useful to ensure that TimescaleDBs modifications
+planner and DDL hooks are compatible with standard PostgreSQL.
+
+## Running
+
+The configuration within adds a new CMake target, `pginstallcheck`,
+that allows running the PostgreSQL test suite using a modified test
+schedule. The target requires access to the PostgreSQL source code,
+which can be configured via the `PG_SOURCE_DIR` CMake variable. The
+source tree needs to be compiled, at least the `src/test/regress`
+directory. If the path to a PostgreSQL source tree is not
+auto-detected, this variable can be set manually to point to the right
+location.
+
+```
+# In top-level directory of a TimescaleDB source tree
+$ mkdir build && cd build
+$ cmake -DPG_SOURCE_DIR=<path/to/pg/source> ..
+```
+
+Once CMake is correctly configured, run:
+
+```
+$ make pginstallcheck
+```


### PR DESCRIPTION
This PR comprises three commits. The main change/commit enables running PostgreSQL's standard regression test suite and is based on @olofr's earlier PR. However, this PR contains some cleanups and test fixes not in the earlier PR. The other two commits fix failures in some of the tests by:

- Making serialize/deserialize functions `STRICT`
- Marking `IMMUTABLE` functions as `PARALLEL SAFE`
- Removing the `IMMUTABLE` label on some functions that aren't immutable

Two tests in the PG test suite still fails. One fails because our metadata tables show up in the test. The other fails on PG10 due to some of our functions being marked with `SECURITY DEFINER`, which none of the PostgreSQL functions are (the PostgreSQL test checks for empty result when querying for such functions). The failing functions have been marked "ignore" in the test schedule but are still run without affecting the outcome.

Note that this summary is not in any of the commit messages.