### PR TITLE
Fix installchecklocal

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,6 @@ set(TEST_CLUSTER ${TEST_OUTPUT_DIR}/testcluster)
 add_subdirectory(sql)
 
 set(PG_REGRESS_OPTS_BASE
-  --user=${TEST_PGUSER}
   --host=${TEST_PGHOST}
   --load-language=plpgsql
   --dlpath=${PROJECT_BINARY_DIR}/src)


### PR DESCRIPTION
Remove user from regression tests so that the local test will work.
The tests itself will still be run with the appropriate user because
of the logic in runner.sh.