### PR TITLE
Fix reindex test

### DIFF
--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -94,10 +94,11 @@ SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
  _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} | t      | t       | f         | 
 (2 rows)
 
-SELECT * FROM _timescaledb_internal.chunk_index_clone('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass);
- chunk_index_clone 
--------------------
-             31375
+SELECT chunk_index_clone::regclass::text
+FROM _timescaledb_internal.chunk_index_clone('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass);
+                      chunk_index_clone                       
+--------------------------------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk_1_1_reindex_test_pkey
 (1 row)
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');

--- a/test/sql/reindex.sql
+++ b/test/sql/reindex.sql
@@ -41,7 +41,8 @@ SELECT * FROM test.show_constraintsp('_timescaledb_internal.%');
 SELECT * FROM reindex_norm;
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
-SELECT * FROM _timescaledb_internal.chunk_index_clone('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass);
+SELECT chunk_index_clone::regclass::text
+FROM _timescaledb_internal.chunk_index_clone('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass);
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
 SELECT * FROM _timescaledb_internal.chunk_index_replace('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass, '_timescaledb_internal."_hyper_1_1_chunk_1_1_reindex_test_pkey"'::regclass);
 


### PR DESCRIPTION
The reindex test outputs the OID of a cloned index. This OID might
change with the state of the database, added tests, etc., causing
frequent test failures. The test is now updated to output the name of
the index instead of the OID.