### PR TITLE
Prevent native partitioning attachment of hypertables

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1291,6 +1291,24 @@ process_altertable_start_table(Node *parsetree)
 				if (ht != NULL)
 					process_alter_column_type_start(ht, cmd);
 				break;
+#if PG10
+			case AT_AttachPartition:
+				{
+					RangeVar   *relation;
+					PartitionCmd *partstmt;
+
+					partstmt = (PartitionCmd *) cmd->def;
+					relation = partstmt->name;
+					Assert(NULL != relation);
+
+					if (InvalidOid != hypertable_relid(relation))
+					{
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("Hypertables do not support native postgres partitioning")));
+					}
+				}
+#endif
 			default:
 				break;
 		}

--- a/test/expected/partitioning-10.out
+++ b/test/expected/partitioning-10.out
@@ -1,0 +1,24 @@
+-- Should expect an error when creating a hypertable from a partition
+\set ON_ERROR_STOP 0
+CREATE TABLE partitioned_ht_create(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+SELECT create_hypertable('partitioned_ht_create', 'time');
+ERROR:  table public.partitioned_ht_create is already partitioned
+\set ON_ERROR_STOP 1
+-- Should expect an error when attaching a hypertable to a partition
+\set ON_ERROR_STOP 0
+CREATE TABLE partitioned_attachment_vanilla(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+CREATE TABLE attachment_hypertable(time timestamptz, temp float, device int);
+SELECT create_hypertable('attachment_hypertable', 'time');
+NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+ALTER TABLE partitioned_attachment_vanilla ATTACH PARTITION attachment_hypertable FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');
+ERROR:  Hypertables do not support native postgres partitioning
+\set ON_ERROR_STOP 1
+-- Should not expect an error when attaching a normal table to a partition
+CREATE TABLE partitioned_vanilla(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+CREATE TABLE attachment_vanilla(time timestamptz, temp float, device int);
+ALTER TABLE partitioned_vanilla ATTACH PARTITION attachment_vanilla FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');

--- a/test/expected/partitioning-9.6.out
+++ b/test/expected/partitioning-9.6.out
@@ -1,0 +1,25 @@
+-- Should expect an error when creating a hypertable from a partition
+\set ON_ERROR_STOP 0
+CREATE TABLE partitioned_ht_create(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION" at character 78
+SELECT create_hypertable('partitioned_ht_create', 'time');
+ERROR:  relation "partitioned_ht_create" does not exist at character 26
+\set ON_ERROR_STOP 1
+-- Should expect an error when attaching a hypertable to a partition
+\set ON_ERROR_STOP 0
+CREATE TABLE partitioned_attachment_vanilla(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION" at character 87
+CREATE TABLE attachment_hypertable(time timestamptz, temp float, device int);
+SELECT create_hypertable('attachment_hypertable', 'time');
+NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+ALTER TABLE partitioned_attachment_vanilla ATTACH PARTITION attachment_hypertable FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');
+ERROR:  syntax error at or near "ATTACH" at character 44
+\set ON_ERROR_STOP 1
+-- Should not expect an error when attaching a normal table to a partition
+CREATE TABLE partitioned_vanilla(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+ERROR:  syntax error at or near "PARTITION" at character 76

--- a/test/sql/.gitignore
+++ b/test/sql/.gitignore
@@ -1,2 +1,4 @@
 /parallel-9.6.sql
 /parallel-10.0.sql
+/partitioning-9.6.sql
+/partitioning-10.sql

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -49,7 +49,8 @@ set(TEST_FILES
   version.sql)
 
 set(TEST_TEMPLATES
-  parallel.sql.in)
+  parallel.sql.in
+  partitioning.sql.in)
 
 # Regression tests that vary with PostgreSQL version. Generated test
 # files are put in the original source directory since all tests must

--- a/test/sql/partitioning.sql.in
+++ b/test/sql/partitioning.sql.in
@@ -1,0 +1,18 @@
+-- Should expect an error when creating a hypertable from a partition
+\set ON_ERROR_STOP 0
+CREATE TABLE partitioned_ht_create(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+SELECT create_hypertable('partitioned_ht_create', 'time');
+\set ON_ERROR_STOP 1
+
+-- Should expect an error when attaching a hypertable to a partition
+\set ON_ERROR_STOP 0
+CREATE TABLE partitioned_attachment_vanilla(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+CREATE TABLE attachment_hypertable(time timestamptz, temp float, device int);
+SELECT create_hypertable('attachment_hypertable', 'time');
+ALTER TABLE partitioned_attachment_vanilla ATTACH PARTITION attachment_hypertable FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');
+\set ON_ERROR_STOP 1
+
+-- Should not expect an error when attaching a normal table to a partition
+CREATE TABLE partitioned_vanilla(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
+CREATE TABLE attachment_vanilla(time timestamptz, temp float, device int);
+ALTER TABLE partitioned_vanilla ATTACH PARTITION attachment_vanilla FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');


### PR DESCRIPTION
Hey guys!

This PR will serve to raise an exception upon an attach partition event on a hypertable to a native postgres partition