### PR TITLE
Modify tests to make more platform agnostic

### DIFF
--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -307,42 +307,42 @@ SELECT * FROM "3dim";
 (3 rows)
 
 -- test that explain works
-EXPLAIN
+EXPLAIN (COSTS FALSE)
 INSERT INTO "3dim" VALUES('2017-01-21T09:00:01', 32.9, 'green', 'nyc'),
                          ('2017-01-21T09:00:47', 27.3, 'purple', 'la') RETURNING *;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.03 rows=2 width=80)
-   ->  Insert on "3dim"  (cost=0.00..0.03 rows=2 width=80)
-         ->  Custom Scan (ChunkDispatch)  (cost=0.00..0.03 rows=2 width=80)
-               ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=2 width=80)
+                 QUERY PLAN                  
+---------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on "3dim"
+         ->  Custom Scan (ChunkDispatch)
+               ->  Values Scan on "*VALUES*"
 (4 rows)
 
-EXPLAIN
+EXPLAIN (COSTS FALSE)
 WITH "3dim_insert" AS (
      INSERT INTO "3dim" VALUES('2017-01-21T09:01:44', 19.3, 'black', 'la') RETURNING time, temp
 ), regular_insert AS (
    INSERT INTO regular_table VALUES('2017-01-21T10:00:51', 14.3) RETURNING time, temp
 ) INSERT INTO "1dim" (SELECT time, temp FROM "3dim_insert" UNION SELECT time, temp FROM regular_insert);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.09..0.12 rows=2 width=16)
-   ->  Insert on "1dim"  (cost=0.09..0.12 rows=2 width=16)
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on "1dim"
          CTE 3dim_insert
-           ->  Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=80)
-                 ->  Insert on "3dim"  (cost=0.00..0.01 rows=1 width=80)
-                       ->  Custom Scan (ChunkDispatch)  (cost=0.00..0.01 rows=1 width=80)
-                             ->  Result  (cost=0.00..0.01 rows=1 width=80)
+           ->  Custom Scan (HypertableInsert)
+                 ->  Insert on "3dim"
+                       ->  Custom Scan (ChunkDispatch)
+                             ->  Result
          CTE regular_insert
-           ->  Insert on regular_table  (cost=0.00..0.01 rows=1 width=16)
-                 ->  Result  (cost=0.00..0.01 rows=1 width=16)
-         ->  Custom Scan (ChunkDispatch)  (cost=0.07..0.09 rows=2 width=16)
-               ->  Unique  (cost=0.07..0.09 rows=2 width=16)
-                     ->  Sort  (cost=0.07..0.08 rows=2 width=16)
+           ->  Insert on regular_table
+                 ->  Result
+         ->  Custom Scan (ChunkDispatch)
+               ->  Unique
+                     ->  Sort
                            Sort Key: "3dim_insert"."time", "3dim_insert".temp
-                           ->  Append  (cost=0.00..0.06 rows=2 width=16)
-                                 ->  CTE Scan on "3dim_insert"  (cost=0.00..0.02 rows=1 width=16)
-                                 ->  CTE Scan on regular_insert  (cost=0.00..0.02 rows=1 width=16)
+                           ->  Append
+                                 ->  CTE Scan on "3dim_insert"
+                                 ->  CTE Scan on regular_insert
 (17 rows)
 
 -- test prepared statement INSERT
@@ -401,7 +401,7 @@ SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>6553
  
 (1 row)
 
---make sure date inserts work even when the timezone changes the 
+--make sure date inserts work even when the timezone changes the
 CREATE TABLE hyper_date(time date, temp float);
 SELECT create_hypertable('"hyper_date"', 'time');
 NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
@@ -413,7 +413,7 @@ NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not al
 SET timezone=+1;
 INSERT INTO "hyper_date" VALUES('2011-01-26', 22.5);
 RESET timezone;
---make sure timestamp inserts work even when the timezone changes the 
+--make sure timestamp inserts work even when the timezone changes the
 SET timezone = 'UTC';
 CREATE TABLE "test_tz"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"test_tz"', 'time', chunk_time_interval=> INTERVAL '1 day');

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -150,11 +150,11 @@ SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2)
 
 --test that when index on time used by constraint, still works correctly
 EXPLAIN (costs off)
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -170,11 +170,11 @@ LIMIT 2;
                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 (10 rows)
 
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
             t             |  avg  |  min  |       avg        
 --------------------------+-------+-------+------------------
@@ -235,7 +235,7 @@ SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
  Wed Dec 31 21:32:00 1969 | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                         QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
@@ -249,7 +249,7 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
 (8 rows)
 
-SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
             t             |   avg   |  min  |       avg        
 --------------------------+---------+-------+------------------
@@ -257,7 +257,7 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
  Wed Dec 31 21:32:00 1969 | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                                                 QUERY PLAN                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------
@@ -271,15 +271,15 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
 (8 rows)
 
-SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-            t             |   avg   |  min  |       avg        
---------------------------+---------+-------+------------------
- Wed Dec 31 21:32:30 1969 |   19975 | 29950 | 141.332930657636
- Wed Dec 31 21:31:30 1969 | 19919.5 | 29890 | 141.136445455771
+            t             |   avg_trunc1   |  min  |  avg_trunc2  
+--------------------------+----------------+-------+--------------
+ Wed Dec 31 21:32:30 1969 | 19975.00000000 | 29950 | 141.33293065
+ Wed Dec 31 21:31:30 1969 | 19919.50000000 | 29890 | 141.13644545
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
@@ -293,15 +293,15 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
 (8 rows)
 
-SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-            t             |   avg   |  min  |       avg        
---------------------------+---------+-------+------------------
- Wed Dec 31 21:32:00 1969 |   19975 | 29950 | 141.332930657636
- Wed Dec 31 21:31:00 1969 | 19919.5 | 29890 | 141.136445455771
+            t             |   avg_trunc1   |  min  |  avg_trunc2  
+--------------------------+----------------+-------+--------------
+ Wed Dec 31 21:32:00 1969 | 19975.00000000 | 29950 | 141.33293065
+ Wed Dec 31 21:31:00 1969 | 19919.50000000 | 29890 | 141.13644545
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                                                 QUERY PLAN                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------
@@ -315,15 +315,15 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
 (8 rows)
 
-SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-            t             |   avg   |  min  |       avg        
---------------------------+---------+-------+------------------
- Wed Dec 31 21:32:30 1969 |   19975 | 29950 | 141.332930657636
- Wed Dec 31 21:31:30 1969 | 19919.5 | 29890 | 141.136445455771
+            t             |   avg_trunc1   |  min  |  avg_trunc2  
+--------------------------+----------------+-------+--------------
+ Wed Dec 31 21:32:30 1969 | 19975.00000000 | 29950 | 141.33293065
+ Wed Dec 31 21:31:30 1969 | 19919.50000000 | 29890 | 141.13644545
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
@@ -337,7 +337,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
 (8 rows)
 
-SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
               t               |   avg   |  min  |       avg        
 ------------------------------+---------+-------+------------------
@@ -345,7 +345,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
  Wed Dec 31 21:32:00 1969 PST | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                                                        QUERY PLAN                                                        
 -------------------------------------------------------------------------------------------------------------------------
@@ -359,7 +359,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
 (8 rows)
 
-SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
             t             |   avg   |  min  |       avg        
 --------------------------+---------+-------+------------------
@@ -367,7 +367,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
  Wed Dec 31 21:32:00 1969 | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
@@ -383,7 +383,7 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_3_5_chunk_time_plain_int on _hyper_3_5_chunk
 (10 rows)
 
-SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
    t   |   avg   |  min  |       avg        
 -------+---------+-------+------------------
@@ -391,7 +391,7 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
  19990 | 19994.5 | 29990 | 141.401909099017
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
@@ -407,7 +407,7 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                      ->  Index Scan using _hyper_3_5_chunk_time_plain_int on _hyper_3_5_chunk
 (10 rows)
 
-SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
    t   |   avg   |  min  |       avg        
 -------+---------+-------+------------------
@@ -417,11 +417,11 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
 
 --plain tables shouldnt be optimized by default
 EXPLAIN (costs off)
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM plain_table 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM plain_table
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -436,11 +436,11 @@ LIMIT 2;
                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 (9 rows)
 
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM plain_table 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM plain_table
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
               t               |  avg  |  min  |       avg        
 ------------------------------+-------+-------+------------------
@@ -452,11 +452,11 @@ LIMIT 2;
 BEGIN;
     SET LOCAL timescaledb.optimize_non_hypertables = 'on';
     EXPLAIN (costs off)
-    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-    FROM plain_table 
-    WHERE time < to_timestamp(900) 
-    GROUP BY t 
-    ORDER BY t DESC 
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+    FROM plain_table
+    WHERE time < to_timestamp(900)
+    GROUP BY t
+    ORDER BY t DESC
     LIMIT 2;
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
@@ -467,11 +467,11 @@ BEGIN;
                Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 (5 rows)
 
-    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-    FROM plain_table 
-    WHERE time < to_timestamp(900) 
-    GROUP BY t 
-    ORDER BY t DESC 
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+    FROM plain_table
+    WHERE time < to_timestamp(900)
+    GROUP BY t
+    ORDER BY t DESC
     LIMIT 2;
               t               |  avg  |  min  |       avg        
 ------------------------------+-------+-------+------------------

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -152,11 +152,11 @@ SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2)
 
 --test that when index on time used by constraint, still works correctly
 EXPLAIN (costs off)
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
@@ -175,11 +175,11 @@ LIMIT 2;
                                        Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 (13 rows)
 
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
             t             |  avg  |  min  |       avg        
 --------------------------+-------+-------+------------------
@@ -240,7 +240,7 @@ SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
  Wed Dec 31 21:32:00 1969 | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
@@ -255,7 +255,7 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_1_1_chunk
 (9 rows)
 
-SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
             t             |   avg   |  min  |       avg        
 --------------------------+---------+-------+------------------
@@ -263,7 +263,7 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
  Wed Dec 31 21:32:00 1969 | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
@@ -278,15 +278,15 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_1_1_chunk
 (9 rows)
 
-SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-            t             |   avg   |  min  |       avg        
---------------------------+---------+-------+------------------
- Wed Dec 31 21:32:30 1969 |   19975 | 29950 | 141.332930657636
- Wed Dec 31 21:31:30 1969 | 19919.5 | 29890 | 141.136445455771
+            t             |   avg_trunc1   |  min  |  avg_trunc2  
+--------------------------+----------------+-------+--------------
+ Wed Dec 31 21:32:30 1969 | 19975.00000000 | 29950 | 141.33293065
+ Wed Dec 31 21:31:30 1969 | 19919.50000000 | 29890 | 141.13644545
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -301,15 +301,15 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_1_1_chunk
 (9 rows)
 
-SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-            t             |   avg   |  min  |       avg        
---------------------------+---------+-------+------------------
- Wed Dec 31 21:32:00 1969 |   19975 | 29950 | 141.332930657636
- Wed Dec 31 21:31:00 1969 | 19919.5 | 29890 | 141.136445455771
+            t             |   avg_trunc1   |  min  |  avg_trunc2  
+--------------------------+----------------+-------+--------------
+ Wed Dec 31 21:32:00 1969 | 19975.00000000 | 29950 | 141.33293065
+ Wed Dec 31 21:31:00 1969 | 19919.50000000 | 29890 | 141.13644545
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
@@ -324,15 +324,15 @@ FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_1_1_chunk
 (9 rows)
 
-SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-            t             |   avg   |  min  |       avg        
---------------------------+---------+-------+------------------
- Wed Dec 31 21:32:30 1969 |   19975 | 29950 | 141.332930657636
- Wed Dec 31 21:31:30 1969 | 19919.5 | 29890 | 141.136445455771
+            t             |   avg_trunc1   |  min  |  avg_trunc2  
+--------------------------+----------------+-------+--------------
+ Wed Dec 31 21:32:30 1969 | 19975.00000000 | 29950 | 141.33293065
+ Wed Dec 31 21:31:30 1969 | 19919.50000000 | 29890 | 141.13644545
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
@@ -347,7 +347,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_2_2_chunk
 (9 rows)
 
-SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
               t               |   avg   |  min  |       avg        
 ------------------------------+---------+-------+------------------
@@ -355,7 +355,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
  Wed Dec 31 21:32:00 1969 PST | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
@@ -370,7 +370,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_2_2_chunk
 (9 rows)
 
-SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
             t             |   avg   |  min  |       avg        
 --------------------------+---------+-------+------------------
@@ -378,7 +378,7 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
  Wed Dec 31 21:32:00 1969 | 19949.5 | 29920 | 141.242685621416
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                            QUERY PLAN                            
 -----------------------------------------------------------------
@@ -395,7 +395,7 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_3_5_chunk
 (11 rows)
 
-SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
    t   |   avg   |  min  |       avg        
 -------+---------+-------+------------------
@@ -403,7 +403,7 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
  19990 | 19994.5 | 29990 | 141.401909099017
 (2 rows)
 
-EXPLAIN (costs off) SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
@@ -420,7 +420,7 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
                            ->  Seq Scan on _hyper_3_5_chunk
 (11 rows)
 
-SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
    t   |   avg   |  min  |       avg        
 -------+---------+-------+------------------
@@ -430,11 +430,11 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
 
 --plain tables shouldnt be optimized by default
 EXPLAIN (costs off)
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM plain_table 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM plain_table
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -449,11 +449,11 @@ LIMIT 2;
                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 (9 rows)
 
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM plain_table 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM plain_table
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
               t               |  avg  |  min  |       avg        
 ------------------------------+-------+-------+------------------
@@ -465,11 +465,11 @@ LIMIT 2;
 BEGIN;
     SET LOCAL timescaledb.optimize_non_hypertables = 'on';
     EXPLAIN (costs off)
-    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-    FROM plain_table 
-    WHERE time < to_timestamp(900) 
-    GROUP BY t 
-    ORDER BY t DESC 
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+    FROM plain_table
+    WHERE time < to_timestamp(900)
+    GROUP BY t
+    ORDER BY t DESC
     LIMIT 2;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
@@ -484,11 +484,11 @@ BEGIN;
                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 (9 rows)
 
-    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-    FROM plain_table 
-    WHERE time < to_timestamp(900) 
-    GROUP BY t 
-    ORDER BY t DESC 
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+    FROM plain_table
+    WHERE time < to_timestamp(900)
+    GROUP BY t
+    ORDER BY t DESC
     LIMIT 2;
               t               |  avg  |  min  |       avg        
 ------------------------------+-------+-------+------------------

--- a/test/sql/include/sql_query_results.sql
+++ b/test/sql/include/sql_query_results.sql
@@ -83,18 +83,18 @@ SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2)
 
 --test that when index on time used by constraint, still works correctly
 EXPLAIN (costs off)
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
 
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
 
 --test that still works with an expression index on data_trunc.
@@ -117,63 +117,63 @@ RESET client_min_messages;
 EXPLAIN (costs off) SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
 SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
 
-
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
 FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
 
 
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
+SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, trunc(avg(series_0)::numeric, 8) as avg_trunc1, min(series_1), trunc(avg(series_2)::numeric, 8) as avg_trunc2
+FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
+
+
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
-
-EXPLAIN (costs off) SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2) 
-FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
 
-EXPLAIN (costs off) SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
+SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
+FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
+
+EXPLAIN (costs off) SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
 
-EXPLAIN (costs off) SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2) 
+EXPLAIN (costs off) SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
-SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2) 
+SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
 
 
 --plain tables shouldnt be optimized by default
 EXPLAIN (costs off)
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM plain_table 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM plain_table
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
 
-SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-FROM plain_table 
-WHERE time < to_timestamp(900) 
-GROUP BY t 
-ORDER BY t DESC 
+SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+FROM plain_table
+WHERE time < to_timestamp(900)
+GROUP BY t
+ORDER BY t DESC
 LIMIT 2;
 
 
@@ -181,17 +181,17 @@ LIMIT 2;
 BEGIN;
     SET LOCAL timescaledb.optimize_non_hypertables = 'on';
     EXPLAIN (costs off)
-    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-    FROM plain_table 
-    WHERE time < to_timestamp(900) 
-    GROUP BY t 
-    ORDER BY t DESC 
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+    FROM plain_table
+    WHERE time < to_timestamp(900)
+    GROUP BY t
+    ORDER BY t DESC
     LIMIT 2;
 
-    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) 
-    FROM plain_table 
-    WHERE time < to_timestamp(900) 
-    GROUP BY t 
-    ORDER BY t DESC 
+    SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
+    FROM plain_table
+    WHERE time < to_timestamp(900)
+    GROUP BY t
+    ORDER BY t DESC
     LIMIT 2;
 ROLLBACK;

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -70,11 +70,11 @@ SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_7_16_chunk');
 SELECT * FROM "3dim";
 
 -- test that explain works
-EXPLAIN
+EXPLAIN (COSTS FALSE)
 INSERT INTO "3dim" VALUES('2017-01-21T09:00:01', 32.9, 'green', 'nyc'),
                          ('2017-01-21T09:00:47', 27.3, 'purple', 'la') RETURNING *;
 
-EXPLAIN
+EXPLAIN (COSTS FALSE)
 WITH "3dim_insert" AS (
      INSERT INTO "3dim" VALUES('2017-01-21T09:01:44', 19.3, 'black', 'la') RETURNING time, temp
 ), regular_insert AS (
@@ -111,14 +111,14 @@ SELECT create_hypertable('"smallinttime_err"', 'time');
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>65535);
 
---make sure date inserts work even when the timezone changes the 
+--make sure date inserts work even when the timezone changes the
 CREATE TABLE hyper_date(time date, temp float);
 SELECT create_hypertable('"hyper_date"', 'time');
 SET timezone=+1;
 INSERT INTO "hyper_date" VALUES('2011-01-26', 22.5);
 RESET timezone;
 
---make sure timestamp inserts work even when the timezone changes the 
+--make sure timestamp inserts work even when the timezone changes the
 SET timezone = 'UTC';
 CREATE TABLE "test_tz"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"test_tz"', 'time', chunk_time_interval=> INTERVAL '1 day');


### PR DESCRIPTION
When testing on Windows these tests were returning differences
because of floating point (sql_query_results_*) differences and
because the cost was trivially higher (insert_single). Here we
remove the costs since it was not relevant to the regressions we
want to detect. Further we truncate the floating point averages
to 8 decimal places; enough to see significant differences.