### PR TITLE
Fix logic for one space partition

### DIFF
--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -126,6 +126,9 @@ BEGIN
             dimension_slice_row.range_end);
         END IF;
 
+        IF array_length(parts, 1) = 0 THEN
+            RETURN NULL;
+        END IF;
         return array_to_string(parts, 'AND');
     ELSE
         --TODO: only works with time for now

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -223,10 +223,11 @@ calculate_closed_range_default(Dimension *dim, int64 value)
 	{
 		range_start = (value / interval) * interval;
 		range_end = range_start + interval;
-		if (0 == range_start)
-		{
-			range_start = DIMENSION_SLICE_MINVALUE;
-		}
+	}
+
+	if (0 == range_start)
+	{
+		range_start = DIMENSION_SLICE_MINVALUE;
 	}
 
 	return dimension_slice_create(dim->fd.id, range_start, range_end);

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -683,3 +683,21 @@ SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
  Wed Dec 31 16:00:00 1969 |   18 | 18
 (10 rows)
 
+CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('one_space_test', 'time', 'device', 1);
+NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO one_space_test VALUES
+('2001-01-01 01:01:01', 1.0, 'device'),
+('2002-01-01 01:02:01', 1.0, 'device');
+SELECT * FROM one_space_test;
+           time           | temp | device 
+--------------------------+------+--------
+ Mon Jan 01 01:01:01 2001 |    1 | device
+ Tue Jan 01 01:02:01 2002 |    1 | device
+(2 rows)
+

--- a/test/sql/chunks.sql
+++ b/test/sql/chunks.sql
@@ -47,3 +47,6 @@ FROM _timescaledb_internal.dimension_calculate_default_range_closed(0,2::smallin
 
 SELECT assert_equal(1073741823::bigint, actual_range_start), assert_equal(9223372036854775807::bigint, actual_range_end)
 FROM _timescaledb_internal.dimension_calculate_default_range_closed(1073741824,2::smallint) AS res(actual_range_start, actual_range_end);
+
+SELECT assert_equal((-9223372036854775808)::bigint, actual_range_start), assert_equal(9223372036854775807::bigint, actual_range_end)
+FROM _timescaledb_internal.dimension_calculate_default_range_closed(1073741824,1::smallint) AS res(actual_range_start, actual_range_end);

--- a/test/sql/insert.sql
+++ b/test/sql/insert.sql
@@ -69,3 +69,10 @@ FROM many_partitions_test
 GROUP BY period, device;
 
 SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
+
+CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('one_space_test', 'time', 'device', 1);
+INSERT INTO one_space_test VALUES
+('2001-01-01 01:01:01', 1.0, 'device'),
+('2002-01-01 01:02:01', 1.0, 'device');
+SELECT * FROM one_space_test;


### PR DESCRIPTION
This PR fixes handling of one space partition. It
avoids creating a CHECK constraint and also fixes the
logic in default dimension range creation.