### PR TITLE
Make TimescaleDB work with pg_upgrade

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -25,7 +25,7 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     partitioning_func       REGPROC = NULL
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE
-    SET search_path = ''
+    SET search_path = '_timescaledb_catalog'
     AS
 $BODY$
 <<vars>>
@@ -142,7 +142,7 @@ CREATE OR REPLACE FUNCTION  add_dimension(
     partitioning_func       REGPROC = NULL
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE
-    SECURITY DEFINER SET search_path = ''
+    SECURITY DEFINER SET search_path = '_timescaledb_catalog'
     AS
 $BODY$
 <<main_block>>
@@ -192,7 +192,7 @@ CREATE OR REPLACE FUNCTION  set_chunk_time_interval(
     chunk_time_interval     anyelement
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE
-    SECURITY DEFINER SET search_path=''
+    SECURITY DEFINER SET search_path='_timescaledb_catalog'
     AS
 $BODY$
 DECLARE

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -577,7 +577,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.truncate_hypertable(
 )
     RETURNS VOID
     LANGUAGE PLPGSQL VOLATILE
-    SET search_path = ''
+    SET search_path = '_timescaledb_internal'
     AS
 $BODY$
 DECLARE
@@ -594,7 +594,7 @@ AS '$libdir/timescaledb', 'indexing_verify_hypertable_indexes' LANGUAGE C STRICT
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_change_owner(main_table OID, new_table_owner NAME)
     RETURNS void LANGUAGE plpgsql
-    SECURITY DEFINER SET search_path = ''
+    SECURITY DEFINER SET search_path = '_timescaledb_internal'
     AS
 $BODY$
 DECLARE

--- a/src/extension.c
+++ b/src/extension.c
@@ -13,6 +13,7 @@
 
 #include "catalog.h"
 #include "extension.h"
+#include "guc.h"
 
 #define EXTENSION_PROXY_TABLE "cache_inval_extension"
 
@@ -184,6 +185,10 @@ extension_invalidate(Oid relid)
 bool
 extension_is_loaded(void)
 {
+	/* when restoring deactivate extension */
+	if (guc_restoring)
+		return false;
+
 	if (EXTENSION_STATE_UNKNOWN == extstate || EXTENSION_STATE_TRANSITIONING == extstate)
 	{
 		/* status may have updated without a relcache invalidate event */

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -37,7 +37,6 @@
 #include "event_trigger.h"
 #include "executor.h"
 #include "extension.h"
-#include "guc.h"
 #include "hypercube.h"
 #include "hypertable_cache.h"
 #include "indexing.h"
@@ -1632,11 +1631,7 @@ timescaledb_ddl_command_start(
 #endif
 	};
 
-	/*
-	 * If we are restoring, we don't want to recurse to chunks or block
-	 * operations on chunks. If we do, the restore will fail.
-	 */
-	if (!extension_is_loaded() || guc_restoring)
+	if (!extension_is_loaded())
 	{
 		prev_ProcessUtility(&args);
 		return;
@@ -1664,7 +1659,7 @@ timescaledb_ddl_command_end(PG_FUNCTION_ARGS)
 	if (!CALLED_AS_EVENT_TRIGGER(fcinfo))
 		elog(ERROR, "not fired by event trigger manager");
 
-	if (!extension_is_loaded() || guc_restoring)
+	if (!extension_is_loaded())
 		PG_RETURN_NULL();
 
 	Assert(strcmp("ddl_command_end", trigdata->event) == 0);

--- a/test/expected/truncate_hypertable.out
+++ b/test/expected/truncate_hypertable.out
@@ -133,7 +133,7 @@ CREATE TRIGGER _test_truncate_after
 TRUNCATE "two_Partitions";
 WARNING:  FIRING trigger when: BEFORE level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_before
 WARNING:  FIRING trigger when: AFTER level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_after
-ERROR:  cannot drop table _timescaledb_internal._hyper_1_5_chunk because other objects depend on it
+ERROR:  cannot drop table _hyper_1_5_chunk because other objects depend on it
 \set ON_ERROR_STOP 1
 TRUNCATE "two_Partitions" CASCADE;
 WARNING:  FIRING trigger when: BEFORE level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_before


### PR DESCRIPTION
Compatibility with pg_upgrade required 2 changes:
1) search_path on functions cannot be blank for pg_upgrade.
2) The timescaledb.restoring GUC had to apply to more code (now moved to
   higher-level check)