### PR TITLE
Improve speed of out-of-order inserts

### DIFF
--- a/src/chunk_dispatch.c
+++ b/src/chunk_dispatch.c
@@ -19,7 +19,7 @@ chunk_dispatch_create(Hypertable *ht, EState *estate, Query *parse)
 	cd->estate = estate;
 	cd->hypertable_result_rel_info = NULL;
 	cd->parse = parse;
-	cd->cache = subspace_store_init(ht->space->num_dimensions, estate->es_query_cxt);
+	cd->cache = subspace_store_init(ht->space->num_dimensions, estate->es_query_cxt, 0);
 
 	return cd;
 }

--- a/src/chunk_dispatch.c
+++ b/src/chunk_dispatch.c
@@ -9,6 +9,7 @@
 #include "chunk_insert_state.h"
 #include "subspace_store.h"
 #include "dimension.h"
+#include "guc.h"
 
 ChunkDispatch *
 chunk_dispatch_create(Hypertable *ht, EState *estate, Query *parse)
@@ -19,7 +20,7 @@ chunk_dispatch_create(Hypertable *ht, EState *estate, Query *parse)
 	cd->estate = estate;
 	cd->hypertable_result_rel_info = NULL;
 	cd->parse = parse;
-	cd->cache = subspace_store_init(ht->space->num_dimensions, estate->es_query_cxt, 0);
+	cd->cache = subspace_store_init(ht->space, estate->es_query_cxt, guc_max_open_chunks_per_insert);
 
 	return cd;
 }

--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -138,6 +138,15 @@ dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id)
 	return -1;
 }
 
+DimensionSlice *
+dimension_vec_get(DimensionVec *vec, int32 index)
+{
+	if (index >= vec->num_slices)
+		return NULL;
+
+	return vec->slices[index];
+}
+
 void
 dimension_vec_free(DimensionVec *vec)
 {

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -29,6 +29,7 @@ extern DimensionVec *dimension_vec_add_slice(DimensionVec **vecptr, DimensionSli
 extern void dimension_vec_remove_slice(DimensionVec **vecptr, int32 index);
 extern DimensionSlice *dimension_vec_find_slice(DimensionVec *vec, int64 coordinate);
 extern int	dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id);
+extern DimensionSlice *dimension_vec_get(DimensionVec *vec, int32 index);
 extern void dimension_vec_free(DimensionVec *vec);
 
 #endif   /* TIMESCALEDB_DIMENSION_VECTOR_H */

--- a/src/guc.c
+++ b/src/guc.c
@@ -1,12 +1,23 @@
 #include <postgres.h>
 #include <utils/guc.h>
+#include <miscadmin.h>
 
 #include "guc.h"
+#include "hypertable_cache.h"
 
 bool		guc_disable_optimizations = false;
 bool		guc_optimize_non_hypertables = false;
 bool		guc_restoring = false;
 bool		guc_constraint_aware_append = true;
+int			guc_max_open_chunks_per_insert = 10;
+int			guc_max_cached_chunks_per_hypertable = 10;
+
+static void
+assign_max_cached_chunks_per_hypertable_hook(int newval, void *extra)
+{
+	/* invalidate the hypertable cache to reset */
+	hypertable_cache_invalidate_callback();
+}
 
 void
 _guc_init(void)
@@ -51,6 +62,35 @@ _guc_init(void)
 							 NULL,
 							 NULL,
 							 NULL);
+
+	DefineCustomIntVariable("timescaledb.max_open_chunks_per_insert",
+							"Maximum open chunks per insert",
+							"Maximum number of open chunk tables per insert",
+							&guc_max_open_chunks_per_insert,
+							work_mem * 1024L / 512L,	/* Assume each chunk
+														 * takes up 512 bytes
+														 * (work_mem is in
+														 * kbytes) */
+							0,
+							65536,
+							PGC_USERSET,
+							0,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomIntVariable("timescaledb.max_cached_chunks_per_hypertable",
+							"Maximum cached chunks",
+							"Maximum number of chunks stored in the cache",
+							&guc_max_cached_chunks_per_hypertable,
+							100,
+							0,
+							65536,
+							PGC_USERSET,
+							0,
+							NULL,
+							assign_max_cached_chunks_per_hypertable_hook,
+							NULL);
 }
 
 void

--- a/src/guc.h
+++ b/src/guc.h
@@ -6,6 +6,8 @@ extern bool guc_disable_optimizations;
 extern bool guc_optimize_non_hypertables;
 extern bool guc_constraint_aware_append;
 extern bool guc_restoring;
+extern int	guc_max_open_chunks_per_insert;
+extern int	guc_max_cached_chunks_per_hypertable;
 
 void		_guc_init(void);
 void		_guc_fini(void);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -23,6 +23,7 @@
 #include "dimension_slice.h"
 #include "dimension_vector.h"
 #include "hypercube.h"
+#include "guc.h"
 
 static Oid
 rel_get_owner(Oid relid)
@@ -77,7 +78,7 @@ hypertable_from_tuple(HeapTuple tuple)
 	namespace_oid = get_namespace_oid(NameStr(h->fd.schema_name), false);
 	h->main_table_relid = get_relname_relid(NameStr(h->fd.table_name), namespace_oid);
 	h->space = dimension_scan(h->fd.id, h->main_table_relid, h->fd.num_dimensions);
-	h->chunk_cache = subspace_store_init(h->space->num_dimensions, CurrentMemoryContext, 1);
+	h->chunk_cache = subspace_store_init(h->space, CurrentMemoryContext, guc_max_cached_chunks_per_hypertable);
 
 	return h;
 }

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -77,7 +77,7 @@ hypertable_from_tuple(HeapTuple tuple)
 	namespace_oid = get_namespace_oid(NameStr(h->fd.schema_name), false);
 	h->main_table_relid = get_relname_relid(NameStr(h->fd.table_name), namespace_oid);
 	h->space = dimension_scan(h->fd.id, h->main_table_relid, h->fd.num_dimensions);
-	h->chunk_cache = subspace_store_init(h->space->num_dimensions, CurrentMemoryContext);
+	h->chunk_cache = subspace_store_init(h->space->num_dimensions, CurrentMemoryContext, 1);
 
 	return h;
 }

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -13,7 +13,7 @@ typedef struct Hypercube Hypercube;
 typedef struct Point Point;
 typedef struct SubspaceStore SubspaceStore;
 
-extern SubspaceStore *subspace_store_init(int16 num_dimensions, MemoryContext mcxt);
+extern SubspaceStore *subspace_store_init(int16 num_dimensions, MemoryContext mcxt, int16 max_slices_first_dimension);
 
 /* Store an object associate with the subspace represented by a hypercube */
 extern void subspace_store_add(SubspaceStore *cache, const Hypercube *hc,

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -2,6 +2,7 @@
 #define TIMESCALEDB_SUBSPACE_STORE_H
 
 #include <postgres.h>
+#include "dimension.h"
 
 /* A subspace store allows you to save data associated with
  * a multidimensional-subspace. Subspaces are defined conceptually
@@ -13,7 +14,7 @@ typedef struct Hypercube Hypercube;
 typedef struct Point Point;
 typedef struct SubspaceStore SubspaceStore;
 
-extern SubspaceStore *subspace_store_init(int16 num_dimensions, MemoryContext mcxt, int16 max_slices_first_dimension);
+extern SubspaceStore *subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items);
 
 /* Store an object associate with the subspace represented by a hypercube */
 extern void subspace_store_add(SubspaceStore *cache, const Hypercube *hc,

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -443,3 +443,49 @@ SELECT * FROM test_tz;
  Thu Sep 21 19:01:00 2017 | 21.2
 (3 rows)
 
+-- test various memory settings --
+SET timescaledb.max_open_chunks_per_insert = 10;
+SET timescaledb.max_cached_chunks_per_hypertable = 10;
+CREATE TABLE "nondefault_mem_settings"(time timestamp PRIMARY KEY, temp float);
+SELECT create_hypertable('"nondefault_mem_settings"', 'time', chunk_time_interval=> INTERVAL '1 Month');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO "nondefault_mem_settings" VALUES('2000-12-01T19:00:00', 21.2);
+INSERT INTO "nondefault_mem_settings" VALUES('2001-12-20T09:00:00', 25.1);
+--lowest possible
+SET timescaledb.max_open_chunks_per_insert = 1;
+SET timescaledb.max_cached_chunks_per_hypertable = 1;
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-01-20T09:00:00', 26.6),
+('2002-02-20T09:00:00', 27.9), 
+('2003-02-20T09:00:00', 28.9);
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-03-20T09:00:00', 30.6),
+('2002-03-20T09:00:00', 31.9), 
+('2003-03-20T09:00:00', 32.9);
+--unlimited
+SET timescaledb.max_open_chunks_per_insert = 0;
+SET timescaledb.max_cached_chunks_per_hypertable = 0;
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-04-20T09:00:00', 33.6),
+('2002-04-20T09:00:00', 34.9), 
+('2003-04-20T09:00:00', 35.9);
+SELECT * FROM "nondefault_mem_settings";
+           time           | temp 
+--------------------------+------
+ Fri Dec 01 19:00:00 2000 | 21.2
+ Thu Dec 20 09:00:00 2001 | 25.1
+ Sat Jan 20 09:00:00 2001 | 26.6
+ Wed Feb 20 09:00:00 2002 | 27.9
+ Thu Feb 20 09:00:00 2003 | 28.9
+ Tue Mar 20 09:00:00 2001 | 30.6
+ Wed Mar 20 09:00:00 2002 | 31.9
+ Thu Mar 20 09:00:00 2003 | 32.9
+ Fri Apr 20 09:00:00 2001 | 33.6
+ Sat Apr 20 09:00:00 2002 | 34.9
+ Sun Apr 20 09:00:00 2003 | 35.9
+(11 rows)
+

--- a/test/loader-mock/src/init.c
+++ b/test/loader-mock/src/init.c
@@ -41,8 +41,8 @@ post_analyze_hook(ParseState *pstate, Query *query)
 		elog(WARNING, "mock post_analyze_hook " STR(TIMESCALEDB_VERSION_MOD));
 	if (prev_post_parse_analyze_hook != NULL)
 		elog(ERROR, "The extension called with a loader should always have a NULL prev hook");
-	if(BROKEN && !creating_extension)
-		elog(ERROR, "mock broken "STR(TIMESCALEDB_VERSION_MOD));
+	if (BROKEN && !creating_extension)
+		elog(ERROR, "mock broken " STR(TIMESCALEDB_VERSION_MOD));
 }
 
 void
@@ -75,6 +75,12 @@ catalog_reset()
 {
 }
 
+/* mock for guc.c */
+void		hypertable_cache_invalidate_callback(void);
+void
+hypertable_cache_invalidate_callback(void)
+{
+}
 
 TS_FUNCTION_INFO_V1(mock_function);
 

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -129,3 +129,35 @@ INSERT INTO "test_tz" VALUES('2017-09-21 19:01:00', 21.2);
 
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_10_20_chunk');
 SELECT * FROM test_tz;
+
+-- test various memory settings --
+SET timescaledb.max_open_chunks_per_insert = 10;
+SET timescaledb.max_cached_chunks_per_hypertable = 10;
+CREATE TABLE "nondefault_mem_settings"(time timestamp PRIMARY KEY, temp float);
+SELECT create_hypertable('"nondefault_mem_settings"', 'time', chunk_time_interval=> INTERVAL '1 Month');
+INSERT INTO "nondefault_mem_settings" VALUES('2000-12-01T19:00:00', 21.2);
+INSERT INTO "nondefault_mem_settings" VALUES('2001-12-20T09:00:00', 25.1);
+
+--lowest possible
+SET timescaledb.max_open_chunks_per_insert = 1;
+SET timescaledb.max_cached_chunks_per_hypertable = 1;
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-01-20T09:00:00', 26.6),
+('2002-02-20T09:00:00', 27.9), 
+('2003-02-20T09:00:00', 28.9);
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-03-20T09:00:00', 30.6),
+('2002-03-20T09:00:00', 31.9), 
+('2003-03-20T09:00:00', 32.9);
+
+--unlimited
+SET timescaledb.max_open_chunks_per_insert = 0;
+SET timescaledb.max_cached_chunks_per_hypertable = 0;
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-04-20T09:00:00', 33.6),
+('2002-04-20T09:00:00', 34.9), 
+('2003-04-20T09:00:00', 35.9);
+
+SELECT * FROM "nondefault_mem_settings";
+
+


### PR DESCRIPTION
Previously, the cache in chunk_dispatch was limited to only hold
the chunk_insert_state for the last time dimension as a consequence
of logic in subspace_store. This has now been relaxed so that a
chunk_dispatch holds the cache for any chunk_insert_states that it
encounters. Logic for the hypertable chunk cache has not been changed.

The rule that we should follow is to limit the subspace store size for
caches that survive across commands. But caches within commands can be
allowed to grow.