### PR TITLE
Make chunks inherit reloptions set on the hypertable

### DIFF
--- a/test/expected/reloptions.out
+++ b/test/expected/reloptions.out
@@ -1,0 +1,56 @@
+CREATE TABLE reloptions_test(time integer, temp float8, color integer)
+WITH (fillfactor=75, oids=true, autovacuum_vacuum_threshold=100);
+SELECT create_hypertable('reloptions_test', 'time', chunk_time_interval => 3);
+NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO reloptions_test VALUES (4, 24.3, 1), (9, 13.3, 2);
+-- Show that reloptions are inherited by chunks
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+     relname      |                   reloptions                    | relhasoids 
+------------------+-------------------------------------------------+------------
+ _hyper_1_1_chunk | {fillfactor=75,autovacuum_vacuum_threshold=100} | t
+ _hyper_1_2_chunk | {fillfactor=75,autovacuum_vacuum_threshold=100} | t
+(2 rows)
+
+-- Alter reloptions
+ALTER TABLE reloptions_test SET (fillfactor=80, parallel_workers=8);
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+     relname      |                             reloptions                             | relhasoids 
+------------------+--------------------------------------------------------------------+------------
+ _hyper_1_1_chunk | {autovacuum_vacuum_threshold=100,fillfactor=80,parallel_workers=8} | t
+ _hyper_1_2_chunk | {autovacuum_vacuum_threshold=100,fillfactor=80,parallel_workers=8} | t
+(2 rows)
+
+ALTER TABLE reloptions_test RESET (fillfactor);
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+     relname      |                      reloptions                      | relhasoids 
+------------------+------------------------------------------------------+------------
+ _hyper_1_1_chunk | {autovacuum_vacuum_threshold=100,parallel_workers=8} | t
+ _hyper_1_2_chunk | {autovacuum_vacuum_threshold=100,parallel_workers=8} | t
+(2 rows)
+
+ALTER TABLE reloptions_test SET WITHOUT OIDS;
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+     relname      |                      reloptions                      | relhasoids 
+------------------+------------------------------------------------------+------------
+ _hyper_1_1_chunk | {autovacuum_vacuum_threshold=100,parallel_workers=8} | f
+ _hyper_1_2_chunk | {autovacuum_vacuum_threshold=100,parallel_workers=8} | f
+(2 rows)
+
+ALTER TABLE reloptions_test SET WITH OIDS;
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+     relname      |                      reloptions                      | relhasoids 
+------------------+------------------------------------------------------+------------
+ _hyper_1_1_chunk | {autovacuum_vacuum_threshold=100,parallel_workers=8} | t
+ _hyper_1_2_chunk | {autovacuum_vacuum_threshold=100,parallel_workers=8} | t
+(2 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_FILES
   plain.sql
   reindex.sql
   relocate_extension.sql
+  reloptions.sql
   size_utils.sql
   sql_query_results_optimized.sql
   sql_query_results_unoptimized.sql

--- a/test/sql/reloptions.sql
+++ b/test/sql/reloptions.sql
@@ -1,0 +1,31 @@
+CREATE TABLE reloptions_test(time integer, temp float8, color integer)
+WITH (fillfactor=75, oids=true, autovacuum_vacuum_threshold=100);
+
+SELECT create_hypertable('reloptions_test', 'time', chunk_time_interval => 3);
+
+INSERT INTO reloptions_test VALUES (4, 24.3, 1), (9, 13.3, 2);
+
+-- Show that reloptions are inherited by chunks
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+
+-- Alter reloptions
+ALTER TABLE reloptions_test SET (fillfactor=80, parallel_workers=8);
+
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+
+ALTER TABLE reloptions_test RESET (fillfactor);
+
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+
+ALTER TABLE reloptions_test SET WITHOUT OIDS;
+
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';
+
+ALTER TABLE reloptions_test SET WITH OIDS;
+
+SELECT relname, reloptions, relhasoids FROM pg_class
+WHERE relname ~ '^_hyper.*' AND relkind = 'r';


### PR DESCRIPTION
When tables are created with storage parameters (reloptions),
these should be inherited by chunks so that one can set options
such as fillfactor and autovacuum settings on the hypertable.
This change makes chunks inherit the reloptions set on a hypertable
and allows altering options via the ALTER TABLE command.