### PR TITLE
Fix subtransaction handling

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -31,6 +31,9 @@ typedef struct Cache
 	void	   *(*create_entry) (struct Cache *, CacheQuery *);
 	void	   *(*update_entry) (struct Cache *, CacheQuery *);
 	void		(*pre_destroy_hook) (struct Cache *);
+	bool		release_on_commit;		/* This should be false if doing
+										 * cross-commit operations like
+										 * CLUSTER or VACUUM */
 } Cache;
 
 extern void cache_init(Cache *cache);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -278,9 +278,14 @@ foreach_chunk_relid(Oid relid, process_chunk_t process_chunk, void *arg)
 	int			ret;
 
 	if (NULL == ht)
+	{
+		cache_release(hcache);
 		return -1;
+	}
 
+	hcache->release_on_commit = false;
 	ret = foreach_chunk(ht, process_chunk, arg);
+	hcache->release_on_commit = true;
 
 	cache_release(hcache);
 
@@ -477,6 +482,8 @@ process_drop_index(DropStmt *stmt)
 					 */
 					chunk_index_delete(chunk, idxrelid, false);
 			}
+
+			cache_release(hcache);
 		}
 	}
 }
@@ -1132,6 +1139,8 @@ process_cluster_start(Node *parsetree, ProcessUtilityContext context)
 		chunk_indexes = chunk_index_get_mappings(ht, index_relid);
 		MemoryContextSwitchTo(old);
 
+		hcache->release_on_commit = false;
+
 		/* Commit to get out of starting transaction */
 		PopActiveSnapshot();
 		CommitTransactionCommand();
@@ -1158,6 +1167,8 @@ process_cluster_start(Node *parsetree, ProcessUtilityContext context)
 			PopActiveSnapshot();
 			CommitTransactionCommand();
 		}
+
+		hcache->release_on_commit = true;
 		/* Start a new transaction for the cleanup work. */
 		StartTransactionCommand();
 
@@ -1166,7 +1177,6 @@ process_cluster_start(Node *parsetree, ProcessUtilityContext context)
 	}
 
 	cache_release(hcache);
-
 	return false;
 }
 

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -489,3 +489,50 @@ SELECT * FROM "nondefault_mem_settings";
  Sun Apr 20 09:00:00 2003 | 35.9
 (11 rows)
 
+--test rollback
+BEGIN;
+\set QUIET off
+CREATE TABLE "data_records" ("time" bigint NOT NULL, "value" integer CHECK (VALUE >= 0));
+CREATE TABLE
+SELECT create_hypertable('data_records', 'time', chunk_time_interval => 2592000000);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO "data_records" ("time", "value") VALUES (0, 1);
+INSERT 0 1
+SAVEPOINT savepoint_1;
+SAVEPOINT
+INSERT INTO "data_records" ("time", "value") VALUES (1, 0);
+INSERT 0 1
+ROLLBACK TO SAVEPOINT savepoint_1;
+ROLLBACK
+INSERT INTO "data_records" ("time", "value") VALUES (2, 1);
+INSERT 0 1
+SAVEPOINT savepoint_2;
+SAVEPOINT
+\set ON_ERROR_STOP 0
+INSERT INTO "data_records" ("time", "value") VALUES (3, -1);
+ERROR:  new row for relation "_hyper_13_34_chunk" violates check constraint "data_records_value_check"
+\set ON_ERROR_STOP 1
+ROLLBACK TO SAVEPOINT savepoint_2;
+ROLLBACK
+INSERT INTO "data_records" ("time", "value") VALUES (4, 1);
+INSERT 0 1
+SAVEPOINT savepoint_3;
+SAVEPOINT
+INSERT INTO "data_records" ("time", "value") VALUES (5, 0);
+INSERT 0 1
+ROLLBACK TO SAVEPOINT savepoint_3;
+ROLLBACK
+SELECT * FROM data_records;
+ time | value 
+------+-------
+    0 |     1
+    2 |     1
+    4 |     1
+(3 rows)
+
+\set QUIET on
+ROLLBACK;


### PR DESCRIPTION
This is a collection of 3 commits that fixes subtxn handling. It addresses #376. These commits reconsider all code that had RegisterXactCallback to add RegisterSubXactCallback. 