### PR TITLE
Add test case for adding metadata entries automatically

### DIFF
--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -265,3 +265,54 @@ WARNING:  FIRING trigger when: AFTER level: ROW op: DELETE cnt: 0 trigger_name z
 WARNING:  FIRING trigger when: AFTER level: ROW op: DELETE cnt: 0 trigger_name _0_test_trigger_delete_after
 WARNING:  FIRING trigger when: AFTER level: ROW op: DELETE cnt: 0 trigger_name z_test_trigger_all_after
 WARNING:  FIRING trigger when: AFTER level: STATEMENT op: DELETE cnt: 0 trigger_name _0_test_trigger_delete_s_after
+CREATE TABLE vehicles (
+  vehicle_id INTEGER PRIMARY KEY,
+  vin_number CHAR(17),
+  last_checkup TIMESTAMP
+);
+CREATE TABLE location (
+  time TIMESTAMP NOT NULL,
+  vehicle_id INTEGER REFERENCES vehicles (vehicle_id),
+  latitude FLOAT,
+  longitude FLOAT
+);
+CREATE OR REPLACE FUNCTION create_vehicle_trigger_fn()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN 
+    INSERT INTO vehicles VALUES(NEW.vehicle_id, NULL, NULL) ON CONFLICT DO NOTHING;
+    RETURN NEW;
+END
+$BODY$;
+CREATE TRIGGER create_vehicle_trigger
+    BEFORE INSERT OR UPDATE ON location
+    FOR EACH ROW EXECUTE PROCEDURE create_vehicle_trigger_fn();
+SELECT create_hypertable('location', 'time');
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO location VALUES('2017-01-01 01:02:03', 1, 40.7493226,-73.9771259);
+INSERT INTO location VALUES('2017-01-01 01:02:04', 1, 24.7493226,-73.9771259);
+INSERT INTO location VALUES('2017-01-01 01:02:03', 23, 40.7493226,-73.9771269);
+INSERT INTO location VALUES('2017-01-01 01:02:03', 53, 40.7493226,-73.9771269);
+UPDATE location SET vehicle_id = 52 WHERE vehicle_id = 53;
+SELECT * FROM location;
+           time           | vehicle_id |  latitude  |  longitude  
+--------------------------+------------+------------+-------------
+ Sun Jan 01 01:02:03 2017 |          1 | 40.7493226 | -73.9771259
+ Sun Jan 01 01:02:04 2017 |          1 | 24.7493226 | -73.9771259
+ Sun Jan 01 01:02:03 2017 |         23 | 40.7493226 | -73.9771269
+ Sun Jan 01 01:02:03 2017 |         52 | 40.7493226 | -73.9771269
+(4 rows)
+
+SELECT * FROM vehicles;
+ vehicle_id | vin_number | last_checkup 
+------------+------------+--------------
+          1 |            | 
+         23 |            | 
+         53 |            | 
+         52 |            | 
+(4 rows)
+


### PR DESCRIPTION
This test adds a case where we use a trigger to automatically populate
a metadata table. This usage of triggers is described in our docs. This
commit makes sure that the code in our docs is tested.
  