### PR TITLE
Bring Windows bootstrap in line with Unix version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,13 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif ()
 
+if (WIN32)
+  if (NOT CMAKE_CONFIGURATION_TYPES)
+    # Default to only include Release builds so MSBuild.exe 'just works'
+    set(CMAKE_CONFIGURATION_TYPES Release CACHE STRING "Semicolon separated list of supported configuration types, only supports Debug, Release, MinSizeRel, and RelWithDebInfo, anything else will be ignored." FORCE)
+  endif ()
+endif (WIN32)
+
 project(timescaledb VERSION ${VERSION} LANGUAGES C)
 
 message(STATUS "TimescaleDB version ${PROJECT_VERSION_MOD}. Can be updated from version ${UPDATE_FROM_VERSION}")

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,20 +1,30 @@
-echo off
-SET BUILD_TYPE=%1
-IF "%BUILD_TYPE%" == "" (SET BUILD_TYPE=Release)
+@echo off
+:: This bootstrap scripts set up the build environment for TimescaleDB
+:: Any flags will be passed on to CMake, e.g.,
+:: ./bootstrap.bat -DCMAKE_BUILD_TYPE="Debug"
 
-SET BUILD_ARCH=%2
-IF "%BUILD_ARCH%" == "" (SET BUILD_ARCH=x64)
+
+:: Get source directory to build from
+set ORIG=%0
+for %%F in (%ORIG%) do set SRC_DIR=%%~dpF
 
 SET BUILD_DIR=./build
-IF NOT EXIST "%BUILD_DIR%" (
-	mkdir "%BUILD_DIR%"
-) ELSE (
+
+IF EXIST "%BUILD_DIR%" (
+	setlocal EnableDelayedExpansion
 	ECHO Build system already initialized in %BUILD_DIR%
-	EXIT
+	SET /P resp="Do you want to remove it (this is IMMEDIATE and PERMANENT), y/n? "
+	IF "!resp!" == "y" (
+		rd /s /q "%BUILD_DIR%"
+	) ELSE (
+		ECHO Exiting
+		EXIT
+	)
 )
 
-cd %BUILD_DIR%
-cmake .. -A %BUILD_ARCH% -B. -DCMAKE_BUILD_TYPE=%BUILD_TYPE%
+mkdir "%BUILD_DIR%"
+cd "%BUILD_DIR%"
+cmake %SRC_DIR% -B. -A x64 %*
 
 ECHO ---
 ECHO TimescaleDB build system initialized in %BUILD_DIR%.


### PR DESCRIPTION
Flags are now passed on to CMake, the source directory is correctly
resolved, and support for removing the old build directory added.

Additionally this will limit the VS solution file to only having
Release targets unless overriden with a flag.