### PR TITLE
Add support for ALTER TABLE RENAME CONSTRAINT.

### DIFF
--- a/src/catalog.h
+++ b/src/catalog.h
@@ -312,6 +312,7 @@ enum Anum_chunk_constraint
 #define Natts_chunk_constraint \
 	(_Anum_chunk_constraint_max - 1)
 
+/* Do Not use GET_STRUCT with FormData_chunk_constraint. It contains NULLS */
 typedef struct FormData_chunk_constraint
 {
 	int32		chunk_id;

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -11,8 +11,10 @@
 #include <catalog/pg_constraint.h>
 #include <catalog/pg_constraint_fn.h>
 #include <catalog/objectaddress.h>
+#include <commands/tablecmds.h>
 #include <catalog/dependency.h>
 #include <funcapi.h>
+#include <nodes/makefuncs.h>
 
 #include "scanner.h"
 #include "chunk_constraint.h"
@@ -65,6 +67,36 @@ chunk_constraints_expand(ChunkConstraints *ccs, int16 new_capacity)
 	ccs->constraints = repalloc(ccs->constraints, CHUNK_CONSTRAINTS_SIZE(new_capacity));
 }
 
+
+static
+void
+chunk_constraint_choose_name(Name dst, bool is_dimension, int32 dimension_slice_id, const char *hypertable_constraint_name, int32 chunk_id)
+{
+	if (is_dimension)
+	{
+		snprintf(NameStr(*dst), NAMEDATALEN, "constraint_%d",
+				 dimension_slice_id);
+	}
+	else
+	{
+		char		constrname[100];
+		CatalogSecurityContext sec_ctx;
+
+		Assert(hypertable_constraint_name != NULL);
+
+		catalog_become_owner(catalog_get(), &sec_ctx);
+		snprintf(constrname,
+				 100,
+				 "%d_" INT64_FORMAT "_%s",
+				 chunk_id,
+				 catalog_table_next_seq_id(catalog_get(), CHUNK_CONSTRAINT),
+				 hypertable_constraint_name);
+		catalog_restore_user(&sec_ctx);
+
+		namestrcpy(dst, constrname);
+	}
+}
+
 static ChunkConstraint *
 chunk_constraints_add(ChunkConstraints *ccs,
 					  int32 chunk_id,
@@ -81,30 +113,14 @@ chunk_constraints_add(ChunkConstraints *ccs,
 
 	if (NULL == constraint_name)
 	{
+		chunk_constraint_choose_name(&cc->fd.constraint_name,
+									 is_dimension_constraint(cc),
+									 cc->fd.dimension_slice_id,
+									 hypertable_constraint_name,
+									 cc->fd.chunk_id);
+
 		if (is_dimension_constraint(cc))
-		{
-			snprintf(NameStr(cc->fd.constraint_name),
-					 NAMEDATALEN,
-					 "constraint_%d",
-					 cc->fd.dimension_slice_id);
 			namestrcpy(&cc->fd.hypertable_constraint_name, "");
-		}
-		else if (NULL != hypertable_constraint_name)
-		{
-			CatalogSecurityContext sec_ctx;
-			char		constrname[100];
-
-			catalog_become_owner(catalog_get(), &sec_ctx);
-			snprintf(constrname,
-					 100,
-					 "%d_" INT64_FORMAT "_%s",
-					 cc->fd.chunk_id,
-				  catalog_table_next_seq_id(catalog_get(), CHUNK_CONSTRAINT),
-					 hypertable_constraint_name);
-			catalog_restore_user(&sec_ctx);
-
-			namestrcpy(&cc->fd.constraint_name, constrname);
-		}
 	}
 	else
 		namestrcpy(&cc->fd.constraint_name, constraint_name);
@@ -189,22 +205,33 @@ chunk_constraint_insert(ChunkConstraint *constraint)
 
 
 static ChunkConstraint *
-chunk_constraints_add_from_tuple(ChunkConstraints *ccs, HeapTuple tuple)
+chunk_constraints_add_from_tuple(ChunkConstraints *ccs, TupleInfo *ti)
 {
-	FormData_chunk_constraint *form = (FormData_chunk_constraint *) GETSTRUCT(tuple);
-	int32		dimension_slice_id = form->dimension_slice_id;
-	const char *hypertable_constraint_name = NameStr(form->hypertable_constraint_name);
+	bool		nulls[Natts_chunk_constraint];
+	Datum		values[Natts_chunk_constraint];
+	int32		dimension_slice_id;
+	Name		constraint_name;
+	Name		hypertable_constraint_name;
 
-	if (heap_attisnull(tuple, Anum_chunk_constraint_dimension_slice_id))
+	heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
+
+	constraint_name = DatumGetName(values[Anum_chunk_constraint_constraint_name - 1]);
+	if (heap_attisnull(ti->tuple, Anum_chunk_constraint_dimension_slice_id))
+	{
 		dimension_slice_id = 0;
+		hypertable_constraint_name = DatumGetName(values[Anum_chunk_constraint_hypertable_constraint_name - 1]);
+	}
 	else
-		hypertable_constraint_name = "";
+	{
+		dimension_slice_id = DatumGetInt32(values[Anum_chunk_constraint_dimension_slice_id - 1]);
+		hypertable_constraint_name = DatumGetName(DirectFunctionCall1(namein, CStringGetDatum("")));
+	}
 
 	return chunk_constraints_add(ccs,
-								 form->chunk_id,
+				   DatumGetInt32(values[Anum_chunk_constraint_chunk_id - 1]),
 								 dimension_slice_id,
-								 NameStr(form->constraint_name),
-								 hypertable_constraint_name);
+								 NameStr(*constraint_name),
+								 NameStr(*hypertable_constraint_name));
 }
 
 /*
@@ -316,7 +343,7 @@ chunk_constraint_tuple_found(TupleInfo *ti, void *data)
 {
 	ChunkConstraints *ccs = data;
 
-	chunk_constraints_add_from_tuple(ccs, ti->tuple);
+	chunk_constraints_add_from_tuple(ccs, ti);
 
 	return true;
 }
@@ -408,7 +435,7 @@ chunk_constraint_dimension_slice_id_tuple_found(TupleInfo *ti, void *data)
 	else
 		chunk = entry->chunk;
 
-	chunk_constraints_add_from_tuple(chunk->constraints, ti->tuple);
+	chunk_constraints_add_from_tuple(chunk->constraints, ti);
 
 	hypercube_add_slice(chunk->cube, ccsd->slice);
 
@@ -546,23 +573,31 @@ chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid)
 							chunk->fd.hypertable_id);
 }
 
-typedef struct DeleteConstraintInfo
+typedef struct ConstraintInfo
 {
-	int32		chunk_id;
-	Oid			chunk_oid;
-	char	   *hypertable_constraint_name;
-} DeleteConstraintInfo;
+	const char *hypertable_constraint_name;
+} ConstraintInfo;
+
+typedef struct RenameHypertableConstraintInfo
+{
+	ConstraintInfo base;
+	const char *newname;
+} RenameHypertableConstraintInfo;
+
 
 static bool
 chunk_constraint_delete_tuple(TupleInfo *ti, void *data)
 {
-	DeleteConstraintInfo *info = data;
 	bool		isnull;
 	Datum		constrname = heap_getattr(ti->tuple, Anum_chunk_constraint_constraint_name,
 										  ti->desc, &isnull);
+	int32		chunk_id = DatumGetInt32(heap_getattr(ti->tuple, Anum_chunk_constraint_chunk_id,
+													  ti->desc, &isnull));
+	Chunk	   *chunk = chunk_get_by_id(chunk_id, 0, true);
+
 	ObjectAddress constrobj = {
 		.classId = ConstraintRelationId,
-		.objectId = get_relation_constraint_oid(info->chunk_oid,
+		.objectId = get_relation_constraint_oid(chunk->table_id,
 								  NameStr(*DatumGetName(constrname)), false),
 	};
 
@@ -575,10 +610,9 @@ chunk_constraint_delete_tuple(TupleInfo *ti, void *data)
 static bool
 hypertable_constraint_tuple_filter(TupleInfo *ti, void *data)
 {
-	DeleteConstraintInfo *info = data;
+	ConstraintInfo *info = data;
 	bool		nulls[Natts_chunk_constraint];
 	Datum		values[Natts_chunk_constraint];
-	int32		chunk_id;
 	const char *constrname;
 
 	heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
@@ -586,11 +620,9 @@ hypertable_constraint_tuple_filter(TupleInfo *ti, void *data)
 	if (nulls[Anum_chunk_constraint_hypertable_constraint_name - 1])
 		return false;
 
-	chunk_id = DatumGetInt32(values[Anum_chunk_constraint_chunk_id - 1]);
 	constrname = NameStr(*DatumGetName(values[Anum_chunk_constraint_hypertable_constraint_name - 1]));
 
-	return info->chunk_id == chunk_id &&
-		NULL != info->hypertable_constraint_name &&
+	return NULL != info->hypertable_constraint_name &&
 		strcmp(info->hypertable_constraint_name, constrname) == 0;
 }
 
@@ -599,9 +631,7 @@ chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id,
 													  Oid chunk_oid,
 											char *hypertable_constraint_name)
 {
-	DeleteConstraintInfo info = {
-		.chunk_id = chunk_id,
-		.chunk_oid = chunk_oid,
+	ConstraintInfo info = {
 		.hypertable_constraint_name = hypertable_constraint_name,
 	};
 
@@ -615,16 +645,10 @@ chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id,
 int
 chunk_constraint_delete_by_chunk_id(int32 chunk_id, Oid chunk_oid)
 {
-	DeleteConstraintInfo info = {
-		.chunk_id = chunk_id,
-		.chunk_oid = chunk_oid,
-		.hypertable_constraint_name = NULL,
-	};
-
 	return chunk_constraint_scan_by_chunk_id_internal(chunk_id,
 											   chunk_constraint_delete_tuple,
 													  NULL,
-													  &info,
+													  NULL,
 													  RowExclusiveLock);
 }
 
@@ -639,4 +663,75 @@ chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid)
 
 	performDeletion(&constrobj, DROP_RESTRICT, 0);
 	chunk_constraint_create_on_table(cc, chunk_oid);
+}
+
+static void
+chunk_constraint_rename_on_chunk_table(int32 chunk_id, char *old_name, char *new_name)
+{
+	Chunk	   *chunk = chunk_get_by_id(chunk_id, 0, true);
+	RenameStmt	rename = {
+		.renameType = OBJECT_TABCONSTRAINT,
+		.relation = makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), 0),
+		.subname = old_name,
+		.newname = new_name,
+	};
+
+	RenameConstraint(&rename);
+}
+
+static bool
+chunk_constraint_rename_hypertable_tuple(TupleInfo *ti, void *data)
+{
+	RenameHypertableConstraintInfo *info = data;
+
+	bool		nulls[Natts_chunk_constraint];
+	Datum		values[Natts_chunk_constraint];
+	bool		repl[Natts_chunk_constraint] = {false};
+
+	HeapTuple	tuple;
+	NameData	new_hypertable_constraint_name;
+	NameData	new_chunk_constraint_name;
+	Name		old_chunk_constraint_name;
+	int32		chunk_id;
+
+	heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
+
+	chunk_id = DatumGetInt32(values[Anum_chunk_constraint_chunk_id - 1]);
+	namestrcpy(&new_hypertable_constraint_name, info->newname);
+	chunk_constraint_choose_name(&new_chunk_constraint_name,
+								 false,
+								 0,
+								 info->newname,
+								 chunk_id);
+
+	values[Anum_chunk_constraint_hypertable_constraint_name - 1] = NameGetDatum(&new_hypertable_constraint_name);
+	repl[Anum_chunk_constraint_hypertable_constraint_name - 1] = true;
+	old_chunk_constraint_name = DatumGetName(values[Anum_chunk_constraint_constraint_name - 1]);
+	values[Anum_chunk_constraint_constraint_name - 1] = NameGetDatum(&new_chunk_constraint_name);
+	repl[Anum_chunk_constraint_constraint_name - 1] = true;
+
+	chunk_constraint_rename_on_chunk_table(chunk_id, NameStr(*old_chunk_constraint_name), NameStr(new_chunk_constraint_name));
+
+	tuple = heap_modify_tuple(ti->tuple, ti->desc, values, nulls, repl);
+	catalog_update(ti->scanrel, tuple);
+	heap_freetuple(tuple);
+
+	return true;
+}
+
+int
+chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname)
+{
+	RenameHypertableConstraintInfo info = {
+		.base = {
+			.hypertable_constraint_name = oldname,
+		},
+		.newname = newname,
+	};
+
+	return chunk_constraint_scan_by_chunk_id_internal(chunk_id,
+									chunk_constraint_rename_hypertable_tuple,
+										  hypertable_constraint_tuple_filter,
+													  &info,
+													  RowExclusiveLock);
 }

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -45,5 +45,7 @@ extern void chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
 extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, Oid chunk_oid, char *hypertable_constraint_name);
 extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_id, Oid chunk_oid);
 extern void chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
+extern int	chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);
+
 
 #endif   /* TIMESCALEDB_CHUNK_CONSTRAINT_H */

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -197,6 +197,52 @@ ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
 ADD CONSTRAINT hyper_unique_invalid UNIQUE (device_id);
 ERROR:  Cannot create a unique index without the column: time (used in partitioning)
 \set ON_ERROR_STOP 1
+----------------------- RENAME CONSTRAINT  ------------------
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT hyper_unique_with_looooooooooooooooooooooooooooooooooo_time_key TO new_name;
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name *
+RENAME CONSTRAINT new_name TO new_name2;
+ALTER TABLE IF EXISTS hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT  hyper_unique_with_looooooooooooooooooooooooooooo_sensor_1_check TO check_2;
+SELECT * FROM test.show_constraints('hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name');
+ Constraint | Type |  Columns   |   Index   |            Expr            
+------------+------+------------+-----------+----------------------------
+ check_2    | c    | {sensor_1} | -         | (sensor_1 > (10)::numeric)
+ new_name2  | u    | {time}     | new_name2 | 
+(2 rows)
+
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_2_4_chunk');
+   Constraint   | Type |  Columns   |                 Index                  |                                           Expr                                           
+----------------+------+------------+----------------------------------------+------------------------------------------------------------------------------------------
+ 4_10_new_name2 | u    | {time}     | _timescaledb_internal."4_10_new_name2" | 
+ check_2        | c    | {sensor_1} | -                                      | (sensor_1 > (10)::numeric)
+ constraint_4   | c    | {time}     | -                                      | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint))
+(3 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk_constraint;
+ chunk_id | dimension_slice_id | constraint_name | hypertable_constraint_name 
+----------+--------------------+-----------------+----------------------------
+        3 |                  3 | constraint_3    | 
+        4 |                  4 | constraint_4    | 
+        5 |                  5 | constraint_5    | 
+        4 |                    | 4_10_new_name2  | new_name2
+        5 |                    | 5_11_new_name2  | new_name2
+(5 rows)
+
+\set ON_ERROR_STOP 0
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT new_name TO new_name2;
+ERROR:  constraint "new_name" for table "hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name" does not exist
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT new_name2 TO check_2;
+ERROR:  constraint "check_2" for relation "hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name" already exists
+ALTER TABLE ONLY hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT new_name2 TO new_name;
+ERROR:  ONLY option not supported when renaming hypertable constraints
+ALTER TABLE _timescaledb_internal._hyper_2_4_chunk
+RENAME CONSTRAINT "4_10_new_name2" TO new_name;
+ERROR:  Renaming constraints on chunks is not supported
+\set ON_ERROR_STOP 1
 ----------------------- PRIMARY KEY  ------------------
 CREATE TABLE hyper_pk (
   time BIGINT NOT NULL PRIMARY KEY,
@@ -214,15 +260,15 @@ INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  duplicate key value violates unique constraint "6_8_hyper_pk_pkey"
+ERROR:  duplicate key value violates unique constraint "6_14_hyper_pk_pkey"
 \set ON_ERROR_STOP 1
 --should have unique constraint not just unique index
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_3_6_chunk');
-       Constraint        | Type |  Columns   |                   Index                   |                                           Expr                                           
--------------------------+------+------------+-------------------------------------------+------------------------------------------------------------------------------------------
- 6_8_hyper_pk_pkey       | p    | {time}     | _timescaledb_internal."6_8_hyper_pk_pkey" | 
- constraint_6            | c    | {time}     | -                                         | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint))
- hyper_pk_sensor_1_check | c    | {sensor_1} | -                                         | (sensor_1 > (10)::numeric)
+       Constraint        | Type |  Columns   |                   Index                    |                                           Expr                                           
+-------------------------+------+------------+--------------------------------------------+------------------------------------------------------------------------------------------
+ 6_14_hyper_pk_pkey      | p    | {time}     | _timescaledb_internal."6_14_hyper_pk_pkey" | 
+ constraint_6            | c    | {time}     | -                                          | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint))
+ hyper_pk_sensor_1_check | c    | {sensor_1} | -                                          | (sensor_1 > (10)::numeric)
 (3 rows)
 
 ALTER TABLE hyper_pk DROP CONSTRAINT hyper_pk_pkey;
@@ -239,7 +285,7 @@ INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 --shouldn't be able to create pk
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_pk ADD CONSTRAINT hyper_pk_pkey PRIMARY KEY (time);
-ERROR:  could not create unique index "6_9_hyper_pk_pkey"
+ERROR:  could not create unique index "6_15_hyper_pk_pkey"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_pk WHERE device_id = 'dev3';
 --cannot create pk constraint on non-partition column
@@ -252,7 +298,7 @@ ALTER TABLE hyper_pk ADD CONSTRAINT hyper_pk_pkey PRIMARY KEY (time);
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_3_6_chunk');
        Constraint        | Type |  Columns   |                   Index                    |                                           Expr                                           
 -------------------------+------+------------+--------------------------------------------+------------------------------------------------------------------------------------------
- 6_10_hyper_pk_pkey      | p    | {time}     | _timescaledb_internal."6_10_hyper_pk_pkey" | 
+ 6_16_hyper_pk_pkey      | p    | {time}     | _timescaledb_internal."6_16_hyper_pk_pkey" | 
  constraint_6            | c    | {time}     | -                                          | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint))
  hyper_pk_sensor_1_check | c    | {sensor_1} | -                                          | (sensor_1 > (10)::numeric)
 (3 rows)
@@ -266,7 +312,7 @@ ERROR:  relation "hyper_pk_pkey" already exists
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  duplicate key value violates unique constraint "6_10_hyper_pk_pkey"
+ERROR:  duplicate key value violates unique constraint "6_16_hyper_pk_pkey"
 \set ON_ERROR_STOP 1
 ----------------------- FOREIGN KEY  ------------------
 CREATE TABLE devices(
@@ -288,7 +334,7 @@ SELECT * FROM create_hypertable('hyper_fk', 'time', chunk_time_interval => 10);
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
-ERROR:  insert or update on table "_hyper_4_7_chunk" violates foreign key constraint "7_11_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_7_chunk" violates foreign key constraint "7_17_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 INSERT INTO devices VALUES ('dev2');
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
@@ -296,7 +342,7 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 --delete should fail
 \set ON_ERROR_STOP 0
 DELETE FROM devices;
-ERROR:  update or delete on table "devices" violates foreign key constraint "8_13_hyper_fk_device_id_fkey" on table "_hyper_4_8_chunk"
+ERROR:  update or delete on table "devices" violates foreign key constraint "8_19_hyper_fk_device_id_fkey" on table "_hyper_4_8_chunk"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_fk DROP CONSTRAINT hyper_fk_device_id_fkey;
 --should now be able to add non-fk rows
@@ -306,7 +352,7 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
 FOREIGN KEY (device_id) REFERENCES devices(device_id);
-ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_15_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_21_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_fk WHERE device_id = 'dev3';
 ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
@@ -314,7 +360,7 @@ FOREIGN KEY (device_id) REFERENCES devices(device_id);
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000002, 'dev3', 11);
-ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_16_hyper_fk_device_id_fkey"
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_22_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
 ----------------------- FOREIGN KEY INTO A HYPERTABLE  ------------------
 --FOREIGN KEY references into a hypertable are currently broken.
@@ -368,7 +414,7 @@ INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_18_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_24_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_ex DROP CONSTRAINT hyper_ex_time_device_id_excl;
 --can now add
@@ -381,7 +427,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
         time WITH =, device_id WITH =
     ) WHERE (not canceled)
 ;
-ERROR:  could not create exclusion constraint "9_19_hyper_ex_time_device_id_excl"
+ERROR:  could not create exclusion constraint "9_25_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_ex WHERE sensor_1 = 12;
 ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
@@ -392,7 +438,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_20_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_26_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 --cannot add exclusion constraint without partition key.
 CREATE TABLE hyper_ex_invalid (

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -120,6 +120,32 @@ ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
 ADD CONSTRAINT hyper_unique_invalid UNIQUE (device_id);
 \set ON_ERROR_STOP 1
 
+----------------------- RENAME CONSTRAINT  ------------------
+
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT hyper_unique_with_looooooooooooooooooooooooooooooooooo_time_key TO new_name;
+
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name *
+RENAME CONSTRAINT new_name TO new_name2;
+
+ALTER TABLE IF EXISTS hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT  hyper_unique_with_looooooooooooooooooooooooooooo_sensor_1_check TO check_2;
+
+
+SELECT * FROM test.show_constraints('hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name');
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_2_4_chunk');
+SELECT * FROM _timescaledb_catalog.chunk_constraint;
+
+\set ON_ERROR_STOP 0
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT new_name TO new_name2;
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT new_name2 TO check_2;
+ALTER TABLE ONLY hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+RENAME CONSTRAINT new_name2 TO new_name;
+ALTER TABLE _timescaledb_internal._hyper_2_4_chunk
+RENAME CONSTRAINT "4_10_new_name2" TO new_name;
+\set ON_ERROR_STOP 1
 
 ----------------------- PRIMARY KEY  ------------------
 


### PR DESCRIPTION
Renaming constraints on hypertables is now supported. Using the ONLY
option with RENAME CONSTRAINT is blocked for hypertables. Renaming
constraints on chunks is also blocked.

This commit also fixes a possible bug in chunk_constraint code.
Previously, `chunk_constraint_add_from_tuple` used GETSTRUCT on the
tuple to convert the tuple to `FormData_chunk_constraint`. This
was incorrect since some fields can be NULL. Using GETSTRUCT for
tables with NULLABLE fields is unsafe and indeed was incorrect·
in this case.