### PR TITLE
Block ONLY hypertable on all ALTER TABLE commands.

### DIFF
--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -19,6 +19,10 @@ INSERT INTO hyper(time, device_id,sensor_1) VALUES
 ERROR:  null value in column "device_id" violates not-null constraint
 ALTER TABLE hyper ALTER COLUMN time DROP NOT NULL;
 ERROR:  Cannot Drop NOT NULL constraint from a time-partitioned column
+ALTER TABLE ONLY hyper ALTER COLUMN sensor_1 SET NOT NULL;
+ERROR:  ONLY option not supported on hypertable operations
+ALTER TABLE ONLY hyper ALTER COLUMN device_id DROP NOT NULL;
+ERROR:  ONLY option not supported on hypertable operations
 \set ON_ERROR_STOP 1
 INSERT INTO hyper(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 11);
@@ -243,7 +247,7 @@ RENAME CONSTRAINT new_name2 TO check_2;
 ERROR:  constraint "check_2" for relation "hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name" already exists
 ALTER TABLE ONLY hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
 RENAME CONSTRAINT new_name2 TO new_name;
-ERROR:  ONLY option not supported when renaming hypertable constraints
+ERROR:  ONLY option not supported on hypertable operations
 ALTER TABLE _timescaledb_internal._hyper_2_4_chunk
 RENAME CONSTRAINT "4_10_new_name2" TO new_name;
 ERROR:  Renaming constraints on chunks is not supported

--- a/test/expected/ddl_alter_column.out
+++ b/test/expected/ddl_alter_column.out
@@ -123,4 +123,9 @@ ERROR:  Cannot change the type of a hash-partitioned column
 -- conversion that messes up partitioning fails
 ALTER TABLE alter_test ALTER COLUMN time_us TYPE timestamptz USING time_us::timestamptz+INTERVAL '1 year';
 ERROR:  check constraint "constraint_1" is violated by some row
+--ONLY blocked
+ALTER TABLE ONLY alter_test RENAME COLUMN colorname TO colorname2;
+ERROR:  inherited column "colorname" must be renamed in child tables too
+ALTER TABLE ONLY alter_test ALTER COLUMN colorname TYPE varchar(10);
+ERROR:  ONLY option not supported on hypertable operations
 \set ON_ERROR_STOP 1

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -18,6 +18,9 @@ INSERT INTO hyper(time, device_id,sensor_1) VALUES
 
 ALTER TABLE hyper ALTER COLUMN time DROP NOT NULL;
 
+ALTER TABLE ONLY hyper ALTER COLUMN sensor_1 SET NOT NULL;
+ALTER TABLE ONLY hyper ALTER COLUMN device_id DROP NOT NULL;
+
 \set ON_ERROR_STOP 1
 
 INSERT INTO hyper(time, device_id,sensor_1) VALUES

--- a/test/sql/ddl_alter_column.sql
+++ b/test/sql/ddl_alter_column.sql
@@ -45,4 +45,7 @@ SELECT * FROM alter_test WHERE time_us > '2017-05-20T10:00:01';
 ALTER TABLE alter_test ALTER COLUMN colorname TYPE varchar(3);
 -- conversion that messes up partitioning fails
 ALTER TABLE alter_test ALTER COLUMN time_us TYPE timestamptz USING time_us::timestamptz+INTERVAL '1 year';
+--ONLY blocked
+ALTER TABLE ONLY alter_test RENAME COLUMN colorname TO colorname2;
+ALTER TABLE ONLY alter_test ALTER COLUMN colorname TYPE varchar(10);
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
ONLY does not make semantic sense for hypertables.
This commit blocks the use of this modifier.