### PR TITLE
Spread chunk indexes across tablespaces like chunks

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -400,7 +400,7 @@ chunk_create_table(Chunk *chunk, Hypertable *ht)
 		.type = T_CreateStmt,
 		.relation = makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), 0),
 		.inhRelations = list_make1(makeRangeVar(NameStr(ht->fd.schema_name), NameStr(ht->fd.table_name), 0)),
-		.tablespacename = hypertable_select_tablespace(ht, chunk),
+		.tablespacename = hypertable_select_tablespace_name(ht, chunk),
 		.options = get_reloptions(ht->main_table_relid),
 	};
 	Oid			uid,

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -30,6 +30,8 @@ extern Chunk *hypertable_get_chunk(Hypertable *h, Point *point);
 extern Oid	hypertable_relid(RangeVar *rv);
 extern bool is_hypertable(Oid relid);
 extern bool hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid);
-extern char *hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
+extern Tablespace *hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
+extern char *hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
+extern Tablespace *hypertable_get_tablespace_at_offset_from(Hypertable *ht, Oid tablespace_oid, int16 offset);
 
 #endif							/* TIMESCALEDB_HYPERTABLE_H */

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -318,15 +318,15 @@ SET timezone = '+1';
 INSERT INTO PUBLIC.drop_chunk_test_ts VALUES(now()-INTERVAL '5 minutes', 1.0, 'dev1');
 INSERT INTO PUBLIC.drop_chunk_test_tstz VALUES(now()-INTERVAL '5 minutes', 1.0, 'dev1');
 SELECT * FROM test.show_subtables('drop_chunk_test_ts');
-                  Child                  
------------------------------------------
- _timescaledb_internal._hyper_4_19_chunk
+                  Child                  | Tablespace 
+-----------------------------------------+------------
+ _timescaledb_internal._hyper_4_19_chunk | 
 (1 row)
 
 SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
-                  Child                  
------------------------------------------
- _timescaledb_internal._hyper_5_20_chunk
+                  Child                  | Tablespace 
+-----------------------------------------+------------
+ _timescaledb_internal._hyper_5_20_chunk | 
 (1 row)
 
 BEGIN;
@@ -337,8 +337,8 @@ BEGIN;
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
     SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_tstz');
@@ -348,8 +348,8 @@ BEGIN;
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
 ROLLBACK;
@@ -361,8 +361,8 @@ BEGIN;
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
     SELECT drop_chunks(now()-interval '1 minute', 'drop_chunk_test_tstz');
@@ -372,8 +372,8 @@ BEGIN;
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
 ROLLBACK;
@@ -405,8 +405,8 @@ BEGIN;
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_date');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
 ROLLBACK;
@@ -418,8 +418,8 @@ BEGIN;
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_date');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
 ROLLBACK;

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -398,7 +398,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 ----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_device_idx | {time,temp,device} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {time,temp,device} | f      | f       | f         | 
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {time,temp,device} | f      | f       | f         | tablespace1
 (3 rows)
 
 -- Creating a new index should propagate to existing chunks, including
@@ -418,7 +418,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 ----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_device_idx | {time,temp,device} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {time,temp,device} | f      | f       | f         | 
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {time,temp,device} | f      | f       | f         | tablespace1
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_time_temp_idx              | {time,temp,device} | f      | f       | f         | tablespace2
 (4 rows)
 

--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -21,13 +21,13 @@ SELECT * FROM test.show_columns('reindex_test');
 (2 rows)
 
 SELECT * FROM test.show_subtables('reindex_test');
-                 Child                  
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
- _timescaledb_internal._hyper_1_5_chunk
+                 Child                  | Tablespace 
+----------------------------------------+------------
+ _timescaledb_internal._hyper_1_1_chunk | 
+ _timescaledb_internal._hyper_1_2_chunk | 
+ _timescaledb_internal._hyper_1_3_chunk | 
+ _timescaledb_internal._hyper_1_4_chunk | 
+ _timescaledb_internal._hyper_1_5_chunk | 
 (5 rows)
 
 -- show reindexing

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -122,10 +122,10 @@ INSERT INTO "int_part" VALUES('2017-01-20T09:00:01', 1, 22.5);
 INSERT INTO "int_part" VALUES('2017-01-20T09:00:01', 2, 22.5);
 --check that there are two chunks
 SELECT * FROM test.show_subtables('int_part');
-                 Child                  
-----------------------------------------
- _timescaledb_internal._hyper_2_5_chunk
- _timescaledb_internal._hyper_2_6_chunk
+                 Child                  | Tablespace 
+----------------------------------------+------------
+ _timescaledb_internal._hyper_2_5_chunk | 
+ _timescaledb_internal._hyper_2_6_chunk | 
 (2 rows)
 
 SELECT * FROM "int_part" WHERE object_id = 1;

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -77,28 +77,42 @@ SELECT * FROM show_tablespaces('tspace_2dim');
 
 --insert into another chunk
 INSERT INTO tspace_2dim VALUES ('2017-01-20T09:00:01', 24.3, 'brown');
-SELECT relname, spcname FROM pg_class c
-INNER JOIN pg_tablespace t ON (c.reltablespace = t.oid)
-INNER JOIN _timescaledb_catalog.chunk ch ON (ch.table_name = c.relname);
-     relname      |   spcname   
-------------------+-------------
- _hyper_1_1_chunk | tablespace1
- _hyper_1_2_chunk | tablespace2
+SELECT * FROM test.show_subtables('tspace_2dim');
+                 Child                  | Tablespace  
+----------------------------------------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | tablespace2
 (2 rows)
+
+--indexes should inherit the tablespace of their chunk
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+                 Table                  |                               Index                                |      Columns       | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+--------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
+(4 rows)
 
 --
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 -- User doesn't have permission on tablespace1 --> error
-CREATE TABLE tspace_1dim(time timestamp, temp float, device text) TABLESPACE tablespace1;
-ERROR:  permission denied for tablespace tablespace1
+CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
 -- Grant permission to tablespace1
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 GRANT CREATE ON TABLESPACE tablespace1 TO :ROLE_DEFAULT_PERM_USER_2;
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;
-CREATE TABLE tspace_1dim(time timestamp, temp float, device text) TABLESPACE tablespace1;
+CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
+ERROR:  relation "tspace_1dim" already exists
 SELECT create_hypertable('tspace_1dim', 'time');
 NOTICE:  Adding NOT NULL constraint to time column time (NULL time values not allowed)
  create_hypertable 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'tspace_1dim');
+ attach_tablespace 
 -------------------
  
 (1 row)
@@ -120,16 +134,32 @@ SELECT * FROM _timescaledb_catalog.tablespace;
 
 INSERT INTO tspace_1dim VALUES ('2017-01-20T09:00:01', 24.3, 'blue');
 INSERT INTO tspace_1dim VALUES ('2017-03-20T09:00:01', 24.3, 'brown');
-SELECT relname, spcname FROM pg_class c
-INNER JOIN pg_tablespace t ON (c.reltablespace = t.oid)
-INNER JOIN _timescaledb_catalog.chunk ch ON (ch.table_name = c.relname);
-     relname      |   spcname   
-------------------+-------------
- _hyper_1_1_chunk | tablespace1
- _hyper_1_2_chunk | tablespace2
- _hyper_2_3_chunk | tablespace1
- _hyper_2_4_chunk | tablespace2
+SELECT * FROM test.show_subtablesp('tspace_%');
+   Parent    |                 Child                  | Tablespace  
+-------------+----------------------------------------+-------------
+ tspace_2dim | _timescaledb_internal._hyper_1_1_chunk | tablespace1
+ tspace_2dim | _timescaledb_internal._hyper_1_2_chunk | tablespace2
+ tspace_1dim | _timescaledb_internal._hyper_2_3_chunk | tablespace1
+ tspace_1dim | _timescaledb_internal._hyper_2_4_chunk | tablespace2
 (4 rows)
+
+--indexes should inherit the tablespace of their chunk, unless the
+--parent index has a tablespace set, in which case the chunks'
+--corresponding indexes are pinned to the parent index's
+--tablespace. The parent index can have a tablespace set in two cases:
+--(1) if explicitly set in CREATE INDEX, or (2) if the main table was
+--created with a tablespace, because then default indexes will be
+--created in that tablespace too.
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+                 Table                  |                               Index                                |      Columns       | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+--------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_2_3_chunk | _timescaledb_internal._hyper_2_3_chunk_tspace_1dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_2_4_chunk | _timescaledb_internal._hyper_2_4_chunk_tspace_1dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
+(6 rows)
 
 --detach tablespace1 from all tables. Due to lack of permissions,
 --should only detach from 'tspace_1dim' (1 tablespace)

--- a/test/expected/truncate_hypertable.out
+++ b/test/expected/truncate_hypertable.out
@@ -45,12 +45,12 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (4 rows)
 
 SELECT * FROM test.show_subtables('"two_Partitions"');
-                 Child                  
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
- _timescaledb_internal._hyper_1_2_chunk
- _timescaledb_internal._hyper_1_3_chunk
- _timescaledb_internal._hyper_1_4_chunk
+                 Child                  | Tablespace 
+----------------------------------------+------------
+ _timescaledb_internal._hyper_1_1_chunk | 
+ _timescaledb_internal._hyper_1_2_chunk | 
+ _timescaledb_internal._hyper_1_3_chunk | 
+ _timescaledb_internal._hyper_1_4_chunk | 
 (4 rows)
 
 SELECT * FROM "two_Partitions";
@@ -85,8 +85,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
 SELECT * FROM "two_Partitions";
@@ -140,8 +140,8 @@ WARNING:  FIRING trigger when: BEFORE level: STATEMENT op: TRUNCATE cnt: <NULL> 
 WARNING:  FIRING trigger when: AFTER level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_after
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
- Child 
--------
+ Child | Tablespace 
+-------+------------
 (0 rows)
 
 SELECT * FROM "two_Partitions";


### PR DESCRIPTION
Currently, chunk indexes are always created in the tablespace of the
index on the main table (which could be none/default one), even if the
chunks themselves are created in different tablespaces. This is
problematic in a multi-disk setting where each disk is a separate
tablespace where chunks are placed. The chunk indexes might exhaust
the space on the common (often default tablespace) which might not
have a lot of disk space. This also prohibits the database, including
index storage to grow by adding new tablespaces.

Instead, chunk indexes are now created in the "next" tablespace after
that of their chunks to both spread indexes across tablespaces and
avoid colocating indexes with their chunks (for I/O throughput
reasons). To optionally avoid this spreading, one can pin chunk
indexes to a specific tablespace by setting an explicit tablespace on
a main table index.