### PR TITLE
Apply new indentation (pgindent) used in PostgreSQL 10

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -31,9 +31,9 @@ typedef struct Cache
 	void	   *(*create_entry) (struct Cache *, CacheQuery *);
 	void	   *(*update_entry) (struct Cache *, CacheQuery *);
 	void		(*pre_destroy_hook) (struct Cache *);
-	bool		release_on_commit;		/* This should be false if doing
-										 * cross-commit operations like
-										 * CLUSTER or VACUUM */
+	bool		release_on_commit;	/* This should be false if doing
+									 * cross-commit operations like CLUSTER or
+									 * VACUUM */
 } Cache;
 
 extern void cache_init(Cache *cache);
@@ -49,4 +49,4 @@ extern int	cache_release(Cache *cache);
 extern void _cache_init(void);
 extern void _cache_fini(void);
 
-#endif   /* TIMESCALEDB_CACHE_H */
+#endif							/* TIMESCALEDB_CACHE_H */

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -237,7 +237,7 @@ catalog_get(void)
 
 	for (i = 0; i < _MAX_CACHE_TYPES; i++)
 		catalog.caches[i].inval_proxy_id = get_relname_relid(cache_proxy_table_names[i],
-													catalog.cache_schema_id);
+															 catalog.cache_schema_id);
 
 	catalog.internal_schema_id = get_namespace_oid(INTERNAL_SCHEMA_NAME, false);
 
@@ -315,7 +315,7 @@ catalog_become_owner(Catalog *catalog, CatalogSecurityContext *sec_ctx)
 	if (sec_ctx->saved_uid != catalog->owner_uid)
 	{
 		SetUserIdAndSecContext(catalog->owner_uid,
-			 sec_ctx->saved_security_context | SECURITY_LOCAL_USERID_CHANGE);
+							   sec_ctx->saved_security_context | SECURITY_LOCAL_USERID_CHANGE);
 		return true;
 	}
 
@@ -398,7 +398,7 @@ catalog_table_next_seq_id(Catalog *catalog, CatalogTable table)
 #define CatalogTupleDelete(relation, tid)		\
 	simple_heap_delete(relation, tid);
 
-#endif   /* PG96 */
+#endif							/* PG96 */
 
 /*
  * Insert a new row into a catalog table.

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -431,7 +431,7 @@ enum Anum_tablespace_pkey_idx
 typedef struct FormData_tablespace_pkey_idx
 {
 	int32		tablespace_id;
-}	FormData_tablespace_pkey_idx;
+}			FormData_tablespace_pkey_idx;
 
 enum Anum_tablespace_hypertable_id_tablespace_name_idx
 {
@@ -444,7 +444,7 @@ typedef struct FormData_tablespace_hypertable_id_tablespace_name_idx
 {
 	int32		hypertable_id;
 	NameData	tablespace_name;
-}	FormData_tablespace_hypertable_id_tablespace_name_idx;
+}			FormData_tablespace_hypertable_id_tablespace_name_idx;
 
 
 #define MAX(a, b) \
@@ -527,4 +527,4 @@ void		catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
 /* Delete only: do not increment command counter or invalidate caches */
 void		catalog_delete_only(Relation rel, HeapTuple tuple);
 
-#endif   /* TIMESCALEDB_CATALOG_H */
+#endif							/* TIMESCALEDB_CATALOG_H */

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -99,7 +99,7 @@ chunk_fill(Chunk *chunk, HeapTuple tuple)
 {
 	memcpy(&chunk->fd, GETSTRUCT(tuple), sizeof(FormData_chunk));
 	chunk->table_id = get_relname_relid(chunk->fd.table_name.data,
-					   get_namespace_oid(chunk->fd.schema_name.data, false));
+										get_namespace_oid(chunk->fd.schema_name.data, false));
 	chunk->hypertable_relid = parent_relid(chunk->table_id);
 }
 
@@ -340,7 +340,7 @@ chunk_add_constraints(Chunk *chunk)
 															chunk->cube);
 	num_added += chunk_constraints_add_inheritable_constraints(chunk->constraints,
 															   chunk->fd.id,
-													chunk->hypertable_relid);
+															   chunk->hypertable_relid);
 
 	return num_added;
 }
@@ -829,7 +829,7 @@ chunk_find(Hyperspace *hs, Point *p)
 		 * constraints to also get the inherited constraints.
 		 */
 		chunk->constraints = chunk_constraint_scan_by_chunk_id(chunk->fd.id,
-														 hs->num_dimensions);
+															   hs->num_dimensions);
 	}
 
 	return chunk;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -75,4 +75,4 @@ extern bool chunk_exists_relid(Oid relid);
 extern void chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
 extern int	chunk_delete_by_relid(Oid chunk_oid);
 
-#endif   /* TIMESCALEDB_CHUNK_H */
+#endif							/* TIMESCALEDB_CHUNK_H */

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -228,7 +228,7 @@ chunk_constraints_add_from_tuple(ChunkConstraints *ccs, TupleInfo *ti)
 	}
 
 	return chunk_constraints_add(ccs,
-				   DatumGetInt32(values[Anum_chunk_constraint_chunk_id - 1]),
+								 DatumGetInt32(values[Anum_chunk_constraint_chunk_id - 1]),
 								 dimension_slice_id,
 								 NameStr(*constraint_name),
 								 NameStr(*hypertable_constraint_name));
@@ -288,8 +288,8 @@ chunk_constraint_create(ChunkConstraint *cc,
 	if (!is_dimension_constraint(cc))
 	{
 		Oid			hypertable_constraint_oid = get_relation_constraint_oid(hypertable_oid,
-								  NameStr(cc->fd.hypertable_constraint_name),
-																	  false);
+																			NameStr(cc->fd.hypertable_constraint_name),
+																			false);
 		HeapTuple	tuple = SearchSysCache1(CONSTROID, hypertable_constraint_oid);
 
 		if (HeapTupleIsValid(tuple))
@@ -374,7 +374,7 @@ chunk_constraint_scan_by_chunk_id_internal(int32 chunk_id,
 	};
 
 	ScanKeyInit(&scankey[0],
-			  Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_chunk_id,
+				Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_chunk_id,
 				BTEqualStrategyNumber,
 				F_INT4EQ,
 				Int32GetDatum(chunk_id));
@@ -394,7 +394,7 @@ chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size num_constraints_hint)
 	int			num_found;
 
 	num_found = chunk_constraint_scan_by_chunk_id_internal(chunk_id,
-												chunk_constraint_tuple_found,
+														   chunk_constraint_tuple_found,
 														   NULL,
 														   constraints,
 														   AccessShareLock);
@@ -473,7 +473,7 @@ chunk_constraint_scan_by_dimension_slice_id(DimensionSlice *slice, ChunkScanCtx 
 	};
 
 	ScanKeyInit(&scankey[0],
-	Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_dimension_slice_id,
+				Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_dimension_slice_id,
 				BTEqualStrategyNumber,
 				F_INT4EQ,
 				Int32GetDatum(slice->fd.id));
@@ -598,7 +598,7 @@ chunk_constraint_delete_tuple(TupleInfo *ti, void *data)
 	ObjectAddress constrobj = {
 		.classId = ConstraintRelationId,
 		.objectId = get_relation_constraint_oid(chunk->table_id,
-								  NameStr(*DatumGetName(constrname)), false),
+												NameStr(*DatumGetName(constrname)), false),
 	};
 
 	catalog_delete(ti->scanrel, ti->tuple);
@@ -629,15 +629,15 @@ hypertable_constraint_tuple_filter(TupleInfo *ti, void *data)
 int
 chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id,
 													  Oid chunk_oid,
-											char *hypertable_constraint_name)
+													  char *hypertable_constraint_name)
 {
 	ConstraintInfo info = {
 		.hypertable_constraint_name = hypertable_constraint_name,
 	};
 
 	return chunk_constraint_scan_by_chunk_id_internal(chunk_id,
-											   chunk_constraint_delete_tuple,
-										  hypertable_constraint_tuple_filter,
+													  chunk_constraint_delete_tuple,
+													  hypertable_constraint_tuple_filter,
 													  &info,
 													  RowExclusiveLock);
 }
@@ -646,7 +646,7 @@ int
 chunk_constraint_delete_by_chunk_id(int32 chunk_id, Oid chunk_oid)
 {
 	return chunk_constraint_scan_by_chunk_id_internal(chunk_id,
-											   chunk_constraint_delete_tuple,
+													  chunk_constraint_delete_tuple,
 													  NULL,
 													  NULL,
 													  RowExclusiveLock);
@@ -658,7 +658,7 @@ chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid)
 	ObjectAddress constrobj = {
 		.classId = ConstraintRelationId,
 		.objectId = get_relation_constraint_oid(chunk_oid,
-									 NameStr(cc->fd.constraint_name), false),
+												NameStr(cc->fd.constraint_name), false),
 	};
 
 	performDeletion(&constrobj, DROP_RESTRICT, 0);
@@ -730,8 +730,8 @@ chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldnam
 	};
 
 	return chunk_constraint_scan_by_chunk_id_internal(chunk_id,
-									chunk_constraint_rename_hypertable_tuple,
-										  hypertable_constraint_tuple_filter,
+													  chunk_constraint_rename_hypertable_tuple,
+													  hypertable_constraint_tuple_filter,
 													  &info,
 													  RowExclusiveLock);
 }

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -48,4 +48,4 @@ extern void chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
 extern int	chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);
 
 
-#endif   /* TIMESCALEDB_CHUNK_CONSTRAINT_H */
+#endif							/* TIMESCALEDB_CHUNK_CONSTRAINT_H */

--- a/src/chunk_dispatch.h
+++ b/src/chunk_dispatch.h
@@ -36,4 +36,4 @@ ChunkDispatch *chunk_dispatch_create(Hypertable *ht, EState *estate, Query *quer
 void		chunk_dispatch_destroy(ChunkDispatch *dispatch);
 ChunkInsertState *chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *p, CmdType operation);
 
-#endif   /* TIMESCALEDB_CHUNK_DISPATCH_H */
+#endif							/* TIMESCALEDB_CHUNK_DISPATCH_H */

--- a/src/chunk_dispatch_info.h
+++ b/src/chunk_dispatch_info.h
@@ -23,4 +23,4 @@ extern ChunkDispatchInfo *chunk_dispatch_info_create(Oid hypertable_relid, Query
 extern void _chunk_dispatch_info_init(void);
 extern void _chunk_dispatch_info_fini(void);
 
-#endif   /* TIMESCALEDB_CHUNK_DISPATCH_INFO_H */
+#endif							/* TIMESCALEDB_CHUNK_DISPATCH_INFO_H */

--- a/src/chunk_dispatch_plan.c
+++ b/src/chunk_dispatch_plan.c
@@ -20,7 +20,7 @@ static Node *
 create_chunk_dispatch_state(CustomScan *cscan)
 {
 	return (Node *) chunk_dispatch_state_create(linitial(cscan->custom_private),
-											  linitial(cscan->custom_plans));
+												linitial(cscan->custom_plans));
 }
 
 static CustomScanMethods chunk_dispatch_plan_methods = {
@@ -100,7 +100,7 @@ build_customscan_targetlist(Relation rel, List *targetlist)
 	if (attno != tupdesc->natts)
 		ereport(ERROR,
 				(errcode(ERRCODE_DATATYPE_MISMATCH),
-		  errmsg("table row type and query-specified row type do not match"),
+				 errmsg("table row type and query-specified row type do not match"),
 				 errdetail("Query has too few columns.")));
 
 	return new_targetlist;

--- a/src/chunk_dispatch_plan.h
+++ b/src/chunk_dispatch_plan.h
@@ -8,4 +8,4 @@
 
 extern CustomScan *chunk_dispatch_plan_create(Plan *subplan, Index hypertable_rti, Oid hypertable_relid, Query *parse);
 
-#endif   /* TIMESCALEDB_CHUNK_DISPATCH_PLAN_H */
+#endif							/* TIMESCALEDB_CHUNK_DISPATCH_PLAN_H */

--- a/src/chunk_dispatch_state.h
+++ b/src/chunk_dispatch_state.h
@@ -36,4 +36,4 @@ typedef struct ChunkDispatchState
 
 ChunkDispatchState *chunk_dispatch_state_create(ChunkDispatchInfo *, Plan *);
 
-#endif   /* TIMESCALEDB_CHUNK_DISPATCH_STATE_H */
+#endif							/* TIMESCALEDB_CHUNK_DISPATCH_STATE_H */

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -236,8 +236,8 @@ chunk_relation_index_create(Relation htrel,
 	indclassoid = (oidvector *) DatumGetPointer(indclass);
 
 	indexname = chunk_index_choose_name(get_rel_name(RelationGetRelid(chunkrel)),
-						   get_rel_name(RelationGetRelid(template_indexrel)),
-							  get_rel_namespace(RelationGetRelid(chunkrel)));
+										get_rel_name(RelationGetRelid(template_indexrel)),
+										get_rel_namespace(RelationGetRelid(chunkrel)));
 
 	chunk_indexrelid = index_create(chunkrel,
 									indexname,
@@ -253,13 +253,13 @@ chunk_relation_index_create(Relation htrel,
 									reloptions,
 									template_indexrel->rd_index->indisprimary,
 									isconstraint,
-									false,		/* deferrable */
-									false,		/* init deferred */
-									false,		/* allow system table mods */
-									false,		/* skip build */
-									false,		/* concurrent */
-									false,		/* is internal */
-									false);		/* if not exists */
+									false,	/* deferrable */
+									false,	/* init deferred */
+									false,	/* allow system table mods */
+									false,	/* skip build */
+									false,	/* concurrent */
+									false,	/* is internal */
+									false); /* if not exists */
 
 	ReleaseSysCache(tuple);
 
@@ -385,7 +385,7 @@ chunk_index_create_from_stmt(IndexStmt *stmt,
 	if (NULL != stmt->idxname)
 		stmt->idxname = chunk_index_choose_name(get_rel_name(chunkrelid),
 												hypertable_indexname,
-											  get_rel_namespace(chunkrelid));
+												get_rel_namespace(chunkrelid));
 
 	idxobj = DefineIndex(chunkrelid,
 						 stmt,
@@ -528,7 +528,7 @@ chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid)
 	List	   *mappings = NIL;
 
 	ScanKeyInit(&scankey[0],
-	  Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
+				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(ht->fd.id));
 	ScanKeyInit(&scankey[1],
 				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_index_name,
@@ -536,7 +536,7 @@ chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid)
 				DirectFunctionCall1(namein, CStringGetDatum((indexname))));
 
 	chunk_index_scan(CHUNK_INDEX_HYPERTABLE_ID_HYPERTABLE_INDEX_NAME_IDX,
-				scankey, 2, chunk_index_collect, &mappings, AccessShareLock);
+					 scankey, 2, chunk_index_collect, &mappings, AccessShareLock);
 
 	return mappings;
 }
@@ -567,7 +567,7 @@ chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool s
 	const char *indexname = get_rel_name(hypertable_indexrelid);
 
 	ScanKeyInit(&scankey[0],
-	  Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
+				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(ht->fd.id));
 	ScanKeyInit(&scankey[1],
 				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_index_name,
@@ -575,7 +575,7 @@ chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool s
 				DirectFunctionCall1(namein, CStringGetDatum((indexname))));
 
 	return chunk_index_scan_update(CHUNK_INDEX_HYPERTABLE_ID_HYPERTABLE_INDEX_NAME_IDX,
-						 scankey, 2, chunk_index_tuple_delete, &should_drop);
+								   scankey, 2, chunk_index_tuple_delete, &should_drop);
 }
 
 int
@@ -593,7 +593,7 @@ chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index)
 				DirectFunctionCall1(namein, CStringGetDatum(indexname)));
 
 	return chunk_index_scan_update(CHUNK_INDEX_CHUNK_ID_INDEX_NAME_IDX,
-						  scankey, 2, chunk_index_tuple_delete, &drop_index);
+								   scankey, 2, chunk_index_tuple_delete, &drop_index);
 }
 
 static bool
@@ -621,7 +621,7 @@ chunk_index_get_by_indexrelid(Chunk *chunk, Oid chunk_indexrelid)
 				BTEqualStrategyNumber, F_NAMEEQ, DirectFunctionCall1(namein, CStringGetDatum(indexname)));
 
 	chunk_index_scan(CHUNK_INDEX_CHUNK_ID_INDEX_NAME_IDX,
-				  scankey, 2, chunk_index_tuple_found, cim, AccessShareLock);
+					 scankey, 2, chunk_index_tuple_found, cim, AccessShareLock);
 
 	return cim;
 }
@@ -651,7 +651,7 @@ chunk_index_tuple_rename(TupleInfo *ti, void *data)
 		Oid			chunk_schemaoid = get_namespace_oid(NameStr(chunk->fd.schema_name), false);
 		const char *chunk_index_name = chunk_index_choose_name(NameStr(chunk->fd.table_name),
 															   info->newname,
-															chunk_schemaoid);
+															   chunk_schemaoid);
 		Oid			chunk_indexrelid = get_relname_relid(NameStr(chunk_index->index_name),
 														 chunk_schemaoid);
 
@@ -690,7 +690,7 @@ chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname)
 				BTEqualStrategyNumber, F_NAMEEQ, CStringGetDatum(indexname));
 
 	return chunk_index_scan_update(CHUNK_INDEX_CHUNK_ID_INDEX_NAME_IDX,
-						  scankey, 2, chunk_index_tuple_rename, &renameinfo);
+								   scankey, 2, chunk_index_tuple_rename, &renameinfo);
 }
 
 int
@@ -705,14 +705,14 @@ chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char 
 	};
 
 	ScanKeyInit(&scankey[0],
-	  Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
+				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(ht->fd.id));
 	ScanKeyInit(&scankey[1],
 				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_index_name,
 				BTEqualStrategyNumber, F_NAMEEQ, CStringGetDatum(indexname));
 
 	return chunk_index_scan_update(CHUNK_INDEX_HYPERTABLE_ID_HYPERTABLE_INDEX_NAME_IDX,
-						  scankey, 2, chunk_index_tuple_rename, &renameinfo);
+								   scankey, 2, chunk_index_tuple_rename, &renameinfo);
 }
 
 static bool
@@ -741,14 +741,14 @@ chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, const char
 	char	   *indexname = get_rel_name(hypertable_indexrelid);
 
 	ScanKeyInit(&scankey[0],
-	  Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
+				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(ht->fd.id));
 	ScanKeyInit(&scankey[1],
 				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_index_name,
 				BTEqualStrategyNumber, F_NAMEEQ, CStringGetDatum(indexname));
 
 	return chunk_index_scan_update(CHUNK_INDEX_HYPERTABLE_ID_HYPERTABLE_INDEX_NAME_IDX,
-								scankey, 2, chunk_index_tuple_set_tablespace,
+								   scankey, 2, chunk_index_tuple_set_tablespace,
 								   (char *) tablespace);
 }
 
@@ -788,7 +788,7 @@ chunk_index_clone(PG_FUNCTION_ARGS)
 	constraint_oid = get_index_constraint(cim->parent_indexoid);
 
 	new_chunk_indexrelid = chunk_relation_index_create(hypertable_rel, chunk_index_rel,
-									  chunk_rel, OidIsValid(constraint_oid));
+													   chunk_rel, OidIsValid(constraint_oid));
 
 	heap_close(chunk_rel, NoLock);
 

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -46,4 +46,4 @@ extern void chunk_index_mark_clustered(Oid chunkrelid, Oid indexrelid);
 PGDLLEXPORT Datum chunk_index_clone(PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum chunk_index_replace(PG_FUNCTION_ARGS);
 
-#endif   /* TIMESCALEDB_CHUNK_INDEX_H */
+#endif							/* TIMESCALEDB_CHUNK_INDEX_H */

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -236,7 +236,7 @@ chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch, CmdType operati
 	Index		rti;
 	MemoryContext old_mcxt;
 	MemoryContext cis_context = AllocSetContextCreate(dispatch->estate->es_query_cxt,
-										 "chunk insert state memory context",
+													  "chunk insert state memory context",
 													  ALLOCSET_DEFAULT_SIZES);
 	Query	   *parse = dispatch->parse;
 	OnConflictAction onconflict = ONCONFLICT_NONE;
@@ -295,7 +295,7 @@ chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch, CmdType operati
 	if (tuple_conversion_needed(RelationGetDescr(parent_rel), RelationGetDescr(rel)))
 		state->tup_conv_map = convert_tuples_by_name(RelationGetDescr(parent_rel),
 													 RelationGetDescr(rel),
-								 gettext_noop("could not convert row type"));
+													 gettext_noop("could not convert row type"));
 
 	/* Need a tuple table slot to store converted tuples */
 	if (state->tup_conv_map)

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -25,4 +25,4 @@ extern HeapTuple chunk_insert_state_convert_tuple(ChunkInsertState *state, HeapT
 extern ChunkInsertState *chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch, CmdType operation);
 extern void chunk_insert_state_destroy(ChunkInsertState *state);
 
-#endif   /* TIMESCALEDB_CHUNK_INSERT_STATE_H */
+#endif							/* TIMESCALEDB_CHUNK_INSERT_STATE_H */

--- a/src/compat-endian.h
+++ b/src/compat-endian.h
@@ -65,8 +65,8 @@ compat_bswap16(uint16_t v)
 #define le32toh(x) ((uint32_t)(x))
 #define le64toh(x) ((uint64_t)(x))
 
-#endif   /* !WORDS_BIGENDIAN */
+#endif							/* !WORDS_BIGENDIAN */
 
-#endif   /* _NEED_ENDIAN_COMPAT */
+#endif							/* _NEED_ENDIAN_COMPAT */
 
 #endif

--- a/src/compat-msvc-enter.h
+++ b/src/compat-msvc-enter.h
@@ -13,6 +13,6 @@
 #undef PGDLLIMPORT
 #define PGDLLIMPORT
 #define extern extern _declspec (dllimport)
-#endif /* _MSC_VER */
+#endif							/* _MSC_VER */
 
-#endif /* TIMESCALEDB_COMPAT_MSVC_ENTER_H */
+#endif							/* TIMESCALEDB_COMPAT_MSVC_ENTER_H */

--- a/src/compat-msvc-exit.h
+++ b/src/compat-msvc-exit.h
@@ -9,6 +9,6 @@
 #undef extern
 #undef PGDLLIMPORT
 #define PGDLLIMPORT __declspec (dllexport)
-#endif /* _MSC_VER */
+#endif							/* _MSC_VER */
 
-#endif /* TIMESCALEDB_COMPAT_MSVC_EXIT_H */
+#endif							/* TIMESCALEDB_COMPAT_MSVC_EXIT_H */

--- a/src/compat.h
+++ b/src/compat.h
@@ -38,10 +38,10 @@
 
 #error "Unsupported PostgreSQL version"
 
-#endif   /* PG_VERSION_NUM */
+#endif							/* PG_VERSION_NUM */
 
 #define TS_FUNCTION_INFO_V1(fn) \
 	PGDLLEXPORT Datum fn(PG_FUNCTION_ARGS); \
 	PG_FUNCTION_INFO_V1(fn)
 
-#endif   /* TIMESCALEDB_COMPAT_H */
+#endif							/* TIMESCALEDB_COMPAT_H */

--- a/src/constraint_aware_append.c
+++ b/src/constraint_aware_append.c
@@ -330,14 +330,13 @@ constraint_aware_append_plan_create(PlannerInfo *root,
 	Plan	   *subplan = linitial(custom_plans);
 
 	cscan->scan.scanrelid = 0;	/* Not a real relation we are scanning */
-	cscan->scan.plan.targetlist = tlist;		/* Target list we expect as
-												 * output */
+	cscan->scan.plan.targetlist = tlist;	/* Target list we expect as output */
 	cscan->custom_plans = custom_plans;
 	cscan->custom_private = list_make3(list_make1_int(rel->relid),
 									   list_copy(root->append_rel_list),
 									   list_copy(clauses));
-	cscan->custom_scan_tlist = subplan->targetlist;		/* Target list of tuples
-														 * we expect as input */
+	cscan->custom_scan_tlist = subplan->targetlist; /* Target list of tuples
+													 * we expect as input */
 	cscan->flags = path->flags;
 	cscan->methods = &constraint_aware_append_plan_methods;
 

--- a/src/constraint_aware_append.h
+++ b/src/constraint_aware_append.h
@@ -22,4 +22,4 @@ typedef struct Hypertable Hypertable;
 Path	   *constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath);
 
 
-#endif   /* TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H */
+#endif							/* TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H */

--- a/src/copy.c
+++ b/src/copy.c
@@ -81,7 +81,7 @@ timescaledb_CopyFrom(CopyState cstate, Relation main_rel, List *range_table, Hyp
 	ResultRelInfo *resultRelInfo;
 	ResultRelInfo *saved_resultRelInfo = NULL;
 	CopyChunkState *ccstate = copy_chunk_state_create(ht, main_rel, cstate);
-	EState	   *estate = ccstate->estate;		/* for ExecConstraints() */
+	EState	   *estate = ccstate->estate;	/* for ExecConstraints() */
 	ExprContext *econtext;
 	TupleTableSlot *myslot;
 	MemoryContext oldcontext = CurrentMemoryContext;
@@ -297,7 +297,7 @@ timescaledb_CopyFrom(CopyState cstate, Relation main_rel, List *range_table, Hyp
 
 			if (slot == NULL)	/* "do nothing" */
 				skip_tuple = true;
-			else	/* trigger might have changed tuple */
+			else				/* trigger might have changed tuple */
 				tuple = ExecMaterializeSlot(slot);
 		}
 
@@ -316,7 +316,7 @@ timescaledb_CopyFrom(CopyState cstate, Relation main_rel, List *range_table, Hyp
 
 				if (resultRelInfo->ri_NumIndices > 0)
 					recheckIndexes = ExecInsertIndexTuples(slot, &(tuple->t_self),
-														 estate, false, NULL,
+														   estate, false, NULL,
 														   NIL);
 
 				/* AFTER ROW INSERT Triggers */
@@ -454,8 +454,8 @@ timescaledb_CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist)
 				if (rel != NULL)
 					ereport(ERROR,
 							(errcode(ERRCODE_UNDEFINED_COLUMN),
-					errmsg("column \"%s\" of relation \"%s\" does not exist",
-						   name, RelationGetRelationName(rel))));
+							 errmsg("column \"%s\" of relation \"%s\" does not exist",
+									name, RelationGetRelationName(rel))));
 				else
 					ereport(ERROR,
 							(errcode(ERRCODE_UNDEFINED_COLUMN),
@@ -499,13 +499,13 @@ timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *proces
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("must be superuser to COPY to or from an external program"),
 					 errhint("Anyone can COPY to stdout or from stdin. "
-						   "psql's \\copy command also works for anyone.")));
+							 "psql's \\copy command also works for anyone.")));
 		else
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					 errmsg("must be superuser to COPY to or from a file"),
 					 errhint("Anyone can COPY to stdout or from stdin. "
-						   "psql's \\copy command also works for anyone.")));
+							 "psql's \\copy command also works for anyone.")));
 	}
 
 	if (!is_from || NULL == stmt->relation)

--- a/src/copy.h
+++ b/src/copy.h
@@ -8,4 +8,4 @@ typedef struct Hypertable Hypertable;
 
 Oid			timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed, Hypertable *ht);
 
-#endif   /* TIMESCALEDB_COPY_H */
+#endif							/* TIMESCALEDB_COPY_H */

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -108,14 +108,14 @@ dimension_fill_in_from_tuple(Dimension *d, TupleInfo *ti, Oid main_table_relid)
 	{
 		d->fd.num_slices = DatumGetInt16(values[Anum_dimension_num_slices - 1]);
 		memcpy(&d->fd.partitioning_func_schema,
-		   DatumGetName(values[Anum_dimension_partitioning_func_schema - 1]),
+			   DatumGetName(values[Anum_dimension_partitioning_func_schema - 1]),
 			   NAMEDATALEN);
 		memcpy(&d->fd.partitioning_func,
 			   DatumGetName(values[Anum_dimension_partitioning_func - 1]),
 			   NAMEDATALEN);
 
 		d->partitioning = partitioning_info_create(NameStr(d->fd.partitioning_func_schema),
-											NameStr(d->fd.partitioning_func),
+												   NameStr(d->fd.partitioning_func),
 												   NameStr(d->fd.column_name),
 												   main_table_relid);
 	}
@@ -305,7 +305,7 @@ dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimensions)
 
 	/* Perform an index scan on hypertable_id. */
 	ScanKeyInit(&scankey[0], Anum_dimension_hypertable_id_idx_hypertable_id,
-			  BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(hypertable_id));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(hypertable_id));
 
 	scanner_scan(&scanctx);
 

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -79,4 +79,4 @@ extern int	dimension_update_name(Dimension *dim, const char *newname);
 #define hyperspace_get_closed_dimension(space, i)				\
 	hyperspace_get_dimension(space, DIMENSION_TYPE_CLOSED, i)
 
-#endif   /* TIMESCALEDB_DIMENSION_H */
+#endif							/* TIMESCALEDB_DIMENSION_H */

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -93,7 +93,7 @@ typedef struct DimensionSliceScanData
 {
 	DimensionVec *slices;
 	int			limit;
-}	DimensionSliceScanData;
+}			DimensionSliceScanData;
 
 static bool
 dimension_vec_tuple_found(TupleInfo *ti, void *data)
@@ -150,7 +150,7 @@ dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit)
 	ScanKeyInit(&scankey[0], Anum_dimension_slice_dimension_id_range_start_range_end_idx_dimension_id,
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(dimension_id));
 	ScanKeyInit(&scankey[1], Anum_dimension_slice_dimension_id_range_start_range_end_idx_range_start,
-			 BTLessEqualStrategyNumber, F_INT8LE, Int64GetDatum(coordinate));
+				BTLessEqualStrategyNumber, F_INT8LE, Int64GetDatum(coordinate));
 	ScanKeyInit(&scankey[2], Anum_dimension_slice_dimension_id_range_start_range_end_idx_range_end,
 				BTGreaterStrategyNumber, F_INT8GT, Int64GetDatum(coordinate));
 
@@ -175,7 +175,7 @@ dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, int6
 	ScanKeyInit(&scankey[1], Anum_dimension_slice_dimension_id_range_start_range_end_idx_range_start,
 				BTLessStrategyNumber, F_INT8LT, Int64GetDatum(range_end));
 	ScanKeyInit(&scankey[2], Anum_dimension_slice_dimension_id_range_start_range_end_idx_range_end,
-			  BTGreaterStrategyNumber, F_INT8GT, Int64GetDatum(range_start));
+				BTGreaterStrategyNumber, F_INT8GT, Int64GetDatum(range_start));
 
 	dimension_slice_scan_limit_internal(scankey, 3, dimension_vec_tuple_found, &slices, limit);
 
@@ -215,11 +215,11 @@ dimension_slice_scan_for_existing(DimensionSlice *slice)
 	ScanKeyData scankey[3];
 
 	ScanKeyInit(&scankey[0], Anum_dimension_slice_dimension_id_range_start_range_end_idx_dimension_id,
-	 BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(slice->fd.dimension_id));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(slice->fd.dimension_id));
 	ScanKeyInit(&scankey[1], Anum_dimension_slice_dimension_id_range_start_range_end_idx_range_start,
-	  BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(slice->fd.range_start));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(slice->fd.range_start));
 	ScanKeyInit(&scankey[2], Anum_dimension_slice_dimension_id_range_start_range_end_idx_range_end,
-		BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(slice->fd.range_end));
+				BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(slice->fd.range_end));
 
 	dimension_slice_scan_limit_internal(scankey, 3, dimension_slice_fill, &slice, 1);
 
@@ -255,7 +255,7 @@ dimension_slice_scan_by_id(int32 dimension_slice_id)
 	};
 
 	ScanKeyInit(&scankey[0], Anum_dimension_slice_dimension_id_idx_dimension_id,
-		 BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(dimension_slice_id));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(dimension_slice_id));
 	scanner_scan(&scanCtx);
 
 	return slice;

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -50,4 +50,4 @@ extern int	dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coo
 	dimension_slice_collision_scan_limit(dimension_id, range_start, range_end, 0)
 
 
-#endif   /* TIMESCALEDB_DIMENSION_SLICE_H */
+#endif							/* TIMESCALEDB_DIMENSION_SLICE_H */

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -32,4 +32,4 @@ extern int	dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_sli
 extern DimensionSlice *dimension_vec_get(DimensionVec *vec, int32 index);
 extern void dimension_vec_free(DimensionVec *vec);
 
-#endif   /* TIMESCALEDB_DIMENSION_VECTOR_H */
+#endif							/* TIMESCALEDB_DIMENSION_VECTOR_H */

--- a/src/event_trigger.h
+++ b/src/event_trigger.h
@@ -8,4 +8,4 @@ extern List *event_trigger_ddl_commands(void);
 extern void _event_trigger_init(void);
 extern void _event_trigger_fini(void);
 
-#endif   /* TIMESCALEDB_EVENT_TRIGGER_H */
+#endif							/* TIMESCALEDB_EVENT_TRIGGER_H */

--- a/src/extension.h
+++ b/src/extension.h
@@ -8,4 +8,4 @@ bool		extension_invalidate(Oid relid);
 bool		extension_is_loaded(void);
 void		extension_check_version(const char *so_version);
 
-#endif   /* TIMESCALEDB_EXTENSION_H */
+#endif							/* TIMESCALEDB_EXTENSION_H */

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -20,7 +20,7 @@
 
 #define EXTENSION_PROXY_TABLE "cache_inval_extension"
 #define CACHE_SCHEMA_NAME "_timescaledb_cache"
-#define MAX_SO_NAME_LEN NAMEDATALEN+NAMEDATALEN+1+1		/* extname+"-"+version */
+#define MAX_SO_NAME_LEN NAMEDATALEN+NAMEDATALEN+1+1 /* extname+"-"+version */
 
 enum ExtensionState
 {

--- a/src/guc.h
+++ b/src/guc.h
@@ -12,4 +12,4 @@ extern int	guc_max_cached_chunks_per_hypertable;
 void		_guc_init(void);
 void		_guc_fini(void);
 
-#endif   /* TIMESCALEDB_GUC_H */
+#endif							/* TIMESCALEDB_GUC_H */

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -32,4 +32,4 @@ extern DimensionSlice *hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 
 extern Hypercube *hypercube_copy(Hypercube *hc);
 extern void hypercube_slice_sort(Hypercube *hc);
 
-#endif   /* TIMESCALEDB_HYPERCUBE_H */
+#endif							/* TIMESCALEDB_HYPERCUBE_H */

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -359,7 +359,7 @@ hypertable_validate_triggers(PG_FUNCTION_ARGS)
 	if (relation_has_transition_table_trigger(PG_GETARG_OID(0)))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-		errmsg("Hypertables do not support transition tables in triggers.")));
+				 errmsg("Hypertables do not support transition tables in triggers.")));
 
 	PG_RETURN_VOID();
 }
@@ -421,9 +421,9 @@ hypertable_check_associated_schema_permissions(PG_FUNCTION_ARGS)
 	else if (pg_namespace_aclcheck(schema_oid, user_oid, ACL_CREATE) != ACLCHECK_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-		errmsg("User %s lacks permissions to create chunks in schema \"%s\"",
-			   GetUserNameFromId(user_oid, false),
-			   NameStr(*schema_name))));
+				 errmsg("User %s lacks permissions to create chunks in schema \"%s\"",
+						GetUserNameFromId(user_oid, false),
+						NameStr(*schema_name))));
 
 	PG_RETURN_VOID();
 }

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -32,4 +32,4 @@ extern bool is_hypertable(Oid relid);
 extern bool hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid);
 extern char *hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
 
-#endif   /* TIMESCALEDB_HYPERTABLE_H */
+#endif							/* TIMESCALEDB_HYPERTABLE_H */

--- a/src/hypertable_cache.h
+++ b/src/hypertable_cache.h
@@ -17,4 +17,4 @@ extern Cache *hypertable_cache_pin(void);
 extern void _hypertable_cache_init(void);
 extern void _hypertable_cache_fini(void);
 
-#endif   /* TIMESCALEDB_HYPERTABLE_CACHE_H */
+#endif							/* TIMESCALEDB_HYPERTABLE_CACHE_H */

--- a/src/hypertable_insert.h
+++ b/src/hypertable_insert.h
@@ -12,4 +12,4 @@ typedef struct HypertableInsertState
 
 Plan	   *hypertable_insert_plan_create(ModifyTable *mt);
 
-#endif   /* TIMESCALEDB_HYPERTABLE_INSERT_H */
+#endif							/* TIMESCALEDB_HYPERTABLE_INSERT_H */

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -117,14 +117,17 @@ indexing_verify_hypertable_indexes(PG_FUNCTION_ARGS)
 	Oid			hypertable_relid = PG_GETARG_OID(0);
 	Cache	   *hcache = hypertable_cache_pin();
 	Hypertable *ht = hypertable_cache_get_entry(hcache, hypertable_relid);
+
 	if (NULL != ht)
 	{
 		Relation	tblrel = relation_open(hypertable_relid, AccessShareLock);
 		List	   *indexlist = RelationGetIndexList(tblrel);
 		ListCell   *lc;
+
 		foreach(lc, indexlist)
 		{
 			Relation	idxrel = relation_open(lfirst_oid(lc), AccessShareLock);
+
 			if (idxrel->rd_index->indisunique || idxrel->rd_index->indisexclusion)
 				indexing_verify_columns(ht->space, build_indexcolumn_list(idxrel));
 			relation_close(idxrel, AccessShareLock);

--- a/src/indexing.h
+++ b/src/indexing.h
@@ -10,4 +10,4 @@
 extern void indexing_verify_columns(Hyperspace *hs, List *indexelems);
 extern void indexing_verify_index(Hyperspace *hs, IndexStmt *stmt);
 
-#endif   /* TIMESCALEDB_INDEXING_H */
+#endif							/* TIMESCALEDB_INDEXING_H */

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -81,6 +81,7 @@ drop_statement_drops_extension(DropStmt *stmt)
 			ext_name = strVal(linitial(names));
 #elif PG10
 			void	   *name = linitial(stmt->objects);
+
 			ext_name = strVal(name);
 #endif
 			if (strcmp(ext_name, EXTENSION_NAME) == 0)
@@ -169,7 +170,7 @@ _PG_init(void)
 			ereport(ERROR,
 					(errmsg("The timescaledb library is not preloaded"),
 					 errhint("Please preload the timescaledb library via shared_preload_libraries.\n\n"
-					 "This can be done by editing the config file at: %1$s\n"
+							 "This can be done by editing the config file at: %1$s\n"
 							 "and adding 'timescaledb' to the list in the shared_preload_libraries config.\n"
 							 "	# Modify postgresql.conf:\n	shared_preload_libraries = 'timescaledb'\n\n"
 							 "Another way to do this, if not preloading other libraries, is with the command:\n"

--- a/src/parse_rewrite.c
+++ b/src/parse_rewrite.c
@@ -92,7 +92,7 @@ create_partition_func_equals_const(ParseState *pstate, PartitioningInfo *pi, Var
 									  -1);
 
 	op_expr = make_op_compat(pstate,
-					   list_make2(makeString("pg_catalog"), makeString("=")),
+							 list_make2(makeString("pg_catalog"), makeString("=")),
 							 f_var,
 							 f_const,
 							 -1);
@@ -155,7 +155,7 @@ add_partitioning_func_qual_mutator(Node *node, AddPartFuncQualCtx *context)
 						 */
 						PartitioningInfo *pi =
 						get_partitioning_info_for_partition_column_var(var_expr,
-																	context);
+																	   context);
 
 						if (pi != NULL)
 						{

--- a/src/parse_rewrite.h
+++ b/src/parse_rewrite.h
@@ -8,4 +8,4 @@ typedef struct Hypertable Hypertable;
 
 extern void parse_rewrite_query(ParseState *pstate, Query *parse, Hypertable *ht);
 
-#endif   /* TIMESCALEDB_PARSE_REWRITE_H */
+#endif							/* TIMESCALEDB_PARSE_REWRITE_H */

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -237,7 +237,7 @@ get_partition_for_key(PG_FUNCTION_ARGS)
 	hash_u = DatumGetUInt32(hash_any((unsigned char *) VARDATA_ANY(data),
 									 VARSIZE_ANY_EXHDR(data)));
 
-	res = (int32) (hash_u & 0x7fffffff);		/* Only positive numbers */
+	res = (int32) (hash_u & 0x7fffffff);	/* Only positive numbers */
 
 	PG_FREE_IF_COPY(data, 0);
 	PG_RETURN_INT32(res);

--- a/src/partitioning.h
+++ b/src/partitioning.h
@@ -49,4 +49,4 @@ extern List *partitioning_func_qualified_name(PartitioningFunc *pf);
 extern int32 partitioning_func_apply(PartitioningInfo *pinfo, Datum value);
 extern int32 partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDesc desc);
 
-#endif   /* TIMESCALEDB_PARTITIONING_H */
+#endif							/* TIMESCALEDB_PARTITIONING_H */

--- a/src/planner_utils.h
+++ b/src/planner_utils.h
@@ -6,4 +6,4 @@
 
 extern void planned_stmt_walker(PlannedStmt *stmt, void (*walker) (Plan **, void *), void *context);
 
-#endif   /* TIMESCALEDB_PLANNER_UTILS_H */
+#endif							/* TIMESCALEDB_PLANNER_UTILS_H */

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -678,7 +678,7 @@ process_rename_constraint(Cache *hcache, Oid relid, RenameStmt *stmt)
 		if (NULL != chunk)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("Renaming constraints on chunks is not supported")));
+					 errmsg("Renaming constraints on chunks is not supported")));
 
 	}
 }
@@ -806,7 +806,7 @@ process_altertable_drop_not_null(Hypertable *ht, AlterTableCmd *cmd)
 		Dimension  *dim = &ht->space->dimensions[i];
 
 		if (IS_OPEN_DIMENSION(dim) &&
-		  strncmp(NameStr(dim->fd.column_name), cmd->name, NAMEDATALEN) == 0)
+			strncmp(NameStr(dim->fd.column_name), cmd->name, NAMEDATALEN) == 0)
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_OPERATION_NOT_SUPPORTED),
 					 errmsg("Cannot Drop NOT NULL constraint from a time-partitioned column")));
@@ -833,7 +833,7 @@ verify_constraint_plaintable(RangeVar *relation, Constraint *constr)
 			if (NULL != ht)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				  errmsg("Foreign keys to hypertables are not supported.")));
+						 errmsg("Foreign keys to hypertables are not supported.")));
 			break;
 		default:
 			break;
@@ -1060,8 +1060,8 @@ find_clustered_index(Oid table_relid)
 	if (!OidIsValid(index_relid))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-			errmsg("there is no previously clustered index for table \"%s\"",
-				   get_rel_name(table_relid))));
+				 errmsg("there is no previously clustered index for table \"%s\"",
+						get_rel_name(table_relid))));
 
 	return index_relid;
 }
@@ -1114,7 +1114,7 @@ process_cluster_start(Node *parsetree, ProcessUtilityContext context)
 			index_relid = find_clustered_index(ht->main_table_relid);
 		else
 			index_relid = get_relname_relid(stmt->indexname,
-									get_rel_namespace(ht->main_table_relid));
+											get_rel_namespace(ht->main_table_relid));
 
 		if (!OidIsValid(index_relid))
 		{
@@ -1247,10 +1247,10 @@ process_alter_column_type_start(Hypertable *ht, AlterTableCmd *cmd)
 		Dimension  *dim = &ht->space->dimensions[i];
 
 		if (IS_CLOSED_DIMENSION(dim) &&
-		  strncmp(NameStr(dim->fd.column_name), cmd->name, NAMEDATALEN) == 0)
+			strncmp(NameStr(dim->fd.column_name), cmd->name, NAMEDATALEN) == 0)
 			ereport(ERROR,
 					(errcode(ERRCODE_IO_OPERATION_NOT_SUPPORTED),
-			 errmsg("Cannot change the type of a hash-partitioned column")));
+					 errmsg("Cannot change the type of a hash-partitioned column")));
 	}
 }
 
@@ -1591,7 +1591,7 @@ process_create_trigger_start(Node *parsetree)
 	if (stmt->transitionRels != NIL)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-		errmsg("Hypertables do not support transition tables in triggers.")));
+				 errmsg("Hypertables do not support transition tables in triggers.")));
 #endif
 }
 

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -6,4 +6,4 @@
 
 extern void process_utility_set_expect_chunk_modification(bool expect);
 
-#endif   /* TIMESCALEDB_PROCESS_UTILITY_H */
+#endif							/* TIMESCALEDB_PROCESS_UTILITY_H */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -185,10 +185,10 @@ scanner_scan(ScannerCtx *ctx)
 				HeapUpdateFailureData hufd;
 
 				ictx.tinfo.lockresult = heap_lock_tuple(ictx.tablerel, ictx.tinfo.tuple,
-												  GetCurrentCommandId(false),
+														GetCurrentCommandId(false),
 														ctx->tuplock.lockmode,
-													 ctx->tuplock.waitpolicy,
-													  false, &buffer, &hufd);
+														ctx->tuplock.waitpolicy,
+														false, &buffer, &hufd);
 
 				/*
 				 * A tuple lock pins the underlying buffer, so we need to

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -86,4 +86,4 @@ int			scanner_scan(ScannerCtx *ctx);
 bool		scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type);
 
 
-#endif   /* TIMESCALEDB_SCANNER_H */
+#endif							/* TIMESCALEDB_SCANNER_H */

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -361,7 +361,7 @@ sort_transform_optimization(PlannerInfo *root, RelOptInfo *rel)
 	 * 3) Transform the  pathkey of the new paths back into the original form
 	 * to make this transparent to upper levels in the planner.
 	 *
-	 * */
+	 */
 	ListCell   *lc_pathkey;
 	List	   *transformed_query_pathkey = NIL;
 	bool		was_transformed = false;

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -112,7 +112,7 @@ subspace_store_add(SubspaceStore *store, const Hypercube *hc,
 		node->descendants += 1;
 
 		Assert(0 == node->vector->num_slices ||
-		node->vector->slices[0]->fd.dimension_id == target->fd.dimension_id);
+			   node->vector->slices[0]->fd.dimension_id == target->fd.dimension_id);
 
 		match = dimension_vec_find_slice(node->vector, target->fd.range_start);
 

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -27,4 +27,4 @@ extern void *subspace_store_get(SubspaceStore *cache, Point *target);
 extern void subspace_store_free(SubspaceStore *cache);
 extern MemoryContext subspace_store_mcxt(SubspaceStore *cache);
 
-#endif   /* TIMESCALEDB_SUBSPACE_STORE_H */
+#endif							/* TIMESCALEDB_SUBSPACE_STORE_H */

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -124,7 +124,7 @@ tablespace_scan(int32 hypertable_id)
 	};
 
 	ScanKeyInit(&scankey[0], Anum_tablespace_hypertable_id_tablespace_name_idx_hypertable_id,
-			  BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(hypertable_id));
+				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(hypertable_id));
 
 	scanner_scan(&scanctx);
 
@@ -209,14 +209,14 @@ tablespace_delete(int32 hypertable_id, const char *tspcname)
 	int			num_deleted;
 
 	ScanKeyInit(&scankey[scanctx.nkeys++],
-			 Anum_tablespace_hypertable_id_tablespace_name_idx_hypertable_id,
+				Anum_tablespace_hypertable_id_tablespace_name_idx_hypertable_id,
 				BTEqualStrategyNumber,
 				F_INT4EQ,
 				Int32GetDatum(hypertable_id));
 
 	if (NULL != tspcname)
 		ScanKeyInit(&scankey[scanctx.nkeys++],
-		   Anum_tablespace_hypertable_id_tablespace_name_idx_tablespace_name,
+					Anum_tablespace_hypertable_id_tablespace_name_idx_tablespace_name,
 					BTEqualStrategyNumber,
 					F_NAMEEQ,
 					DirectFunctionCall1(namein, CStringGetDatum(tspcname)));
@@ -320,7 +320,7 @@ tablespace_attach(PG_FUNCTION_ARGS)
 	if (!OidIsValid(tspc_oid))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_OBJECT),
-			  errmsg("Tablespace \"%s\" does not exist", NameStr(*tspcname)),
+				 errmsg("Tablespace \"%s\" does not exist", NameStr(*tspcname)),
 				 errhint("A tablespace needs to be created"
 						 " before attaching it to a hypertable")));
 
@@ -331,8 +331,8 @@ tablespace_attach(PG_FUNCTION_ARGS)
 	if (aclresult != ACLCHECK_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-		 errmsg("Table owner \"%s\" lacks permissions for tablespace \"%s\"",
-				GetUserNameFromId(ownerid, true), NameStr(*tspcname))));
+				 errmsg("Table owner \"%s\" lacks permissions for tablespace \"%s\"",
+						GetUserNameFromId(ownerid, true), NameStr(*tspcname))));
 
 	hcache = hypertable_cache_pin();
 	ht = hypertable_cache_get_entry(hcache, hypertable_oid);
@@ -346,8 +346,8 @@ tablespace_attach(PG_FUNCTION_ARGS)
 	if (hypertable_has_tablespace(ht, tspc_oid))
 		ereport(ERROR,
 				(errcode(ERRCODE_IO_TABLESPACE_ALREADY_ATTACHED),
-		 errmsg("Tablespace \"%s\" is already attached to hypertable \"%s\"",
-				NameStr(*tspcname), get_rel_name(hypertable_oid))));
+				 errmsg("Tablespace \"%s\" is already attached to hypertable \"%s\"",
+						NameStr(*tspcname), get_rel_name(hypertable_oid))));
 
 	catalog_become_owner(catalog_get(), &sec_ctx);
 	tablespace_insert(ht->fd.id, NameStr(*tspcname));
@@ -379,8 +379,8 @@ tablespace_detach_one(Oid hypertable_oid, const char *tspcname, Oid tspcoid)
 	if (!hypertable_has_tablespace(ht, tspcoid))
 		ereport(ERROR,
 				(errcode(ERRCODE_IO_TABLESPACE_NOT_ATTACHED),
-			 errmsg("Tablespace \"%s\" is not attached to hypertable \"%s\"",
-					tspcname, get_rel_name(hypertable_oid))));
+				 errmsg("Tablespace \"%s\" is not attached to hypertable \"%s\"",
+						tspcname, get_rel_name(hypertable_oid))));
 
 	ret = tablespace_delete(ht->fd.id, tspcname);
 
@@ -510,7 +510,7 @@ tablespace_show(PG_FUNCTION_ARGS)
 	{
 		Oid			tablespace_oid = tspcs->tablespaces[funcctx->call_cntr].tablespace_oid;
 		const char *tablespace_name = get_tablespace_name(tablespace_oid);
-		Datum name;
+		Datum		name;
 
 		Assert(tablespace_name != NULL);
 		name = DirectFunctionCall1(namein, CStringGetDatum(tablespace_name));

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -23,4 +23,4 @@ extern int	tablespaces_clear(Tablespaces *tspcs);
 extern bool tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
 extern Tablespaces *tablespace_scan(int32 hypertable_id);
 
-#endif   /* TIMESCALEDB_TABLESPACE_H */
+#endif							/* TIMESCALEDB_TABLESPACE_H */

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -135,7 +135,7 @@ create_trigger_handler(Trigger *trigger, void *arg)
 		TRIGGER_USES_TRANSITION_TABLE(trigger->tgoldtable))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-		errmsg("Hypertables do not support transition tables in triggers.")));
+				 errmsg("Hypertables do not support transition tables in triggers.")));
 #endif
 	if (trigger_is_chunk_trigger(trigger))
 		trigger_create_on_chunk(trigger->tgoid,

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -14,4 +14,4 @@ extern void trigger_create_on_chunk(Oid trigger_oid, char *chunk_schema_name, ch
 extern void trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk);
 extern bool relation_has_transition_table_trigger(Oid relid);
 
-#endif   /* TIMESCALEDB_TRIGGER_H */
+#endif							/* TIMESCALEDB_TRIGGER_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -229,8 +229,8 @@ create_fmgr(char *schema, char *function_name, int num_args)
 {
 	FmgrInfo   *finfo = palloc(sizeof(FmgrInfo));
 	FuncCandidateList func_list = FuncnameGetCandidates(list_make2(makeString(schema),
-												  makeString(function_name)),
-										num_args, NULL, false, false, false);
+																   makeString(function_name)),
+														num_args, NULL, false, false, false);
 
 	if (func_list == NULL)
 	{

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,4 +32,4 @@ extern int	int_cmp(const void *a, const void *b);
 #define DATUM_GET(values, attno) \
 	values[attno-1]
 
-#endif   /* TIMESCALEDB_UTILS_H */
+#endif							/* TIMESCALEDB_UTILS_H */


### PR DESCRIPTION
Source code indentation has been updated in PostgreSQL 10 to fix a
number of issues. This update applies this new indentation to the
entire code base.

The new indentation requires a new version of pg_bsd_indent, which can
be found here:

https://git.postgresql.org/git/pg_bsd_indent.git