### PR TITLE
Add check for null in ca_append_rescan to prevent segfault

### DIFF
--- a/src/constraint_aware_append.c
+++ b/src/constraint_aware_append.c
@@ -273,7 +273,10 @@ ca_append_rescan(CustomScanState *node)
 #if PG96
 	node->ss.ps.ps_TupFromTlist = false;
 #endif
-	ExecReScan(linitial(node->custom_ps));
+	if (node->custom_ps != NIL)
+	{
+		ExecReScan(linitial(node->custom_ps));
+	}
 }
 
 static void


### PR DESCRIPTION
My Postgres server (10.1) with timescaledb (0.8) crashed with a segfault on queries like the following, where table_a is a regular table and timescale_table is a timescaledb hypertable:

`select count(*) from table_a i cross join lateral (select * from timescale_table g where g.a_id=i.id and updated_at > make_custom_timestamp(now()) order by updated_at desc limit 1) s where i.b=3;`

If there are no partitions to scan for the subquery (for example, in the case that there are no partitions for the specified timestamp), the Postgres planner figures out that it can exclude all existing partitions. During execution it does call this ca_append_rescan function with an empty list. ca_append_rescan tries to take the first element, which obviously fails.

There may be more occurrences in the timescaledb code where something like this happens, but I am unfamiliar with the source code. Please feel free to add other changes if you feel it is necessary.