### PR TITLE
 Handle deletes on metadata objects via native catalog API

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -1,34 +1,3 @@
--- Drops a hypertable
-CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_hypertable(
-    hypertable_id INT,
-    is_cascade BOOLEAN
-)
-    RETURNS VOID LANGUAGE PLPGSQL VOLATILE AS
-$BODY$
-DECLARE
-    cascade_mod TEXT := '';
-    chunk_row _timescaledb_catalog.chunk;
-BEGIN
-    IF is_cascade THEN
-        cascade_mod = 'CASCADE';
-    END IF;
-    FOR chunk_row IN SELECT c.*
-        FROM _timescaledb_catalog.hypertable h
-        INNER JOIN _timescaledb_catalog.chunk c ON (c.hypertable_id = h.id)
-        WHERE h.id = drop_hypertable.hypertable_id
-        LOOP
-            EXECUTE format(
-                $$
-                DROP TABLE %I.%I %s
-                $$, chunk_row.schema_name, chunk_row.table_name, cascade_mod
-            );
-        END LOOP;
-
-    DELETE FROM _timescaledb_catalog.hypertable h
-    WHERE h.id = drop_hypertable.hypertable_id;
-END
-$BODY$;
-
 CREATE OR REPLACE FUNCTION _timescaledb_internal.dimension_get_time(
     hypertable_id INT
 )

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -95,8 +95,6 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.dimension_slice (
     CHECK (range_start <= range_end),
     UNIQUE (dimension_id, range_start, range_end)
 );
-CREATE INDEX IF NOT EXISTS dimension_slice_dimension_id_range_start_range_end_idx
-ON _timescaledb_catalog.dimension_slice(dimension_id, range_start, range_end);
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension_slice', '');
 SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.dimension_slice','id'), '');
 

--- a/sql/updates/pre-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/pre-0.8.0--0.9.0-dev.sql
@@ -43,3 +43,10 @@ DROP FUNCTION _timescaledb_internal.chunk_create_table(int, name);
 DROP INDEX _timescaledb_catalog.dimension_slice_dimension_id_range_start_range_end_idx;
 
 DROP FUNCTION _timescaledb_internal.drop_hypertable(int,boolean);
+
+-- Delete orphaned slices
+DELETE FROM _timescaledb_catalog.dimension_slice WHERE id IN
+(SELECT dimension_id FROM _timescaledb_catalog.chunk_constraint cc
+ FULL OUTER JOIN _timescaledb_catalog.dimension_slice ds
+ ON (ds.id = cc.dimension_slice_id)
+ WHERE dimension_slice_id IS NULL);

--- a/sql/updates/pre-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/pre-0.8.0--0.9.0-dev.sql
@@ -38,3 +38,8 @@ DROP FUNCTION _timescaledb_internal.show_tablespaces(regclass);
 DROP FUNCTION _timescaledb_internal.verify_hypertable_indexes(regclass);
 DROP FUNCTION _timescaledb_internal.validate_triggers(regclass);
 DROP FUNCTION _timescaledb_internal.chunk_create_table(int, name);
+
+-- Remove redundant index
+DROP INDEX _timescaledb_catalog.dimension_slice_dimension_id_range_start_range_end_idx;
+
+DROP FUNCTION _timescaledb_internal.drop_hypertable(int,boolean);

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -57,7 +57,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length = _MAX_DIMENSION_SLICE_INDEX,
 		.names = (char *[]) {
 			[DIMENSION_SLICE_ID_IDX] = "dimension_slice_pkey",
-			[DIMENSION_SLICE_DIMENSION_ID_RANGE_START_RANGE_END_IDX] = "dimension_slice_dimension_id_range_start_range_end_idx",
+			[DIMENSION_SLICE_DIMENSION_ID_RANGE_START_RANGE_END_IDX] = "dimension_slice_dimension_id_range_start_range_end_key",
 		}
 	},
 	[CHUNK] = {
@@ -114,10 +114,6 @@ const static InternalFunctionDef internal_function_definitions[_MAX_INTERNAL_FUN
 	[DDL_ADD_CHUNK_CONSTRAINT] = {
 		.name = "chunk_constraint_add_table_constraint",
 		.args = 1,
-	},
-	[DDL_DROP_HYPERTABLE] = {
-		.name = "drop_hypertable",
-		.args = 2
 	},
 	[TRUNCATE_HYPERTABLE] = {
 		.name = "truncate_hypertable",

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -48,7 +48,6 @@ typedef enum InternalFunction
 {
 	DDL_CHANGE_OWNER = 0,
 	DDL_ADD_CHUNK_CONSTRAINT,
-	DDL_DROP_HYPERTABLE,
 	TRUNCATE_HYPERTABLE,
 	_MAX_INTERNAL_FUNCTIONS,
 } InternalFunction;
@@ -217,6 +216,15 @@ typedef struct FormData_dimension_slice
 
 typedef FormData_dimension_slice *Form_dimension_slice;
 
+enum Anum_dimension_slice_id_idx
+{
+	Anum_dimension_slice_id_idx_id = 1,
+	_Anum_dimension_slice_id_idx_max,
+};
+
+#define Natts_dimension_slice_id_idx \
+	(_Anum_dimension_slice_id_idx_max - 1)
+
 enum Anum_dimension_slice_dimension_id_range_start_range_end_idx
 {
 	Anum_dimension_slice_dimension_id_range_start_range_end_idx_dimension_id = 1,
@@ -224,13 +232,6 @@ enum Anum_dimension_slice_dimension_id_range_start_range_end_idx
 	Anum_dimension_slice_dimension_id_range_start_range_end_idx_range_end,
 	_Anum_dimension_slice_dimension_id_range_start_range_end_idx_max,
 };
-
-enum Anum_dimension_slice_dimension_id_idx
-{
-	Anum_dimension_slice_dimension_id_idx_dimension_id = 1,
-	_Anum_dimension_slice_dimension_id_idx_max,
-};
-
 
 #define Natts_dimension_slice_dimension_id_range_start_range_end_idx \
 	(_Anum_dimension_slice_dimension_id_range_start_range_end_idx_max - 1)
@@ -283,6 +284,11 @@ enum
 enum Anum_chunk_idx
 {
 	Anum_chunk_idx_id = 1,
+};
+
+enum Anum_chunk_hypertable_id_idx
+{
+	Anum_chunk_hypertable_id_idx_hypertable_id = 1,
 };
 
 enum Anum_chunk_schema_name_idx

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -74,5 +74,6 @@ extern bool chunk_exists(const char *schema_name, const char *table_name);
 extern bool chunk_exists_relid(Oid relid);
 extern void chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
 extern int	chunk_delete_by_relid(Oid chunk_oid);
+extern int	chunk_delete_by_hypertable_id(int32 hypertable_id);
 
 #endif							/* TIMESCALEDB_CHUNK_H */

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -36,14 +36,14 @@ typedef struct ChunkScanCtx ChunkScanCtx;
 extern ChunkConstraints *chunk_constraints_alloc(int size_hint);
 extern ChunkConstraints *chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint);
 extern ChunkConstraints *chunk_constraints_copy(ChunkConstraints *constraints);
+extern int	chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx *ctx);
+extern int	chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkConstraints *ccs);
 extern int	chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, int32 chunk_id, Hypercube *cube);
 extern int	chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs, int32 chunk_id, Oid hypertable_oid);
 extern void chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid, int32 chunk_id, Oid hypertable_oid, int32 hypertable_id);
-
-extern int	chunk_constraint_scan_by_dimension_slice_id(DimensionSlice *slice, ChunkScanCtx *ctx);
 extern void chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
 extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, char *hypertable_constraint_name);
-extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_i);
+extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_id, ChunkConstraints *ccs);
 extern int	chunk_constraint_delete_by_dimension_slice_id(int32 dimension_slice_id);
 extern void chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
 extern int	chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -42,8 +42,9 @@ extern void chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid, int32
 
 extern int	chunk_constraint_scan_by_dimension_slice_id(DimensionSlice *slice, ChunkScanCtx *ctx);
 extern void chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
-extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, Oid chunk_oid, char *hypertable_constraint_name);
-extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_id, Oid chunk_oid);
+extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, char *hypertable_constraint_name);
+extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_i);
+extern int	chunk_constraint_delete_by_dimension_slice_id(int32 dimension_slice_id);
 extern void chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
 extern int	chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);
 

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -20,6 +20,8 @@ extern void chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid, in
 extern Oid	chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid, int32 hypertable_id, Oid hypertable_indexrelid);
 extern int	chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool should_drop);
 extern int	chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index);
+extern int	chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
+extern int	chunk_index_delete_by_hypertable_id(int32 hypertable_id, bool drop_index);
 extern int	chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname);
 extern int	chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *newname);
 extern int	chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, const char *tablespace);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -103,6 +103,7 @@ extern Dimension *hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionType
 extern DimensionVec *dimension_get_slices(Dimension *dim);
 extern int	dimension_set_type(Dimension *dim, Oid newtype);
 extern int	dimension_set_name(Dimension *dim, const char *newname);
+extern int	dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete_slices);
 extern void dimension_validate_info(DimensionInfo *info);
 extern void dimension_add_from_info(DimensionInfo *info);
 

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -30,6 +30,8 @@ extern Hypercube *dimension_slice_point_scan(Hyperspace *space, int64 point[]);
 extern DimensionSlice *dimension_slice_scan_for_existing(DimensionSlice *slice);
 extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id);
 extern DimensionVec *dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
+extern int	dimension_slice_delete_by_dimension_id(int32 dimension_id, bool delete_constraints);
+extern int	dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraints);
 extern DimensionSlice *dimension_slice_create(int dimension_id, int64 range_start, int64 range_end);
 extern DimensionSlice *dimension_slice_copy(const DimensionSlice *original);
 extern bool dimension_slices_collide(DimensionSlice *slice1, DimensionSlice *slice2);

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -31,6 +31,7 @@ extern bool hypertable_lock_tuple_simple(Oid table_relid);
 extern int	hypertable_set_name(Hypertable *ht, const char *newname);
 extern int	hypertable_set_schema(Hypertable *ht, const char *newname);
 extern int	hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
+extern int	hypertable_delete_by_id(int32 hypertable_id);
 extern Oid	hypertable_id_to_relid(int32 hypertable_id);
 extern Chunk *hypertable_get_chunk(Hypertable *h, Point *point);
 extern Oid	hypertable_relid(RangeVar *rv);

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -187,7 +187,7 @@ tablespace_tuple_delete(TupleInfo *ti, void *data)
 	return (info->stopcount == 0 || ti->count < info->stopcount);
 }
 
-static int
+int
 tablespace_delete(int32 hypertable_id, const char *tspcname)
 {
 	ScanKeyData scankey[2];

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -23,5 +23,7 @@ extern int	tablespaces_clear(Tablespaces *tspcs);
 extern bool tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
 extern Tablespaces *tablespace_scan(int32 hypertable_id);
 extern Datum tablespace_attach(PG_FUNCTION_ARGS);
+extern int	tablespace_delete(int32 hypertable_id, const char *tspcname);
+
 
 #endif							/* TIMESCALEDB_TABLESPACE_H */

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -23,6 +23,25 @@ NOTICE:  adding NOT NULL constraint to column "time"
  
 (1 row)
 
+-- Add space dimensions to ensure chunks share dimension slices
+SELECT add_dimension('public.drop_chunk_test1', 'device_id', 2);
+ add_dimension 
+---------------
+ 
+(1 row)
+
+SELECT add_dimension('public.drop_chunk_test2', 'device_id', 2);
+ add_dimension 
+---------------
+ 
+(1 row)
+
+SELECT add_dimension('public.drop_chunk_test3', 'device_id', 2);
+ add_dimension 
+---------------
+ 
+(1 row)
+
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
@@ -122,12 +141,228 @@ CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chu
 SELECT drop_chunks(2);
 ERROR:  cannot drop table _timescaledb_internal._hyper_1_1_chunk because other objects depend on it
 \set ON_ERROR_STOP 1
+-- show created constraints and dimension slices for each chunk
+SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (c.id = cc.chunk_id)
+FULL OUTER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.id = cc.dimension_slice_id);
+    table_name     | constraint_name | dimension_slice_id |     range_start      |      range_end      
+-------------------+-----------------+--------------------+----------------------+---------------------
+ _hyper_1_1_chunk  | constraint_1    |                  1 |                    1 |                   2
+ _hyper_1_1_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_2_chunk  | constraint_3    |                  3 |                    2 |                   3
+ _hyper_1_2_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_3_chunk  | constraint_4    |                  4 |                    3 |                   4
+ _hyper_1_3_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_4_chunk  | constraint_5    |                  5 |                    4 |                   5
+ _hyper_1_4_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_1_5_chunk  | constraint_7    |                  7 |                    5 |                   6
+ _hyper_1_5_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_1_6_chunk  | constraint_8    |                  8 |                    6 |                   7
+ _hyper_1_6_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_2_7_chunk  | constraint_9    |                  9 |                    1 |                   2
+ _hyper_2_7_chunk  | constraint_10   |                 10 |           1073741823 | 9223372036854775807
+ _hyper_2_8_chunk  | constraint_11   |                 11 |                    2 |                   3
+ _hyper_2_8_chunk  | constraint_10   |                 10 |           1073741823 | 9223372036854775807
+ _hyper_2_9_chunk  | constraint_12   |                 12 |                    3 |                   4
+ _hyper_2_9_chunk  | constraint_10   |                 10 |           1073741823 | 9223372036854775807
+ _hyper_2_10_chunk | constraint_13   |                 13 |                    4 |                   5
+ _hyper_2_10_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_2_11_chunk | constraint_15   |                 15 |                    5 |                   6
+ _hyper_2_11_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_2_12_chunk | constraint_16   |                 16 |                    6 |                   7
+ _hyper_2_12_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_3_13_chunk | constraint_17   |                 17 |                    1 |                   2
+ _hyper_3_13_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_14_chunk | constraint_19   |                 19 |                    2 |                   3
+ _hyper_3_14_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_15_chunk | constraint_20   |                 20 |                    3 |                   4
+ _hyper_3_15_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_16_chunk | constraint_21   |                 21 |                    4 |                   5
+ _hyper_3_16_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+ _hyper_3_17_chunk | constraint_23   |                 23 |                    5 |                   6
+ _hyper_3_17_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+ _hyper_3_18_chunk | constraint_24   |                 24 |                    6 |                   7
+ _hyper_3_18_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+(36 rows)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice;
+ id | dimension_id |     range_start      |      range_end      
+----+--------------+----------------------+---------------------
+  1 |            1 |                    1 |                   2
+  2 |            4 |           1073741823 | 9223372036854775807
+  3 |            1 |                    2 |                   3
+  4 |            1 |                    3 |                   4
+  5 |            1 |                    4 |                   5
+  6 |            4 | -9223372036854775808 |          1073741823
+  7 |            1 |                    5 |                   6
+  8 |            1 |                    6 |                   7
+  9 |            2 |                    1 |                   2
+ 10 |            5 |           1073741823 | 9223372036854775807
+ 11 |            2 |                    2 |                   3
+ 12 |            2 |                    3 |                   4
+ 13 |            2 |                    4 |                   5
+ 14 |            5 | -9223372036854775808 |          1073741823
+ 15 |            2 |                    5 |                   6
+ 16 |            2 |                    6 |                   7
+ 17 |            3 |                    1 |                   2
+ 18 |            6 |           1073741823 | 9223372036854775807
+ 19 |            3 |                    2 |                   3
+ 20 |            3 |                    3 |                   4
+ 21 |            3 |                    4 |                   5
+ 22 |            6 | -9223372036854775808 |          1073741823
+ 23 |            3 |                    5 |                   6
+ 24 |            3 |                    6 |                   7
+(24 rows)
+
+-- Drop one chunk "manually" and verify that dimension slices and
+-- constraints are cleaned up. Each chunk has two constraints and two
+-- dimension slices. Both constraints should be deleted, but only one
+-- slice should be deleted since the space-dimension slice is shared
+-- with other chunks in the same hypertable
+DROP TABLE _timescaledb_internal._hyper_2_7_chunk;
+-- Two constraints deleted compared to above
+SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (c.id = cc.chunk_id)
+FULL OUTER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.id = cc.dimension_slice_id);
+    table_name     | constraint_name | dimension_slice_id |     range_start      |      range_end      
+-------------------+-----------------+--------------------+----------------------+---------------------
+ _hyper_1_1_chunk  | constraint_1    |                  1 |                    1 |                   2
+ _hyper_1_1_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_2_chunk  | constraint_3    |                  3 |                    2 |                   3
+ _hyper_1_2_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_3_chunk  | constraint_4    |                  4 |                    3 |                   4
+ _hyper_1_3_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_4_chunk  | constraint_5    |                  5 |                    4 |                   5
+ _hyper_1_4_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_1_5_chunk  | constraint_7    |                  7 |                    5 |                   6
+ _hyper_1_5_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_1_6_chunk  | constraint_8    |                  8 |                    6 |                   7
+ _hyper_1_6_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_2_8_chunk  | constraint_11   |                 11 |                    2 |                   3
+ _hyper_2_8_chunk  | constraint_10   |                 10 |           1073741823 | 9223372036854775807
+ _hyper_2_9_chunk  | constraint_12   |                 12 |                    3 |                   4
+ _hyper_2_9_chunk  | constraint_10   |                 10 |           1073741823 | 9223372036854775807
+ _hyper_2_10_chunk | constraint_13   |                 13 |                    4 |                   5
+ _hyper_2_10_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_2_11_chunk | constraint_15   |                 15 |                    5 |                   6
+ _hyper_2_11_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_2_12_chunk | constraint_16   |                 16 |                    6 |                   7
+ _hyper_2_12_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_3_13_chunk | constraint_17   |                 17 |                    1 |                   2
+ _hyper_3_13_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_14_chunk | constraint_19   |                 19 |                    2 |                   3
+ _hyper_3_14_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_15_chunk | constraint_20   |                 20 |                    3 |                   4
+ _hyper_3_15_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_16_chunk | constraint_21   |                 21 |                    4 |                   5
+ _hyper_3_16_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+ _hyper_3_17_chunk | constraint_23   |                 23 |                    5 |                   6
+ _hyper_3_17_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+ _hyper_3_18_chunk | constraint_24   |                 24 |                    6 |                   7
+ _hyper_3_18_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+(34 rows)
+
+-- Only one dimension slice deleted
+SELECT * FROM _timescaledb_catalog.dimension_slice;
+ id | dimension_id |     range_start      |      range_end      
+----+--------------+----------------------+---------------------
+  1 |            1 |                    1 |                   2
+  2 |            4 |           1073741823 | 9223372036854775807
+  3 |            1 |                    2 |                   3
+  4 |            1 |                    3 |                   4
+  5 |            1 |                    4 |                   5
+  6 |            4 | -9223372036854775808 |          1073741823
+  7 |            1 |                    5 |                   6
+  8 |            1 |                    6 |                   7
+ 10 |            5 |           1073741823 | 9223372036854775807
+ 11 |            2 |                    2 |                   3
+ 12 |            2 |                    3 |                   4
+ 13 |            2 |                    4 |                   5
+ 14 |            5 | -9223372036854775808 |          1073741823
+ 15 |            2 |                    5 |                   6
+ 16 |            2 |                    6 |                   7
+ 17 |            3 |                    1 |                   2
+ 18 |            6 |           1073741823 | 9223372036854775807
+ 19 |            3 |                    2 |                   3
+ 20 |            3 |                    3 |                   4
+ 21 |            3 |                    4 |                   5
+ 22 |            6 | -9223372036854775808 |          1073741823
+ 23 |            3 |                    5 |                   6
+ 24 |            3 |                    6 |                   7
+(23 rows)
+
 SELECT drop_chunks(2, CASCADE=>true);
 NOTICE:  drop cascades to view dependent_view
  drop_chunks 
 -------------
  
 (1 row)
+
+SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (c.id = cc.chunk_id)
+FULL OUTER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.id = cc.dimension_slice_id);
+    table_name     | constraint_name | dimension_slice_id |     range_start      |      range_end      
+-------------------+-----------------+--------------------+----------------------+---------------------
+ _hyper_1_2_chunk  | constraint_3    |                  3 |                    2 |                   3
+ _hyper_1_2_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_3_chunk  | constraint_4    |                  4 |                    3 |                   4
+ _hyper_1_3_chunk  | constraint_2    |                  2 |           1073741823 | 9223372036854775807
+ _hyper_1_4_chunk  | constraint_5    |                  5 |                    4 |                   5
+ _hyper_1_4_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_1_5_chunk  | constraint_7    |                  7 |                    5 |                   6
+ _hyper_1_5_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_1_6_chunk  | constraint_8    |                  8 |                    6 |                   7
+ _hyper_1_6_chunk  | constraint_6    |                  6 | -9223372036854775808 |          1073741823
+ _hyper_2_8_chunk  | constraint_11   |                 11 |                    2 |                   3
+ _hyper_2_8_chunk  | constraint_10   |                 10 |           1073741823 | 9223372036854775807
+ _hyper_2_9_chunk  | constraint_12   |                 12 |                    3 |                   4
+ _hyper_2_9_chunk  | constraint_10   |                 10 |           1073741823 | 9223372036854775807
+ _hyper_2_10_chunk | constraint_13   |                 13 |                    4 |                   5
+ _hyper_2_10_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_2_11_chunk | constraint_15   |                 15 |                    5 |                   6
+ _hyper_2_11_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_2_12_chunk | constraint_16   |                 16 |                    6 |                   7
+ _hyper_2_12_chunk | constraint_14   |                 14 | -9223372036854775808 |          1073741823
+ _hyper_3_14_chunk | constraint_19   |                 19 |                    2 |                   3
+ _hyper_3_14_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_15_chunk | constraint_20   |                 20 |                    3 |                   4
+ _hyper_3_15_chunk | constraint_18   |                 18 |           1073741823 | 9223372036854775807
+ _hyper_3_16_chunk | constraint_21   |                 21 |                    4 |                   5
+ _hyper_3_16_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+ _hyper_3_17_chunk | constraint_23   |                 23 |                    5 |                   6
+ _hyper_3_17_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+ _hyper_3_18_chunk | constraint_24   |                 24 |                    6 |                   7
+ _hyper_3_18_chunk | constraint_22   |                 22 | -9223372036854775808 |          1073741823
+(30 rows)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice;
+ id | dimension_id |     range_start      |      range_end      
+----+--------------+----------------------+---------------------
+  2 |            4 |           1073741823 | 9223372036854775807
+  3 |            1 |                    2 |                   3
+  4 |            1 |                    3 |                   4
+  5 |            1 |                    4 |                   5
+  6 |            4 | -9223372036854775808 |          1073741823
+  7 |            1 |                    5 |                   6
+  8 |            1 |                    6 |                   7
+ 10 |            5 |           1073741823 | 9223372036854775807
+ 11 |            2 |                    2 |                   3
+ 12 |            2 |                    3 |                   4
+ 13 |            2 |                    4 |                   5
+ 14 |            5 | -9223372036854775808 |          1073741823
+ 15 |            2 |                    5 |                   6
+ 16 |            2 |                    6 |                   7
+ 18 |            6 |           1073741823 | 9223372036854775807
+ 19 |            3 |                    2 |                   3
+ 20 |            3 |                    3 |                   4
+ 21 |            3 |                    4 |                   5
+ 22 |            6 | -9223372036854775808 |          1073741823
+ 23 |            3 |                    5 |                   6
+ 24 |            3 |                    6 |                   7
+(21 rows)
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -49,7 +49,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    97
+    96
 (1 row)
 
 SELECT * FROM test.show_columns('public."two_Partitions"');
@@ -235,7 +235,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    97
+    96
 (1 row)
 
 --main table and chunk schemas should be the same

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -245,9 +245,39 @@ SELECT * FROM show_tablespaces('tspace_2dim');
 ------------------
 (0 rows)
 
---cleanup
-DROP TABLE tspace_1dim CASCADE;
-DROP TABLE tspace_2dim CASCADE;
+--cleanup - make sure tablespace metadata is removed
+SELECT attach_tablespace('tablespace2', 'tspace_1dim');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'tspace_2dim');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.tablespace;
+ id | hypertable_id | tablespace_name 
+----+---------------+-----------------
+  5 |             2 | tablespace2
+  6 |             1 | tablespace1
+(2 rows)
+
+DROP TABLE tspace_1dim;
+SELECT * FROM _timescaledb_catalog.tablespace;
+ id | hypertable_id | tablespace_name 
+----+---------------+-----------------
+  6 |             1 | tablespace1
+(1 row)
+
+DROP TABLE tspace_2dim;
+SELECT * FROM _timescaledb_catalog.tablespace;
+ id | hypertable_id | tablespace_name 
+----+---------------+-----------------
+(0 rows)
+
 DROP TABLESPACE tablespace1;
 DROP TABLESPACE tablespace2;
 -- revoke grants

--- a/test/sql/tablespace.sql
+++ b/test/sql/tablespace.sql
@@ -116,9 +116,14 @@ SELECT * FROM _timescaledb_catalog.tablespace;
 SELECT * FROM show_tablespaces('tspace_1dim');
 SELECT * FROM show_tablespaces('tspace_2dim');
 
---cleanup
-DROP TABLE tspace_1dim CASCADE;
-DROP TABLE tspace_2dim CASCADE;
+--cleanup - make sure tablespace metadata is removed
+SELECT attach_tablespace('tablespace2', 'tspace_1dim');
+SELECT attach_tablespace('tablespace1', 'tspace_2dim');
+SELECT * FROM _timescaledb_catalog.tablespace;
+DROP TABLE tspace_1dim;
+SELECT * FROM _timescaledb_catalog.tablespace;
+DROP TABLE tspace_2dim;
+SELECT * FROM _timescaledb_catalog.tablespace;
 
 DROP TABLESPACE tablespace1;
 DROP TABLESPACE tablespace2;


### PR DESCRIPTION
This is a multi-commit PR. 

Commit 1: Handle deletes on metadata objects via native catalog API

Handle deletes on metadata objects via native catalog API  …
Deletes on metadata in the TimescaleDB catalog has so far been a mix
of native deletes using the C-based catalog API and SQL-based DELETE
statements that CASCADEs.

This mixed environment is confusing, and SQL-based DELETEs do not
consistently clean up objects that are related to the deleted
metadata.

This change moves towards A C-based API for deletes that consistently
deletes also the dependent objects (such as indexes, tables and
constraints).  Ideally, we should prohobit direct manipulation of
catalog tables using SQL statements to avoid ending up in a bad state.

Once all catalog manipulations happend via the native API, we can also
remove the cache invalidation triggers on the catalog tables.


Commit 2: Delete orphaned dimension slices 

When chunks are deleted, dimension slices can be orphaned, i.e., there
are no chunks or chunk constraints that reference such slices. This
change ensures that, when chunks are deleted, orphaned slices are also
deleted.