### PR TITLE
Improve tablespace handling, including blocks for DROP and REVOKE

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -127,10 +127,18 @@ CREATE OR REPLACE FUNCTION  add_dimension(
 ) RETURNS VOID
 AS '@MODULE_PATHNAME@', 'dimension_add' LANGUAGE C VOLATILE;
 
-CREATE OR REPLACE FUNCTION attach_tablespace(tablespace NAME, hypertable REGCLASS) RETURNS VOID
+CREATE OR REPLACE FUNCTION attach_tablespace(
+    tablespace NAME,
+    hypertable REGCLASS,
+    if_not_attached BOOLEAN = false
+) RETURNS VOID
 AS '@MODULE_PATHNAME@', 'tablespace_attach' LANGUAGE C VOLATILE;
 
-CREATE OR REPLACE FUNCTION detach_tablespace(tablespace NAME, hypertable REGCLASS = NULL) RETURNS INTEGER
+CREATE OR REPLACE FUNCTION detach_tablespace(
+    tablespace NAME,
+    hypertable REGCLASS = NULL,
+    if_attached BOOLEAN = false
+) RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'tablespace_detach' LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE FUNCTION detach_tablespaces(hypertable REGCLASS) RETURNS INTEGER

--- a/sql/updates/pre-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/pre-0.8.0--0.9.0-dev.sql
@@ -40,6 +40,8 @@ DROP FUNCTION _timescaledb_internal.validate_triggers(regclass);
 DROP FUNCTION _timescaledb_internal.chunk_create_table(int, name);
 DROP FUNCTION _timescaledb_internal.ddl_change_owner(oid, name);
 DROP FUNCTION _timescaledb_internal.truncate_hypertable(name,name,boolean);
+DROP FUNCTION attach_tablespace(name,regclass);
+DROP FUNCTION detach_tablespace(name,regclass);
 
 -- Remove redundant index
 DROP INDEX _timescaledb_catalog.dimension_slice_dimension_id_range_start_range_end_idx;

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -33,7 +33,7 @@
 #include "guc.h"
 #include "errors.h"
 
-static Oid
+Oid
 rel_get_owner(Oid relid)
 {
 	HeapTuple	tuple;
@@ -963,7 +963,7 @@ hypertable_create(PG_FUNCTION_ARGS)
 		NameData	tspc_name;
 
 		namestrcpy(&tspc_name, get_tablespace_name(tspc_oid));
-		tablespace_attach_internal(&tspc_name, table_relid);
+		tablespace_attach_internal(&tspc_name, table_relid, false);
 	}
 
 	cache_release(hcache);

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -21,6 +21,8 @@ typedef struct Hypertable
 	SubspaceStore *chunk_cache;
 } Hypertable;
 
+
+extern Oid	rel_get_owner(Oid relid);
 extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
 extern Oid	hypertable_permissions_check(Oid hypertable_oid, Oid userid);
 extern Hypertable *hypertable_from_tuple(HeapTuple tuple);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -198,7 +198,7 @@ scanner_scan(ScannerCtx *ctx)
 			}
 
 			/* Abort the scan if the handler wants us to */
-			if (!ctx->tuple_found(&ictx.tinfo, ctx->data))
+			if (ctx->tuple_found != NULL && !ctx->tuple_found(&ictx.tinfo, ctx->data))
 				break;
 		}
 

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -2,6 +2,8 @@
 #define TIMESCALEDB_TABLESPACE_H
 
 #include <postgres.h>
+#include <nodes/parsenodes.h>
+
 #include "catalog.h"
 
 typedef struct Tablespace
@@ -22,8 +24,10 @@ extern bool tablespaces_delete(Tablespaces *tspcs, Oid tspc_oid);
 extern int	tablespaces_clear(Tablespaces *tspcs);
 extern bool tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
 extern Tablespaces *tablespace_scan(int32 hypertable_id);
-extern void tablespace_attach_internal(Name tspcname, Oid hypertable_oid);
+extern void tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_attached);
 extern int	tablespace_delete(int32 hypertable_id, const char *tspcname);
-
+extern int	tablespace_count_attached(const char *tspcname);
+extern void tablespace_validate_revoke(GrantStmt *stmt);
+extern void tablespace_validate_revoke_role(GrantRoleStmt *stmt);
 
 #endif							/* TIMESCALEDB_TABLESPACE_H */

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -20,16 +20,17 @@ SELECT * FROM alter_before;
 SELECT c.relname, a.attname, a.attnum FROM pg_attribute a, pg_class c
 WHERE a.attrelid = c.oid
 AND (c.relname LIKE '_hyper_1%_chunk' OR c.relname = 'alter_before')
-AND a.attnum > 0;
+AND a.attnum > 0
+ORDER BY c.relname, a.attnum;
      relname      |           attname            | attnum 
 ------------------+------------------------------+--------
+ _hyper_1_1_chunk | time                         |      1
+ _hyper_1_1_chunk | temp                         |      2
+ _hyper_1_1_chunk | colorid                      |      3
  alter_before     | ........pg.dropped.1........ |      1
  alter_before     | time                         |      2
  alter_before     | temp                         |      3
  alter_before     | colorid                      |      4
- _hyper_1_1_chunk | time                         |      1
- _hyper_1_1_chunk | temp                         |      2
- _hyper_1_1_chunk | colorid                      |      3
 (7 rows)
 
 -- DROP a table's column after making it a hypertable and having data
@@ -67,13 +68,10 @@ SELECT * FROM alter_after;
 SELECT c.relname, a.attname, a.attnum FROM pg_attribute a, pg_class c
 WHERE a.attrelid = c.oid
 AND (c.relname LIKE '_hyper_2%_chunk' OR c.relname = 'alter_after')
-AND a.attnum > 0;
+AND a.attnum > 0
+ORDER BY c.relname, a.attnum;
      relname      |           attname            | attnum 
 ------------------+------------------------------+--------
- alter_after      | ........pg.dropped.1........ |      1
- alter_after      | time                         |      2
- alter_after      | temp                         |      3
- alter_after      | colorid                      |      4
  _hyper_2_2_chunk | ........pg.dropped.1........ |      1
  _hyper_2_2_chunk | time                         |      2
  _hyper_2_2_chunk | temp                         |      3
@@ -84,6 +82,10 @@ AND a.attnum > 0;
  _hyper_2_4_chunk | time                         |      1
  _hyper_2_4_chunk | temp                         |      2
  _hyper_2_4_chunk | colorid                      |      3
+ alter_after      | ........pg.dropped.1........ |      1
+ alter_after      | time                         |      2
+ alter_after      | temp                         |      3
+ alter_after      | colorid                      |      4
 (14 rows)
 
 -- Add an ID column again
@@ -92,14 +94,10 @@ INSERT INTO alter_after (time, temp, colorid) VALUES ('2017-08-22T09:19:14', 12.
 SELECT c.relname, a.attname, a.attnum FROM pg_attribute a, pg_class c
 WHERE a.attrelid = c.oid
 AND (c.relname LIKE '_hyper_2%_chunk' OR c.relname = 'alter_after')
-AND a.attnum > 0;
+AND a.attnum > 0
+ORDER BY c.relname, a.attnum;
      relname      |           attname            | attnum 
 ------------------+------------------------------+--------
- alter_after      | ........pg.dropped.1........ |      1
- alter_after      | time                         |      2
- alter_after      | temp                         |      3
- alter_after      | colorid                      |      4
- alter_after      | id                           |      5
  _hyper_2_2_chunk | ........pg.dropped.1........ |      1
  _hyper_2_2_chunk | time                         |      2
  _hyper_2_2_chunk | temp                         |      3
@@ -113,6 +111,11 @@ AND a.attnum > 0;
  _hyper_2_4_chunk | temp                         |      2
  _hyper_2_4_chunk | colorid                      |      3
  _hyper_2_4_chunk | id                           |      4
+ alter_after      | ........pg.dropped.1........ |      1
+ alter_after      | time                         |      2
+ alter_after      | temp                         |      3
+ alter_after      | colorid                      |      4
+ alter_after      | id                           |      5
 (18 rows)
 
 SELECT * FROM alter_after;

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -62,7 +62,7 @@ ERROR:  permission denied for relation "one_Partition"
 select add_dimension('"one_Partition"', 'device_id', 2);
 ERROR:  permission denied for relation "one_Partition"
 select attach_tablespace('tablespace1', '"one_Partition"');
-ERROR:  Tablespace "tablespace1" does not exist
+ERROR:  tablespace "tablespace1" does not exist
 \set ON_ERROR_STOP 1
 CREATE TABLE "1dim"(time timestamp, temp float);
 SELECT create_hypertable('"1dim"', 'time');

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -28,19 +28,27 @@ INNER JOIN _timescaledb_catalog.chunk ch ON (ch.table_name = c.relname);
 
 --check some error conditions
 SELECT attach_tablespace('tablespace2', NULL);
-ERROR:  Invalid hypertable
+ERROR:  invalid hypertable
 SELECT attach_tablespace(NULL, 'tspace_2dim');
-ERROR:  Invalid tablespace name
+ERROR:  invalid tablespace name
 SELECT attach_tablespace('none_existing_tablespace', 'tspace_2dim');
-ERROR:  Tablespace "none_existing_tablespace" does not exist
+ERROR:  tablespace "none_existing_tablespace" does not exist
 SELECT attach_tablespace('tablespace2', 'none_existing_table');
 ERROR:  relation "none_existing_table" does not exist at character 41
 --attach another tablespace without first creating it --> should generate error
 SELECT attach_tablespace('tablespace2', 'tspace_2dim');
-ERROR:  Tablespace "tablespace2" does not exist
+ERROR:  tablespace "tablespace2" does not exist
 --attach the same tablespace twice to same table should also generate error
 SELECT attach_tablespace('tablespace1', 'tspace_2dim');
-ERROR:  Tablespace "tablespace1" is already attached to hypertable "tspace_2dim"
+ERROR:  tablespace "tablespace1" is already attached to hypertable "tspace_2dim"
+--no error if if_not_attached is given
+SELECT attach_tablespace('tablespace1', 'tspace_2dim', if_not_attached => true);
+NOTICE:  tablespace "tablespace1" is already attached to hypertable "tspace_2dim", skipping
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
 \c single :ROLE_SUPERUSER
 CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER_2 LOCATION :TEST_TABLESPACE2_PATH;
 \c single :ROLE_DEFAULT_PERM_USER_2
@@ -50,7 +58,7 @@ ERROR:  permission denied for relation "tspace_2dim"
 \c single :ROLE_DEFAULT_PERM_USER
 --attach without permissions on the tablespace should also fail
 SELECT attach_tablespace('tablespace2', 'tspace_2dim');
-ERROR:  Table owner "default_perm_user" lacks permissions for tablespace "tablespace2"
+ERROR:  permission denied for tablespace "tablespace2" by table owner "default_perm_user"
 \c single :ROLE_SUPERUSER
 GRANT :ROLE_DEFAULT_PERM_USER_2 TO :ROLE_DEFAULT_PERM_USER;
 \c single :ROLE_DEFAULT_PERM_USER
@@ -96,14 +104,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 
 --
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;
--- User doesn't have permission on tablespace1 --> error
 CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
--- Grant permission to tablespace1
-SET ROLE :ROLE_DEFAULT_PERM_USER;
-GRANT CREATE ON TABLESPACE tablespace1 TO :ROLE_DEFAULT_PERM_USER_2;
-SET ROLE :ROLE_DEFAULT_PERM_USER_2;
-CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
-ERROR:  relation "tspace_1dim" already exists
 SELECT create_hypertable('tspace_1dim', 'time');
 NOTICE:  adding NOT NULL constraint to column "time"
  create_hypertable 
@@ -111,6 +112,14 @@ NOTICE:  adding NOT NULL constraint to column "time"
  
 (1 row)
 
+--user doesn't have permission on tablespace1 --> error
+SELECT attach_tablespace('tablespace1', 'tspace_1dim');
+ERROR:  permission denied for tablespace "tablespace1" by table owner "default_perm_user_2"
+--grant permission to tablespace1
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+GRANT CREATE ON TABLESPACE tablespace1 TO :ROLE_DEFAULT_PERM_USER_2;
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
+--should work fine now
 SELECT attach_tablespace('tablespace1', 'tspace_1dim');
  attach_tablespace 
 -------------------
@@ -123,6 +132,13 @@ SELECT attach_tablespace('tablespace2', 'tspace_1dim');
  
 (1 row)
 
+--trying to revoke permissions while attached should fail
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+REVOKE CREATE ON TABLESPACE tablespace1 FROM :ROLE_DEFAULT_PERM_USER_2;
+ERROR:  cannot revoke privilege while tablespace "tablespace1" is attached to hypertable "tspace_1dim"
+REVOKE ALL ON TABLESPACE tablespace1 FROM :ROLE_DEFAULT_PERM_USER_2;
+ERROR:  cannot revoke privilege while tablespace "tablespace1" is attached to hypertable "tspace_1dim"
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 SELECT * FROM _timescaledb_catalog.tablespace;
  id | hypertable_id | tablespace_name 
 ----+---------------+-----------------
@@ -161,10 +177,13 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
  _timescaledb_internal._hyper_2_4_chunk | _timescaledb_internal._hyper_2_4_chunk_tspace_1dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
 (6 rows)
 
---detach tablespace1 from all tables. Due to lack of permissions,
---should only detach from 'tspace_1dim' (1 tablespace)
+--detach tablespace1 from tspace_2dim should fail due to lack of permissions
+SELECT detach_tablespace('tablespace1', 'tspace_2dim');
+ERROR:  permission denied for relation "tspace_2dim"
+--detach tablespace1 from all tables. Should only detach from
+--'tspace_1dim' (1 tablespace) due to lack of permissions
 SELECT detach_tablespace('tablespace1');
-NOTICE:  Tablespace "tablespace1" remains attached to 1 hypertable(s) due to lack of permissions
+NOTICE:  tablespace "tablespace1" remains attached to 1 hypertable(s) due to lack of permissions
  detach_tablespace 
 -------------------
                  1
@@ -191,6 +210,10 @@ SELECT * FROM show_tablespaces('tspace_2dim');
  tablespace2
 (2 rows)
 
+--it should now be possible to revoke permissions on tablespace1
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+REVOKE CREATE ON TABLESPACE tablespace1 FROM :ROLE_DEFAULT_PERM_USER_2;
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 --detach the other tablespace
 SELECT detach_tablespace('tablespace2', 'tspace_1dim');
  detach_tablespace 
@@ -217,11 +240,18 @@ SELECT * FROM show_tablespaces('tspace_2dim');
  tablespace2
 (2 rows)
 
---detaching a tablespace from table without permissions should fail
+--detaching tablespace2 from a table without permissions should fail
 SELECT detach_tablespace('tablespace2', 'tspace_2dim');
 ERROR:  permission denied for relation "tspace_2dim"
 SELECT detach_tablespaces('tspace_2dim');
 ERROR:  permission denied for relation "tspace_2dim"
+\c single :ROLE_SUPERUSER
+-- PERM_USER_2 owns tablespace2, and PERM_USER owns the table
+-- 'tspace_2dim', which has tablespace2 attached. Revoking PERM_USER_2
+-- FROM PERM_USER should therefore fail
+REVOKE :ROLE_DEFAULT_PERM_USER_2 FROM :ROLE_DEFAULT_PERM_USER;
+ERROR:  cannot revoke privilege while tablespace "tablespace2" is attached to hypertable "tspace_2dim"
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 --set other user should make detach work
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT detach_tablespaces('tspace_2dim');
@@ -245,7 +275,25 @@ SELECT * FROM show_tablespaces('tspace_2dim');
 ------------------
 (0 rows)
 
---cleanup - make sure tablespace metadata is removed
+\c single :ROLE_SUPERUSER
+-- It should now be possible to revoke PERM_USER_2 from PERM_USER
+-- since tablespace2 is no longer attched to tspace_2dim
+REVOKE :ROLE_DEFAULT_PERM_USER_2 FROM :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--detaching twice should fail
+SELECT detach_tablespace('tablespace2', 'tspace_2dim');
+ERROR:  tablespace "tablespace2" is not attached to hypertable "tspace_2dim"
+--adding if_attached should only generate notice
+SELECT detach_tablespace('tablespace2', 'tspace_2dim', if_attached => true);
+NOTICE:  tablespace "tablespace2" is not attached to hypertable "tspace_2dim", skipping
+ detach_tablespace 
+-------------------
+                 0
+(1 row)
+
+--attach tablespaces again to verify that tablespaces are cleaned up
+--when tables are dropped
+\c single :ROLE_SUPERUSER
 SELECT attach_tablespace('tablespace2', 'tspace_1dim');
  attach_tablespace 
 -------------------
@@ -278,8 +326,36 @@ SELECT * FROM _timescaledb_catalog.tablespace;
 ----+---------------+-----------------
 (0 rows)
 
+-- verify that one cannot DROP a tablespace while it is attached to a
+-- hypertable
+CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
+SELECT create_hypertable('tspace_1dim', 'time');
+NOTICE:  adding NOT NULL constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'tspace_1dim');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT * FROM show_tablespaces('tspace_1dim');
+ show_tablespaces 
+------------------
+ tablespace1
+(1 row)
+
+DROP TABLESPACE tablespace1;
+ERROR:  tablespace "tablespace1" is still attached to 1 hypertables
+--after detaching we should now be able to drop the tablespace
+SELECT detach_tablespace('tablespace1', 'tspace_1dim');
+ detach_tablespace 
+-------------------
+                 1
+(1 row)
+
 DROP TABLESPACE tablespace1;
 DROP TABLESPACE tablespace2;
--- revoke grants
-\c single :ROLE_SUPERUSER
-REVOKE :ROLE_DEFAULT_PERM_USER_2 FROM :ROLE_DEFAULT_PERM_USER;

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -13,7 +13,8 @@ SELECT * FROM alter_before;
 SELECT c.relname, a.attname, a.attnum FROM pg_attribute a, pg_class c
 WHERE a.attrelid = c.oid
 AND (c.relname LIKE '_hyper_1%_chunk' OR c.relname = 'alter_before')
-AND a.attnum > 0;
+AND a.attnum > 0
+ORDER BY c.relname, a.attnum;
 
 -- DROP a table's column after making it a hypertable and having data
 CREATE TABLE alter_after(id serial, time timestamp, temp float, colorid integer);
@@ -40,7 +41,8 @@ SELECT * FROM alter_after;
 SELECT c.relname, a.attname, a.attnum FROM pg_attribute a, pg_class c
 WHERE a.attrelid = c.oid
 AND (c.relname LIKE '_hyper_2%_chunk' OR c.relname = 'alter_after')
-AND a.attnum > 0;
+AND a.attnum > 0
+ORDER BY c.relname, a.attnum;
 
 -- Add an ID column again
 ALTER TABLE alter_after ADD COLUMN id serial;
@@ -50,6 +52,7 @@ INSERT INTO alter_after (time, temp, colorid) VALUES ('2017-08-22T09:19:14', 12.
 SELECT c.relname, a.attname, a.attnum FROM pg_attribute a, pg_class c
 WHERE a.attrelid = c.oid
 AND (c.relname LIKE '_hyper_2%_chunk' OR c.relname = 'alter_after')
-AND a.attnum > 0;
+AND a.attnum > 0
+ORDER BY c.relname, a.attnum;
 
 SELECT * FROM alter_after;


### PR DESCRIPTION
This change improves the handling of tablespaces as follows:

- Add if_not_attached / if_attached options to attach_tablespace() and
  detach_tablespace(), respectively
- Block DROP tablespace if it is still attached to a table
- Block REVOKE if it means the table owner no longer has CREATE
  permissions on an attached tablespace
- Make error messages follow the PostgreSQL style guide