### PR TITLE
Fix several Windows compile errors and warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ find_path(PG_SOURCE_DIR
   $ENV{HOME}/Projects
   $ENV{HOME}/development
   $ENV{HOME}/Development
+  $ENV{HOME}/workspace
   PATH_SUFFIXES
   postgres
   postgresql

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -8,6 +8,9 @@
 #include <utils/timestamp.h>
 #include <funcapi.h>
 #include <miscadmin.h>
+#ifdef _WIN32
+#include <stdint.h>
+#endif
 
 #include "catalog.h"
 #include "compat.h"

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -364,9 +364,10 @@ hypertable_lock_tuple_simple(Oid table_relid)
 			return false;
 		case HeapTupleInvisible:
 			elog(ERROR, "attempted to lock invisible tuple");
-			break;
+			return false;
 		default:
 			elog(ERROR, "unexpected tuple lock status");
+			return false;
 	}
 }
 
@@ -899,7 +900,7 @@ hypertable_create(PG_FUNCTION_ARGS)
 		NameData	tspc_name;
 
 		namestrcpy(&tspc_name, get_tablespace_name(tspc_oid));
-		DirectFunctionCall2(tablespace_attach, NameGetDatum(&tspc_name), ObjectIdGetDatum(table_relid));
+		tablespace_attach_internal(&tspc_name, table_relid);
 	}
 
 	cache_release(hcache);

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -154,6 +154,7 @@ should_load_on_create_extension(Node *utility_stmt)
 			 errmsg("the session already has \"%s\" shared library version \"%s\" loaded",
 					stmt->extname, soversion),
 			 errhint("You should start a new session and execute CREATE EXTENSION as the first command")));
+	return false;
 }
 
 static bool

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -238,5 +238,6 @@ scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type)
 			return true;
 		default:
 			elog(ERROR, "More than one %s found.", item_type);
+			return false;
 	}
 }

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -296,12 +296,6 @@ tablespace_attach(PG_FUNCTION_ARGS)
 {
 	Oid			hypertable_oid;
 	Name		tspcname;
-	Cache	   *hcache;
-	Hypertable *ht;
-	Oid			tspc_oid;
-	Oid			ownerid;
-	AclResult	aclresult;
-	CatalogSecurityContext sec_ctx;
 
 	if (PG_NARGS() != 2)
 		elog(ERROR, "Invalid number of arguments");
@@ -314,6 +308,21 @@ tablespace_attach(PG_FUNCTION_ARGS)
 
 	tspcname = PG_GETARG_NAME(0);
 	hypertable_oid = PG_GETARG_OID(1);
+
+	tablespace_attach_internal(tspcname, hypertable_oid);
+
+	PG_RETURN_VOID();
+}
+
+void
+tablespace_attach_internal(Name tspcname, Oid hypertable_oid)
+{
+	Cache	   *hcache;
+	Hypertable *ht;
+	Oid			tspc_oid;
+	Oid			ownerid;
+	AclResult	aclresult;
+	CatalogSecurityContext sec_ctx;
 
 	tspc_oid = get_tablespace_oid(NameStr(*tspcname), true);
 
@@ -354,8 +363,6 @@ tablespace_attach(PG_FUNCTION_ARGS)
 	catalog_restore_user(&sec_ctx);
 
 	cache_release(hcache);
-
-	PG_RETURN_VOID();
 }
 
 static int

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -22,7 +22,7 @@ extern bool tablespaces_delete(Tablespaces *tspcs, Oid tspc_oid);
 extern int	tablespaces_clear(Tablespaces *tspcs);
 extern bool tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
 extern Tablespaces *tablespace_scan(int32 hypertable_id);
-extern Datum tablespace_attach(PG_FUNCTION_ARGS);
+extern void tablespace_attach_internal(Name tspcname, Oid hypertable_oid);
 extern int	tablespace_delete(int32 hypertable_id, const char *tspcname);
 
 


### PR DESCRIPTION
Previously stdint.h was not included on Windows so INT16_MAX and
friends were not defined. Additionally, having tablespace_attach
with PG_FUNCTION_ARGS in the header file caused issues during
linking, so a direct call version of the function is now exported
for others to use instead of the PG_FUNCTION_ARGS version.

Two minor warnings regarding not having a return in all cases are
also addressed.

Reported by RaedA on slack.