### PR TITLE
Move index and constraints drop handling to object_access hook

### DIFF
--- a/sql/updates/post-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/post-0.8.0--0.9.0-dev.sql
@@ -1,0 +1,42 @@
+DO $$
+DECLARE 
+    r record;
+    cnt INTEGER;
+BEGIN
+    FOR r IN 
+        SELECT * 
+        FROM _timescaledb_catalog.chunk_constraint cc
+        INNER JOIN _timescaledb_catalog.chunk c ON (c.id = cc.chunk_id)
+    LOOP
+        SELECT count(*) INTO cnt
+        FROM pg_constraint
+        WHERE conname = r.constraint_name
+        AND conrelid = format('%I.%I', r.schema_name, r.table_name)::regclass;
+
+        IF cnt = 0 THEN
+            DELETE FROM _timescaledb_catalog.chunk_constraint
+            WHERE chunk_id = r.chunk_id AND constraint_name = r.constraint_name;
+        END IF;
+    END LOOP;
+END$$;
+
+DO $$
+DECLARE 
+    r record;
+    cnt INTEGER;
+BEGIN
+    FOR r IN 
+        SELECT * 
+        FROM _timescaledb_catalog.chunk_index cc
+        INNER JOIN _timescaledb_catalog.chunk c ON (c.id = cc.chunk_id)
+    LOOP
+        SELECT count(*) INTO cnt
+        FROM pg_class
+        WHERE relname = r.index_name;
+
+        IF cnt = 0 THEN
+            DELETE FROM _timescaledb_catalog.chunk_index
+            WHERE chunk_id = r.chunk_id AND index_name = r.index_name;
+        END IF;
+    END LOOP;
+END$$;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ set(HEADERS
   hypertable.h
   hypertable_insert.h
   indexing.h
+  object_access.h
   parse_rewrite.h
   partitioning.h
   planner_utils.h
@@ -95,6 +96,7 @@ set(SOURCES
   hypertable_insert.c
   indexing.c
   init.c
+  object_access.c
   parse_analyze.c
   parse_rewrite.c
   partitioning.c

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -71,6 +71,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 	[CHUNK_CONSTRAINT] = {
 		.length = _MAX_CHUNK_CONSTRAINT_INDEX,
 		.names = (char *[]) {
+			[CHUNK_CONSTRAINT_CHUNK_ID_CONSTRAINT_NAME_IDX] = "chunk_constraint_chunk_id_constraint_name_key",
 			[CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX] = "chunk_constraint_chunk_id_dimension_slice_id_idx",
 		}
 	},

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -331,7 +331,8 @@ typedef FormData_chunk_constraint *Form_chunk_constraint;
 
 enum
 {
-	CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX = 0,
+	CHUNK_CONSTRAINT_CHUNK_ID_CONSTRAINT_NAME_IDX = 0,
+	CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX,
 	_MAX_CHUNK_CONSTRAINT_INDEX,
 };
 
@@ -341,6 +342,14 @@ enum Anum_chunk_constraint_chunk_id_dimension_slice_id_idx
 	Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_dimension_slice_id,
 	_Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_max,
 };
+
+enum Anum_chunk_constraint_chunk_id_constraint_name_idx
+{
+	Anum_chunk_constraint_chunk_id_constraint_name_idx_chunk_id = 1,
+	Anum_chunk_constraint_chunk_id_constraint_name_idx_constraint_name,
+	_Anum_chunk_constraint_chunk_id_constraint_name_idx_max,
+};
+
 
 /************************************
  *

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -993,8 +993,14 @@ chunk_tuple_delete(TupleInfo *ti, void *data)
 	ChunkConstraints *ccs = chunk_constraints_alloc(2);
 	int			i;
 
+	/*
+	 * FIXME should we be deleting constraints and indexes? Perhaps better
+	 * handle in object_access? right now its necessary to get the ccs for
+	 * dimension delete below.
+	 */
 	chunk_constraint_delete_by_chunk_id(form->id, ccs);
-	chunk_index_delete_by_chunk_id(form->id, true);
+
+	chunk_index_delete_by_chunk_id(form->id, false);
 
 	/* Check for dimension slices that are orphaned by the chunk deletion */
 	for (i = 0; i < ccs->num_constraints; i++)

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -42,11 +42,11 @@ extern int	chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, in
 extern int	chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs, int32 chunk_id, Oid hypertable_oid);
 extern void chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid, int32 chunk_id, Oid hypertable_oid, int32 hypertable_id);
 extern void chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
-extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, char *hypertable_constraint_name);
 extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_id, ChunkConstraints *ccs);
 extern int	chunk_constraint_delete_by_dimension_slice_id(int32 dimension_slice_id);
+extern int	chunk_constraint_drop_by_hypertable_constraint_name(int32 chunk_id, Oid chunk_oid, char *hypertable_constraint_name);
 extern void chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
 extern int	chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);
-
+extern int	chunk_constraint_delete_by_constraint_oid(int32 chunk_id, Oid constraint_oid);
 
 #endif							/* TIMESCALEDB_CHUNK_CONSTRAINT_H */

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -18,7 +18,7 @@ typedef struct ChunkIndexMapping
 
 extern void chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid, int32 chunk_id, Oid chunkrelid);
 extern Oid	chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid, int32 hypertable_id, Oid hypertable_indexrelid);
-extern int	chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool should_drop);
+extern int	chunk_index_drop_children_of(Hypertable *ht, Oid hypertable_indexrelid);
 extern int	chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index);
 extern int	chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
 extern int	chunk_index_delete_by_hypertable_id(int32 hypertable_id, bool drop_index);

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -21,6 +21,8 @@ typedef struct Hypertable
 	SubspaceStore *chunk_cache;
 } Hypertable;
 
+typedef void (*process_chunk_t) (Hypertable *ht, Oid chunk_relid, void *arg);
+
 extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
 extern Oid	hypertable_permissions_check(Oid hypertable_oid, Oid userid);
 extern Hypertable *hypertable_from_tuple(HeapTuple tuple);
@@ -41,5 +43,6 @@ extern Tablespace *hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
 extern char *hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
 extern Tablespace *hypertable_get_tablespace_at_offset_from(Hypertable *ht, Oid tablespace_oid, int16 offset);
 extern bool hypertable_has_tuples(Oid table_relid, LOCKMODE lockmode);
+extern int	hypertable_foreach_chunk(Hypertable *ht, process_chunk_t process_chunk, void *arg);
 
 #endif							/* TIMESCALEDB_HYPERTABLE_H */

--- a/src/init.c
+++ b/src/init.c
@@ -9,6 +9,7 @@
 #include "guc.h"
 #include "catalog.h"
 #include "version.h"
+#include "object_access.h"
 
 #ifdef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -58,6 +59,7 @@ _PG_init(void)
 	_planner_init();
 	_event_trigger_init();
 	_process_utility_init();
+	_object_access_init();
 	_parse_analyze_init();
 	_guc_init();
 }
@@ -71,6 +73,7 @@ _PG_fini(void)
 	 */
 	_guc_fini();
 	_parse_analyze_fini();
+	_object_access_fini();
 	_process_utility_fini();
 	_event_trigger_fini();
 	_planner_fini();

--- a/src/object_access.c
+++ b/src/object_access.c
@@ -1,0 +1,232 @@
+#include <postgres.h>
+#include <catalog/objectaccess.h>
+#include <catalog/objectaddress.h>
+#include <catalog/pg_class.h>
+#include <catalog/pg_constraint.h>
+#include <catalog/pg_constraint_fn.h>
+#include <catalog/pg_authid.h>
+#include <catalog/indexing.h>
+#include <catalog/index.h>
+#include <access/sysattr.h>
+#include <access/genam.h>
+#include <access/htup_details.h>
+#include <utils/fmgroids.h>
+#include <utils/tqual.h>
+#include <utils/lsyscache.h>
+#include <utils/builtins.h>
+#include <utils/rel.h>
+#include <access/heapam.h>
+
+#include "object_access.h"
+#include "extension.h"
+#include "hypertable_cache.h"
+#include "cache.h"
+#include "chunk.h"
+#include "chunk_index.h"
+#include "chunk_constraint.h"
+
+static object_access_hook_type prev_object_hook;
+
+static HeapTuple
+get_object_by_oid(Relation catalog, Oid objectId, Snapshot snapshot)
+{
+	HeapTuple	tuple;
+	Oid			classId = RelationGetRelid(catalog);
+
+	Oid			oidIndexId = get_object_oid_index(classId);
+	SysScanDesc scan;
+	ScanKeyData skey;
+
+	Assert(OidIsValid(oidIndexId));
+
+	ScanKeyInit(&skey,
+				ObjectIdAttributeNumber,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(objectId));
+
+	scan = systable_beginscan(catalog, oidIndexId, true,
+							  snapshot, 1, &skey);
+	tuple = systable_getnext(scan);
+	if (!HeapTupleIsValid(tuple))
+	{
+		systable_endscan(scan);
+		return NULL;
+	}
+	tuple = heap_copytuple(tuple);
+
+	systable_endscan(scan);
+
+	return tuple;
+}
+
+static void
+drop_chunk_constraint(Hypertable *ht, Oid chunk_relid, void *arg)
+{
+	char	   *hypertable_constraint_name = arg;
+	Chunk	   *chunk = chunk_get_by_relid(chunk_relid, ht->space->num_dimensions, true);
+
+	chunk_constraint_drop_by_hypertable_constraint_name(chunk->fd.id, chunk->table_id, hypertable_constraint_name);
+}
+
+static void
+drop_constraint(Oid constraint_oid)
+{
+	Cache	   *hcache = hypertable_cache_pin();
+	Hypertable *ht;
+	Relation	rel = heap_open(ConstraintRelationId, AccessShareLock);
+
+
+	HeapTuple	constrainttup = get_object_by_oid(rel, constraint_oid, SnapshotSelf);
+	Form_pg_constraint constraint = (Form_pg_constraint) GETSTRUCT(constrainttup);
+
+	ht = hypertable_cache_get_entry(hcache, constraint->conrelid);
+	if (ht != NULL)
+	{
+		CatalogSecurityContext sec_ctx;
+
+		/* Note cannot drop related indexes here since they are dropped first */
+
+		catalog_become_owner(catalog_get(), &sec_ctx);
+
+		/* Recurse to each chunk and drop the corresponding constraint */
+		hypertable_foreach_chunk(ht, drop_chunk_constraint, constraint->conname.data);
+
+		catalog_restore_user(&sec_ctx);
+	}
+	else
+	{
+		Chunk	   *chunk = chunk_get_by_relid(constraint->conrelid, 0, false);
+
+		if (NULL != chunk)
+		{
+			/* drop corresponding chunk metadata */
+			chunk_constraint_delete_by_constraint_oid(chunk->fd.id, constraint_oid);
+		}
+	}
+
+	heap_close(rel, AccessShareLock);
+	cache_release(hcache);
+}
+
+static void
+drop_index(Oid idxrelid)
+{
+	Cache	   *hcache = hypertable_cache_pin();
+	Oid			tblrelid = IndexGetRelation(idxrelid, false);
+	Hypertable *ht;
+
+	ht = hypertable_cache_get_entry(hcache, tblrelid);
+	if (NULL != ht)
+	{
+		Oid			constraint_oid = get_index_constraint(idxrelid);
+
+		/*
+		 * Only drop the index if there is no associated constraint.
+		 * Constraint drops will take care of this. Note inside PG logic an
+		 * index dropped before a constraint
+		 */
+		if (!OidIsValid(constraint_oid))
+			chunk_index_drop_children_of(ht, idxrelid);
+	}
+	else
+	{
+		Chunk	   *chunk = chunk_get_by_relid(tblrelid, 0, false);
+
+		if (NULL != chunk)
+		{
+			chunk_index_delete(chunk, idxrelid, false);
+		}
+	}
+
+	cache_release(hcache);
+}
+
+static void
+drop_relation(Oid class_id)
+{
+	Relation	rel = heap_open(RelationRelationId, AccessShareLock);
+	HeapTuple	relationtup = get_object_by_oid(rel, class_id, SnapshotSelf);
+	Form_pg_class class = (Form_pg_class) GETSTRUCT(relationtup);
+
+	switch (class->relkind)
+	{
+		case 'i':
+			drop_index(class_id);
+			break;
+		default:
+			break;
+	}
+	heap_close(rel, AccessShareLock);
+}
+
+static
+void
+object_access_drop(Oid classId,
+				   Oid objectId,
+				   int subId,
+				   void *arg)
+{
+	ObjectAccessDrop *drop_arg;
+
+	drop_arg = arg;
+
+	/*
+	 * A good example of  PERFORM_DELETION_INTERNAL is what happens when a
+	 * column type changes. In that case constraints are deleted and
+	 * recreated: both in PG and in TimescaleDB code. when that happens
+	 * PERFORM_DELETION_INTERNAL is set and the operation should be ignored
+	 */
+	if (drop_arg->dropflags & PERFORM_DELETION_INTERNAL)
+		return;
+
+	switch (classId)
+	{
+		case ConstraintRelationId:
+			drop_constraint(objectId);
+			break;
+		case RelationRelationId:
+			drop_relation(objectId);
+			break;
+		default:
+			break;
+	}
+}
+
+static
+void
+timescaledb_object_access(ObjectAccessType access,
+						  Oid classId,
+						  Oid objectId,
+						  int subId,
+						  void *arg)
+{
+	if (prev_object_hook != NULL)
+	{
+		prev_object_hook(access, classId, objectId, subId, arg);
+	}
+
+	if (!extension_is_loaded())
+		return;
+
+	switch (access)
+	{
+		case OAT_DROP:
+			object_access_drop(classId, objectId, subId, arg);
+			break;
+		default:
+			break;
+	}
+}
+
+void
+_object_access_init(void)
+{
+	prev_object_hook = object_access_hook;
+	object_access_hook = timescaledb_object_access;
+}
+
+void
+_object_access_fini(void)
+{
+	object_access_hook = prev_object_hook;
+}

--- a/src/object_access.h
+++ b/src/object_access.h
@@ -1,0 +1,9 @@
+#ifndef TIMESCALEDB_OBJECT_ACCESS_H
+#define TIMESCALEDB_OBJECT_ACCESS_H
+
+#include <postgres.h>
+
+extern void _object_access_init(void);
+extern void _object_access_fini(void);
+
+#endif							/* TIMESCALEDB_OBJECT_ACCESS_H */

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -407,13 +407,12 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
         5 | _hyper_3_5_chunk_Hypertable_1_time_Device_id_idx          |             3 | Hypertable_1_time_Device_id_idx
         5 | _hyper_3_5_chunk_Hypertable_1_time_idx                    |             3 | Hypertable_1_time_idx
         5 | _hyper_3_5_chunk_Hypertable_1_Device_id_time_idx          |             3 | Hypertable_1_Device_id_time_idx
-        5 | _hyper_3_5_chunk_Hypertable_1_time_temp_c_idx             |             3 | Hypertable_1_time_temp_c_idx
         5 | _hyper_3_5_chunk_Unique1                                  |             3 | Unique1
         6 | _hyper_4_6_chunk_Hypertable_1_time_Device_id_idx          |             4 | Hypertable_1_time_Device_id_idx
         6 | _hyper_4_6_chunk_Hypertable_1_time_idx                    |             4 | Hypertable_1_time_idx
         6 | _hyper_4_6_chunk_Unique1                                  |             4 | Unique1
         5 | _hyper_3_5_chunk_ind_humdity2                             |             3 | ind_humdity2
-(28 rows)
+(27 rows)
 
 --create column with same name as previously renamed one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 131;

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -95,6 +95,13 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
         5 |                  5 | constraint_5    | 
 (3 rows)
 
+-- The index should also have been removed
+SELECT * FROM _timescaledb_catalog.chunk_index;
+ chunk_id |           index_name            | hypertable_id | hypertable_index_name 
+----------+---------------------------------+---------------+-----------------------
+        3 | _hyper_1_3_chunk_hyper_time_idx |             1 | hyper_time_idx
+(1 row)
+
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_2_4_chunk');
                            Constraint                            | Type |  Columns   | Index |                                           Expr                                           
 -----------------------------------------------------------------+------+------------+-------+------------------------------------------------------------------------------------------
@@ -371,6 +378,26 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000002, 'dev3', 11);
 ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_22_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
+--test CASCADE drop behavior
+DROP TABLE devices CASCADE;
+NOTICE:  drop cascades to 2 other objects
+--the fk went away.
+INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
+(1257987700000000002, 'dev3', 11);
+CREATE TABLE devices(
+    device_id TEXT NOT NULL,
+    PRIMARY KEY (device_id)
+);
+INSERT INTO devices VALUES ('dev2'), ('dev3');
+ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
+FOREIGN KEY (device_id) REFERENCES devices(device_id);
+\set ON_ERROR_STOP 0
+INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
+(1257987700000000003, 'dev4', 11);
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_23_hyper_fk_device_id_fkey"
+\set ON_ERROR_STOP 1
+--this tests that there are no extra chunk_constraints left on hyper_fk
+TRUNCATE hyper_fk;
 ----------------------- FOREIGN KEY INTO A HYPERTABLE  ------------------
 --FOREIGN KEY references into a hypertable are currently broken.
 --The referencing table will never find the corresponding row in the hypertable
@@ -423,7 +450,7 @@ INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_24_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_25_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_ex DROP CONSTRAINT hyper_ex_time_device_id_excl;
 --can now add
@@ -436,7 +463,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
         time WITH =, device_id WITH =
     ) WHERE (not canceled)
 ;
-ERROR:  could not create exclusion constraint "9_25_hyper_ex_time_device_id_excl"
+ERROR:  could not create exclusion constraint "9_26_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_ex WHERE sensor_1 = 12;
 ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
@@ -447,7 +474,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_26_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_27_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 --cannot add exclusion constraint without partition key.
 CREATE TABLE hyper_ex_invalid (

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -336,13 +336,12 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
         1 | _hyper_1_1_chunk_Hypertable_1_time_Device_id_idx |             1 | Hypertable_1_time_Device_id_idx
         1 | _hyper_1_1_chunk_Hypertable_1_time_idx           |             1 | Hypertable_1_time_idx
         1 | _hyper_1_1_chunk_Hypertable_1_Device_id_time_idx |             1 | Hypertable_1_Device_id_time_idx
-        1 | _hyper_1_1_chunk_Hypertable_1_time_temp_c_idx    |             1 | Hypertable_1_time_temp_c_idx
         1 | _hyper_1_1_chunk_Unique1                         |             1 | Unique1
         2 | _hyper_2_2_chunk_Hypertable_1_time_Device_id_idx |             2 | Hypertable_1_time_Device_id_idx
         2 | _hyper_2_2_chunk_Hypertable_1_time_idx           |             2 | Hypertable_1_time_idx
         2 | _hyper_2_2_chunk_Unique1                         |             2 | Unique1
         1 | _hyper_1_1_chunk_ind_humdity2                    |             1 | ind_humdity2
-(9 rows)
+(8 rows)
 
 --create column with same name as previously renamed one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 131;

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -299,13 +299,12 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
         1 | _hyper_1_1_chunk_Hypertable_1_time_Device_id_idx |             1 | Hypertable_1_time_Device_id_idx
         1 | _hyper_1_1_chunk_Hypertable_1_time_idx           |             1 | Hypertable_1_time_idx
         1 | _hyper_1_1_chunk_Hypertable_1_Device_id_time_idx |             1 | Hypertable_1_Device_id_time_idx
-        1 | _hyper_1_1_chunk_Hypertable_1_time_temp_c_idx    |             1 | Hypertable_1_time_temp_c_idx
         1 | _hyper_1_1_chunk_Unique1                         |             1 | Unique1
         2 | _hyper_2_2_chunk_Hypertable_1_time_Device_id_idx |             2 | Hypertable_1_time_Device_id_idx
         2 | _hyper_2_2_chunk_Hypertable_1_time_idx           |             2 | Hypertable_1_time_idx
         2 | _hyper_2_2_chunk_Unique1                         |             2 | Unique1
         1 | _hyper_1_1_chunk_ind_humdity2                    |             1 | ind_humdity2
-(9 rows)
+(8 rows)
 
 --create column with same name as previously renamed one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 131;

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -66,8 +66,9 @@ SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_2_4_chunk');
 ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name DROP CONSTRAINT hyper_unique_with_looooooooooooooooooooooooooooooooooo_time_key;
 -- The constraint should have been removed from the chunk as well
 SELECT * FROM _timescaledb_catalog.chunk_constraint;
+-- The index should also have been removed
+SELECT * FROM _timescaledb_catalog.chunk_index;
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_2_4_chunk');
-
 --uniqueness not enforced
 INSERT INTO hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev3', 11);
@@ -268,6 +269,30 @@ FOREIGN KEY (device_id) REFERENCES devices(device_id);
 INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000002, 'dev3', 11);
 \set ON_ERROR_STOP 1
+
+--test CASCADE drop behavior
+DROP TABLE devices CASCADE;
+--the fk went away.
+INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
+(1257987700000000002, 'dev3', 11);
+
+CREATE TABLE devices(
+    device_id TEXT NOT NULL,
+    PRIMARY KEY (device_id)
+);
+
+INSERT INTO devices VALUES ('dev2'), ('dev3');
+
+ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
+FOREIGN KEY (device_id) REFERENCES devices(device_id);
+
+\set ON_ERROR_STOP 0
+INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
+(1257987700000000003, 'dev4', 11);
+\set ON_ERROR_STOP 1
+
+--this tests that there are no extra chunk_constraints left on hyper_fk
+TRUNCATE hyper_fk;
 
 ----------------------- FOREIGN KEY INTO A HYPERTABLE  ------------------
 


### PR DESCRIPTION
This fixes at least two bugs:

1) A drop of a referenced table used to drop the associated
FK constraint but not the metadata associated with the constraint.
Fixes #43.

2) A drop of a column removed any indexes associated with the column
but not the metadata associated with the index.