### PR TITLE
Handle TRUNCATE without upcall and handle ONLY modifier

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -112,26 +112,6 @@ BEGIN
 END
 $BODY$;
 
-
-CREATE OR REPLACE FUNCTION _timescaledb_internal.truncate_hypertable(
-    schema_name     NAME,
-    table_name      NAME,
-    cascade      BOOLEAN = FALSE
-)
-    RETURNS VOID
-    LANGUAGE PLPGSQL VOLATILE
-    SET search_path = '_timescaledb_internal'
-    AS
-$BODY$
-DECLARE
-    hypertable_row _timescaledb_catalog.hypertable;
-    chunk_row _timescaledb_catalog.chunk;
-BEGIN
-    --TODO: should this cascade?
-    PERFORM  _timescaledb_internal.drop_chunks_impl(NULL, table_name, schema_name, cascade, true);
-END
-$BODY$;
-
 --documentation of these function located in chunk_index.h
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_index_clone(chunk_index_oid OID) RETURNS OID
 AS '@MODULE_PATHNAME@', 'chunk_index_clone' LANGUAGE C VOLATILE STRICT;

--- a/sql/updates/pre-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/pre-0.8.0--0.9.0-dev.sql
@@ -39,6 +39,7 @@ DROP FUNCTION _timescaledb_internal.verify_hypertable_indexes(regclass);
 DROP FUNCTION _timescaledb_internal.validate_triggers(regclass);
 DROP FUNCTION _timescaledb_internal.chunk_create_table(int, name);
 DROP FUNCTION _timescaledb_internal.ddl_change_owner(oid, name);
+DROP FUNCTION _timescaledb_internal.truncate_hypertable(name,name,boolean);
 
 -- Remove redundant index
 DROP INDEX _timescaledb_catalog.dimension_slice_dimension_id_range_start_range_end_idx;

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -110,10 +110,6 @@ const static InternalFunctionDef internal_function_definitions[_MAX_INTERNAL_FUN
 	[DDL_ADD_CHUNK_CONSTRAINT] = {
 		.name = "chunk_constraint_add_table_constraint",
 		.args = 1,
-	},
-	[TRUNCATE_HYPERTABLE] = {
-		.name = "truncate_hypertable",
-		.args = 3
 	}
 };
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -47,7 +47,6 @@ typedef enum CatalogTable
 typedef enum InternalFunction
 {
 	DDL_ADD_CHUNK_CONSTRAINT,
-	TRUNCATE_HYPERTABLE,
 	_MAX_INTERNAL_FUNCTIONS,
 } InternalFunction;
 

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -49,7 +49,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    95
+    94
 (1 row)
 
 SELECT * FROM test.show_columns('public."two_Partitions"');
@@ -235,7 +235,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    95
+    94
 (1 row)
 
 --main table and chunk schemas should be the same

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -133,9 +133,29 @@ CREATE TRIGGER _test_truncate_after
 TRUNCATE "two_Partitions";
 WARNING:  FIRING trigger when: BEFORE level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_before
 WARNING:  FIRING trigger when: AFTER level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_after
-ERROR:  cannot drop table _hyper_1_5_chunk because other objects depend on it
+ERROR:  cannot drop table _timescaledb_internal._hyper_1_5_chunk because other objects depend on it
+-- cannot TRUNCATE ONLY a hypertable
+TRUNCATE ONLY "two_Partitions" CASCADE;
+ERROR:  cannot truncate only a hypertable
 \set ON_ERROR_STOP 1
-TRUNCATE "two_Partitions" CASCADE;
+-- create a regular table to make sure we can truncate it in the same call
+CREATE TABLE truncate_normal (color int);
+INSERT INTO truncate_normal VALUES (1);
+SELECT * FROM truncate_normal;
+ color 
+-------
+     1
+(1 row)
+
+SELECT * FROM test.show_subtables('"two_Partitions"');
+                 Child                  | Tablespace 
+----------------------------------------+------------
+ _timescaledb_internal._hyper_1_5_chunk | 
+ _timescaledb_internal._hyper_1_6_chunk | 
+ _timescaledb_internal._hyper_1_7_chunk | 
+(3 rows)
+
+TRUNCATE "two_Partitions", truncate_normal CASCADE;
 WARNING:  FIRING trigger when: BEFORE level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_before
 WARNING:  FIRING trigger when: AFTER level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_after
 -- should be empty
@@ -147,5 +167,10 @@ SELECT * FROM test.show_subtables('"two_Partitions"');
 SELECT * FROM "two_Partitions";
  timeCustom | device_id | series_0 | series_1 | series_2 | series_bool 
 ------------+-----------+----------+----------+----------+-------------
+(0 rows)
+
+SELECT * FROM truncate_normal;
+ color 
+-------
 (0 rows)
 

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -42,7 +42,7 @@ set(TEST_FILES
   tablespace.sql
   timestamp.sql
   triggers.sql
-  truncate_hypertable.sql
+  truncate.sql
   update.sql
   upsert.sql
   util.sql

--- a/test/sql/truncate.sql
+++ b/test/sql/truncate.sql
@@ -53,9 +53,19 @@ CREATE TRIGGER _test_truncate_after
 
 \set ON_ERROR_STOP 0
 TRUNCATE "two_Partitions";
+-- cannot TRUNCATE ONLY a hypertable
+TRUNCATE ONLY "two_Partitions" CASCADE;
 \set ON_ERROR_STOP 1
 
-TRUNCATE "two_Partitions" CASCADE;
+-- create a regular table to make sure we can truncate it in the same call
+CREATE TABLE truncate_normal (color int);
+INSERT INTO truncate_normal VALUES (1);
+SELECT * FROM truncate_normal;
+
+SELECT * FROM test.show_subtables('"two_Partitions"');
+
+TRUNCATE "two_Partitions", truncate_normal CASCADE;
 -- should be empty
 SELECT * FROM test.show_subtables('"two_Partitions"');
 SELECT * FROM "two_Partitions";
+SELECT * FROM truncate_normal;


### PR DESCRIPTION
This change refactors the handling of TRUNCATE so
that it is performed directly in process utility without
doing an upcall to PL/pgSQL.

It also adds handling for the ONLY modifier to TRUNCATE,
which shouldn't work on a hypertable. TRUNCATE now generates
an error if TRUNCATE ONLY is used on a hypertable.