### PR TITLE
Handle change owner without upcall

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -132,32 +132,6 @@ BEGIN
 END
 $BODY$;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_change_owner(main_table OID, new_table_owner NAME)
-    RETURNS void LANGUAGE plpgsql
-    SECURITY DEFINER SET search_path = '_timescaledb_internal'
-    AS
-$BODY$
-DECLARE
-    hypertable_row _timescaledb_catalog.hypertable;
-    chunk_row      _timescaledb_catalog.chunk;
-BEGIN
-    hypertable_row := _timescaledb_internal.hypertable_from_main_table(main_table);
-    FOR chunk_row IN
-        SELECT *
-        FROM _timescaledb_catalog.chunk
-        WHERE hypertable_id = hypertable_row.id
-        LOOP
-            EXECUTE format(
-                $$
-                ALTER TABLE %1$I.%2$I OWNER TO %3$I
-                $$,
-                chunk_row.schema_name, chunk_row.table_name,
-                new_table_owner
-            );
-    END LOOP;
-END
-$BODY$;
-
 --documentation of these function located in chunk_index.h
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_index_clone(chunk_index_oid OID) RETURNS OID
 AS '@MODULE_PATHNAME@', 'chunk_index_clone' LANGUAGE C VOLATILE STRICT;

--- a/sql/updates/pre-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/pre-0.8.0--0.9.0-dev.sql
@@ -38,6 +38,7 @@ DROP FUNCTION _timescaledb_internal.show_tablespaces(regclass);
 DROP FUNCTION _timescaledb_internal.verify_hypertable_indexes(regclass);
 DROP FUNCTION _timescaledb_internal.validate_triggers(regclass);
 DROP FUNCTION _timescaledb_internal.chunk_create_table(int, name);
+DROP FUNCTION _timescaledb_internal.ddl_change_owner(oid, name);
 
 -- Remove redundant index
 DROP INDEX _timescaledb_catalog.dimension_slice_dimension_id_range_start_range_end_idx;

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -107,10 +107,6 @@ typedef struct InternalFunctionDef
 } InternalFunctionDef;
 
 const static InternalFunctionDef internal_function_definitions[_MAX_INTERNAL_FUNCTIONS] = {
-	[DDL_CHANGE_OWNER] = {
-		.name = "ddl_change_owner",
-		.args = 2,
-	},
 	[DDL_ADD_CHUNK_CONSTRAINT] = {
 		.name = "chunk_constraint_add_table_constraint",
 		.args = 1,

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -46,7 +46,6 @@ typedef enum CatalogTable
 
 typedef enum InternalFunction
 {
-	DDL_CHANGE_OWNER = 0,
 	DDL_ADD_CHUNK_CONSTRAINT,
 	TRUNCATE_HYPERTABLE,
 	_MAX_INTERNAL_FUNCTIONS,

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -49,7 +49,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    96
+    95
 (1 row)
 
 SELECT * FROM test.show_columns('public."two_Partitions"');
@@ -235,7 +235,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    96
+    95
 (1 row)
 
 --main table and chunk schemas should be the same


### PR DESCRIPTION
Changing the owner of a hypertable is now handled
entirely in the process utility hook without doing
an upcall to PL/pgSQL.