### PR TITLE
Move index and constraints drop handling to event trigger

### DIFF
--- a/sql/ddl_triggers.sql
+++ b/sql/ddl_triggers.sql
@@ -1,8 +1,12 @@
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
-AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
+CREATE OR REPLACE FUNCTION _timescaledb_internal.process_ddl_event() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_process_ddl_event' LANGUAGE C;
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_command_end;
 --EVENT TRIGGER MUST exclude the ALTER EXTENSION tag.
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end
 WHEN TAG IN ('ALTER TABLE','CREATE TRIGGER','CREATE TABLE','CREATE INDEX','ALTER INDEX')
-EXECUTE PROCEDURE _timescaledb_internal.ddl_command_end();
+EXECUTE PROCEDURE _timescaledb_internal.process_ddl_event();
+
+DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_sql_drop;
+CREATE EVENT TRIGGER timescaledb_ddl_sql_drop ON sql_drop
+EXECUTE PROCEDURE _timescaledb_internal.process_ddl_event();

--- a/sql/updates/post-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/post-0.8.0--0.9.0-dev.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION _timescaledb_internal.ddl_command_end();

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -71,6 +71,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 	[CHUNK_CONSTRAINT] = {
 		.length = _MAX_CHUNK_CONSTRAINT_INDEX,
 		.names = (char *[]) {
+			[CHUNK_CONSTRAINT_CHUNK_ID_CONSTRAINT_NAME_IDX] = "chunk_constraint_chunk_id_constraint_name_key",
 			[CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX] = "chunk_constraint_chunk_id_dimension_slice_id_idx",
 		}
 	},

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -34,6 +34,10 @@ typedef enum CatalogTable
 } CatalogTable;
 
 #define INVALID_CATALOG_TABLE _MAX_CATALOG_TABLES
+#define INVALID_INDEXID -1
+
+#define CATALOG_INDEX(catalog, tableid, indexid) \
+    (indexid == INVALID_INDEXID ? InvalidOid : (catalog)->tables[tableid].index_ids[indexid])
 
 #define CatalogInternalCall1(func, datum1) \
 	OidFunctionCall1(catalog_get_internal_function_id(catalog_get(), func), datum1)
@@ -329,7 +333,8 @@ typedef FormData_chunk_constraint *Form_chunk_constraint;
 
 enum
 {
-	CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX = 0,
+	CHUNK_CONSTRAINT_CHUNK_ID_CONSTRAINT_NAME_IDX = 0,
+	CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX,
 	_MAX_CHUNK_CONSTRAINT_INDEX,
 };
 
@@ -338,6 +343,13 @@ enum Anum_chunk_constraint_chunk_id_dimension_slice_id_idx
 	Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_chunk_id = 1,
 	Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_dimension_slice_id,
 	_Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_max,
+};
+
+enum Anum_chunk_constraint_chunk_id_constraint_name_idx
+{
+	Anum_chunk_constraint_chunk_id_constraint_name_idx_chunk_id = 1,
+	Anum_chunk_constraint_chunk_id_constraint_name_idx_constraint_name,
+	_Anum_chunk_constraint_chunk_id_constraint_name_idx_max,
 };
 
 /************************************

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -566,7 +566,6 @@ chunk_fill_stub(Chunk *chunk_stub, bool tuplock)
 	ScannerCtx	ctx = {
 		.table = catalog->tables[CHUNK].id,
 		.index = catalog->tables[CHUNK].index_ids[CHUNK_ID_INDEX],
-		.scantype = ScannerTypeIndex,
 		.nkeys = 1,
 		.scankey = scankey,
 		.data = chunk_stub,
@@ -868,7 +867,6 @@ chunk_scan_internal(int indexid,
 	ScannerCtx	ctx = {
 		.table = catalog->tables[CHUNK].id,
 		.index = catalog->tables[CHUNK].index_ids[indexid],
-		.scantype = ScannerTypeIndex,
 		.nkeys = nkeys,
 		.data = data,
 		.scankey = scankey,

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -42,9 +42,10 @@ extern int	chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, in
 extern int	chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs, int32 chunk_id, Oid hypertable_oid);
 extern void chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid, int32 chunk_id, Oid hypertable_oid, int32 hypertable_id);
 extern void chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
-extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, char *hypertable_constraint_name);
+extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, char *hypertable_constraint_name, bool delete_metadata, bool drop_constraint);
 extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_id, ChunkConstraints *ccs);
 extern int	chunk_constraint_delete_by_dimension_slice_id(int32 dimension_slice_id);
+extern int	chunk_constraint_delete_by_constraint_name(int32 chunk_id, const char *constraint_name, bool delete_metadata, bool drop_constraint);
 extern void chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
 extern int	chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);
 

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -22,6 +22,7 @@ extern int	chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexre
 extern int	chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index);
 extern int	chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
 extern int	chunk_index_delete_by_hypertable_id(int32 hypertable_id, bool drop_index);
+extern void chunk_index_delete_by_name(const char *schema, const char *index_name, bool drop_index);
 extern int	chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname);
 extern int	chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *newname);
 extern int	chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, const char *tablespace);

--- a/src/compat.c
+++ b/src/compat.c
@@ -2,6 +2,7 @@
 #include <funcapi.h>
 
 #include "compat.h"
+#include "extension.h"
 
 /* Old functions that are no longer used but are needed for compatibility when
  * updating the extension. */
@@ -55,6 +56,18 @@ TS_FUNCTION_INFO_V1(hypertable_validate_triggers);
 Datum
 hypertable_validate_triggers(PG_FUNCTION_ARGS)
 {
+	elog(ERROR, "Deprecated function should not be invoked");
+	PG_RETURN_NULL();
+}
+
+TS_FUNCTION_INFO_V1(timescaledb_ddl_command_end);
+
+Datum
+timescaledb_ddl_command_end(PG_FUNCTION_ARGS)
+{
+	if (!extension_is_loaded())
+		PG_RETURN_NULL();
+
 	elog(ERROR, "Deprecated function should not be invoked");
 	PG_RETURN_NULL();
 }

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -321,7 +321,6 @@ dimension_scan_internal(ScanKeyData *scankey,
 	ScannerCtx	scanctx = {
 		.table = catalog->tables[DIMENSION].id,
 		.index = catalog->tables[DIMENSION].index_ids[DIMENSION_HYPERTABLE_ID_IDX],
-		.scantype = ScannerTypeIndex,
 		.nkeys = nkeys,
 		.limit = limit,
 		.scankey = scankey,
@@ -367,7 +366,6 @@ dimension_scan_update(int32 dimension_id, tuple_found_func tuple_found, void *da
 	ScannerCtx	scanctx = {
 		.table = catalog->tables[DIMENSION].id,
 		.index = catalog->tables[DIMENSION].index_ids[DIMENSION_ID_IDX],
-		.scantype = ScannerTypeIndex,
 		.nkeys = 1,
 		.limit = 1,
 		.scankey = scankey,

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -119,7 +119,6 @@ dimension_slice_scan_limit_internal(int indexid,
 	ScannerCtx	scanCtx = {
 		.table = catalog->tables[DIMENSION_SLICE].id,
 		.index = catalog->tables[DIMENSION_SLICE].index_ids[indexid],
-		.scantype = ScannerTypeIndex,
 		.nkeys = nkeys,
 		.scankey = scankey,
 		.data = scandata,

--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -1,16 +1,22 @@
 #include <postgres.h>
 #include <commands/event_trigger.h>
+#include <utils/builtins.h>
 #include <executor/executor.h>
 #include <access/htup_details.h>
+#include <catalog/pg_type.h>
+#include <catalog/pg_constraint.h>
+#include <catalog/pg_class.h>
 
 #include "event_trigger.h"
 
 #define DDL_INFO_NATTS 9
+#define DROPPED_OBJECTS_NATTS 12
 
 /* Function manager info for the event "pg_event_trigger_ddl_commands", which is
  * used to retrieve information on executed DDL commands in an event
  * trigger. The function manager info is initialized on extension load. */
 static FmgrInfo ddl_commands_fmgrinfo;
+static FmgrInfo dropped_objects_fmgrinfo;
 
 /*
  * Get a list of executed DDL commands in an event trigger.
@@ -63,11 +69,145 @@ event_trigger_ddl_commands(void)
 	return objects;
 }
 
+/* Given a TEXT[] of addrnames return a list of heap allocated char *
+ *
+ * similar to textarray_to_strvaluelist */
+static List *
+extract_addrnames(ArrayType *arr)
+{
+	Datum	   *elems;
+	bool	   *nulls;
+	int			nelems;
+	List	   *list = NIL;
+	int			i;
+
+	deconstruct_array(arr, TEXTOID, -1, false, 'i',
+					  &elems, &nulls, &nelems);
+
+	for (i = 0; i < nelems; i++)
+	{
+		if (nulls[i])
+			elog(ERROR, "unexpected null in name list");
+
+		/* TextDatumGetCString heap allocates the string */
+		list = lappend(list, TextDatumGetCString(elems[i]));
+	}
+
+	return list;
+}
+
+static EventTriggerDropTableConstraint *
+makeEventTriggerDropTableConstraint(char *constraint_name, char *schema, char *table)
+{
+	EventTriggerDropTableConstraint *obj = palloc(sizeof(EventTriggerDropTableConstraint));
+
+	*obj = (EventTriggerDropTableConstraint)
+	{
+		.obj =
+		{
+			.type = EVENT_TRIGGER_DROP_TABLE_CONSTRAINT
+		},
+			.constraint_name = constraint_name,
+			.schema = schema,
+			.table = table
+	};
+
+	return obj;
+}
+
+static EventTriggerDropIndex *
+makeEventTriggerDropIndex(char *index_name, char *schema)
+{
+	EventTriggerDropIndex *obj = palloc(sizeof(EventTriggerDropIndex));
+
+	*obj = (EventTriggerDropIndex)
+	{
+		.obj =
+		{
+			.type = EVENT_TRIGGER_DROP_INDEX
+		},
+			.index_name = index_name,
+			.schema = schema,
+	};
+	return obj;
+}
+
+List *
+event_trigger_dropped_objects(void)
+{
+	ReturnSetInfo rsinfo;
+	FunctionCallInfoData fcinfo;
+	TupleTableSlot *slot;
+	EState	   *estate = CreateExecutorState();
+	List	   *objects = NIL;
+
+	InitFunctionCallInfoData(fcinfo, &dropped_objects_fmgrinfo, 0, InvalidOid, NULL, NULL);
+	MemSet(&rsinfo, 0, sizeof(rsinfo));
+	rsinfo.type = T_ReturnSetInfo;
+	rsinfo.allowedModes = SFRM_Materialize;
+	rsinfo.econtext = CreateExprContext(estate);
+	fcinfo.resultinfo = (fmNodePtr) &rsinfo;
+
+	FunctionCallInvoke(&fcinfo);
+
+	slot = MakeSingleTupleTableSlot(rsinfo.setDesc);
+
+	while (tuplestore_gettupleslot(rsinfo.setResult, true, false, slot))
+	{
+		HeapTuple	tuple = ExecFetchSlotTuple(slot);
+		Datum		values[DROPPED_OBJECTS_NATTS];
+		bool		nulls[DROPPED_OBJECTS_NATTS];
+		Oid			class_id;
+		char	   *objtype;
+
+		heap_deform_tuple(tuple, rsinfo.setDesc, values, nulls);
+
+		class_id = DatumGetObjectId(values[0]);
+
+		switch (class_id)
+		{
+			case ConstraintRelationId:
+				objtype = TextDatumGetCString(values[6]);
+				if (objtype != NULL && strcmp(objtype, "table constraint") == 0)
+				{
+					List	   *addrnames = extract_addrnames(DatumGetArrayTypeP(values[10]));
+
+					objects = lappend(objects,
+									  makeEventTriggerDropTableConstraint(lthird(addrnames),
+																		  linitial(addrnames),
+																		  lsecond(addrnames)));
+				}
+				break;
+			case RelationRelationId:
+				objtype = TextDatumGetCString(values[6]);
+				if (objtype != NULL && strcmp(objtype, "index") == 0)
+				{
+					List	   *addrnames = extract_addrnames(DatumGetArrayTypeP(values[10]));
+
+					objects = lappend(objects,
+									  makeEventTriggerDropIndex(lsecond(addrnames),
+																linitial(addrnames)));
+				}
+				break;
+			default:
+				break;
+		}
+	}
+
+	FreeExprContext(rsinfo.econtext, false);
+	FreeExecutorState(estate);
+	ExecDropSingleTupleTableSlot(slot);
+
+	return objects;
+}
+
 void
 _event_trigger_init(void)
 {
 	fmgr_info(fmgr_internal_function("pg_event_trigger_ddl_commands"),
 			  &ddl_commands_fmgrinfo);
+	fmgr_info(fmgr_internal_function("pg_event_trigger_dropped_objects"),
+			  &dropped_objects_fmgrinfo);
 }
 
 void

--- a/src/event_trigger.h
+++ b/src/event_trigger.h
@@ -4,6 +4,33 @@
 #include <postgres.h>
 #include <nodes/pg_list.h>
 
+typedef enum EventTriggerDropType
+{
+	EVENT_TRIGGER_DROP_TABLE_CONSTRAINT,
+	EVENT_TRIGGER_DROP_INDEX,
+} EventTriggerDropType;
+
+typedef struct EventTriggerDropObject
+{
+	EventTriggerDropType type;
+} EventTriggerDropObject;
+
+typedef struct EventTriggerDropTableConstraint
+{
+	EventTriggerDropObject obj;
+	char	   *constraint_name;
+	char	   *schema;
+	char	   *table;
+} EventTriggerDropTableConstraint;
+
+typedef struct EventTriggerDropIndex
+{
+	EventTriggerDropObject obj;
+	char	   *index_name;
+	char	   *schema;
+} EventTriggerDropIndex;
+
+extern List *event_trigger_dropped_objects(void);
 extern List *event_trigger_ddl_commands(void);
 extern void _event_trigger_init(void);
 extern void _event_trigger_fini(void);

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -23,6 +23,8 @@ typedef struct Hypertable
 
 
 extern Oid	rel_get_owner(Oid relid);
+extern Hypertable *hypertable_get_by_id(int32 hypertable_id);
+extern Hypertable *hypertable_get_by_name(char *schema, char *name);
 extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
 extern Oid	hypertable_permissions_check(Oid hypertable_oid, Oid userid);
 extern Hypertable *hypertable_from_tuple(HeapTuple tuple);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -154,10 +154,16 @@ scanner_scan(ScannerCtx *ctx)
 {
 	TupleDesc	tuple_desc;
 	bool		is_valid;
-	Scanner    *scanner = &scanners[ctx->scantype];
+	Scanner    *scanner;
+
 	InternalScannerCtx ictx = {
 		.sctx = ctx,
 	};
+
+	if (OidIsValid(ctx->index))
+		scanner = &scanners[ScannerTypeIndex];
+	else
+		scanner = &scanners[ScannerTypeHeap];
 
 	scanner->openheap(&ictx);
 	scanner->beginscan(&ictx);

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -11,7 +11,7 @@ typedef enum ScannerType
 {
 	ScannerTypeHeap,
 	ScannerTypeIndex,
-} ScannerType;
+}			ScannerType;
 
 /* Tuple information passed on to handlers when scanning for tuples. */
 typedef struct TupleInfo
@@ -32,12 +32,12 @@ typedef struct TupleInfo
 } TupleInfo;
 
 typedef bool (*tuple_found_func) (TupleInfo *ti, void *data);
+typedef bool (*tuple_filter_func) (TupleInfo *ti, void *data);
 
 typedef struct ScannerCtx
 {
 	Oid			table;
 	Oid			index;
-	ScannerType scantype;
 	ScanKey		scankey;
 	int			nkeys,
 				norderbys,

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -106,8 +106,6 @@ tablespace_tuple_found(TupleInfo *ti, void *data)
 	return true;
 }
 
-#define NO_INDEX -1
-
 static int
 tablespace_scan_internal(int indexid,
 						 ScanKeyData *scankey,
@@ -121,8 +119,7 @@ tablespace_scan_internal(int indexid,
 	Catalog    *catalog = catalog_get();
 	ScannerCtx	scanctx = {
 		.table = catalog->tables[TABLESPACE].id,
-		.index = (indexid == NO_INDEX) ? 0 : catalog->tables[TABLESPACE].index_ids[indexid],
-		.scantype = (indexid == NO_INDEX) ? ScannerTypeHeap : ScannerTypeIndex,
+		.index = CATALOG_INDEX(catalog, TABLESPACE, indexid),
 		.nkeys = nkeys,
 		.scankey = scankey,
 		.tuple_found = tuple_found,
@@ -180,7 +177,7 @@ tablespace_scan_by_name(const char *tspcname, tuple_found_func tuple_found, void
 					BTEqualStrategyNumber, F_NAMEEQ,
 					DirectFunctionCall1(namein, CStringGetDatum(tspcname)));
 
-	return tablespace_scan_internal(NO_INDEX,
+	return tablespace_scan_internal(INVALID_INDEXID,
 									scankey,
 									nkeys,
 									tuple_found,
@@ -433,7 +430,7 @@ tablespace_delete_from_all(const char *tspcname, Oid userid)
 				BTEqualStrategyNumber, F_NAMEEQ,
 				DirectFunctionCall1(namein, CStringGetDatum(tspcname)));
 
-	num_deleted = tablespace_scan_internal(NO_INDEX,
+	num_deleted = tablespace_scan_internal(INVALID_INDEXID,
 										   scankey,
 										   1,
 										   tablespace_tuple_delete,

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -407,13 +407,12 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
         5 | _hyper_3_5_chunk_Hypertable_1_time_Device_id_idx          |             3 | Hypertable_1_time_Device_id_idx
         5 | _hyper_3_5_chunk_Hypertable_1_time_idx                    |             3 | Hypertable_1_time_idx
         5 | _hyper_3_5_chunk_Hypertable_1_Device_id_time_idx          |             3 | Hypertable_1_Device_id_time_idx
-        5 | _hyper_3_5_chunk_Hypertable_1_time_temp_c_idx             |             3 | Hypertable_1_time_temp_c_idx
         5 | _hyper_3_5_chunk_Unique1                                  |             3 | Unique1
         6 | _hyper_4_6_chunk_Hypertable_1_time_Device_id_idx          |             4 | Hypertable_1_time_Device_id_idx
         6 | _hyper_4_6_chunk_Hypertable_1_time_idx                    |             4 | Hypertable_1_time_idx
         6 | _hyper_4_6_chunk_Unique1                                  |             4 | Unique1
         5 | _hyper_3_5_chunk_ind_humdity2                             |             3 | ind_humdity2
-(28 rows)
+(27 rows)
 
 --create column with same name as previously renamed one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 131;

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -63,6 +63,14 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
         5 |                    | 5_2_hyper_unique_with_looooooooooooooooooooooooooooooooooo_time | hyper_unique_with_looooooooooooooooooooooooooooooooooo_time_key
 (5 rows)
 
+SELECT * FROM _timescaledb_catalog.chunk_index;
+ chunk_id |                           index_name                            | hypertable_id |                      hypertable_index_name                      
+----------+-----------------------------------------------------------------+---------------+-----------------------------------------------------------------
+        3 | _hyper_1_3_chunk_hyper_time_idx                                 |             1 | hyper_time_idx
+        4 | 4_1_hyper_unique_with_looooooooooooooooooooooooooooooooooo_time |             2 | hyper_unique_with_looooooooooooooooooooooooooooooooooo_time_key
+        5 | 5_2_hyper_unique_with_looooooooooooooooooooooooooooooooooo_time |             2 | hyper_unique_with_looooooooooooooooooooooooooooooooooo_time_key
+(3 rows)
+
 SELECT * FROM test.show_constraints('hyper');
       Constraint      | Type |  Columns   | Index |            Expr            
 ----------------------+------+------------+-------+----------------------------
@@ -94,6 +102,13 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
         4 |                  4 | constraint_4    | 
         5 |                  5 | constraint_5    | 
 (3 rows)
+
+-- The index should also have been removed
+SELECT * FROM _timescaledb_catalog.chunk_index;
+ chunk_id |           index_name            | hypertable_id | hypertable_index_name 
+----------+---------------------------------+---------------+-----------------------
+        3 | _hyper_1_3_chunk_hyper_time_idx |             1 | hyper_time_idx
+(1 row)
 
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_2_4_chunk');
                            Constraint                            | Type |  Columns   | Index |                                           Expr                                           
@@ -371,6 +386,72 @@ INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
 (1257987700000000002, 'dev3', 11);
 ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_22_hyper_fk_device_id_fkey"
 \set ON_ERROR_STOP 1
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_4_8_chunk');
+          Constraint          | Type |   Columns   |                   Index                    |                                           Expr                                           
+------------------------------+------+-------------+--------------------------------------------+------------------------------------------------------------------------------------------
+ 8_20_hyper_fk_pkey           | p    | {time}      | _timescaledb_internal."8_20_hyper_fk_pkey" | 
+ 8_22_hyper_fk_device_id_fkey | f    | {device_id} | devices_pkey                               | 
+ constraint_8                 | c    | {time}      | -                                          | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint))
+ hyper_fk_sensor_1_check      | c    | {sensor_1}  | -                                          | (sensor_1 > (10)::numeric)
+(4 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk_constraint;
+ chunk_id | dimension_slice_id |       constraint_name        | hypertable_constraint_name 
+----------+--------------------+------------------------------+----------------------------
+        3 |                  3 | constraint_3                 | 
+        4 |                  4 | constraint_4                 | 
+        5 |                  5 | constraint_5                 | 
+        4 |                    | 4_10_new_name2               | new_name2
+        5 |                    | 5_11_new_name2               | new_name2
+        6 |                  6 | constraint_6                 | 
+        6 |                    | 6_16_hyper_pk_pkey           | hyper_pk_pkey
+        8 |                  8 | constraint_8                 | 
+        8 |                    | 8_20_hyper_fk_pkey           | hyper_fk_pkey
+        8 |                    | 8_22_hyper_fk_device_id_fkey | hyper_fk_device_id_fkey
+(10 rows)
+
+--test CASCADE drop behavior
+DROP TABLE devices CASCADE;
+NOTICE:  drop cascades to 2 other objects
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_4_8_chunk');
+       Constraint        | Type |  Columns   |                   Index                    |                                           Expr                                           
+-------------------------+------+------------+--------------------------------------------+------------------------------------------------------------------------------------------
+ 8_20_hyper_fk_pkey      | p    | {time}     | _timescaledb_internal."8_20_hyper_fk_pkey" | 
+ constraint_8            | c    | {time}     | -                                          | (("time" >= '1257987700000000000'::bigint) AND ("time" < '1257987700000000010'::bigint))
+ hyper_fk_sensor_1_check | c    | {sensor_1} | -                                          | (sensor_1 > (10)::numeric)
+(3 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk_constraint;
+ chunk_id | dimension_slice_id |  constraint_name   | hypertable_constraint_name 
+----------+--------------------+--------------------+----------------------------
+        3 |                  3 | constraint_3       | 
+        4 |                  4 | constraint_4       | 
+        5 |                  5 | constraint_5       | 
+        4 |                    | 4_10_new_name2     | new_name2
+        5 |                    | 5_11_new_name2     | new_name2
+        6 |                  6 | constraint_6       | 
+        6 |                    | 6_16_hyper_pk_pkey | hyper_pk_pkey
+        8 |                  8 | constraint_8       | 
+        8 |                    | 8_20_hyper_fk_pkey | hyper_fk_pkey
+(9 rows)
+
+--the fk went away.
+INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
+(1257987700000000002, 'dev3', 11);
+CREATE TABLE devices(
+    device_id TEXT NOT NULL,
+    PRIMARY KEY (device_id)
+);
+INSERT INTO devices VALUES ('dev2'), ('dev3');
+ALTER TABLE hyper_fk ADD CONSTRAINT hyper_fk_device_id_fkey
+FOREIGN KEY (device_id) REFERENCES devices(device_id);
+\set ON_ERROR_STOP 0
+INSERT INTO hyper_fk(time, device_id,sensor_1) VALUES
+(1257987700000000003, 'dev4', 11);
+ERROR:  insert or update on table "_hyper_4_8_chunk" violates foreign key constraint "8_23_hyper_fk_device_id_fkey"
+\set ON_ERROR_STOP 1
+--this tests that there are no extra chunk_constraints left on hyper_fk
+TRUNCATE hyper_fk;
 ----------------------- FOREIGN KEY INTO A HYPERTABLE  ------------------
 --FOREIGN KEY references into a hypertable are currently broken.
 --The referencing table will never find the corresponding row in the hypertable
@@ -423,7 +504,7 @@ INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_24_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_25_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 ALTER TABLE hyper_ex DROP CONSTRAINT hyper_ex_time_device_id_excl;
 --can now add
@@ -436,7 +517,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
         time WITH =, device_id WITH =
     ) WHERE (not canceled)
 ;
-ERROR:  could not create exclusion constraint "9_25_hyper_ex_time_device_id_excl"
+ERROR:  could not create exclusion constraint "9_26_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_ex WHERE sensor_1 = 12;
 ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
@@ -447,7 +528,7 @@ ALTER TABLE hyper_ex ADD CONSTRAINT hyper_ex_time_device_id_excl
 \set ON_ERROR_STOP 0
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
 (1257987700000000000, 'dev2', 12);
-ERROR:  conflicting key value violates exclusion constraint "9_26_hyper_ex_time_device_id_excl"
+ERROR:  conflicting key value violates exclusion constraint "9_27_hyper_ex_time_device_id_excl"
 \set ON_ERROR_STOP 1
 --cannot add exclusion constraint without partition key.
 CREATE TABLE hyper_ex_invalid (

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -336,13 +336,12 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
         1 | _hyper_1_1_chunk_Hypertable_1_time_Device_id_idx |             1 | Hypertable_1_time_Device_id_idx
         1 | _hyper_1_1_chunk_Hypertable_1_time_idx           |             1 | Hypertable_1_time_idx
         1 | _hyper_1_1_chunk_Hypertable_1_Device_id_time_idx |             1 | Hypertable_1_Device_id_time_idx
-        1 | _hyper_1_1_chunk_Hypertable_1_time_temp_c_idx    |             1 | Hypertable_1_time_temp_c_idx
         1 | _hyper_1_1_chunk_Unique1                         |             1 | Unique1
         2 | _hyper_2_2_chunk_Hypertable_1_time_Device_id_idx |             2 | Hypertable_1_time_Device_id_idx
         2 | _hyper_2_2_chunk_Hypertable_1_time_idx           |             2 | Hypertable_1_time_idx
         2 | _hyper_2_2_chunk_Unique1                         |             2 | Unique1
         1 | _hyper_1_1_chunk_ind_humdity2                    |             1 | ind_humdity2
-(9 rows)
+(8 rows)
 
 --create column with same name as previously renamed one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 131;

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -299,13 +299,12 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
         1 | _hyper_1_1_chunk_Hypertable_1_time_Device_id_idx |             1 | Hypertable_1_time_Device_id_idx
         1 | _hyper_1_1_chunk_Hypertable_1_time_idx           |             1 | Hypertable_1_time_idx
         1 | _hyper_1_1_chunk_Hypertable_1_Device_id_time_idx |             1 | Hypertable_1_Device_id_time_idx
-        1 | _hyper_1_1_chunk_Hypertable_1_time_temp_c_idx    |             1 | Hypertable_1_time_temp_c_idx
         1 | _hyper_1_1_chunk_Unique1                         |             1 | Unique1
         2 | _hyper_2_2_chunk_Hypertable_1_time_Device_id_idx |             2 | Hypertable_1_time_Device_id_idx
         2 | _hyper_2_2_chunk_Hypertable_1_time_idx           |             2 | Hypertable_1_time_idx
         2 | _hyper_2_2_chunk_Unique1                         |             2 | Unique1
         1 | _hyper_1_1_chunk_ind_humdity2                    |             1 | ind_humdity2
-(9 rows)
+(8 rows)
 
 --create column with same name as previously renamed one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 131;

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -49,7 +49,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    94
+    95
 (1 row)
 
 SELECT * FROM test.show_columns('public."two_Partitions"');
@@ -235,7 +235,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    94
+    95
 (1 row)
 
 --main table and chunk schemas should be the same


### PR DESCRIPTION
This Fixes at least two bugs:

1) A drop of a referenced table used to drop the associated
FK constraint but not the metadata associated with the constraint.
Fixes #43.

2) A drop of a column removed any indexes associated with the column
but not the metadata associated with the index.