### PR TITLE
Migrate table data when creating a hypertable

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -12,6 +12,7 @@
 -- create_default_indexes - (Optional) Whether or not to create the default indexes
 -- if_not_exists - (Optional) Do not fail if table is already a hypertable
 -- partitioning_func - (Optional) The partitioning function to use for spatial partitioning
+-- migrate_data - (Optional) Set to true to migrate any existing data in the table to chunks
 CREATE OR REPLACE FUNCTION  create_hypertable(
     main_table              REGCLASS,
     time_column_name        NAME,
@@ -22,7 +23,8 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     chunk_time_interval     anyelement = NULL::bigint,
     create_default_indexes  BOOLEAN = TRUE,
     if_not_exists           BOOLEAN = FALSE,
-    partitioning_func       REGPROC = NULL
+    partitioning_func       REGPROC = NULL,
+    migrate_data            BOOLEAN = FALSE
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'hypertable_create' LANGUAGE C VOLATILE;
 
 -- Update chunk_time_interval for a hypertable.

--- a/sql/updates/pre-0.8.0--0.9.0-dev.sql
+++ b/sql/updates/pre-0.8.0--0.9.0-dev.sql
@@ -22,6 +22,7 @@ DROP FUNCTION add_dimension(regclass, name, integer, anyelement, regproc);
 DROP FUNCTION _timescaledb_internal.time_interval_specification_to_internal(regtype, anyelement, interval, text, boolean);
 DROP FUNCTION _timescaledb_internal.time_interval_specification_to_internal_with_default_time(regtype, anyelement, text, boolean);
 DROP FUNCTION _timescaledb_internal.create_hypertable(regclass, name, name, name, name, integer, name, name, bigint, name, boolean, regproc);
+DROP FUNCTION create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc);
 DROP FUNCTION set_chunk_time_interval(regclass, anyelement);
 
 -- Hypertable and related functions

--- a/src/copy.h
+++ b/src/copy.h
@@ -3,9 +3,13 @@
 
 #include <postgres.h>
 #include <nodes/parsenodes.h>
+#include <access/xact.h>
+#include <executor/executor.h>
+#include <commands/copy.h>
 
 typedef struct Hypertable Hypertable;
 
-Oid			timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed, Hypertable *ht);
+void		timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed, Hypertable *ht);
+void		timescaledb_copy_from_table_to_chunks(Hypertable *ht, LOCKMODE lockmode);
 
 #endif							/* TIMESCALEDB_COPY_H */

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -177,8 +177,8 @@ create_default_indexes(Hypertable *ht,
  * Default indexes are assumed to cover the first open ("time") dimension, and,
  * optionally, the first closed ("space") dimension.
  */
-void
-indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_default)
+static void
+indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_default, bool verify)
 {
 	Relation	tblrel = relation_open(ht->main_table_relid, AccessShareLock);
 	Dimension  *time_dim = hyperspace_get_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);
@@ -192,7 +192,7 @@ indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_defaul
 	{
 		Relation	idxrel = relation_open(lfirst_oid(lc), AccessShareLock);
 
-		if (idxrel->rd_index->indisunique || idxrel->rd_index->indisexclusion)
+		if (verify && (idxrel->rd_index->indisunique || idxrel->rd_index->indisexclusion))
 			indexing_verify_columns(ht->space, build_indexcolumn_list(idxrel));
 
 		/* Check for existence of "default" indexes */
@@ -225,4 +225,17 @@ indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_defaul
 		create_default_indexes(ht, time_dim, space_dim, has_time_idx, has_time_space_idx);
 
 	relation_close(tblrel, AccessShareLock);
+}
+
+void
+indexing_verify_indexes(Hypertable *ht)
+{
+	indexing_create_and_verify_hypertable_indexes(ht, false, true);
+}
+
+
+void
+indexing_create_default_indexes(Hypertable *ht)
+{
+	indexing_create_and_verify_hypertable_indexes(ht, true, false);
 }

--- a/src/indexing.h
+++ b/src/indexing.h
@@ -9,6 +9,7 @@
 
 extern void indexing_verify_columns(Hyperspace *hs, List *indexelems);
 extern void indexing_verify_index(Hyperspace *hs, IndexStmt *stmt);
-extern void indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_default);
+extern void indexing_verify_indexes(Hypertable *ht);
+extern void indexing_create_default_indexes(Hypertable *ht);
 
 #endif							/* TIMESCALEDB_INDEXING_H */

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -288,6 +288,79 @@ NOTICE:  table "test_1dim" is already a hypertable, skipping
 select create_hypertable('test_schema.test_1dim', 'time');
 ERROR:  table "test_1dim" is already a hypertable
 \set ON_ERROR_STOP 1
+--test data migration
+create table test_schema.test_migrate(time timestamp, temp float);
+insert into test_schema.test_migrate VALUES ('2004-10-19 10:23:54+02', 1.0), ('2004-12-19 10:23:54+02', 2.0);
+select * from only test_schema.test_migrate;
+           time           | temp 
+--------------------------+------
+ Tue Oct 19 10:23:54 2004 |    1
+ Sun Dec 19 10:23:54 2004 |    2
+(2 rows)
+
+\set ON_ERROR_STOP 0
+--should fail without migrate_data => true
+select create_hypertable('test_schema.test_migrate', 'time');
+ERROR:  table "test_migrate" is not empty
+\set ON_ERROR_STOP 1
+select create_hypertable('test_schema.test_migrate', 'time', migrate_data => true);
+NOTICE:  adding NOT NULL constraint to column "time"
+NOTICE:  migrating data to chunks
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+--there should be two new chunks
+select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
+ id | schema_name |  table_name  | associated_schema_name | associated_table_prefix | num_dimensions 
+----+-------------+--------------+------------------------+-------------------------+----------------
+  6 | test_schema | test_migrate | _timescaledb_internal  | _hyper_6                |              1
+(1 row)
+
+select * from _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    
+----+---------------+-----------------------+------------------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             2 | chunk_schema          | _hyper_2_2_chunk
+  3 |             5 | _timescaledb_internal | _hyper_5_3_chunk
+  4 |             6 | _timescaledb_internal | _hyper_6_4_chunk
+  5 |             6 | _timescaledb_internal | _hyper_6_5_chunk
+(5 rows)
+
+select * from test_schema.test_migrate;
+           time           | temp 
+--------------------------+------
+ Tue Oct 19 10:23:54 2004 |    1
+ Sun Dec 19 10:23:54 2004 |    2
+(2 rows)
+
+--main table should now be empty
+select * from only test_schema.test_migrate;
+ time | temp 
+------+------
+(0 rows)
+
+select * from only _timescaledb_internal._hyper_6_4_chunk;
+           time           | temp 
+--------------------------+------
+ Tue Oct 19 10:23:54 2004 |    1
+(1 row)
+
+select * from only _timescaledb_internal._hyper_6_5_chunk;
+           time           | temp 
+--------------------------+------
+ Sun Dec 19 10:23:54 2004 |    2
+(1 row)
+
+create table test_schema.test_migrate_empty(time timestamp, temp float);
+select create_hypertable('test_schema.test_migrate_empty', 'time', migrate_data => true);
+NOTICE:  adding NOT NULL constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
 -- Reset GRANTS
 \c single :ROLE_SUPERUSER
 REVOKE :ROLE_DEFAULT_PERM_USER FROM :ROLE_DEFAULT_PERM_USER_2;


### PR DESCRIPTION
Tables can now hold existing data, which is optionally migrated from
the main table to chunks when create_hypertable() is called.

The data migration is similar to the COPY path, with the single
difference that the inserted/copied tuples come from an existing table
instead of being read from a file. After the data has been migrated,
the main table is truncated.

One potential downside of this approach is that all of this happens in
a single transaction, which means that the table is blocked while
migration is ongoing, preventing inserts by other transactions.