### PR TITLE
Fix: pg_config --version shows unexpected content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,10 @@ message(STATUS "Using pg_config ${PG_CONFIG}")
 
 # Check PostgreSQL version
 execute_process(
-  COMMAND ${PG_CONFIG} --version
+  #COMMAND ${PG_CONFIG} --version
+  # Fix: If some PostgreSQL distribution returns something like PostgreSQL 10.2 (Ubuntu 10.2-1.pgdg16.04+1)
+  # Just strip distribution information out.
+  COMMAND /bin/sh -c "${PG_CONFIG} --version | grep -o -E 'PostgreSQL [0-9]*\.?[0-9]+'"
   OUTPUT_VARIABLE PG_VERSION_STRING
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ find_package(Git)
 message(STATUS "Using pg_config ${PG_CONFIG}")
 
 # Check PostgreSQL version
+if (UNIX)
 execute_process(
   #COMMAND ${PG_CONFIG} --version
   # Fix: If some PostgreSQL distribution returns something like PostgreSQL 10.2 (Ubuntu 10.2-1.pgdg16.04+1)
@@ -94,6 +95,14 @@ execute_process(
   COMMAND /bin/sh -c "${PG_CONFIG} --version | grep -o -E 'PostgreSQL [0-9]*\.?[0-9]+'"
   OUTPUT_VARIABLE PG_VERSION_STRING
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif (UNIX)
+
+if (WIN32)
+execute_process(
+  COMMAND ${PG_CONFIG} --version
+  OUTPUT_VARIABLE PG_VERSION_STRING
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif (WIN32)
 
 if (NOT ${PG_VERSION_STRING} MATCHES "^PostgreSQL[ ]+([0-9]+)\\.([0-9]+)(\\.([0-9]+))*$")
   message(FATAL_ERROR "Could not parse PostgreSQL version ${PG_VERSION}")


### PR DESCRIPTION
If some PostgreSQL distribution returns something like `PostgreSQL 10.2 (Ubuntu 10.2-1.pgdg16.04+1)`, just strip distribution information out to get rid of `Could not parse PostgreSQL version ${PG_VERSION}`.