### PR TITLE
Add ABI compatibility tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,17 @@ jobs:
       script:
         - PGTEST_TMPDIR=/tmp/ bash -x ./scripts/test_updates_all.sh
 
+    - if: type = cron
+      stage: test
+      script:
+        # There is a breakage of ABI between 10.1->10.2 so test starting at 10.2
+        - PG_MAJOR=10 PG_MINOR_COMPILE=2 bash -x ./scripts/docker-run-abi-test.sh
+
+    - if: type = cron
+      stage: test
+      script:
+        - PG_MAJOR=9.6 PG_MINOR_COMPILE=1 bash -x ./scripts/docker-run-abi-test.sh
+
     - stage: test
       env:
         - secure: "jy4DQH2syPR2v13igCNPTr044h3H/ilbJk6FifDMxGZVrOZR0dnkBx3O7qJMQOkEQvNxKsoq41k6HCP16qcgt4+HjxhcZonz5hKIiF8IpcB9r+TIlZunNTx7HjSNFZ3WCnham4AvMEthBHgAttRUhscy39ELCNUEobKS/youi7OHLOEXXShc84yTh3aSuGR3SnDVK1diLN5ufX6tN20pc3QvLMGZmA/jmJFcIQHGilhWGwwiJ45LSLwM9slvgGKbTM/K6btVBMOUnjM0h5WqPjRjDUL2tF+iZLEIpY8lFN/MQCnj0vP/BryDdoVPZS3TDQYwYuvASevQ4sOmULnM770jFqzClq4zkeM2GhMq67aYMmXjblu/qcLeCjZL+vfjMKpBMUydK/bCb097HvdRWDEPA0zItKWX9Kd6lVf2XbJCCh0ljp5REJEyk+plJ2V12nLpOPwY6zTtzcoTxEN6wcvUJfHAdNovpp63hWTnbAbEZamIdxwyCqpzThDobeD354TeXFUaKvrUw00iAiIhGL2QvwapaCbhlwM6NQAmdU3tMy3nZpka6bRI1kjyTh7CXfdwXV98ZJSiPdUFxyIgFNI2dKiL3BI1pvFDfq3mnmi3WqzZHCaQqDKNEtUrzxC40swIJGLcLUiqc5xX37P47jNDWrNIRDs8IdbM0tS9pFM="

--- a/scripts/docker-run-abi-test.sh
+++ b/scripts/docker-run-abi-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# This script test abi-compatibility wrt timescale between minor version of postgres
+# It will compile timescale on a release version of postgres ($PG_MAJOR.PG_MINOR_COMPILE)
+# and then run that compiled .so on the latest snapshot of postgres ($PG_MAJOR branch).
+# This script will then run the regression tests on that machine. 
+#
+set -e
+
+PG_MAJOR=${PG_MAJOR:-10}
+PG_MINOR_COMPILE=${PG_MINOR_COMPILE:-2}
+
+
+SCRIPT_DIR=$(dirname $0)
+BASE_DIR=${PWD}/${SCRIPT_DIR}/..
+PG_IMAGE_TAG_COMPILE=${PG_IMAGE_TAG_COMPILE:-postgres:$PG_MAJOR.$PG_MINOR_COMPILE-alpine}
+PG_IMAGE_TAG_RUN=${PG_IMAGE_TAG_RUN:-postgres_snapshot:$PG_MAJOR-snapshot-alpine}
+CONTAINER_NAME_COMPILE=${CONTAINER_NAME_COMPILE:-pgtest_compile}
+CONTAINER_NAME_RUN=${CONTAINER_NAME_RUN:-pgtest_run}
+COMPILE_VOLUME=${COMPILE_VOLUME:-pgtest_compile}
+
+set +e
+docker rm -f $(docker ps -a -q -f name=${CONTAINER_NAME_COMPILE} 2>/dev/null) 2>/dev/null
+docker rm -f $(docker ps -a -q -f name=${CONTAINER_NAME_RUN} 2>/dev/null) 2>/dev/null
+docker volume rm $COMPILE_VOLUME
+set -e
+
+#build the snapshot image
+docker build --no-cache --build-arg major_version=$PG_MAJOR -t $PG_IMAGE_TAG_RUN -f ${SCRIPT_DIR}/docker_postgres_snapshot/Dockerfile ${SCRIPT_DIR}/docker_postgres_snapshot/
+
+create_base_container() {
+  echo "Creating container $1 for tag $2"
+  docker rm $1 2>/dev/null || true
+  # Run a Postgres container
+  docker run -u postgres -d --name $1 -v ${BASE_DIR}:/src -v ${COMPILE_VOLUME}:/compile $2
+  # Install build dependencies
+  docker exec -u root -it $1 /bin/bash -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake bison flex && mkdir -p /build/debug"
+
+  # Copy the source files to build directory
+  docker exec -u root -it $1 /bin/bash -c "cp -a /src/{src,sql,scripts,test,CMakeLists.txt,timescaledb.control.in,version.config} /build/ && cd /build/debug/ && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug && make -C /build/debug install && chown -R postgres /build/debug"
+}
+
+create_base_container $CONTAINER_NAME_COMPILE $PG_IMAGE_TAG_COMPILE
+
+docker exec -u root -it  $CONTAINER_NAME_COMPILE /bin/bash -c "cp /build/debug/src/*.so /compile && cp /build/debug/src/loader/*.so /compile"
+docker rm -f $CONTAINER_NAME_COMPILE
+
+create_base_container $CONTAINER_NAME_RUN $PG_IMAGE_TAG_RUN
+
+docker exec -u root -it $CONTAINER_NAME_RUN /bin/bash -c "cp /compile/* \`pg_config --pkglibdir\`/"
+
+# Run tests
+docker exec -u postgres -it ${CONTAINER_NAME_RUN} /bin/bash -c "make -C /build/debug installcheck TEST_INSTANCE_OPTS='--temp-instance=/tmp/pgdata --temp-config=/build/test/postgresql.conf'"
+
+if [ "$?" != "0" ]; then
+    docker exec -it ${CONTAINER_NAME_RUN} cat /build/debug/test/regression.diffs
+fi

--- a/scripts/docker_postgres_snapshot/Dockerfile
+++ b/scripts/docker_postgres_snapshot/Dockerfile
@@ -1,0 +1,114 @@
+# vim:set ft=dockerfile:
+ARG major_version=10
+FROM postgres:$major_version-alpine
+
+ARG major_version
+ENV PG_MAJOR $major_version
+
+# build latest snapshot code
+RUN set -ex \
+	\
+	&& apk add --no-cache --virtual .fetch-deps \
+		ca-certificates \
+		openssl \
+		tar \
+	\
+	&& wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/snapshot/$PG_MAJOR/postgresql-$PG_MAJOR-snapshot.tar.bz2" \
+	&& mkdir -p /usr/src/postgresql \
+	&& tar \
+		--extract \
+		--file postgresql.tar.bz2 \
+		--directory /usr/src/postgresql \
+		--strip-components 1 \
+	&& rm postgresql.tar.bz2 \
+	\
+	&& apk add --no-cache --virtual .build-deps \
+		bison \
+		coreutils \
+		dpkg-dev dpkg \
+		flex \
+		gcc \
+#		krb5-dev \
+		libc-dev \
+		libedit-dev \
+		libxml2-dev \
+		libxslt-dev \
+		make \
+#		openldap-dev \
+		openssl-dev \
+# configure: error: prove not found
+#		perl-utils \
+# configure: error: Perl module IPC::Run is required to run TAP tests
+#		perl-ipc-run \
+#		perl-dev \
+#		python-dev \
+#		python3-dev \
+#		tcl-dev \
+		util-linux-dev \
+		zlib-dev \
+	\
+	&& cd /usr/src/postgresql \
+# update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
+# see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
+	&& awk '$1 == "#define" && $2 == "DEFAULT_PGSOCKET_DIR" && $3 == "\"/tmp\"" { $3 = "\"/var/run/postgresql\""; print; next } { print }' src/include/pg_config_manual.h > src/include/pg_config_manual.h.new \
+	&& grep '/var/run/postgresql' src/include/pg_config_manual.h.new \
+	&& mv src/include/pg_config_manual.h.new src/include/pg_config_manual.h \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+# explicitly update autoconf config.guess and config.sub so they support more arches/libcs
+	&& wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb' \
+	&& wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb' \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
+	&& ./configure \
+		--build="$gnuArch" \
+# "/usr/src/postgresql/src/backend/access/common/tupconvert.c:105: undefined reference to `libintl_gettext'"
+#		--enable-nls \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+#		--enable-tap-tests \
+# skip debugging info -- we want tiny size instead
+#		--enable-debug \
+		--disable-rpath \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		\
+# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
+#		--with-krb5 \
+#		--with-gssapi \
+#		--with-ldap \
+#		--with-tcl \
+#		--with-perl \
+#		--with-python \
+#		--with-pam \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+	&& make -j "$(nproc)" world \
+	&& make install-world \
+	&& make -C contrib install \
+	\
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& apk add --no-cache --virtual .postgresql-rundeps \
+		$runDeps \
+		bash \
+		su-exec \
+# tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
+# https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
+		tzdata \
+	&& apk del .fetch-deps .build-deps \
+	&& cd / \
+	&& rm -rf \
+		/usr/src/postgresql \
+		/usr/local/share/doc \
+		/usr/local/share/man \
+	&& find /usr/local -name '*.a' -delete


### PR DESCRIPTION
Test the ABI compatibility of postgres across minor version updates
wrt timescale. Namely, compile the extension on an early minor version
of postgres and test it on the latest snapshot of the major branch.