### PR TITLE
Fix regex for version reported by pg_config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ execute_process(
   OUTPUT_VARIABLE PG_VERSION_STRING
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-if (NOT ${PG_VERSION_STRING} MATCHES "^PostgreSQL[ ]+([0-9]+)\\.([0-9]+)(\\.([0-9]+))*$")
+if (NOT ${PG_VERSION_STRING} MATCHES "^PostgreSQL[ ]+([0-9]+)\\.([0-9]+)(\\.([0-9]+))*")
   message(FATAL_ERROR "Could not parse PostgreSQL version ${PG_VERSION}")
 endif ()
 


### PR DESCRIPTION
Sometimes pg_config reports versions like `PostgreSQL 10.2 (Ubuntu
10.2-1.pgdg16.04+1)`. Thus the regex is adjusted to allow for suffixes
after the postgres version number.