### PR TITLE
Fix upgrades by removing cache invalidation triggers on ALTER EXTENSION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
     - stage: test
       script:
         - PGTEST_TMPDIR=/tmp/ bash -x ./scripts/test_updates.sh
-
     - stage: test
       env:
         - secure: "jy4DQH2syPR2v13igCNPTr044h3H/ilbJk6FifDMxGZVrOZR0dnkBx3O7qJMQOkEQvNxKsoq41k6HCP16qcgt4+HjxhcZonz5hKIiF8IpcB9r+TIlZunNTx7HjSNFZ3WCnham4AvMEthBHgAttRUhscy39ELCNUEobKS/youi7OHLOEXXShc84yTh3aSuGR3SnDVK1diLN5ufX6tN20pc3QvLMGZmA/jmJFcIQHGilhWGwwiJ45LSLwM9slvgGKbTM/K6btVBMOUnjM0h5WqPjRjDUL2tF+iZLEIpY8lFN/MQCnj0vP/BryDdoVPZS3TDQYwYuvASevQ4sOmULnM770jFqzClq4zkeM2GhMq67aYMmXjblu/qcLeCjZL+vfjMKpBMUydK/bCb097HvdRWDEPA0zItKWX9Kd6lVf2XbJCCh0ljp5REJEyk+plJ2V12nLpOPwY6zTtzcoTxEN6wcvUJfHAdNovpp63hWTnbAbEZamIdxwyCqpzThDobeD354TeXFUaKvrUw00iAiIhGL2QvwapaCbhlwM6NQAmdU3tMy3nZpka6bRI1kjyTh7CXfdwXV98ZJSiPdUFxyIgFNI2dKiL3BI1pvFDfq3mnmi3WqzZHCaQqDKNEtUrzxC40swIJGLcLUiqc5xX37P47jNDWrNIRDs8IdbM0tS9pFM="

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -119,7 +119,7 @@ docker_run timescaledb-clean-rerun ${UPDATE_TO_IMAGE}:${UPDATE_TO_TAG}
 CLEAN_VOLUME=$(docker inspect timescaledb-clean-restore --format='{{range .Mounts }}{{.Name}}{{end}}')
 UPDATE_VOLUME=$(docker inspect timescaledb-orig --format='{{range .Mounts }}{{.Name}}{{end}}')
 
-echo "Executing setup script on 0.1.0"
+echo "Executing setup script on version '${UPDATE_FROM_TAG}'"
 docker_pgscript timescaledb-orig /src/test/sql/updates/setup.sql
 docker rm -f timescaledb-orig
 


### PR DESCRIPTION
When upgrading the extension, changes to the extension's metadata
catalog will fire the cache invalidation triggers on the catalog
tables, which in turn will cause a failed load of the old extension
library. This effectively breaks extension upgrades.

To fix this issue, cache invalidation triggers are now removed by the
loader whenever an ALTER EXTENSION command is detected. The triggers
will be readded once the new version of the extension is loaded.

The cache invalidation triggers are also part of a legacy cache
invalidation strategy that effectively isn't used anymore. Instead,
cache invalidation happens as part of catalog update using the
internal catalog C API. Therefore, these triggers might be removed in
the future.