### PR TITLE
Change trigger behavior on upgrades

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -49,8 +49,7 @@ set(EXT_SQL_EXTRA_FILES
   timescaledb--0.7.1--0.8.0.sql
 )
 
-#TODO handle these manually.
-set(EXT_SQL_SPECIAL_FILES
+set(EXT_SQL_SKIPPED_FILES
     timescaledb--0.6.1--0.7.0.sql
     timescaledb--0.7.0--0.7.1.sql
 )
@@ -122,15 +121,23 @@ add_custom_target(sqlreleaseupdate ALL DEPENDS  ${CMAKE_CURRENT_BINARY_DIR}/${EX
 #replace MODULE_PATHNAME in all the intermediate update files to point to $libdir/timescaledb-current_version
 #note that intermediate update files are never installed/packaged. Rather, they are only used to build the
 #update scripts below.
-set(INTERMEDIATE_UPDATE_VERSIONED "")
-foreach(intermediate_update_file ${EXT_SQL_EXTRA_FILES})
-  set(intermediate_update_file_versioned ${intermediate_update_file}.${PROJECT_VERSION_MOD})
-  configure_file(${intermediate_update_file} ${intermediate_update_file_versioned} @ONLY)
-  list(APPEND INTERMEDIATE_UPDATE_VERSIONED ${CMAKE_CURRENT_BINARY_DIR}/${intermediate_update_file_versioned})
-endforeach(intermediate_update_file)
+version_files("${EXT_SQL_EXTRA_FILES}" INTERMEDIATE_UPDATE_VERSIONED)
+version_files("${EXT_SQL_SKIPPED_FILES}" SKIPPED_FILES_VERSIONED)
+
 
 #we expect INTERMEDIATE_UPDATE_VERSIONED to be in order. For example, it should be 1--2, 2--3.
 set(INTERMEDIATE_FILE_REGEX "${CMAKE_CURRENT_BINARY_DIR}/timescaledb--([0-9]+\\.[0-9]+\\.*[0-9]*)--([0-9]+\\.[0-9]+\\.*[0-9]*).sql.${PROJECT_VERSION_MOD}")
+
+set(SKIPPED_FILE_START "")
+set(SKIPPED_FILE_END "")
+foreach(skipped_file ${SKIPPED_FILES_VERSIONED})
+  if (NOT (${skipped_file} MATCHES ${INTERMEDIATE_FILE_REGEX}))
+    message(FATAL_ERROR "Cannot parse update file name ${skipped_file}")
+  endif ()
+  list(APPEND SKIPPED_FILE_START ${CMAKE_MATCH_1})
+  list(APPEND SKIPPED_FILE_END ${CMAKE_MATCH_2})
+endforeach(skipped_file)
+
 #build the actual update scripts for historic versions.
 set(PREVIOUS_UPDATE_SCRIPTS "")
 while(INTERMEDIATE_UPDATE_VERSIONED) #while list not empty
@@ -148,6 +155,16 @@ while(INTERMEDIATE_UPDATE_VERSIONED) #while list not empty
 
   cat_files("${UPDATE_FILES}" ${CMAKE_CURRENT_BINARY_DIR}/${PREV_UPDATE_FILE})
   list(APPEND PREVIOUS_UPDATE_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/${PREV_UPDATE_FILE})
+
+  list(FIND SKIPPED_FILE_END ${START_VERSION} skipped_index)
+  if(NOT (skipped_index EQUAL -1))
+    list(GET SKIPPED_FILE_START ${skipped_index} skipped_start)
+    list(GET SKIPPED_FILES_VERSIONED ${skipped_index} skipped_file)
+    set(SKIPPED_UPDATE_FILENAME "${PROJECT_NAME}--${skipped_start}--${PROJECT_VERSION_MOD}.sql")
+    set(SKIPPED_UPDATE_FILES ${skipped_file} ${UPDATE_FILES})
+    cat_files("${SKIPPED_UPDATE_FILES}" ${CMAKE_CURRENT_BINARY_DIR}/${SKIPPED_UPDATE_FILENAME})
+    list(APPEND PREVIOUS_UPDATE_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/${SKIPPED_UPDATE_FILENAME})
+  endif()
 
   #drop the head and start again
   list(REMOVE_AT INTERMEDIATE_UPDATE_VERSIONED 0)

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -3,8 +3,19 @@ set(EXT_SQL_UPDATE_FILE ${PROJECT_NAME}--${UPDATE_FROM_VERSION}--${PROJECT_VERSI
 set(EXT_SQL_UPDATE_PRE_FILE updates/pre-${UPDATE_FROM_VERSION}--${PROJECT_VERSION_MOD}.sql)
 set(EXT_SQL_UPDATE_POST_FILE updates/post-${UPDATE_FROM_VERSION}--${PROJECT_VERSION_MOD}.sql)
 
-set(SQL_FILES
+#These files called before anything else
+set(PRE_UPDATE_FILES
+  updates/pre-global.sql
+  #trigger functions need to go first to associate them with new .so before they are called
+  trigger_functions.sql
+)
+
+set(PRE_INSTALL_FILES
   schemas.sql
+  trigger_functions.sql
+)
+
+set(COMMON_FILES
   tables.sql
   permissions.sql
   chunk.sql
@@ -44,22 +55,24 @@ set(EXT_SQL_SPECIAL_FILES
     timescaledb--0.7.0--0.7.1.sql
 )
 
-set(EXT_SQL_UPDATE_PRE_GLOBAL_FILE updates/pre-global.sql)
-set(EXT_SQL_UPDATE_POST_GLOBAL_FILE updates/post-global.sql)
-set(UPDATE_FILE_LIST ${EXT_SQL_UPDATE_PRE_GLOBAL_FILE} ${EXT_SQL_UPDATE_PRE_FILE} ${SQL_FILES} ${EXT_SQL_UPDATE_POST_FILE}  ${EXT_SQL_UPDATE_POST_GLOBAL_FILE})
+set(SQL_FILES ${PRE_INSTALL_FILES} ${COMMON_FILES})
+set(UPDATE_FILE_LIST ${PRE_UPDATE_FILES} ${EXT_SQL_UPDATE_PRE_FILE} ${COMMON_FILES} ${EXT_SQL_UPDATE_POST_FILE})
 
 #replace MODULE PATHNAME for files making up EXT_SQL_FILE (timescaledb--version.sql) and EXT_SQL_UPDATE_FILE (timescaledb--previous_version--version.sql)
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")
-set(UPDATE_FILE_LIST_VERSIONED "")
-set(SQL_FILES_VERSIONED "")
-foreach(update_file ${UPDATE_FILE_LIST})
-  set(update_file_versioned ${update_file}.${PROJECT_VERSION_MOD})
-  configure_file(${update_file} ${update_file_versioned} @ONLY)
-  list(APPEND UPDATE_FILE_LIST_VERSIONED ${CMAKE_CURRENT_BINARY_DIR}/${update_file_versioned})
-  if (${update_file} IN_LIST SQL_FILES)
-    list(APPEND SQL_FILES_VERSIONED ${CMAKE_CURRENT_BINARY_DIR}/${update_file_versioned})
-  endif()
-endforeach(update_file)
+
+function(version_files SRC_FILE_LIST OUTPUT_FILE_LIST)
+  set(result "")
+  foreach(unversioned_file ${SRC_FILE_LIST})
+    set(versioned_file ${unversioned_file}.${PROJECT_VERSION_MOD})
+    configure_file(${unversioned_file} ${versioned_file} @ONLY)
+    list(APPEND result ${CMAKE_CURRENT_BINARY_DIR}/${versioned_file})
+  endforeach(unversioned_file)
+  set(${OUTPUT_FILE_LIST} "${result}" PARENT_SCOPE)
+endfunction()
+
+version_files("${UPDATE_FILE_LIST}" UPDATE_FILE_LIST_VERSIONED)
+version_files("${SQL_FILES}" SQL_FILES_VERSIONED)
 
 #function to concatenate all files in SRC_FILE_LIST into file OUTPUT_FILE
 function(cat_files SRC_FILE_LIST OUTPUT_FILE)

--- a/sql/cache_functions.sql
+++ b/sql/cache_functions.sql
@@ -1,8 +1,3 @@
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
-RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C STRICT;
-
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(catalog_table REGCLASS)
 RETURNS BOOLEAN AS '@MODULE_PATHNAME@', 'invalidate_relcache' LANGUAGE C STRICT;

--- a/sql/ddl_triggers.sql
+++ b/sql/ddl_triggers.sql
@@ -1,6 +1,3 @@
-CREATE OR REPLACE FUNCTION _timescaledb_internal.process_ddl_event() RETURNS event_trigger
-AS '@MODULE_PATHNAME@', 'timescaledb_process_ddl_event' LANGUAGE C;
-
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_command_end;
 --EVENT TRIGGER MUST exclude the ALTER EXTENSION tag.
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end

--- a/sql/timescaledb--0.1.0--0.2.0.sql
+++ b/sql/timescaledb--0.1.0--0.2.0.sql
@@ -1,3 +1,8 @@
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
+
 ALTER TABLE _timescaledb_catalog.hypertable ADD UNIQUE (id, schema_name);
 
 ALTER TABLE _timescaledb_catalog.hypertable_index
@@ -2241,10 +2246,6 @@ $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.2.0--0.3.0.sql
+++ b/sql/timescaledb--0.2.0--0.3.0.sql
@@ -1,3 +1,7 @@
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 -- Error codes defined in errors.h
 -- The functions in this file are just utility commands for throwing common errors.
 
@@ -2202,10 +2206,6 @@ $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.3.0--0.4.0.sql
+++ b/sql/timescaledb--0.3.0--0.4.0.sql
@@ -1,3 +1,7 @@
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 ALTER TABLE _timescaledb_catalog.dimension_slice
 DROP CONSTRAINT dimension_slice_range_start_check,
 DROP CONSTRAINT dimension_slice_range_end_check;
@@ -2243,10 +2247,6 @@ $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.4.0--0.4.1.sql
+++ b/sql/timescaledb--0.4.0--0.4.1.sql
@@ -1,3 +1,7 @@
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 -- Error codes defined in errors.h
 -- The functions in this file are just utility commands for throwing common errors.
 
@@ -2287,10 +2291,6 @@ $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.4.1--0.4.2.sql
+++ b/sql/timescaledb--0.4.1--0.4.2.sql
@@ -1,3 +1,7 @@
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 -- Error codes defined in errors.h
 -- The functions in this file are just utility commands for throwing common errors.
 
@@ -2353,10 +2357,6 @@ $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.4.2--0.5.0.sql
+++ b/sql/timescaledb--0.4.2--0.5.0.sql
@@ -1,3 +1,7 @@
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 DROP FUNCTION _timescaledb_internal.ddl_is_change_owner(pg_ddl_command);
 DROP FUNCTION _timescaledb_internal.ddl_change_owner_to(pg_ddl_command);
 
@@ -2163,10 +2167,6 @@ $BODY$;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.5.0--0.6.0.sql
+++ b/sql/timescaledb--0.5.0--0.6.0.sql
@@ -1,3 +1,7 @@
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 DROP FUNCTION public.time_bucket(INTERVAL, TIMESTAMP);
 DROP FUNCTION public.time_bucket(INTERVAL, TIMESTAMPTZ);
 DROP FUNCTION public.time_bucket(INTERVAL, DATE);
@@ -1937,10 +1941,6 @@ $BODY$
 $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.6.0--0.6.1.sql
+++ b/sql/timescaledb--0.6.0--0.6.1.sql
@@ -1,3 +1,9 @@
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C IMMUTABLE STRICT;
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 CREATE SCHEMA IF NOT EXISTS _timescaledb_catalog;
 CREATE SCHEMA IF NOT EXISTS _timescaledb_internal;
 CREATE SCHEMA IF NOT EXISTS _timescaledb_cache;
@@ -1619,8 +1625,6 @@ BEGIN
     PERFORM _timescaledb_internal.attach_tablespace(hypertable_id, tablespace);
 END
 $BODY$;
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
-AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C IMMUTABLE STRICT;
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_command_end;
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end
@@ -1880,10 +1884,6 @@ $BODY$
 $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 	AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.6.1--0.7.0.sql
+++ b/sql/timescaledb--0.6.1--0.7.0.sql
@@ -1,3 +1,10 @@
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
+
 DROP FUNCTION IF EXISTS drop_chunks(INTEGER, NAME, NAME, BOOLEAN);
 
 DROP FUNCTION _timescaledb_internal.create_chunk_constraint(integer,oid);
@@ -1751,8 +1758,6 @@ BEGIN
     PERFORM _timescaledb_internal.attach_tablespace(hypertable_id, tablespace);
 END
 $BODY$;
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
-AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_command_end;
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end
@@ -2010,10 +2015,6 @@ $BODY$
 $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
     AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.6.1--0.7.1.sql
+++ b/sql/timescaledb--0.6.1--0.7.1.sql
@@ -6,6 +6,13 @@
 -- of 0.7.0 -> 0.7.1 that does not contain the "fixup" (WITH ind AS...) because
 -- it is corrected in the first half.
 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+ RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
+
 DROP FUNCTION IF EXISTS drop_chunks(INTEGER, NAME, NAME, BOOLEAN);
 
 DROP FUNCTION _timescaledb_internal.create_chunk_constraint(integer,oid);
@@ -1760,8 +1767,6 @@ BEGIN
     PERFORM _timescaledb_internal.attach_tablespace(hypertable_id, tablespace);
 END
 $BODY$;
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
-AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_command_end;
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end
@@ -2019,10 +2024,6 @@ $BODY$
 $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
     AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
- RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(proxy_oid OID)

--- a/sql/timescaledb--0.7.0--0.7.1.sql
+++ b/sql/timescaledb--0.7.0--0.7.1.sql
@@ -1,3 +1,7 @@
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C STRICT;
 DROP FUNCTION _timescaledb_internal.create_hypertable_row(REGCLASS, NAME, NAME, NAME, NAME, INTEGER, NAME, NAME, BIGINT, NAME, REGPROC);
 DROP FUNCTION _timescaledb_internal.rename_hypertable(NAME, NAME, NAME, NAME);
 

--- a/sql/timescaledb--0.7.1--0.8.0.sql
+++ b/sql/timescaledb--0.7.1--0.8.0.sql
@@ -1,3 +1,9 @@
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C STRICT;
 DROP FUNCTION _timescaledb_cache.invalidate_relcache(oid);
 
 
@@ -1841,8 +1847,6 @@ CREATE OR REPLACE FUNCTION show_tablespaces(hypertable REGCLASS)
 $BODY$
     SELECT * FROM _timescaledb_internal.show_tablespaces(hypertable);
 $BODY$;
-CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
-AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_command_end;
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end
@@ -2069,10 +2073,6 @@ $BODY$
 $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
     AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
-RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C STRICT;
 
 -- This function is only used for debugging
 CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(catalog_table REGCLASS)

--- a/sql/trigger_functions.sql
+++ b/sql/trigger_functions.sql
@@ -1,0 +1,15 @@
+-- Make sure any trigger functions or event trigger functions defined here.
+-- This file is called first in any upgrade or install script to make sure 
+-- these functions match the new .so before they are called.
+-- All functions here should be disabled -- in c -- during upgrades.
+
+-- This function is called for any ddl event.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.process_ddl_event() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_process_ddl_event' LANGUAGE C;
+
+-- this trigger function causes an invalidation event on the table whose name is
+-- passed in as the first element.
+CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
+RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C STRICT;
+
+

--- a/sql/updates/post-global.sql
+++ b/sql/updates/post-global.sql
@@ -1,1 +1,0 @@
-ALTER EVENT TRIGGER timescaledb_ddl_command_end ENABLE;

--- a/sql/updates/pre-global.sql
+++ b/sql/updates/pre-global.sql
@@ -1,4 +1,3 @@
---Disable the event trigger during updates. Two reasons:
----1- Prevents the old extension .so being loaded during upgrade to process the event trigger.
----2- Probably the right thing to do anyway since you don't necessarly know which version of the trigger will be fired during upgrade.
-ALTER EVENT TRIGGER timescaledb_ddl_command_end DISABLE;
+--need to keep this legacy functions around for 0.9 since it's still used in 0.8, delete after 0.9
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ddl_command_end() RETURNS event_trigger
+AS '@MODULE_PATHNAME@', 'timescaledb_ddl_command_end' LANGUAGE C;


### PR DESCRIPTION
For multi-version upgrades it is necessary to change the location of
trigger functions before doing anything else in upgrade scripts.
Otherwise, it is possible to trigger an even before you change the
location of the functions, which would load the old shared library
and break the system.

This commit also fixes `/sql/timescaledb--0.8.0--0.9.0.sql` to
come from the release build.