### PR TITLE
Remove unused cache invalidation triggers

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -30,7 +30,6 @@ set(COMMON_FILES
   bookend.sql
   time_bucket.sql
   version.sql
-  cache_functions.sql
   size_utils.sql
   histogram.sql
   cache.sql

--- a/sql/cache.sql
+++ b/sql/cache.sql
@@ -14,23 +14,3 @@ CREATE TABLE IF NOT EXISTS  _timescaledb_cache.cache_inval_extension();
 -- not actually strictly needed but good for sanity as all tables should be dumped.
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_hypertable', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_extension', '');
-
-DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.hypertable;
-CREATE TRIGGER "0_cache_inval" AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON _timescaledb_catalog.hypertable
-FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_cache.invalidate_relcache_trigger();
-
-DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.chunk;
-CREATE TRIGGER "0_cache_inval" AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON _timescaledb_catalog.chunk
-FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_cache.invalidate_relcache_trigger();
-
-DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.chunk_constraint;
-CREATE TRIGGER "0_cache_inval" AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON _timescaledb_catalog.chunk_constraint
-FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_cache.invalidate_relcache_trigger();
-
-DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.dimension_slice;
-CREATE TRIGGER "0_cache_inval" AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON _timescaledb_catalog.dimension_slice
-FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_cache.invalidate_relcache_trigger();
-
-DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.dimension;
-CREATE TRIGGER "0_cache_inval" AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON _timescaledb_catalog.dimension
-FOR EACH STATEMENT EXECUTE PROCEDURE _timescaledb_cache.invalidate_relcache_trigger();

--- a/sql/cache_functions.sql
+++ b/sql/cache_functions.sql
@@ -1,4 +1,0 @@
--- This function is only used for debugging
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache(catalog_table REGCLASS)
-RETURNS BOOLEAN AS '@MODULE_PATHNAME@', 'invalidate_relcache' LANGUAGE C STRICT;
-

--- a/sql/trigger_functions.sql
+++ b/sql/trigger_functions.sql
@@ -1,15 +1,8 @@
 -- Make sure any trigger functions or event trigger functions defined here.
--- This file is called first in any upgrade or install script to make sure 
+-- This file is called first in any upgrade or install script to make sure
 -- these functions match the new .so before they are called.
 -- All functions here should be disabled -- in c -- during upgrades.
 
 -- This function is called for any ddl event.
 CREATE OR REPLACE FUNCTION _timescaledb_internal.process_ddl_event() RETURNS event_trigger
 AS '@MODULE_PATHNAME@', 'timescaledb_process_ddl_event' LANGUAGE C;
-
--- this trigger function causes an invalidation event on the table whose name is
--- passed in as the first element.
-CREATE OR REPLACE FUNCTION _timescaledb_cache.invalidate_relcache_trigger()
-RETURNS TRIGGER AS '@MODULE_PATHNAME@', 'invalidate_relcache_trigger' LANGUAGE C STRICT;
-
-

--- a/sql/updates/pre-0.8.0--0.9.0.sql
+++ b/sql/updates/pre-0.8.0--0.9.0.sql
@@ -1,3 +1,12 @@
+-- Cache invalidation functions and triggers
+DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.hypertable;
+DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.chunk;
+DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.chunk_constraint;
+DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.dimension_slice;
+DROP TRIGGER IF EXISTS "0_cache_inval" ON _timescaledb_catalog.dimension;
+DROP FUNCTION _timescaledb_cache.invalidate_relcache_trigger();
+DROP FUNCTION _timescaledb_cache.invalidate_relcache(regclass);
+
 -- Tablespace changes
 DROP FUNCTION _timescaledb_internal.select_tablespace(integer, integer[]);
 DROP FUNCTION _timescaledb_internal.select_tablespace(integer, integer);

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -37,7 +37,7 @@ typedef enum CatalogTable
 #define INVALID_INDEXID -1
 
 #define CATALOG_INDEX(catalog, tableid, indexid) \
-    (indexid == INVALID_INDEXID ? InvalidOid : (catalog)->tables[tableid].index_ids[indexid])
+	(indexid == INVALID_INDEXID ? InvalidOid : (catalog)->tables[tableid].index_ids[indexid])
 
 #define CatalogInternalCall1(func, datum1) \
 	OidFunctionCall1(catalog_get_internal_function_id(catalog_get(), func), datum1)

--- a/src/compat.c
+++ b/src/compat.c
@@ -1,5 +1,6 @@
 #include <postgres.h>
 #include <funcapi.h>
+#include <commands/trigger.h>
 
 #include "compat.h"
 #include "extension.h"
@@ -68,6 +69,31 @@ timescaledb_ddl_command_end(PG_FUNCTION_ARGS)
 	if (!extension_is_loaded())
 		PG_RETURN_NULL();
 
+	elog(ERROR, "Deprecated function should not be invoked");
+	PG_RETURN_NULL();
+}
+
+TS_FUNCTION_INFO_V1(invalidate_relcache_trigger);
+
+Datum
+invalidate_relcache_trigger(PG_FUNCTION_ARGS)
+{
+	TriggerData *trigdata = (TriggerData *) fcinfo->context;
+
+	if (!CALLED_AS_TRIGGER(fcinfo))
+		elog(ERROR, "not called by trigger manager");
+
+	if (TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
+		PG_RETURN_POINTER(trigdata->tg_newtuple);
+	else
+		PG_RETURN_POINTER(trigdata->tg_trigtuple);
+}
+
+TS_FUNCTION_INFO_V1(invalidate_relcache);
+
+Datum
+invalidate_relcache(PG_FUNCTION_ARGS)
+{
 	elog(ERROR, "Deprecated function should not be invoked");
 	PG_RETURN_NULL();
 }

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -49,7 +49,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    95
+    93
 (1 row)
 
 SELECT * FROM test.show_columns('public."two_Partitions"');
@@ -235,7 +235,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    95
+    93
 (1 row)
 
 --main table and chunk schemas should be the same


### PR DESCRIPTION
The cache invalidation triggers on our catalog tables
aren't used anymore as all modifications to catalog tables
happen using the C API, which won't invoke triggers and
has its own cache invalidation functionality.