### PR TITLE
Fix update scripts for version 0.6.1

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -122,27 +122,34 @@ set(UPDATE_SCRIPTS "")
 set(CURR_MOD_FILES "")
 
 # Now loop through the modfiles and generate the update files
-foreach(mod_file ${MOD_FILES_LIST})
+foreach(transition_mod_file ${MOD_FILES_LIST})
 
-  if (NOT (${mod_file} MATCHES ${MOD_FILE_REGEX}))
+  if (NOT (${transition_mod_file} MATCHES ${MOD_FILE_REGEX}))
     message(FATAL_ERROR "Cannot parse update file name ${mod_file}")
   endif ()
 
   set(START_VERSION ${CMAKE_MATCH_1})
   set(END_VERSION ${CMAKE_MATCH_2})
+  set(PRE_FILES ${PRE_UPDATE_FILES_VERSIONED})
+
+  # Check for version-specific update code with fixes
+  if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/updates/${START_VERSION}.sql)
+    version_files("updates/${START_VERSION}.sql" ORIGIN_MOD_FILE)
+    list(APPEND PRE_FILES ${ORIGIN_MOD_FILE})
+  endif ()
 
   # There might not have been any changes in the modfile, in which
   # case the modfile need not be present
-  if (EXISTS ${mod_file})
-    # Prepend the modfile as we are moving throught the version in
+  if (EXISTS ${transition_mod_file})
+    # Prepend the modfile as we are moving through the versions in
     # descending order
-    list(INSERT CURR_MOD_FILES 0 ${mod_file})
+    list(INSERT CURR_MOD_FILES 0 ${transition_mod_file})
   endif ()
 
   set(UPDATE_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/timescaledb--${START_VERSION}--${PROJECT_VERSION_MOD}.sql)
-  cat_files("${PRE_UPDATE_FILES_VERSIONED};${CURR_MOD_FILES};${SOURCE_FILES_VERSIONED}" ${UPDATE_SCRIPT})
   list(APPEND UPDATE_SCRIPTS ${UPDATE_SCRIPT})
-endforeach(mod_file)
+  cat_files("${PRE_FILES};${CURR_MOD_FILES};${SOURCE_FILES_VERSIONED}" ${UPDATE_SCRIPT})
+endforeach(transition_mod_file)
 
 add_custom_target(sqlupdatescripts ALL DEPENDS ${UPDATE_SCRIPTS})
 

--- a/sql/updates/0.6.1--0.7.0.sql
+++ b/sql/updates/0.6.1--0.7.0.sql
@@ -13,6 +13,7 @@ INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = 
 INNER JOIN pg_constraint pg_chunk_con ON (
         pg_chunk_con.conrelid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass
         AND pg_chunk_con.conname = chunk_con.constraint_name
+        AND pg_chunk_con.contype != 'f'
 )
 INNER JOIN pg_class pg_chunk_index_class ON (
     pg_chunk_con.conindid = pg_chunk_index_class.oid

--- a/sql/updates/0.7.0--0.7.1.sql
+++ b/sql/updates/0.7.0--0.7.1.sql
@@ -3,22 +3,3 @@ DROP FUNCTION IF EXISTS _timescaledb_internal.rename_hypertable(NAME, NAME, NAME
 
 DROP FUNCTION IF EXISTS drop_chunks(bigint,name,name,boolean);
 DROP FUNCTION IF EXISTS drop_chunks(timestamptz,name,name,boolean);
-
-WITH ind AS (
-    SELECT chunk_con.chunk_id, pg_chunk_index_class.relname AS index_name
-FROM _timescaledb_catalog.chunk_constraint chunk_con
-INNER JOIN _timescaledb_catalog.chunk chunk ON (chunk_con.chunk_id = chunk.id)
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-INNER JOIN pg_constraint pg_chunk_con ON (
-        pg_chunk_con.conrelid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass
-        AND pg_chunk_con.conname = chunk_con.constraint_name
-        AND pg_chunk_con.contype = 'f'
-)
-INNER JOIN pg_class pg_chunk_index_class ON (
-    pg_chunk_con.conindid = pg_chunk_index_class.oid
-)
-)
-DELETE
-FROM _timescaledb_catalog.chunk_index ci
-USING ind
-WHERE ci.chunk_id = ind.chunk_id AND ci.index_name = ind.index_name;

--- a/sql/updates/0.7.0.sql
+++ b/sql/updates/0.7.0.sql
@@ -1,0 +1,19 @@
+-- Fix for potentially broken 0.6.1--0.7.0 update
+WITH ind AS (
+    SELECT chunk_con.chunk_id, pg_chunk_index_class.relname AS index_name
+FROM _timescaledb_catalog.chunk_constraint chunk_con
+INNER JOIN _timescaledb_catalog.chunk chunk ON (chunk_con.chunk_id = chunk.id)
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+INNER JOIN pg_constraint pg_chunk_con ON (
+        pg_chunk_con.conrelid = format('%I.%I', chunk.schema_name, chunk.table_name)::regclass
+        AND pg_chunk_con.conname = chunk_con.constraint_name
+        AND pg_chunk_con.contype = 'f'
+)
+INNER JOIN pg_class pg_chunk_index_class ON (
+    pg_chunk_con.conindid = pg_chunk_index_class.oid
+)
+)
+DELETE
+FROM _timescaledb_catalog.chunk_index ci
+USING ind
+WHERE ci.chunk_id = ind.chunk_id AND ci.index_name = ind.index_name;

--- a/sql/updates/README.md
+++ b/sql/updates/README.md
@@ -1,22 +1,35 @@
 ## Extension updates
 
-This directory contains SQL files (modfiles) with idempotent
-modifications that happen when updating from one version to another.
+This directory contains "modfiles" (SQL scripts) with modifications
+that are applied when updating from one version of the extension to
+another.
 
 The actual update scripts are compiled from modfiles by concatenating
-them with the current source code. Modfiles should always be
-first. Update scripts can "jump" several versions by using multiple
-modfiles in order.
+them with the current source code (which should come at the end of the
+resulting update script). Update scripts can "jump" several versions
+by using multiple modfiles in order. There are two types of modfiles:
+
+* Transition modfiles named `<from>-<to>.sql`, where `from` and `to`
+  indicate the (adjacent) versions transitioning between. Transition
+  modfiles are concatenated to form the lineage from an origin version
+  to any later version.
+* Origin modfiles named <version>.sql, which are included only in
+  update scripts that origin at the particular version given in the
+  name. So, for instance, `0.7.0.sql` is only included in the script
+  moving from `0.7.0` to the current version, but not in, e.g., the
+  update script for `0.4.0` to the current version. These files
+  typically contain fixes for bugs that are specific to the origin
+  version, but are no longer present in the transition modfiles.
 
 To ensure that this update process works, there are a few principles
-to considered.
+to consider.
 
 1. Modfiles should, in most cases, only contain `ALTER` or `DROP`
    commands that change or remove objects. In some cases,
    modifications of metadata are also necessary.
-2. DROP FUNCTION needs to be idempotent. In most cases that means
+2. `DROP FUNCTION` needs to be idempotent. In most cases that means
    commands should have an `IF NOT EXISTS` clause. The reason is that
-   some modfiles might try to, e.g., DROP functions that aren't
+   some modfiles might try to, e.g., `DROP` functions that aren't
    present because they only exist in an intermediate version of the
    database, which is skipped over.
 3. Modfiles cannot rely on objects or functions that are present in a
@@ -24,10 +37,10 @@ to considered.
    modfile should work when upgrading from any previous version of the
    extension, where those functions or objects aren't present yet.
 4. The creation of new metadata tables need to be part of modfiles,
-   similar to ALTERs of such tables. Otherwise, later modfiles cannot
-   rely on those tables being present.
+   similar to `ALTER`s of such tables. Otherwise, later modfiles
+   cannot rely on those tables being present.
 
 Note that modfiles that contain no changes need not exist as a
-file. They need, however, to be listed in the `CMakeLists.txt` file in
-the parent directory for an update script to be built for that
-version.
+file. Transition modfiles must, however, be listed in the
+`CMakeLists.txt` file in the parent directory for an update script to
+be built for that version.


### PR DESCRIPTION
A fix for updates of version 0.6.1 was lost in the previous PR that
refactored the update process. This change adds back that fix.

The build process for update scripts now also supports versioned
"origin" modfiles, which are included only in the update scripts that
origins in a particular version given by the origin modfile's
name. Origin modfiles make it possible to add fixes that should be
included only for the version upgrading from.