### PR TITLE
Do not fail add_dimension() on non-empty table with 'if_not_exists'

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -972,12 +972,6 @@ dimension_add(PG_FUNCTION_ARGS)
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(info.table_relid))));
 
-	if (hypertable_has_tuples(info.table_relid, AccessShareLock))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("hypertable \"%s\" is not empty", get_rel_name(info.table_relid)),
-				 errdetail("It is not possible to add dimensions to a non-empty hypertable")));
-
 	if ((!info.num_slices_is_set && !OidIsValid(info.interval_type)) ||
 		(info.num_slices_is_set && OidIsValid(info.interval_type)))
 		ereport(ERROR,
@@ -988,6 +982,12 @@ dimension_add(PG_FUNCTION_ARGS)
 
 	if (!info.skip)
 	{
+		if (hypertable_has_tuples(info.table_relid, AccessShareLock))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("hypertable \"%s\" is not empty", get_rel_name(info.table_relid)),
+					 errdetail("It is not possible to add dimensions to a non-empty hypertable")));
+
 		/*
 		 * Note that space->num_dimensions reflects the actual number of
 		 * dimension rows and not the num_dimensions in the hypertable catalog

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -159,7 +159,7 @@ should_load_on_create_extension(Node *utility_stmt)
 	/* disallow loading two .so from different versions */
 	ereport(ERROR,
 			(errcode(ERRCODE_DUPLICATE_OBJECT),
-             errmsg("the session already has another shared library loaded for extension \"%s\"", stmt->extname),
+			 errmsg("the session already has another shared library loaded for extension \"%s\"", stmt->extname),
 			 errdetail("The loaded version is \"%s\"", soversion),
 			 errhint("You should start a new session and execute CREATE EXTENSION as the first command")));
 	return false;

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -229,7 +229,18 @@ ERROR:  cannot specify both the number of partitions and an interval
 insert into test_schema.test_table values (123456789, 23.8, 'blue', 'type1', 'nyc', 1, 1);
 select add_dimension('test_schema.test_table', 'device_type', 2);
 ERROR:  hypertable "test_table" is not empty
+-- should fail on non-empty table with 'if_not_exists' in case the dimension does not exists
+select add_dimension('test_schema.test_table', 'device_type', 2, if_not_exists => true);
+ERROR:  hypertable "test_table" is not empty
 \set ON_ERROR_STOP 1
+-- should not fail on non-empty table with 'if_not_exists' in case the dimension exists
+select add_dimension('test_schema.test_table', 'location', 2, if_not_exists => true);
+NOTICE:  column "location" is already a dimension, skipping
+ add_dimension 
+---------------
+ 
+(1 row)
+
 --show chunks in the associated schema
 \dt "chunk_schema".*
                       List of relations

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -120,7 +120,14 @@ select add_dimension('test_schema.test_table', 'id2', number_partitions => 2, ch
 --adding a new dimension on a non-empty table should also fail
 insert into test_schema.test_table values (123456789, 23.8, 'blue', 'type1', 'nyc', 1, 1);
 select add_dimension('test_schema.test_table', 'device_type', 2);
+
+-- should fail on non-empty table with 'if_not_exists' in case the dimension does not exists
+select add_dimension('test_schema.test_table', 'device_type', 2, if_not_exists => true);
+
 \set ON_ERROR_STOP 1
+
+-- should not fail on non-empty table with 'if_not_exists' in case the dimension exists
+select add_dimension('test_schema.test_table', 'location', 2, if_not_exists => true);
 
 --show chunks in the associated schema
 \dt "chunk_schema".*


### PR DESCRIPTION
This fixes an issue with the `if_not_exists` option to add_dimension()
that caused the command to fail on a non-empty table. When this option
is set, the command should only fail if the dimension does not exists
and the table is non-empty.