### PR TITLE
Move more drops into event trigger system

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ analysis that are not present in vanilla PostgreSQL. (For example, the `time_buc
 
 TimescaleDB can be installed via a variety of ways:
 
-- Linux: [yum](https://docs.timescale.com/latest/getting-started/installation/linux/installation-yum), [apt (Ubuntu)](https://docs.timescale.com/latest/getting-started/installation/linux/installation-apt-ubuntu), [apt (Debian)](https://docs.timescale.com/latest/getting-started/installation/linux/installation-apt-debian) [Docker](https://docs.timescale.com/latest/getting-started/installation/linux/installation-docker)
+- Linux: [yum](https://docs.timescale.com/latest/getting-started/installation/linux/installation-yum), [apt (Ubuntu)](https://docs.timescale.com/latest/getting-started/installation/linux/installation-apt-ubuntu), [apt (Debian)](https://docs.timescale.com/latest/getting-started/installation/linux/installation-apt-debian), [Docker](https://docs.timescale.com/latest/getting-started/installation/linux/installation-docker)
 - MacOS: [brew](https://docs.timescale.com/latest/getting-started/installation/mac/installation-homebrew), [Docker](https://docs.timescale.com/latest/getting-started/installation/mac/installation-docker)
 - Windows: [Docker](https://docs.timescale.com/latest/getting-started/installation/windows/installation-docker)
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -75,6 +75,6 @@ extern bool chunk_exists_relid(Oid relid);
 extern void chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
 extern int	chunk_delete_by_relid(Oid chunk_oid);
 extern int	chunk_delete_by_hypertable_id(int32 hypertable_id);
-extern int	chunk_delete_by_schema_name(const char *schema_name);
+extern int	chunk_delete_by_name(const char *schema, const char *table);
 
 #endif							/* TIMESCALEDB_CHUNK_H */

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -446,11 +446,11 @@ chunk_index_create_from_stmt(IndexStmt *stmt,
 }
 
 static inline Oid
-chunk_index_get_schemaid(Form_chunk_index chunk_index)
+chunk_index_get_schemaid(Form_chunk_index chunk_index, bool missing_ok)
 {
 	Chunk	   *chunk = chunk_get_by_id(chunk_index->chunk_id, 0, true);
 
-	return get_namespace_oid(NameStr(chunk->fd.schema_name), false);
+	return get_namespace_oid(NameStr(chunk->fd.schema_name), missing_ok);
 }
 
 #define chunk_index_tuple_get_schema(tuple) \
@@ -591,7 +591,7 @@ static bool
 chunk_index_tuple_delete(TupleInfo *ti, void *data)
 {
 	FormData_chunk_index *chunk_index = (FormData_chunk_index *) GETSTRUCT(ti->tuple);
-	Oid			schemaid = chunk_index_get_schemaid(chunk_index);
+	Oid			schemaid = chunk_index_get_schemaid(chunk_index, true);
 	ChunkIndexDeleteData *cid = data;
 
 	catalog_delete(ti->scanrel, ti->tuple);
@@ -852,7 +852,7 @@ chunk_index_tuple_set_tablespace(TupleInfo *ti, void *data)
 {
 	char	   *tablespace = data;
 	FormData_chunk_index *chunk_index = (FormData_chunk_index *) GETSTRUCT(ti->tuple);
-	Oid			schemaoid = chunk_index_get_schemaid(chunk_index);
+	Oid			schemaoid = chunk_index_get_schemaid(chunk_index, false);
 	Oid			indexrelid = get_relname_relid(NameStr(chunk_index->index_name), schemaoid);
 	AlterTableCmd *cmd = makeNode(AlterTableCmd);
 	List	   *cmds = NIL;

--- a/src/event_trigger.h
+++ b/src/event_trigger.h
@@ -8,6 +8,9 @@ typedef enum EventTriggerDropType
 {
 	EVENT_TRIGGER_DROP_TABLE_CONSTRAINT,
 	EVENT_TRIGGER_DROP_INDEX,
+	EVENT_TRIGGER_DROP_TABLE,
+	EVENT_TRIGGER_DROP_SCHEMA,
+	EVENT_TRIGGER_DROP_TRIGGER
 } EventTriggerDropType;
 
 typedef struct EventTriggerDropObject
@@ -29,6 +32,27 @@ typedef struct EventTriggerDropIndex
 	char	   *index_name;
 	char	   *schema;
 } EventTriggerDropIndex;
+
+typedef struct EventTriggerDropTable
+{
+	EventTriggerDropObject obj;
+	char	   *table_name;
+	char	   *schema;
+} EventTriggerDropTable;
+
+typedef struct EventTriggerDropSchema
+{
+	EventTriggerDropObject obj;
+	char	   *schema;
+} EventTriggerDropSchema;
+
+typedef struct EventTriggerDropTrigger
+{
+	EventTriggerDropObject obj;
+	char	   *trigger_name;
+	char	   *schema;
+	char	   *table;
+} EventTriggerDropTrigger;
 
 extern List *event_trigger_dropped_objects(void);
 extern List *event_trigger_ddl_commands(void);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -301,16 +301,20 @@ hypertable_delete_by_id(int32 hypertable_id)
 
 
 int
-hypertable_delete_by_schema_name(const char *schema_name)
+hypertable_delete_by_name(const char *schema_name, const char *table_name)
 {
-	ScanKeyData scankey[1];
+	ScanKeyData scankey[2];
 
 	ScanKeyInit(&scankey[0], Anum_hypertable_name_idx_schema,
 				BTEqualStrategyNumber, F_NAMEEQ,
 				DirectFunctionCall1(namein, CStringGetDatum(schema_name)));
 
+	ScanKeyInit(&scankey[1], Anum_hypertable_name_idx_table,
+				BTEqualStrategyNumber, F_NAMEEQ,
+				DirectFunctionCall1(namein, CStringGetDatum(table_name)));
+
 	return hypertable_scan_limit_internal(scankey,
-										  1,
+										  2,
 										  HYPERTABLE_NAME_INDEX,
 										  hypertable_tuple_delete,
 										  NULL,

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -36,7 +36,7 @@ extern int	hypertable_set_name(Hypertable *ht, const char *newname);
 extern int	hypertable_set_schema(Hypertable *ht, const char *newname);
 extern int	hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
 extern int	hypertable_delete_by_id(int32 hypertable_id);
-extern int	hypertable_delete_by_schema_name(const char *schema_name);
+extern int	hypertable_delete_by_name(const char *schema_name, const char *table_name);
 extern int	hypertable_reset_associated_schema_name(const char *associated_schema);
 extern Oid	hypertable_id_to_relid(int32 hypertable_id);
 extern Chunk *hypertable_get_chunk(Hypertable *h, Point *point);

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -151,6 +151,10 @@ partitioning_info_create(const char *schema,
 	StrNCpy(pinfo->column, partcol, NAMEDATALEN);
 	pinfo->column_attnum = get_attnum(relid, pinfo->column);
 
+	/* handle the case that the attribute has been dropped */
+	if (pinfo->column_attnum == InvalidAttrNumber)
+		return NULL;
+
 	if (schema != NULL)
 		StrNCpy(pinfo->partfunc.schema, schema, NAMEDATALEN);
 

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -1,0 +1,82 @@
+\c single :ROLE_SUPERUSER
+CREATE SCHEMA hypertable_schema;
+GRANT ALL ON SCHEMA hypertable_schema TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+CREATE TABLE hypertable_schema.default_perm_user (time timestamptz, temp float, location int);
+SELECT create_hypertable('hypertable_schema.default_perm_user', 'time', 'location', 2);
+NOTICE:  adding NOT NULL constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO hypertable_schema.default_perm_user VALUES ('2001-01-01 01:01:01', 23.3, 1);
+RESET ROLE;
+CREATE TABLE hypertable_schema.superuser (time timestamptz, temp float, location int);
+SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
+NOTICE:  adding NOT NULL constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO hypertable_schema.superuser VALUES ('2001-01-01 01:01:01', 23.3, 1);
+SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
+ id |    schema_name    |    table_name     | associated_schema_name | associated_table_prefix | num_dimensions 
+----+-------------------+-------------------+------------------------+-------------------------+----------------
+  1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2
+  2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2
+(2 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    
+----+---------------+-----------------------+------------------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk
+(2 rows)
+
+DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
+SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
+ id |    schema_name    | table_name | associated_schema_name | associated_table_prefix | num_dimensions 
+----+-------------------+------------+------------------------+-------------------------+----------------
+  2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    
+----+---------------+-----------------------+------------------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk
+(1 row)
+
+DROP TABLE  hypertable_schema.superuser;
+--everything should be cleaned up
+SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions 
+----+-------------+------------+------------------------+-------------------------+----------------
+(0 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id | schema_name | table_name 
+----+---------------+-------------+------------
+(0 rows)
+
+SELECT * FROM _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------
+(0 rows)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice;
+ id | dimension_id | range_start | range_end 
+----+--------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk_index;
+ chunk_id | index_name | hypertable_id | hypertable_index_name 
+----------+------------+---------------+-----------------------
+(0 rows)
+
+SELECT * FROM _timescaledb_catalog.chunk_constraint;
+ chunk_id | dimension_slice_id | constraint_name | hypertable_constraint_name 
+----------+--------------------+-----------------+----------------------------
+(0 rows)
+

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -44,8 +44,8 @@ RESET ROLE;
 --drop the associated schema. We drop the extra schema to show we can
 --handle multi-schema drops
 DROP SCHEMA chunk_schema1, extra_schema CASCADE;
-NOTICE:  the chunk storage schema changed to "_timescaledb_internal" for 1 hypertable
 NOTICE:  drop cascades to table chunk_schema1._hyper_1_1_chunk
+NOTICE:  the chunk storage schema changed to "_timescaledb_internal" for 1 hypertable
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 --show that the metadata for the table using the dropped schema is
 --changed. The other table is not affected.
@@ -75,7 +75,7 @@ RESET ROLE;
 --dropping the internal schema should not work
 \set ON_ERROR_STOP 0
 DROP SCHEMA _timescaledb_internal CASCADE;
-ERROR:  cannot drop the internal schema for extension "timescaledb"
+ERROR:  cannot drop schema _timescaledb_internal because extension timescaledb requires it
 \set ON_ERROR_STOP 1
 --dropping the hypertable schema should delete everything
 DROP SCHEMA hypertable_schema CASCADE;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_FILES
   ddl.sql
   delete.sql
   drop_schema.sql
+  drop_owned.sql
   drop_chunks.sql
   drop_extension.sql
   drop_hypertable.sql

--- a/test/sql/drop_owned.sql
+++ b/test/sql/drop_owned.sql
@@ -1,0 +1,32 @@
+\c single :ROLE_SUPERUSER
+CREATE SCHEMA hypertable_schema;
+GRANT ALL ON SCHEMA hypertable_schema TO :ROLE_DEFAULT_PERM_USER;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+CREATE TABLE hypertable_schema.default_perm_user (time timestamptz, temp float, location int);
+SELECT create_hypertable('hypertable_schema.default_perm_user', 'time', 'location', 2);
+INSERT INTO hypertable_schema.default_perm_user VALUES ('2001-01-01 01:01:01', 23.3, 1);
+
+
+RESET ROLE;
+CREATE TABLE hypertable_schema.superuser (time timestamptz, temp float, location int);
+SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
+INSERT INTO hypertable_schema.superuser VALUES ('2001-01-01 01:01:01', 23.3, 1);
+
+SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
+SELECT * FROM _timescaledb_catalog.chunk;
+
+DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
+
+SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
+SELECT * FROM _timescaledb_catalog.chunk;
+
+DROP TABLE  hypertable_schema.superuser;
+
+--everything should be cleaned up
+SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
+SELECT * FROM _timescaledb_catalog.chunk;
+SELECT * FROM _timescaledb_catalog.dimension;
+SELECT * FROM _timescaledb_catalog.dimension_slice;
+SELECT * FROM _timescaledb_catalog.chunk_index;
+SELECT * FROM _timescaledb_catalog.chunk_constraint;


### PR DESCRIPTION
This PR moves table, schema, and trigger drop handling into the event
trigger system. The event trigger system is a more reliable method of
intercepting object drops especially as they can CASCADE via other
object drops.

This PR also adds a test for DROP OWNED which was previously broken.