### PR TITLE
Fix Cache Pinning for Subtxns

### DIFF
--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -11,7 +11,8 @@ DECLARE
 BEGIN
     SELECT count(*) INTO cnt FROM hyper;
     RAISE WARNING 'FIRING trigger when: % level: % op: % cnt: % trigger_name %',
-          tg_when, tg_level, tg_op, cnt, tg_name;
+        tg_when, tg_level, tg_op, cnt, tg_name;
+
     IF TG_OP = 'DELETE' THEN
         RETURN OLD;
     END IF;
@@ -270,9 +271,14 @@ CREATE TABLE vehicles (
   vin_number CHAR(17),
   last_checkup TIMESTAMP
 );
+CREATE TABLE color (
+  color_id INTEGER PRIMARY KEY,
+  notes text
+);
 CREATE TABLE location (
   time TIMESTAMP NOT NULL,
   vehicle_id INTEGER REFERENCES vehicles (vehicle_id),
+  color_id INTEGER, --no reference since gonna populate a hypertable
   latitude FLOAT,
   longitude FLOAT
 );
@@ -284,27 +290,50 @@ BEGIN
     RETURN NEW;
 END
 $BODY$;
+CREATE OR REPLACE FUNCTION create_color_trigger_fn()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+    --test subtxns within triggers
+    BEGIN
+        INSERT INTO color VALUES(NEW.color_id, 'n/a');
+    EXCEPTION WHEN unique_violation THEN
+			-- Nothing to do, just continue
+	END;
+    RETURN NEW;
+END
+$BODY$;
 CREATE TRIGGER create_vehicle_trigger
     BEFORE INSERT OR UPDATE ON location
     FOR EACH ROW EXECUTE PROCEDURE create_vehicle_trigger_fn();
+CREATE TRIGGER create_color_trigger
+    BEFORE INSERT OR UPDATE ON location
+    FOR EACH ROW EXECUTE PROCEDURE create_color_trigger_fn();
 SELECT create_hypertable('location', 'time');
  create_hypertable 
 -------------------
  
 (1 row)
 
-INSERT INTO location VALUES('2017-01-01 01:02:03', 1, 40.7493226,-73.9771259);
-INSERT INTO location VALUES('2017-01-01 01:02:04', 1, 24.7493226,-73.9771259);
-INSERT INTO location VALUES('2017-01-01 01:02:03', 23, 40.7493226,-73.9771269);
-INSERT INTO location VALUES('2017-01-01 01:02:03', 53, 40.7493226,-73.9771269);
+--make color also a hypertable
+SELECT create_hypertable('color', 'color_id', chunk_time_interval=>10);
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO location VALUES('2017-01-01 01:02:03', 1, 1, 40.7493226,-73.9771259);
+INSERT INTO location VALUES('2017-01-01 01:02:04', 1, 20, 24.7493226,-73.9771259);
+INSERT INTO location VALUES('2017-01-01 01:02:03', 23, 1, 40.7493226,-73.9771269);
+INSERT INTO location VALUES('2017-01-01 01:02:03', 53, 20, 40.7493226,-73.9771269);
 UPDATE location SET vehicle_id = 52 WHERE vehicle_id = 53;
 SELECT * FROM location;
-           time           | vehicle_id |  latitude  |  longitude  
---------------------------+------------+------------+-------------
- Sun Jan 01 01:02:03 2017 |          1 | 40.7493226 | -73.9771259
- Sun Jan 01 01:02:04 2017 |          1 | 24.7493226 | -73.9771259
- Sun Jan 01 01:02:03 2017 |         23 | 40.7493226 | -73.9771269
- Sun Jan 01 01:02:03 2017 |         52 | 40.7493226 | -73.9771269
+           time           | vehicle_id | color_id |  latitude  |  longitude  
+--------------------------+------------+----------+------------+-------------
+ Sun Jan 01 01:02:03 2017 |          1 |        1 | 40.7493226 | -73.9771259
+ Sun Jan 01 01:02:04 2017 |          1 |       20 | 24.7493226 | -73.9771259
+ Sun Jan 01 01:02:03 2017 |         23 |        1 | 40.7493226 | -73.9771269
+ Sun Jan 01 01:02:03 2017 |         52 |       20 | 40.7493226 | -73.9771269
 (4 rows)
 
 SELECT * FROM vehicles;
@@ -315,4 +344,11 @@ SELECT * FROM vehicles;
          53 |            | 
          52 |            | 
 (4 rows)
+
+SELECT * FROM color;
+ color_id | notes 
+----------+-------
+        1 | n/a
+       20 | n/a
+(2 rows)
 


### PR DESCRIPTION
Previously, all Subtxn aborts released all cache pins. This is
wrong because that can release pins that are still in use by
higher-level subtxns and top-level txns. Now, we release only
pins corresponding to the appropriate subtxn. That means that we
now track the subtxn a pin was created in.