### PR TITLE
Add no preload error to versioned library.

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -45,6 +45,16 @@ static Oid	extension_proxy_oid = InvalidOid;
 
 static enum ExtensionState extstate = EXTENSION_STATE_UNKNOWN;
 
+static bool
+extension_loader_present()
+{
+	char	   *guc_value = GetConfigOptionByName(GUC_LOADER_PRESENT_NAME, NULL, true);
+
+	if (guc_value != NULL && strcmp(guc_value, "on") == 0)
+		return true;
+	return false;
+}
+
 void
 extension_check_version(const char *so_version)
 {
@@ -60,6 +70,12 @@ extension_check_version(const char *so_version)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("Mismatched timescaledb version. Shared object file %s, SQL %s", so_version, sql_version)));
+	}
+
+
+	if (!process_shared_preload_libraries_in_progress && !extension_loader_present())
+	{
+		extension_load_without_preload();
 	}
 }
 

--- a/src/extension.c
+++ b/src/extension.c
@@ -69,7 +69,7 @@ extension_check_version(const char *so_version)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("Mismatched timescaledb version. Shared object file %s, SQL %s", so_version, sql_version)));
+				 errmsg("extension \"%s\" version mismatch: shared library version %s; SQL version %s", EXTENSION_NAME, so_version, sql_version)));
 	}
 
 

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -13,9 +13,11 @@
 #include <commands/extension.h>
 #include <access/relscan.h>
 #include <catalog/pg_extension.h>
+#include <catalog/pg_authid.h>
 #include <utils/fmgroids.h>
 #include <utils/builtins.h>
 #include <utils/rel.h>
+#include <utils/guc.h>
 #include <catalog/indexing.h>
 
 #include "extension.h"
@@ -23,6 +25,8 @@
 #define EXTENSION_PROXY_TABLE "cache_inval_extension"
 #define CACHE_SCHEMA_NAME "_timescaledb_cache"
 #define MAX_SO_NAME_LEN NAMEDATALEN+NAMEDATALEN+1+1 /* extname+"-"+version */
+
+#define GUC_LOADER_PRESENT_NAME "timescaledb.loader_present"
 
 enum ExtensionState
 {
@@ -171,4 +175,57 @@ extension_current_state()
 	}
 
 	return EXTENSION_STATE_NOT_INSTALLED;
+}
+
+static void
+extension_load_without_preload()
+{
+	/* cannot use GUC variable here since extension not yet loaded */
+	char	   *allow_install_without_preload = GetConfigOptionByName("timescaledb.allow_install_without_preload", NULL, true);
+
+	if (allow_install_without_preload == NULL ||
+		strcmp(allow_install_without_preload, "on") != 0)
+	{
+		/*
+		 * These are FATAL because otherwise the loader ends up in a weird
+		 * half-loaded state after an ERROR
+		 */
+		/* Only privileged users can get the value of `config file` */
+#if PG10
+		if (is_member_of_role(GetUserId(), DEFAULT_ROLE_READ_ALL_SETTINGS))
+#else
+		if (superuser())
+#endif
+		{
+			char	   *config_file = GetConfigOptionByName("config_file", NULL, false);
+
+			ereport(FATAL,
+					(errmsg("The timescaledb library is not preloaded"),
+					 errhint("Please preload the timescaledb library via shared_preload_libraries.\n\n"
+							 "This can be done by editing the config file at: %1$s\n"
+							 "and adding 'timescaledb' to the list in the shared_preload_libraries config.\n"
+							 "	# Modify postgresql.conf:\n	shared_preload_libraries = 'timescaledb'\n\n"
+							 "Another way to do this, if not preloading other libraries, is with the command:\n"
+							 "	echo \"shared_preload_libraries = 'timescaledb'\" >> %1$s \n\n"
+							 "(Will require a database restart.)\n\n"
+							 "If you REALLY know what you are doing and would like to load the library without preloading, you can disable this check with: \n"
+							 "	SET timescaledb.allow_install_without_preload = 'on';", config_file)));
+		}
+		else
+		{
+			ereport(FATAL,
+					(errmsg("The timescaledb library is not preloaded"),
+					 errhint("Please preload the timescaledb library via shared_preload_libraries.\n\n"
+							 "This can be done by editing the postgres config file \n"
+							 "and adding 'timescaledb' to the list in the shared_preload_libraries config.\n"
+							 "	# Modify postgresql.conf:\n	shared_preload_libraries = 'timescaledb'\n\n"
+							 "Another way to do this, if not preloading other libraries, is with the command:\n"
+							 "	echo \"shared_preload_libraries = 'timescaledb'\" >> /path/to/config/file \n\n"
+							 "(Will require a database restart.)\n\n"
+							 "If you REALLY know what you are doing and would like to load the library without preloading, you can disable this check with: \n"
+							 "	SET timescaledb.allow_install_without_preload = 'on';")));
+		}
+
+		return;
+	}
 }

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -101,7 +101,7 @@ extension_version(void)
 
 	if (sql_version == NULL)
 	{
-		elog(ERROR, "Extension not found when getting version");
+		elog(ERROR, "extension not found while getting version");
 	}
 	return sql_version;
 }
@@ -136,7 +136,7 @@ extension_is_transitioning()
 		char	   *current_extension_name = get_extension_name(CurrentExtensionObject);
 
 		if (NULL == current_extension_name)
-			elog(ERROR, "Unknown current extension while creating");
+			elog(ERROR, "current extension name is missing");
 
 		if (strcmp(EXTENSION_NAME, current_extension_name) == 0)
 			return true;
@@ -200,7 +200,7 @@ extension_load_without_preload()
 			char	   *config_file = GetConfigOptionByName("config_file", NULL, false);
 
 			ereport(FATAL,
-					(errmsg("The timescaledb library is not preloaded"),
+					(errmsg("extension \"%s\" must be preloaded", EXTENSION_NAME),
 					 errhint("Please preload the timescaledb library via shared_preload_libraries.\n\n"
 							 "This can be done by editing the config file at: %1$s\n"
 							 "and adding 'timescaledb' to the list in the shared_preload_libraries config.\n"
@@ -214,7 +214,7 @@ extension_load_without_preload()
 		else
 		{
 			ereport(FATAL,
-					(errmsg("The timescaledb library is not preloaded"),
+					(errmsg("extension \"%s\" must be preloaded", EXTENSION_NAME),
 					 errhint("Please preload the timescaledb library via shared_preload_libraries.\n\n"
 							 "This can be done by editing the postgres config file \n"
 							 "and adding 'timescaledb' to the list in the shared_preload_libraries config.\n"

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -212,33 +212,21 @@ post_analyze_hook(ParseState *pstate, Query *query)
 	}
 }
 
+static void
+extension_mark_loader_present()
+{
+	SetConfigOption(GUC_LOADER_PRESENT_NAME, "on", PGC_USERSET, PGC_S_SESSION);
+}
+
 void
 _PG_init(void)
 {
 	if (!process_shared_preload_libraries_in_progress)
 	{
-		/* cannot use GUC variable here since extension not yet loaded */
-		char	   *allow_install_without_preload = GetConfigOptionByName("timescaledb.allow_install_without_preload", NULL, true);
-
-		if (allow_install_without_preload == NULL ||
-			strcmp(allow_install_without_preload, "on") != 0)
-		{
-			char	   *config_file = GetConfigOptionByName("config_file", NULL, false);
-
-			ereport(ERROR,
-					(errmsg("The timescaledb library is not preloaded"),
-					 errhint("Please preload the timescaledb library via shared_preload_libraries.\n\n"
-							 "This can be done by editing the config file at: %1$s\n"
-							 "and adding 'timescaledb' to the list in the shared_preload_libraries config.\n"
-							 "	# Modify postgresql.conf:\n	shared_preload_libraries = 'timescaledb'\n\n"
-							 "Another way to do this, if not preloading other libraries, is with the command:\n"
-							 "	echo \"shared_preload_libraries = 'timescaledb'\" >> %1$s \n\n"
-							 "(Will require a database restart.)\n\n"
-							 "If you REALLY know what you are doing and would like to load the library without preloading, you can disable this check with: \n"
-							 "	SET timescaledb.allow_install_without_preload = 'on';", config_file)));
-			return;
-		}
+		extension_load_without_preload();
 	}
+	extension_mark_loader_present();
+
 	elog(INFO, "timescaledb loaded");
 
 	/* This is a safety-valve variable to prevent loading the full extension */

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -124,8 +124,8 @@ should_load_on_alter_extension(Node *utility_stmt)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("extension \"%s\" cannot be updated after the old version has already been loaded", stmt->extname),
-				 errhint("You should start a new session and execute ALTER EXTENSION as the first command")));
-
+				 errhint("Start a new session and execute ALTER EXTENSION as the first command. "
+						 "Make sure to pass the \"-X\" flag to psql.")));
 	/* do not load the current (old) version's .so */
 	return false;
 }
@@ -159,9 +159,10 @@ should_load_on_create_extension(Node *utility_stmt)
 	/* disallow loading two .so from different versions */
 	ereport(ERROR,
 			(errcode(ERRCODE_DUPLICATE_OBJECT),
-			 errmsg("the session already has another shared library loaded for extension \"%s\"", stmt->extname),
-			 errdetail("The loaded version is \"%s\"", soversion),
-			 errhint("You should start a new session and execute CREATE EXTENSION as the first command")));
+			 errmsg("extension \"%s\" has already been loaded with another version", stmt->extname),
+			 errdetail("The loaded version is \"%s\".", soversion),
+			 errhint("Start a new session and execute CREATE EXTENSION as the first command. "
+					 "Make sure to pass the \"-X\" flag to psql.")));
 	return false;
 }
 

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -36,7 +36,7 @@ CREATE EXTENSION timescaledb;
 -- Test that calling twice generates proper error
 \set ON_ERROR_STOP 0
 CREATE EXTENSION timescaledb;
-ERROR:  the session already has another shared library loaded for extension "timescaledb"
+ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
 \c single :ROLE_DEFAULT_PERM_USER
 -- CREATE twice with IF NOT EXISTS should be OK

--- a/test/expected/loader.out
+++ b/test/expected/loader.out
@@ -43,7 +43,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 \set ON_ERROR_STOP 0
 --test that we cannot accidentally load another library version
 CREATE EXTENSION IF NOT EXISTS timescaledb VERSION 'mock-2';
-ERROR:  the session already has another shared library loaded for extension "timescaledb"
+ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
 \c single :ROLE_SUPERUSER
 --no extension
@@ -376,7 +376,7 @@ SELECT 1;
 \set ON_ERROR_STOP 0
 --mock-4 has mismatched versions, so the .so load should throw an error
 CREATE EXTENSION timescaledb VERSION 'mock-4';
-ERROR:  Mismatched timescaledb version. Shared object file mock-4-mismatch, SQL mock-4
+ERROR:  extension "timescaledb" version mismatch: shared library version mock-4-mismatch; SQL version mock-4
 \set ON_ERROR_STOP 1
 --mock-4 not installed.
 \dx
@@ -389,7 +389,7 @@ ERROR:  Mismatched timescaledb version. Shared object file mock-4-mismatch, SQL 
 \set ON_ERROR_STOP 0
 --should not allow since the errored-out mock-4 above already poisoned the well.
 CREATE EXTENSION timescaledb VERSION 'mock-5';
-ERROR:  the session already has another shared library loaded for extension "timescaledb"
+ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
 \c single_2 :ROLE_SUPERUSER
 --broken version and drop
@@ -463,7 +463,7 @@ WARNING:  mock init "mock-6"
 --This should be an error.
 SELECT mock_function();
 WARNING:  mock post_analyze_hook "mock-6"
-ERROR:  Mismatched timescaledb version. Shared object file mock-5, SQL mock-6
+ERROR:  extension "timescaledb" version mismatch: shared library version mock-5; SQL version mock-6
 \set ON_ERROR_STOP 1
 \dx
 WARNING:  mock post_analyze_hook "mock-6"
@@ -498,7 +498,7 @@ WARNING:  mock post_analyze_hook "mock-1"
 
 \set ON_ERROR_STOP 0
 CREATE EXTENSION timescaledb VERSION 'mock-2';
-ERROR:  the session already has another shared library loaded for extension "timescaledb"
+ERROR:  extension "timescaledb" has already been loaded with another version
 \set ON_ERROR_STOP 1
 \dx
                  List of installed extensions


### PR DESCRIPTION
Previously, only the loader would complain if it was dynamically
loaded after preload. This PR adds a FATAL error message if the
versioned .so is not preloaded AND the loader has not been previously
loaded. This is a common case if the user forgets to edit
shared_preload_libraries to add the loader.

This PR also fixes the error in cases when it's encountered by a
non-superuser.