### PR TITLE
Fix EXPLAIN output for ConstraintAwareAppend inside CTE

### DIFF
--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -326,10 +326,97 @@ psql:include/append.sql:130: NOTICE:  Stable function now_s() called!
                      Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
 (9 rows)
 
+--test with cte
+EXPLAIN (costs off)
+WITH data AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
+    FROM append_test
+    WHERE
+        TIME > now_s() - INTERVAL '400 day'
+    AND colorid > 0
+    GROUP BY btime
+),
+period AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime
+      FROM  GENERATE_SERIES('2017-03-22T01:01:01', '2017-08-23T01:01:01', INTERVAL '30 day') TIME
+  )
+SELECT period.btime, VALUE
+    FROM period
+    LEFT JOIN DATA USING (btime)
+    ORDER BY period.btime;
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Merge Left Join
+   Merge Cond: (period.btime = data.btime)
+   CTE data
+     ->  HashAggregate
+           Group Key: time_bucket('@ 30 days'::interval, append_test."time")
+           ->  Custom Scan (ConstraintAwareAppend)
+                 Hypertable: append_test
+                 Chunks left after exclusion: 3
+                 ->  Append
+                       ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
+                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
+                             Filter: (colorid > 0)
+                       ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
+                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
+                             Filter: (colorid > 0)
+                       ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
+                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
+                             Filter: (colorid > 0)
+   CTE period
+     ->  Function Scan on generate_series "time"
+   ->  Sort
+         Sort Key: period.btime
+         ->  CTE Scan on period
+   ->  Sort
+         Sort Key: data.btime
+         ->  CTE Scan on data
+(26 rows)
+
+WITH data AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
+    FROM append_test
+    WHERE
+        TIME > now_s() - INTERVAL '400 day'
+    AND colorid > 0
+    GROUP BY btime
+),
+period AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime
+      FROM  GENERATE_SERIES('2017-03-22T01:01:01', '2017-08-23T01:01:01', INTERVAL '30 day') TIME
+  )
+SELECT period.btime, VALUE
+    FROM period
+    LEFT JOIN DATA USING (btime)
+    ORDER BY period.btime;
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+            btime             | value 
+------------------------------+-------
+ Wed Mar 01 16:00:00 2017 PST |  22.5
+ Fri Mar 31 17:00:00 2017 PDT |      
+ Sun Apr 30 17:00:00 2017 PDT |  25.7
+ Tue May 30 17:00:00 2017 PDT |      
+ Thu Jun 29 17:00:00 2017 PDT |      
+ Sat Jul 29 17:00:00 2017 PDT |  34.1
+(6 rows)
+
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:135: NOTICE:  adding NOT NULL constraint to column "time"
+psql:include/append.sql:172: NOTICE:  adding NOT NULL constraint to column "time"
  create_hypertable 
 -------------------
  
@@ -347,16 +434,16 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Nested Loop
@@ -382,20 +469,20 @@ psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
              time             | temp | colorid |             time             | temp | colorid 
 ------------------------------+------+---------+------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3 | Tue Aug 22 09:18:22 2017 PDT | 23.1 |       3

--- a/test/expected/append_unoptimized.out
+++ b/test/expected/append_unoptimized.out
@@ -358,10 +358,95 @@ psql:include/append.sql:130: NOTICE:  Stable function now_s() called!
                      Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
 (9 rows)
 
+--test with cte
+EXPLAIN (costs off)
+WITH data AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
+    FROM append_test
+    WHERE
+        TIME > now_s() - INTERVAL '400 day'
+    AND colorid > 0
+    GROUP BY btime
+),
+period AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime
+      FROM  GENERATE_SERIES('2017-03-22T01:01:01', '2017-08-23T01:01:01', INTERVAL '30 day') TIME
+  )
+SELECT period.btime, VALUE
+    FROM period
+    LEFT JOIN DATA USING (btime)
+    ORDER BY period.btime;
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Merge Left Join
+   Merge Cond: (period.btime = data.btime)
+   CTE data
+     ->  HashAggregate
+           Group Key: time_bucket('@ 30 days'::interval, append_test."time")
+           ->  Result
+                 ->  Append
+                       ->  Seq Scan on append_test
+                             Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+                       ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
+                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
+                             Filter: (colorid > 0)
+                       ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
+                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
+                             Filter: (colorid > 0)
+                       ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
+                             Index Cond: ("time" > (now_s() - '@ 400 days'::interval))
+                             Filter: (colorid > 0)
+   CTE period
+     ->  Function Scan on generate_series "time"
+   ->  Sort
+         Sort Key: period.btime
+         ->  CTE Scan on period
+   ->  Sort
+         Sort Key: data.btime
+         ->  CTE Scan on data
+(26 rows)
+
+WITH data AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime, AVG(temp) AS VALUE
+    FROM append_test
+    WHERE
+        TIME > now_s() - INTERVAL '400 day'
+    AND colorid > 0
+    GROUP BY btime
+),
+period AS (
+    SELECT time_bucket(INTERVAL '30 day', TIME) AS btime
+      FROM  GENERATE_SERIES('2017-03-22T01:01:01', '2017-08-23T01:01:01', INTERVAL '30 day') TIME
+  )
+SELECT period.btime, VALUE
+    FROM period
+    LEFT JOIN DATA USING (btime)
+    ORDER BY period.btime;
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+            btime             | value 
+------------------------------+-------
+ Wed Mar 01 16:00:00 2017 PST |  22.5
+ Fri Mar 31 17:00:00 2017 PDT |      
+ Sun Apr 30 17:00:00 2017 PDT |  25.7
+ Tue May 30 17:00:00 2017 PDT |      
+ Thu Jun 29 17:00:00 2017 PDT |      
+ Sat Jul 29 17:00:00 2017 PDT |  34.1
+(6 rows)
+
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:135: NOTICE:  adding NOT NULL constraint to column "time"
+psql:include/append.sql:172: NOTICE:  adding NOT NULL constraint to column "time"
  create_hypertable 
 -------------------
  
@@ -379,14 +464,14 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Nested Loop
@@ -414,20 +499,20 @@ psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
              time             | temp | colorid |             time             | temp | colorid 
 ------------------------------+------+---------+------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3 | Tue Aug 22 09:18:22 2017 PDT | 23.1 |       3

--- a/test/expected/append_x_diff.out
+++ b/test/expected/append_x_diff.out
@@ -234,15 +234,44 @@
 >                Hypertable: append_test
 >                Chunks left after exclusion: 0
 > (7 rows)
-390,391c358,361
+383,384c351,353
+<                                               QUERY PLAN                                               
+< -------------------------------------------------------------------------------------------------------
+---
+> psql:include/append.sql:149: NOTICE:  Stable function now_s() called!
+>                                                   QUERY PLAN                                                   
+> ---------------------------------------------------------------------------------------------------------------
+390c359,361
+<            ->  Result
+---
+>            ->  Custom Scan (ConstraintAwareAppend)
+>                  Hypertable: append_test
+>                  Chunks left after exclusion: 3
+392,394c363
+<                        ->  Seq Scan on append_test
+<                              Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
+<                        ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
+---
+>                        ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
+397c366
+<                        ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
+---
+>                        ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
+400c369
+<                        ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
+---
+>                        ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
+435a405
+> psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
+475,476c445,448
 <                                          QUERY PLAN                                         
 < --------------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:150: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:187: NOTICE:  Stable function now_s() called!
 >                                             QUERY PLAN                                            
 > --------------------------------------------------------------------------------------------------
-394,412c364,380
+479,497c451,467
 <    ->  Append
 <          ->  Seq Scan on append_test a
 <                Filter: ("time" > (now_s() - '@ 3 hours'::interval))


### PR DESCRIPTION
The explain output previously relied on the fact that the
estate->rtable was indexed the same way as the simple_rte_array
during planning. This is not always true when using CTEs. This
commit instead passes the oid of the hypertable to the EXPLAIN
directly.