### PR TITLE
Enable hypertable inserts within CTEs

### DIFF
--- a/src/chunk_dispatch.h
+++ b/src/chunk_dispatch.h
@@ -8,6 +8,7 @@
 #include "hypertable_cache.h"
 #include "cache.h"
 #include "subspace_store.h"
+#include "chunk_dispatch_state.h"
 
 /*
  * ChunkDispatch keeps cached state needed to dispatch tuples to chunks. It is
@@ -25,15 +26,17 @@ typedef struct ChunkDispatch
 	 * will reset the pointer in EState as we lookup new chunks.
 	 */
 	ResultRelInfo *hypertable_result_rel_info;
-	Query	   *parse;
+	OnConflictAction on_conflict;
+	List	   *arbiter_indexes;
+	CmdType		cmd_type;
 
 } ChunkDispatch;
 
 typedef struct Point Point;
 typedef struct ChunkInsertState ChunkInsertState;
 
-ChunkDispatch *chunk_dispatch_create(Hypertable *ht, EState *estate, Query *query);
+ChunkDispatch *chunk_dispatch_create(Hypertable *ht, EState *estate);
 void		chunk_dispatch_destroy(ChunkDispatch *dispatch);
-ChunkInsertState *chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *p, CmdType operation);
+ChunkInsertState *chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *p);
 
 #endif							/* TIMESCALEDB_CHUNK_DISPATCH_H */

--- a/src/chunk_dispatch_info.c
+++ b/src/chunk_dispatch_info.c
@@ -11,7 +11,6 @@ chunk_dispatch_info_copy(struct ExtensibleNode *newnode,
 	const ChunkDispatchInfo *oldinfo = (const ChunkDispatchInfo *) oldnode;
 
 	newinfo->hypertable_relid = oldinfo->hypertable_relid;
-	newinfo->parse = copyObject(oldinfo->parse);
 }
 
 static bool
@@ -21,8 +20,7 @@ chunk_dispatch_info_equal(const struct ExtensibleNode *an,
 	const ChunkDispatchInfo *a = (const ChunkDispatchInfo *) an;
 	const ChunkDispatchInfo *b = (const ChunkDispatchInfo *) bn;
 
-	return a->hypertable_relid == b->hypertable_relid &&
-		equal(a->parse, b->parse);
+	return a->hypertable_relid == b->hypertable_relid;
 }
 
 static void
@@ -32,8 +30,6 @@ chunk_dispatch_info_out(struct StringInfoData *str,
 	const ChunkDispatchInfo *info = (const ChunkDispatchInfo *) node;
 
 	appendStringInfo(str, " :hypertableOid %d", info->hypertable_relid);
-	appendStringInfo(str, " :Query ");
-	outNode(str, info->parse);
 }
 
 static void
@@ -59,8 +55,6 @@ chunk_dispatch_info_read(struct ExtensibleNode *node)
 
 	if (token == NULL)
 		elog(ERROR, "Missing Query node");
-
-	info->parse = stringToNode(token);
 }
 
 static ExtensibleNodeMethods chunk_dispatch_info_methods = {
@@ -80,7 +74,6 @@ chunk_dispatch_info_create(Oid hypertable_relid, Query *parse)
 
 	info->enode.extnodename = chunk_dispatch_info_methods.extnodename;
 	info->hypertable_relid = hypertable_relid;
-	info->parse = parse;
 	return info;
 }
 

--- a/src/chunk_dispatch_info.h
+++ b/src/chunk_dispatch_info.h
@@ -15,7 +15,6 @@ typedef struct ChunkDispatchInfo
 	ExtensibleNode enode;
 	/* Copied fields */
 	Oid			hypertable_relid;
-	Query	   *parse;
 } ChunkDispatchInfo;
 
 extern ChunkDispatchInfo *chunk_dispatch_info_create(Oid hypertable_relid, Query *parse);

--- a/src/chunk_dispatch_state.h
+++ b/src/chunk_dispatch_state.h
@@ -22,7 +22,6 @@ typedef struct ChunkDispatchState
 	 * plan node. We need these to compute and update the arbiter indexes for
 	 * each chunk we INSERT into.
 	 */
-	Query	   *parse;
 	ModifyTableState *parent;
 
 	/*
@@ -35,5 +34,8 @@ typedef struct ChunkDispatchState
 #define CHUNK_DISPATCH_STATE_NAME "ChunkDispatchState"
 
 ChunkDispatchState *chunk_dispatch_state_create(ChunkDispatchInfo *, Plan *);
+void
+			chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *parent);
+
 
 #endif							/* TIMESCALEDB_CHUNK_DISPATCH_STATE_H */

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -28,6 +28,7 @@ extern int	chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, 
 extern int	chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, const char *tablespace);
 extern void chunk_index_create_from_constraint(int32 hypertable_id, Oid hypertable_constaint, int32 chunk_id, Oid chunk_constraint);
 extern List *chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid);
+extern ChunkIndexMapping *chunk_index_get_by_hypertable_indexrelid(Chunk *chunk, Oid hypertable_indexrelid);
 extern void chunk_index_mark_clustered(Oid chunkrelid, Oid indexrelid);
 
 /* chunk_index_recreate  is a process akin to reindex

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -8,6 +8,7 @@
 #include "hypertable.h"
 #include "chunk.h"
 #include "cache.h"
+#include "chunk_dispatch_state.h"
 
 typedef struct ChunkInsertState
 {
@@ -22,7 +23,7 @@ typedef struct ChunkInsertState
 typedef struct ChunkDispatch ChunkDispatch;
 
 extern HeapTuple chunk_insert_state_convert_tuple(ChunkInsertState *state, HeapTuple tuple, TupleTableSlot **existing_slot);
-extern ChunkInsertState *chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch, CmdType operation);
+extern ChunkInsertState *chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch);
 extern void chunk_insert_state_destroy(ChunkInsertState *state);
 
 #endif							/* TIMESCALEDB_CHUNK_INSERT_STATE_H */

--- a/src/copy.c
+++ b/src/copy.c
@@ -70,7 +70,7 @@ copy_chunk_state_create(Hypertable *ht, Relation rel, CopyFromFunc from_func, vo
 	ccstate = palloc(sizeof(CopyChunkState));
 	ccstate->rel = rel;
 	ccstate->estate = estate;
-	ccstate->dispatch = chunk_dispatch_create(ht, estate, NULL);
+	ccstate->dispatch = chunk_dispatch_create(ht, estate);
 	ccstate->fromctx.data = fromctx;
 	ccstate->next_copy_from = from_func;
 
@@ -271,7 +271,7 @@ timescaledb_CopyFrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht)
 			dispatch->hypertable_result_rel_info = estate->es_result_relation_info;
 
 		/* Find or create the insert state matching the point */
-		cis = chunk_dispatch_get_chunk_insert_state(dispatch, point, CMD_INSERT);
+		cis = chunk_dispatch_get_chunk_insert_state(dispatch, point);
 
 		Assert(cis != NULL);
 

--- a/src/hypertable_insert.c
+++ b/src/hypertable_insert.c
@@ -51,7 +51,7 @@ hypertable_insert_begin(CustomScanState *node, EState *estate, int eflags)
 				{
 					ChunkDispatchState *cdstate = (ChunkDispatchState *) mtstate->mt_plans[i];
 
-					cdstate->parent = mtstate;
+					chunk_dispatch_state_set_parent(cdstate, mtstate);
 				}
 			}
 		}

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -122,3 +122,38 @@ INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'purpl
 DO UPDATE set temp = 23.5;
 ERROR:  duplicate key value violates unique constraint "_hyper_3_3_chunk_multi_time_temp_idx"
 \set ON_ERROR_STOP 1
+WITH CTE AS (
+    INSERT INTO upsert_test_multi_unique
+    VALUES ('2017-01-20T09:00:01', 25.9, 'purple')
+    ON CONFLICT DO NOTHING
+    RETURNING *
+) SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+WITH CTE AS (
+    INSERT INTO upsert_test_multi_unique
+    VALUES ('2017-01-20T09:00:01', 25.9, 'purple'),
+    ('2017-01-20T09:00:01', 29.9, 'purple1')
+    ON CONFLICT DO NOTHING
+    RETURNING *
+) SELECT * FROM CTE;
+           time           | temp |  color  
+--------------------------+------+---------
+ Fri Jan 20 09:00:01 2017 | 29.9 | purple1
+(1 row)
+
+WITH CTE AS (
+    INSERT INTO upsert_test_multi_unique
+    VALUES ('2017-01-20T09:00:01', 25.9, 'blue')
+    ON CONFLICT (time, temp) DO UPDATE SET color = 'blue'
+    RETURNING *
+)
+SELECT * FROM CTE;
+           time           | temp | color 
+--------------------------+------+-------
+ Fri Jan 20 09:00:01 2017 | 25.9 | blue
+(1 row)
+

--- a/test/sql/upsert.sql
+++ b/test/sql/upsert.sql
@@ -48,3 +48,26 @@ SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'purple') ON CONFLICT (time, color)
 DO UPDATE set temp = 23.5;
 \set ON_ERROR_STOP 1
+
+WITH CTE AS (
+    INSERT INTO upsert_test_multi_unique
+    VALUES ('2017-01-20T09:00:01', 25.9, 'purple')
+    ON CONFLICT DO NOTHING
+    RETURNING *
+) SELECT 1;
+
+WITH CTE AS (
+    INSERT INTO upsert_test_multi_unique
+    VALUES ('2017-01-20T09:00:01', 25.9, 'purple'),
+    ('2017-01-20T09:00:01', 29.9, 'purple1')
+    ON CONFLICT DO NOTHING
+    RETURNING *
+) SELECT * FROM CTE;
+
+WITH CTE AS (
+    INSERT INTO upsert_test_multi_unique
+    VALUES ('2017-01-20T09:00:01', 25.9, 'blue')
+    ON CONFLICT (time, temp) DO UPDATE SET color = 'blue'
+    RETURNING *
+)
+SELECT * FROM CTE;


### PR DESCRIPTION
Previously, the chunk dispatch node used arbiter index and other
information from the top-level Query node. This did not work with CTEs
(and probably subqueries) because the info for this insert was not at
the top-level. This commit changes the logic to use that same info from the
parent ModifyTable node (and ModifyTableState).

This commit also changes the logic to translate the arbiter indexes
from the hypertable index to the chunk index directly using our catalog
tables instead of re-inferring the index on the chunk.