### PR TITLE
Fix crash on explain analyze with insert CTE

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -198,7 +198,8 @@ timescaledb_CopyFrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht)
 	resultRelInfo = makeNode(ResultRelInfo);
 	InitResultRelInfoCompat(resultRelInfo,
 							ccstate->rel,
-							1,	/* dummy rangetable index */
+							0,	/* dummy rangetable index - original was 1
+								 * which isn't dummy-nuf */
 							0);
 
 	ExecOpenIndices(resultRelInfo, false);

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -701,3 +701,30 @@ SELECT * FROM one_space_test;
  Tue Jan 01 01:02:01 2002 |    1 | device
 (2 rows)
 
+--CTE & EXPLAIN ANALYZE TESTS
+WITH insert_cte as (
+	INSERT INTO one_space_test VALUES
+		('2001-01-01 01:02:01', 1.0, 'device')
+	RETURNING *)
+SELECT * FROM insert_cte;
+           time           | temp | device 
+--------------------------+------+--------
+ Mon Jan 01 01:02:01 2001 |    1 | device
+(1 row)
+
+EXPLAIN (analyze, costs off, timing off) --can't turn summary off in 9.6 so instead grep it away at end.
+WITH insert_cte as (
+	INSERT INTO one_space_test VALUES
+		('2001-01-01 01:03:01', 1.0, 'device')
+	)
+SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   CTE insert_cte
+     ->  Custom Scan (HypertableInsert) (never executed)
+           ->  Insert on one_space_test (actual rows=0 loops=1)
+                 ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
+                       ->  Result (actual rows=1 loops=1)
+(8 rows)
+

--- a/test/sql/insert.sql
+++ b/test/sql/insert.sql
@@ -76,3 +76,17 @@ INSERT INTO one_space_test VALUES
 ('2001-01-01 01:01:01', 1.0, 'device'),
 ('2002-01-01 01:02:01', 1.0, 'device');
 SELECT * FROM one_space_test;
+
+--CTE & EXPLAIN ANALYZE TESTS
+WITH insert_cte as (
+	INSERT INTO one_space_test VALUES
+		('2001-01-01 01:02:01', 1.0, 'device')
+	RETURNING *)
+SELECT * FROM insert_cte;
+
+EXPLAIN (analyze, costs off, timing off) --can't turn summary off in 9.6 so instead grep it away at end.
+WITH insert_cte as (
+	INSERT INTO one_space_test VALUES
+		('2001-01-01 01:03:01', 1.0, 'device')
+	)
+SELECT 1 \g | grep -v "Planning" | grep -v "Execution"


### PR DESCRIPTION
Discovered a crash when doing an explain analyze on a CTE containing an insert that
did not reference the CTE in the select statement. This fixes by copying the eref
from the parent hypertable to the chunk so that columns can be described. It will
only copy the eref from the hypertable if there is a range table entry available.

Also modify copy so it actually sets a dummy variable as the RTE index rather than 1,
which is a valid RTE index, even if there is no RTE for the hypertable.