### PR TITLE
Add median aggregate function (purely hypothetically)

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCE_FILES
   size_utils.sql
   histogram.sql
   cache.sql
+  median.sql
 )
 
 # These files should be pre-pended to update scripts so that they are

--- a/sql/median.sql
+++ b/sql/median.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION _timescaledb_internal.median_numeric_finalfunc(state INTERNAL, var NUMERIC)
+RETURNS NUMERIC
+AS '@MODULE_PATHNAME@', 'median_numeric_finalfunc'
+LANGUAGE C IMMUTABLE;
+
+-- Tell Postgres how to use the new function
+DROP AGGREGATE IF EXISTS median (NUMERIC);
+CREATE AGGREGATE median (NUMERIC)
+(
+    SFUNC = array_agg_transfn,
+    STYPE = INTERNAL,
+    FINALFUNC = _timescaledb_internal.median_numeric_finalfunc,
+    FINALFUNC_EXTRA
+);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(HEADERS
   hypertable.h
   hypertable_insert.h
   indexing.h
+  median_quickselect.h
   parse_rewrite.h
   partitioning.h
   planner_utils.h
@@ -95,6 +96,8 @@ set(SOURCES
   hypertable_insert.c
   indexing.c
   init.c
+  median.c
+  median_quickselect.c
   parse_analyze.c
   parse_rewrite.c
   partitioning.c

--- a/src/median.c
+++ b/src/median.c
@@ -1,0 +1,129 @@
+#include <postgres.h>
+
+#include "median_quickselect.h"
+
+#include <catalog/pg_type.h>
+#include <utils/array.h>
+#include <utils/numeric.h>
+#include "nodes/makefuncs.h"
+#include "utils/lsyscache.h"
+
+#include "compat.h"
+
+#include <stddef.h>
+
+/*
+ * The postgres aggregate takes advantage of existing functions for
+ * collecting array data- since the computation of the median requires seeing
+ * all rows at once, we can use the existing array_append accumulate function
+ * and simply provide a 'finalfunc' that computes the median given the
+ * complete dataset.
+ *
+ * ---------- CREATE AGGREGATE avg (float8) ( sfunc = array_append, stype =
+ * anyarray, finalfunc = median_numeric_finalfunc ); ----------
+ */
+
+/* a bare bones wrapper around an array of Numerics */
+typedef struct NumericArray {
+	Size		size;
+	Numeric	       *data;
+}		NumericArray;
+
+/*
+ * Create a NumericArray allocated using the specified 'agg_context' from the
+ * specified 'array', IGNORING any null values.
+ *
+ * This function relies on the fact that 'array' is filled with Datums that
+ * contain Numeric values. To call it with any other array is undefined
+ * behavior.
+ *
+ * On error, this function will call elog(ERROR, ...)
+ */
+static
+NumericArray pgArrayToNumericArray(ArrayType * array,
+				   MemoryContext * agg_context) {
+	Assert(array);
+	Assert(agg_context);
+
+	NumericArray	result;
+
+	int		number_of_dimensions = ARR_NDIM(array);
+	int	       *array_of_dim_lengths = ARR_DIMS(array);
+	if (number_of_dimensions != 1) {
+		elog(ERROR, "median undefined on an array column");
+	}
+	size_t		length = array_of_dim_lengths[0];
+
+	result.data = MemoryContextAllocZero(*agg_context, length * sizeof(Numeric));
+
+	int		slice_ndim = 0;	/* iterate item by item */
+	ArrayMetaState *meta_state = NULL;
+	ArrayIterator	iterator
+	= array_create_iterator(array, slice_ndim, meta_state);
+
+	/* iterate through array */
+	Datum		value;
+	bool		is_null;
+	int		i = 0;
+	size_t		actual_length = 0;
+	while (array_iterate(iterator, &value, &is_null)) {
+		result.data[i] = DatumGetNumeric(value);
+		++actual_length;
+		++i;
+	}
+	array_free_iterator(iterator);
+
+	result.size = actual_length;
+
+	return result;
+}
+
+/*
+ * The final function for the median aggregate, specialized for Numeric
+ * values. Takes as an argument an ArrayType of Numeric values, returning the
+ * median.
+ *
+ * Unpacks the array into a c-style array, taking O(N) extra space.
+ *
+ * Uses the Quickselect algorithm, taking O(N) on average, O(N^2) in the
+ * worst case.
+ */
+TS_FUNCTION_INFO_V1(median_numeric_finalfunc);
+Datum
+median_numeric_finalfunc(PG_FUNCTION_ARGS)
+{
+	MemoryContext	agg_context;
+	ArrayBuildState *state = NULL;
+	Datum		array_datum;
+	NumericArray	numeric_array = {0};
+	ArrayType      *array;
+
+	Numeric		result = {0};
+
+	if (!AggCheckCallContext(fcinfo, &agg_context)) {
+		elog(ERROR, "timescale median_numeric_finalfunc called "
+		     "in non-aggregate context");
+	}
+
+	if (PG_ARGISNULL(0)) {
+		PG_RETURN_NULL();
+	}
+
+	state = (ArrayBuildState *) PG_GETARG_POINTER(0);
+
+	if (state == NULL) {
+		PG_RETURN_NULL();
+	}
+
+	array_datum = makeArrayResult(state, agg_context);
+	array = DatumGetArrayTypeP(array_datum);
+	numeric_array = pgArrayToNumericArray(array, &agg_context);
+
+	if (numeric_array.size == 0) {
+		PG_RETURN_NULL();
+	}
+
+	result = median_numeric_quickselect(numeric_array.data, numeric_array.size);
+
+	PG_RETURN_NUMERIC(result);
+}

--- a/src/median_quickselect.c
+++ b/src/median_quickselect.c
@@ -1,0 +1,107 @@
+/*
+ * This median function implements the 'quickselect' algorithm, aka Hoare's
+ * "Algorithm 65: Find".
+ *
+ * https://en.wikipedia.org/wiki/Quickselect
+ *
+ * The typedef 'QuickSelectType' and macro 'TIMESCALE_MEDIAN_COMPARE' are in
+ * place to lay the groundwork for refactoring this code to provide multiple
+ * specializations for postgres datatypes: right now, only Numeric is
+ * supported, which provides good generality, since all numeric types can be
+ * converted into Numeric values, but poor performance, since the creation
+ * and comparison of Numeric values is expensive.
+ */
+
+#include <postgres.h>
+#include <utils/builtins.h>
+#include <utils/numeric.h>
+
+#include "median_quickselect.h"
+
+typedef Numeric QuickSelectType;
+
+/*
+ * A function on two 'QuickSelectType' values 'a' and 'b': ---------- Match
+ * a, b with | a is bigger than b  ->  1 | a is smaller than b -> -1 | a and
+ * b are equal   ->  0 ----------
+ */
+#define TIMESCALE_MEDIAN_COMPARE(a, b) \
+    DatumGetInt32(DirectFunctionCall2(numeric_cmp, \
+                                      NumericGetDatum(a), \
+                                      NumericGetDatum(b)))
+
+static inline
+void
+swap(QuickSelectType * a, QuickSelectType * b)
+{
+	QuickSelectType	temp = *a;
+	*a = *b;
+	*b = temp;
+}
+
+/*
+ * Group in place the sublist of the specified 'list' delimited by the
+ * indices 'left' and 'right' into two parts, those less than than the item
+ * at the specified 'pivot_index' and those greater than the item at the
+ * specified 'pivot_index.
+ */
+static
+size_t partition(QuickSelectType * list,
+		 size_t left, size_t right, size_t pivot_index) {
+	QuickSelectType	pivot_value = list[pivot_index];
+	swap(&list[pivot_index], &list[right]);
+	size_t		store_index = left;
+	for (size_t i = left; i < right; ++i) {
+		if (TIMESCALE_MEDIAN_COMPARE(list[i], pivot_value) == -1) {
+			swap(&list[store_index], &list[i]);
+			++store_index;
+		}
+	}
+	swap(&list[right], &list[store_index]);
+	return store_index;
+}
+
+/*
+ * Iteratively partitions the 'list' in place, selecting at each point the
+ * half we know the median to be in, until the partition we are in is has
+ * just one item, which is the median.
+ */
+static
+QuickSelectType select(QuickSelectType * list, size_t arr_size) {
+	size_t		left = 0;
+	size_t		right = arr_size - 1;
+	size_t		k = ((arr_size - 1) / 2);	/* the median index */
+	for (;;) {
+		if (left == right) {
+			return list[left];
+		}
+		size_t		pivot_index = right - 1;
+		/* to do - randomly select value between left and right */
+		pivot_index = partition(list, left, right, pivot_index);
+		if (k == pivot_index) {
+			return list[k];
+		} else if (k < pivot_index) {
+			right = pivot_index - 1;
+		} else {
+			left = pivot_index + 1;
+		}
+	}
+}
+
+/*
+ * Find the median in the specified 'arr' of 'arr_size'. NOTE: Partially
+ * sorts 'arr' in the process of computing the median.
+ */
+
+QuickSelectType
+median_numeric_quickselect(QuickSelectType * arr, size_t arr_size) {
+	Assert(arr != NULL);
+	Assert(arr_size > 0);
+	if (arr_size == 1) {
+		return *arr;
+	}
+	return select(arr, arr_size);
+}
+
+#undef TIMESCALE_MEDIAN_COMPARE
+

--- a/src/median_quickselect.h
+++ b/src/median_quickselect.h
@@ -1,0 +1,17 @@
+#ifndef TIMESCALE_MEDIAN_QUICKSELECT
+#define TIMESCALE_MEDIAN_QUICKSELECT
+
+/*
+ * This median function implements the 'quickselect' algorithm, aka Hoare's
+ * "Algorithm 65: Find".
+ *
+ * https://en.wikipedia.org/wiki/Quickselect
+ *
+ */
+
+#include <postgres.h>
+#include <utils/numeric.h>
+
+extern Numeric median_numeric_quickselect(Numeric * arr, size_t arr_size);
+
+#endif

--- a/test/expected/median_test.out
+++ b/test/expected/median_test.out
@@ -1,0 +1,122 @@
+-------------------------------------------
+-- Basic even test, integer.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_even"(val int);
+INSERT INTO "mediantest_even" (val) VALUES
+    (1),
+    (3),
+    (1),
+    (3),
+    (2);
+-- ASCERTAIN
+SELECT median(val) FROM mediantest_even;
+ median 
+--------
+      2
+(1 row)
+
+-------------------------------------------
+-- Basic odd test, integer.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_odd"(val int);
+INSERT INTO "mediantest_odd" VALUES
+    (3),
+    (1),
+    (3),
+    (2);
+-- ASCERTAIN
+SELECT median(val) FROM mediantest_odd;
+ median 
+--------
+      2
+(1 row)
+
+-------------------------------------------
+-- Repeated values.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_repeated"(val int);
+INSERT INTO "mediantest_repeated"
+SELECT 3 FROM generate_series(0, 1000) as T(i);
+-- ASCERTAIN
+SELECT median(val) FROM mediantest_repeated;
+ median 
+--------
+      3
+(1 row)
+
+-------------------------------------------
+-- Float test.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_float"(val float);
+INSERT INTO "mediantest_float" VALUES
+    (3.0),
+    (1.3),
+    (90000.0),
+    (-3),
+    (15.123141),
+    (-134141);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_float;
+ median 
+--------
+    1.3
+(1 row)
+
+-------------------------------------------
+-- Empty table.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_empty"(val float);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_empty;
+ median 
+--------
+       
+(1 row)
+
+-------------------------------------------
+-- Gigantic odd table
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_gigantic_odd"(val int);
+INSERT INTO mediantest_gigantic_odd (val)
+SELECT i FROM generate_series(0, 10001) as T(i);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_gigantic_odd;
+ median 
+--------
+   5000
+(1 row)
+
+-------------------------------------------
+-- Gigantic even table
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_gigantic_even"(val int);
+INSERT INTO mediantest_gigantic_even (val)
+SELECT i FROM generate_series(0, 10000) as T(i);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_gigantic_even;
+ median 
+--------
+   5000
+(1 row)
+
+-------------------------------------------
+-- Multiple Selects
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_multiple"(a int, b int);
+INSERT INTO mediantest_multiple (a, b)
+SELECT i, 1000000 - i FROM generate_series(0, 10000) as T(i);
+-- ASCERTAIN
+SELECT median(a), median(b) FROM mediantest_multiple;
+ median | median 
+--------+--------
+   5000 | 995000
+(1 row)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_FILES
   index.sql
   insert_single.sql
   insert.sql
+  median_test.sql
   partitioning.sql
   pg_dump.sql
   plain.sql
@@ -49,7 +50,8 @@ set(TEST_FILES
   upsert.sql
   util.sql
   vacuum.sql
-  version.sql)
+  version.sql
+)
 
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES
@@ -57,8 +59,9 @@ IF(CMAKE_BUILD_TYPE MATCHES Debug)
 ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
 
 set(TEST_TEMPLATES
-  parallel.sql.in
-  partitioning.sql.in)
+    parallel.sql.in
+    partitioning.sql.in
+  )
 
 # Regression tests that vary with PostgreSQL version. Generated test
 # files are put in the original source directory since all tests must

--- a/test/sql/median_test.sql
+++ b/test/sql/median_test.sql
@@ -1,0 +1,89 @@
+-------------------------------------------
+-- Basic even test, integer.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_even"(val int);
+INSERT INTO "mediantest_even" (val) VALUES
+    (1),
+    (3),
+    (1),
+    (3),
+    (2);
+-- ASCERTAIN
+SELECT median(val) FROM mediantest_even;
+
+-------------------------------------------
+-- Basic odd test, integer.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_odd"(val int);
+INSERT INTO "mediantest_odd" VALUES
+    (3),
+    (1),
+    (3),
+    (2);
+-- ASCERTAIN
+SELECT median(val) FROM mediantest_odd;
+
+-------------------------------------------
+-- Repeated values.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_repeated"(val int);
+INSERT INTO "mediantest_repeated"
+SELECT 3 FROM generate_series(0, 1000) as T(i);
+-- ASCERTAIN
+SELECT median(val) FROM mediantest_repeated;
+
+-------------------------------------------
+-- Float test.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_float"(val float);
+INSERT INTO "mediantest_float" VALUES
+    (3.0),
+    (1.3),
+    (90000.0),
+    (-3),
+    (15.123141),
+    (-134141);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_float;
+
+-------------------------------------------
+-- Empty table.
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_empty"(val float);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_empty;
+
+-------------------------------------------
+-- Gigantic odd table
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_gigantic_odd"(val int);
+INSERT INTO mediantest_gigantic_odd (val)
+SELECT i FROM generate_series(0, 10001) as T(i);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_gigantic_odd;
+
+-------------------------------------------
+-- Gigantic even table
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_gigantic_even"(val int);
+INSERT INTO mediantest_gigantic_even (val)
+SELECT i FROM generate_series(0, 10000) as T(i);
+-- ASCERTAIN
+SELECT median(val::numeric) FROM mediantest_gigantic_even;
+
+-------------------------------------------
+-- Multiple Selects
+-------------------------------------------
+-- ARRANGE
+CREATE TABLE "mediantest_multiple"(a int, b int);
+INSERT INTO mediantest_multiple (a, b)
+SELECT i, 1000000 - i FROM generate_series(0, 10000) as T(i);
+-- ASCERTAIN
+SELECT median(a), median(b) FROM mediantest_multiple;


### PR DESCRIPTION
The algorithm implemented is the 'quickselect'
algorithm, which is very similar in characteristics
to quick sort, with O(N^2) worst case time complexity,
but O(N) average complexity. In my implementation,
I am using O(N) additional space.

Since this algorithm requires the entire
set of data, I reused the internal functions
used for the array_agg aggregation function,
only implementing the final function.

A future optimization could include switching
over to an on-line median algorithm such as the
binmedian algorithm, which would allow for
support for parallelization, as well as possible
windowing.

Currently, the function is only implemented for
Numeric values. The pro is that this is a fairly
flexible implementation - all numeric types can
be converted losslessly into Numeric. However,
this has the significant downside of having
absolutely abysmal performance, due to the cost
of comparisons and conversions.

An important optimization going forward would
to implement specializations of the median
calculation for float and integer types, making
use of native comparisons for what should be a
truely massive speedup.

A final minor TODO includes adjusting the
quick select implementation to select its
pivots randomly, instead of deterministically
as it does now.