### PR TITLE
add support for binary compatible custom types as timescale column

### DIFF
--- a/sql/util_time.sql
+++ b/sql/util_time.sql
@@ -24,6 +24,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.time_literal_sql(
     RETURNS text LANGUAGE PLPGSQL STABLE AS
 $BODY$
 DECLARE
+    ret text;
 BEGIN
     IF time_value IS NULL THEN
         RETURN format('%L', NULL);
@@ -39,6 +40,9 @@ BEGIN
         RETURN format('TIMESTAMPTZ %1$L', _timescaledb_internal.to_timestamp(time_value)); -- microseconds
       WHEN 'DATE'::regtype THEN
         RETURN format('%L', timezone('UTC',_timescaledb_internal.to_timestamp(time_value))::date);
+      ELSE
+         EXECUTE 'SELECT format(''%L'', $1::' || column_type::text || ')' into ret using time_value;
+         RETURN ret;
     END CASE;
 END
 $BODY$;

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -6,6 +6,7 @@
 #include <access/htup_details.h>
 
 #include "catalog.h"
+#include "utils.h"
 
 typedef struct PartitioningInfo PartitioningInfo;
 typedef struct DimensionSlice DimensionSlice;
@@ -41,7 +42,7 @@ typedef struct Dimension
 	(type == TIMESTAMPOID || type == TIMESTAMPTZOID || type == DATEOID)
 
 #define IS_VALID_OPEN_DIM_TYPE(type)					\
-	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type))
+	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type) || type_is_int8_binary_compatible(type))
 
 /*
  * A hyperspace defines how to partition in a N-dimensional space.

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,6 +7,9 @@
 #include <catalog/pg_proc.h>
 #include <utils/datetime.h>
 
+
+extern bool type_is_int8_binary_compatible(Oid sourcetype);
+
 /*
  * Convert a column value into the internal time representation.
  */

--- a/test/expected/custom_type.out
+++ b/test/expected/custom_type.out
@@ -1,0 +1,98 @@
+\c single :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION customtype_in(cstring) RETURNS customtype AS
+'timestamptz_in'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  type "customtype" is not yet defined
+CREATE OR REPLACE FUNCTION customtype_out(customtype) RETURNS cstring AS
+'timestamptz_out'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type customtype is only a shell
+CREATE OR REPLACE FUNCTION customtype_recv(internal) RETURNS customtype AS
+'timestamptz_recv'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type customtype is only a shell
+CREATE OR REPLACE FUNCTION customtype_send(customtype) RETURNS bytea AS
+'timestamptz_send'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type customtype is only a shell
+CREATE TYPE customtype (
+ INPUT = customtype_in,
+ OUTPUT = customtype_out,
+ RECEIVE = customtype_recv,
+ SEND = customtype_send,
+ INTERNALLENGTH = 8,
+ PASSEDBYVALUE,
+ ALIGNMENT = double,
+ STORAGE = plain
+);
+CREATE CAST (customtype AS bigint)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (bigint AS customtype)
+WITHOUT FUNCTION AS IMPLICIT;
+CREATE CAST (customtype AS timestamptz)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (timestamptz AS customtype)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE OR REPLACE FUNCTION customtype_lt(customtype, customtype) RETURNS bool AS
+'timestamp_lt'
+LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR < (
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_lt,
+	COMMUTATOR = >,
+	NEGATOR = >=,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
+);
+CREATE OR REPLACE FUNCTION customtype_ge(customtype, customtype) RETURNS bool AS
+'timestamp_ge'
+LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR >= (
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_ge,
+	COMMUTATOR = <=,
+	NEGATOR = <,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
+);
+\c single :ROLE_DEFAULT_PERM_USER
+CREATE TABLE customtype_test(time_custom customtype, val int);
+SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
+NOTICE:  adding not-null constraint to column "time_custom"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
+EXPLAIN (costs off) SELECT * FROM customtype_test;
+             QUERY PLAN             
+------------------------------------
+ Append
+   ->  Seq Scan on customtype_test
+   ->  Seq Scan on _hyper_1_1_chunk
+(3 rows)
+
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:23'::customtype, 11);
+EXPLAIN (costs off) SELECT * FROM customtype_test;
+             QUERY PLAN             
+------------------------------------
+ Append
+   ->  Seq Scan on customtype_test
+   ->  Seq Scan on _hyper_1_1_chunk
+   ->  Seq Scan on _hyper_1_2_chunk
+(4 rows)
+
+SELECT * FROM customtype_test;
+         time_custom          | val 
+------------------------------+-----
+ Mon Jan 01 01:02:03 2001 PST |  10
+ Mon Jan 01 01:02:03 2001 PST |  10
+ Mon Jan 01 01:02:03 2001 PST |  10
+ Mon Jan 01 01:02:23 2001 PST |  11
+(4 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_FILES
   create_chunks.sql
   create_hypertable.sql
   create_table.sql
+  custom_type.sql
   ddl_alter_column.sql
   ddl_errors.sql
   ddl_single.sql

--- a/test/sql/custom_type.sql
+++ b/test/sql/custom_type.sql
@@ -1,0 +1,76 @@
+\c single :ROLE_SUPERUSER
+
+CREATE OR REPLACE FUNCTION customtype_in(cstring) RETURNS customtype AS
+'timestamptz_in'
+LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION customtype_out(customtype) RETURNS cstring AS
+'timestamptz_out'
+LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION customtype_recv(internal) RETURNS customtype AS
+'timestamptz_recv'
+LANGUAGE internal IMMUTABLE STRICT;
+CREATE OR REPLACE FUNCTION customtype_send(customtype) RETURNS bytea AS
+'timestamptz_send'
+LANGUAGE internal IMMUTABLE STRICT;
+
+
+CREATE TYPE customtype (
+ INPUT = customtype_in,
+ OUTPUT = customtype_out,
+ RECEIVE = customtype_recv,
+ SEND = customtype_send,
+ INTERNALLENGTH = 8,
+ PASSEDBYVALUE,
+ ALIGNMENT = double,
+ STORAGE = plain
+);
+
+CREATE CAST (customtype AS bigint)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (bigint AS customtype)
+WITHOUT FUNCTION AS IMPLICIT;
+
+CREATE CAST (customtype AS timestamptz)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (timestamptz AS customtype)
+WITHOUT FUNCTION AS ASSIGNMENT;
+
+CREATE OR REPLACE FUNCTION customtype_lt(customtype, customtype) RETURNS bool AS
+'timestamp_lt'
+LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR < (
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_lt,
+	COMMUTATOR = >,
+	NEGATOR = >=,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
+);
+
+CREATE OR REPLACE FUNCTION customtype_ge(customtype, customtype) RETURNS bool AS
+'timestamp_ge'
+LANGUAGE internal IMMUTABLE STRICT;
+CREATE OPERATOR >= (
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_ge,
+	COMMUTATOR = <=,
+	NEGATOR = <,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
+);
+
+\c single :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE customtype_test(time_custom customtype, val int);
+SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
+
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
+EXPLAIN (costs off) SELECT * FROM customtype_test;
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:23'::customtype, 11);
+EXPLAIN (costs off) SELECT * FROM customtype_test;
+
+SELECT * FROM customtype_test;


### PR DESCRIPTION
I was wondering what you think about adding support for custom types as a timescale column. This PR adds support for custom types that are binary castable to bigint type. It could quite easily be extended for different types I guess. I added specifically this case, as it involves little to no overhead at run-time to cast to a binary-compatible type.

Main use case that we have is that we have a custom timestamp type with extra precision, based on a bigint. We'd like to use this custom timestamp type instead of the bigint directly, because it is a nice abstraction and we can add custom casts/functions to it.
