### PR TITLE
Add relid chunk cache and improve memory allocation

### DIFF
--- a/sql/cache.sql
+++ b/sql/cache.sql
@@ -2,6 +2,7 @@
 -- metadata caches kept in C. Please look at cache_invalidate.c for a
 -- description of how this works.
 CREATE TABLE IF NOT EXISTS  _timescaledb_cache.cache_inval_hypertable();
+CREATE TABLE IF NOT EXISTS  _timescaledb_cache.cache_inval_chunk();
 
 -- This is pretty subtle. We create this dummy cache_inval_extension table
 -- solely for the purpose of getting a relcache invalidation event when it is

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADERS
   chunk_dispatch_plan.h
   chunk_dispatch_state.h
   chunk.h
+  chunk_cache.h
   chunk_index.h
   chunk_insert_state.h
   compat.h
@@ -73,6 +74,7 @@ set(SOURCES
   cache_invalidate.c
   catalog.c
   chunk.c
+  chunk_cache.c
   chunk_constraint.c
   chunk_dispatch.c
   chunk_dispatch_info.c

--- a/src/cache.c
+++ b/src/cache.c
@@ -6,6 +6,7 @@
 /* List of pinned caches. A cache occurs once in this list for every pin
  * taken */
 static List *pinned_caches = NIL;
+
 typedef struct CachePin
 {
 	Cache	   *cache;
@@ -17,7 +18,7 @@ cache_init(Cache *cache)
 {
 	if (cache->htab != NULL)
 	{
-		elog(ERROR, "Cache %s is already initialized", cache->name);
+		elog(ERROR, "cache %s is already initialized", cache->name);
 		return;
 	}
 
@@ -144,10 +145,12 @@ cache_fetch(Cache *cache, CacheQuery *query)
 	HASHACTION	action = cache->create_entry == NULL ? HASH_FIND : HASH_ENTER;
 
 	if (cache->htab == NULL)
-	{
-		elog(ERROR, "Hash %s not initialized", cache->name);
-	}
+		elog(ERROR, "hash %s is not initialized", cache->name);
 
+	if (query->enteronly)
+		action = HASH_ENTER;
+
+	query->mctx = CurrentMemoryContext;
 	query->result = hash_search(cache->htab, cache->get_key(query), action, &found);
 
 	if (found)
@@ -155,24 +158,19 @@ cache_fetch(Cache *cache, CacheQuery *query)
 		cache->stats.hits++;
 
 		if (cache->update_entry != NULL)
-		{
-			MemoryContext old = cache_switch_to_memory_context(cache);
-
 			query->result = cache->update_entry(cache, query);
-			MemoryContextSwitchTo(old);
-		}
 	}
 	else
 	{
 		cache->stats.misses++;
 
-		if (cache->create_entry != NULL)
-		{
-			MemoryContext old = cache_switch_to_memory_context(cache);
-
+		if (cache->create_entry != NULL && !query->enteronly)
 			query->result = cache->create_entry(cache, query);
-			MemoryContextSwitchTo(old);
+
+		if (action == HASH_ENTER)
+		{
 			cache->stats.numelements++;
+			memset(query->result, 0, sizeof(cache->hctl.entrysize));
 		}
 	}
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -9,6 +9,14 @@ typedef struct CacheQuery
 {
 	void	   *result;
 	void	   *data;
+	/* The memory context the query was initiated on */
+	MemoryContext mctx;
+
+	/*
+	 * If entry is not found, only allocate a new slot, but do not fill it.
+	 * Defaults to false.
+	 */
+	bool		enteronly;
 } CacheQuery;
 
 typedef struct CacheStats
@@ -38,7 +46,7 @@ typedef struct Cache
 
 extern void cache_init(Cache *cache);
 extern void cache_invalidate(Cache *cache);
-extern void *cache_fetch(Cache *cache, CacheQuery *ctx);
+extern void *cache_fetch(Cache *cache, CacheQuery *query);
 extern bool cache_remove(Cache *cache, void *key);
 
 extern MemoryContext cache_memory_ctx(Cache *cache);

--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -10,6 +10,7 @@
 #include "compat.h"
 #include "extension.h"
 #include "hypertable_cache.h"
+#include "chunk_cache.h"
 
 /*
  * Notes on the way cache invalidation works.
@@ -46,6 +47,7 @@ static void
 cache_invalidate_all(void)
 {
 	hypertable_cache_invalidate_callback();
+	chunk_cache_invalidate_callback();
 }
 
 /*
@@ -70,6 +72,16 @@ cache_invalidate_callback(Datum arg, Oid relid)
 
 	if (relid == catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE))
 		hypertable_cache_invalidate_callback();
+	else if (relid == catalog_get_cache_proxy_id(catalog, CACHE_TYPE_CHUNK))
+	{
+		chunk_cache_invalidate_callback();
+
+		/*
+		 * Need to invalidate hypertable cache as well since each hypertable
+		 * keeps references to its chunks
+		 */
+		hypertable_cache_invalidate_callback();
+	}
 }
 
 TS_FUNCTION_INFO_V1(timescaledb_invalidate_cache);

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -484,6 +484,13 @@ catalog_invalidate_cache(Oid catalog_relid, CmdType operation)
 		case DIMENSION_SLICE:
 			if (operation == CMD_UPDATE || operation == CMD_DELETE)
 			{
+				relid = catalog_get_cache_proxy_id(catalog, CACHE_TYPE_CHUNK);
+				CacheInvalidateRelcacheByRelid(relid);
+
+				/*
+				 * Hypertable cache entries have embedded chunk caches, so
+				 * need to invalidate the hypertable cache as well
+				 */
 				relid = catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE);
 				CacheInvalidateRelcacheByRelid(relid);
 			}

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -61,13 +61,12 @@ typedef struct ChunkScanEntry
 	Chunk	   *chunk;
 } ChunkScanEntry;
 
-extern Chunk *chunk_create_from_tuple(HeapTuple tuple, int16 num_constraints);
 extern Chunk *chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
 extern Chunk *chunk_create_stub(int32 id, int16 num_constraints);
 extern void chunk_free(Chunk *chunk);
 extern Chunk *chunk_find(Hyperspace *hs, Point *p);
 extern Chunk *chunk_copy(Chunk *chunk);
-extern Chunk *chunk_get_by_name(const char *schema_name, const char *table_name, int16 num_constraints, bool fail_if_not_found);
+extern Chunk *chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name, int16 num_constraints, MemoryContext mctx, bool fail_if_not_found);
 extern Chunk *chunk_get_by_relid(Oid relid, int16 num_constraints, bool fail_if_not_found);
 extern Chunk *chunk_get_by_id(int32 id, int16 num_constraints, bool fail_if_not_found);
 extern bool chunk_exists(const char *schema_name, const char *table_name);
@@ -76,5 +75,9 @@ extern void chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 d
 extern int	chunk_delete_by_relid(Oid chunk_oid);
 extern int	chunk_delete_by_hypertable_id(int32 hypertable_id);
 extern int	chunk_delete_by_name(const char *schema, const char *table);
+
+#define chunk_get_by_name(schema_name, table_name, num_constraints, fail_if_not_found) \
+	chunk_get_by_name_with_memory_context(schema_name, table_name, num_constraints, \
+										  CurrentMemoryContext, fail_if_not_found)
 
 #endif							/* TIMESCALEDB_CHUNK_H */

--- a/src/chunk_cache.c
+++ b/src/chunk_cache.c
@@ -1,0 +1,188 @@
+#include <postgres.h>
+#include <catalog/namespace.h>
+#include <utils/catcache.h>
+#include <utils/lsyscache.h>
+#include <utils/builtins.h>
+
+#include "chunk_cache.h"
+#include "chunk.h"
+#include "catalog.h"
+#include "cache.h"
+#include "utils.h"
+
+static void *chunk_cache_create_entry(Cache *cache, CacheQuery *query);
+
+typedef struct ChunkCacheQuery
+{
+	CacheQuery	q;
+	Oid			relid;
+	int16		num_constraints;
+	const char *schema;
+	const char *table;
+} ChunkCacheQuery;
+
+static void *
+chunk_cache_get_key(CacheQuery *query)
+{
+	return &((ChunkCacheQuery *) query)->relid;
+}
+
+typedef struct ChunkCacheEntry
+{
+	Oid			relid;
+	Chunk	   *chunk;
+} ChunkCacheEntry;
+
+
+static Cache *
+chunk_cache_create()
+{
+	MemoryContext ctx = AllocSetContextCreate(CacheMemoryContext,
+											  "Chunk cache",
+											  ALLOCSET_DEFAULT_SIZES);
+
+	Cache	   *cache = MemoryContextAlloc(ctx, sizeof(Cache));
+	Cache		template =
+	{
+		.hctl =
+		{
+			.keysize = sizeof(Oid),
+			.entrysize = sizeof(ChunkCacheEntry),
+			.hcxt = ctx,
+		},
+		.name = "chunk_cache",
+		.numelements = 16,
+		.flags = HASH_ELEM | HASH_CONTEXT | HASH_BLOBS,
+		.get_key = chunk_cache_get_key,
+		.create_entry = chunk_cache_create_entry,
+	};
+
+	*cache = template;
+
+	cache_init(cache);
+
+	return cache;
+}
+
+static Cache *chunk_cache_current = NULL;
+
+static void *
+chunk_cache_create_entry(Cache *cache, CacheQuery *query)
+{
+	ChunkCacheQuery *q = (ChunkCacheQuery *) query;
+	ChunkCacheEntry *cache_entry = query->result;
+
+	if (NULL == q->schema)
+		q->schema = get_namespace_name(get_rel_namespace(q->relid));
+
+	if (NULL == q->table)
+		q->table = get_rel_name(q->relid);
+
+	cache_entry->chunk = chunk_get_by_name_with_memory_context(q->schema,
+															   q->table,
+															   q->num_constraints,
+															   cache_memory_ctx(cache),
+															   false);
+
+	return query->result;
+}
+
+void
+chunk_cache_invalidate_callback(void)
+{
+	cache_invalidate(chunk_cache_current);
+	chunk_cache_current = chunk_cache_create();
+}
+
+Chunk *
+chunk_cache_get_by_name(Cache *cache, const char *schema, const char *table, int16 num_constraints)
+{
+	Oid			nsoid = get_namespace_oid(schema, true);
+	ChunkCacheQuery query = {
+		.relid = get_relname_relid(table, nsoid),
+		.schema = schema,
+		.table = table,
+		.num_constraints = num_constraints,
+	};
+	ChunkCacheEntry *entry;
+
+	if (!OidIsValid(nsoid) || !OidIsValid(query.relid))
+		return NULL;
+
+	entry = cache_fetch(cache, &query.q);
+
+	return entry->chunk;
+}
+
+static Chunk *
+chunk_cache_get_by_relid(Cache *cache, Oid relid, int16 num_constraints)
+{
+	ChunkCacheQuery query = {
+		.relid = relid,
+		.schema = get_namespace_name(get_rel_namespace(relid)),
+		.table = get_rel_name(relid),
+		.num_constraints = num_constraints,
+	};
+
+	ChunkCacheEntry *entry = cache_fetch(cache, &query.q);
+
+	return entry->chunk;
+}
+
+/*
+ * Get a chunk from the cache.
+ */
+Chunk *
+chunk_cache_get(Cache *cache, Oid relid, int16 num_constraints)
+{
+	if (!OidIsValid(relid))
+		return NULL;
+
+	return chunk_cache_get_by_relid(cache, relid, num_constraints);
+}
+
+Chunk *
+chunk_cache_get_or_add(Cache *cache, Chunk *chunk)
+{
+	ChunkCacheQuery query = {
+		.q.enteronly = true,
+		.relid = chunk->table_id,
+	};
+	ChunkCacheEntry *entry = cache_fetch(cache, &query.q);
+
+	if (!OidIsValid(entry->relid))
+	{
+		MemoryContext old = MemoryContextSwitchTo(cache->hctl.hcxt);
+
+		entry->relid = query.relid;
+		entry->chunk = chunk_copy(chunk);
+		MemoryContextSwitchTo(old);
+	}
+
+	return entry->chunk;
+}
+
+Chunk *
+chunk_cache_get_entry_rv(Cache *cache, RangeVar *rv, int16 num_constraints)
+{
+	return chunk_cache_get(cache, RangeVarGetRelid(rv, NoLock, true), num_constraints);
+}
+
+extern Cache *
+chunk_cache_pin()
+{
+	return cache_pin(chunk_cache_current);
+}
+
+void
+_chunk_cache_init(void)
+{
+	CreateCacheMemoryContext();
+	chunk_cache_current = chunk_cache_create();
+}
+
+void
+_chunk_cache_fini(void)
+{
+	cache_invalidate(chunk_cache_current);
+}

--- a/src/chunk_cache.h
+++ b/src/chunk_cache.h
@@ -1,0 +1,20 @@
+#ifndef TIMESCALEDB_CHUNK_CACHE_H
+#define TIMESCALEDB_CHUNK_CACHE_H
+
+#include <postgres.h>
+#include "cache.h"
+#include "chunk.h"
+
+extern Chunk *chunk_cache_get(Cache *cache, Oid relid, int16 num_constraints);
+extern Chunk *chunk_cache_get_entry_rv(Cache *cache, RangeVar *rv, int16 num_constraints);
+extern Chunk *chunk_cache_get_by_name(Cache *cache, const char *schema, const char *table, int16 num_constraints);
+extern Chunk *chunk_cache_get_or_add(Cache *cache, Chunk *chunk);
+
+extern void chunk_cache_invalidate_callback(void);
+
+extern Cache *chunk_cache_pin(void);
+
+extern void _chunk_cache_init(void);
+extern void _chunk_cache_fini(void);
+
+#endif							/* TIMESCALEDB_CHUNK_CACHE_H */

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -15,6 +15,7 @@ typedef struct ChunkConstraint
 
 typedef struct ChunkConstraints
 {
+	MemoryContext mctx;
 	int16		capacity;
 	int16		num_constraints;
 	int16		num_dimension_constraints;
@@ -33,8 +34,8 @@ typedef struct DimensionSlice DimensionSlice;
 typedef struct Hypercube Hypercube;
 typedef struct ChunkScanCtx ChunkScanCtx;
 
-extern ChunkConstraints *chunk_constraints_alloc(int size_hint);
-extern ChunkConstraints *chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint);
+extern ChunkConstraints *chunk_constraints_alloc(int size_hint, MemoryContext mctx);
+extern ChunkConstraints *chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint, MemoryContext mctx);
 extern ChunkConstraints *chunk_constraints_copy(ChunkConstraints *constraints);
 extern int	chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx *ctx);
 extern int	chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkConstraints *ccs);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -94,7 +94,7 @@ typedef struct DimensionInfo
 	 (di)->colname != NULL &&											\
 	 ((di)->num_slices_is_set || OidIsValid((di)->interval_datum)))
 
-extern Hyperspace *dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension);
+extern Hyperspace *dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension, MemoryContext mctx);
 extern DimensionSlice *dimension_calculate_default_slice(Dimension *dim, int64 value);
 extern Point *hyperspace_calculate_point(Hyperspace *h, HeapTuple tuple, TupleDesc tupdesc);
 extern Dimension *hyperspace_get_dimension_by_id(Hyperspace *hs, int32 id);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -28,7 +28,7 @@ extern DimensionVec *dimension_slice_scan_limit(int32 dimension_id, int64 coordi
 extern DimensionVec *dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, int64 range_end, int limit);
 extern Hypercube *dimension_slice_point_scan(Hyperspace *space, int64 point[]);
 extern DimensionSlice *dimension_slice_scan_for_existing(DimensionSlice *slice);
-extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id);
+extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
 extern DimensionVec *dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
 extern int	dimension_slice_delete_by_dimension_id(int32 dimension_id, bool delete_constraints);
 extern int	dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraints);

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -130,10 +130,15 @@ hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id)
  * Given a set of constraints, build the corresponding hypercube.
  */
 Hypercube *
-hypercube_from_constraints(ChunkConstraints *constraints)
+hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx)
 {
-	Hypercube  *hc = hypercube_alloc(constraints->num_dimension_constraints);
+	Hypercube  *hc;
 	int			i;
+	MemoryContext old;
+
+	old = MemoryContextSwitchTo(mctx);
+	hc = hypercube_alloc(constraints->num_dimension_constraints);
+	MemoryContextSwitchTo(old);
 
 	for (i = 0; i < constraints->num_constraints; i++)
 	{
@@ -144,7 +149,7 @@ hypercube_from_constraints(ChunkConstraints *constraints)
 			DimensionSlice *slice;
 
 			Assert(hc->num_slices < constraints->num_dimension_constraints);
-			slice = dimension_slice_scan_by_id(cc->fd.dimension_slice_id);
+			slice = dimension_slice_scan_by_id(cc->fd.dimension_slice_id, mctx);
 			Assert(slice != NULL);
 			hc->slices[hc->num_slices++] = slice;
 		}

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -25,7 +25,7 @@ typedef struct Hypercube
 extern Hypercube *hypercube_alloc(int16 num_dimensions);
 extern void hypercube_free(Hypercube *hc);
 extern void hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
-extern Hypercube *hypercube_from_constraints(ChunkConstraints *constraints);
+extern Hypercube *hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
 extern Hypercube *hypercube_calculate_from_point(Hyperspace *hs, Point *p);
 extern bool hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
 extern DimensionSlice *hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -20,6 +20,7 @@
 #include "hypertable.h"
 #include "dimension.h"
 #include "chunk.h"
+#include "chunk_cache.h"
 #include "compat.h"
 #include "subspace_store.h"
 #include "hypertable_cache.h"
@@ -76,17 +77,17 @@ hypertable_permissions_check(Oid hypertable_oid, Oid userid)
 
 
 Hypertable *
-hypertable_from_tuple(HeapTuple tuple)
+hypertable_from_tuple(HeapTuple tuple, MemoryContext mctx)
 {
 	Hypertable *h;
 	Oid			namespace_oid;
 
-	h = palloc0(sizeof(Hypertable));
+	h = MemoryContextAllocZero(mctx, sizeof(Hypertable));
 	memcpy(&h->fd, GETSTRUCT(tuple), sizeof(FormData_hypertable));
 	namespace_oid = get_namespace_oid(NameStr(h->fd.schema_name), false);
 	h->main_table_relid = get_relname_relid(NameStr(h->fd.table_name), namespace_oid);
-	h->space = dimension_scan(h->fd.id, h->main_table_relid, h->fd.num_dimensions);
-	h->chunk_cache = subspace_store_init(h->space, CurrentMemoryContext, guc_max_cached_chunks_per_hypertable);
+	h->space = dimension_scan(h->fd.id, h->main_table_relid, h->fd.num_dimensions, mctx);
+	h->chunk_cache = subspace_store_init(h->space, mctx, guc_max_cached_chunks_per_hypertable);
 
 	return h;
 }
@@ -131,16 +132,16 @@ hypertable_id_to_relid(int32 hypertable_id)
 	return relid;
 }
 
-typedef struct ChunkCacheEntry
+typedef struct ChunkStoreEntry
 {
 	MemoryContext mcxt;
 	Chunk	   *chunk;
-} ChunkCacheEntry;
+} ChunkStoreEntry;
 
 static void
-chunk_cache_entry_free(void *cce)
+chunk_subspace_store_entry_free(void *cse)
 {
-	MemoryContextDelete(((ChunkCacheEntry *) cce)->mcxt);
+	MemoryContextDelete(((ChunkStoreEntry *) cse)->mcxt);
 }
 
 static int
@@ -151,7 +152,8 @@ hypertable_scan_limit_internal(ScanKeyData *scankey,
 							   void *scandata,
 							   int limit,
 							   LOCKMODE lock,
-							   bool tuplock)
+							   bool tuplock,
+							   MemoryContext mctx)
 {
 	Catalog    *catalog = catalog_get();
 	ScannerCtx	scanctx = {
@@ -164,6 +166,7 @@ hypertable_scan_limit_internal(ScanKeyData *scankey,
 		.tuple_found = on_tuple_found,
 		.lockmode = lock,
 		.scandirection = ForwardScanDirection,
+		.result_mctx = mctx,
 		.tuplock = {
 			.waitpolicy = LockWaitBlock,
 			.lockmode = LockTupleExclusive,
@@ -212,16 +215,18 @@ hypertable_update_form(FormData_hypertable *update)
 										  update,
 										  1,
 										  RowExclusiveLock,
-										  false);
+										  false,
+										  CurrentMemoryContext);
 }
 
 int
-hypertable_scan(const char *schema,
-				const char *table,
-				tuple_found_func tuple_found,
-				void *data,
-				LOCKMODE lockmode,
-				bool tuplock)
+hypertable_scan_with_memory_context(const char *schema,
+									const char *table,
+									tuple_found_func tuple_found,
+									void *data,
+									LOCKMODE lockmode,
+									bool tuplock,
+									MemoryContext mctx)
 {
 	ScanKeyData scankey[2];
 	NameData	schema_name,
@@ -244,7 +249,8 @@ hypertable_scan(const char *schema,
 										  data,
 										  1,
 										  lockmode,
-										  tuplock);
+										  tuplock,
+										  mctx);
 }
 
 int
@@ -296,7 +302,8 @@ hypertable_delete_by_id(int32 hypertable_id)
 										  NULL,
 										  1,
 										  RowExclusiveLock,
-										  false);
+										  false,
+										  CurrentMemoryContext);
 }
 
 
@@ -320,7 +327,8 @@ hypertable_delete_by_name(const char *schema_name, const char *table_name)
 										  NULL,
 										  0,
 										  RowExclusiveLock,
-										  false);
+										  false,
+										  CurrentMemoryContext);
 }
 
 static bool
@@ -359,7 +367,8 @@ hypertable_reset_associated_schema_name(const char *associated_schema)
 										  NULL,
 										  0,
 										  RowExclusiveLock,
-										  false);
+										  false,
+										  CurrentMemoryContext);
 }
 
 static bool
@@ -525,7 +534,7 @@ hypertable_tuple_found(TupleInfo *ti, void *data)
 {
 	Hypertable **entry = data;
 
-	*entry = hypertable_from_tuple(ti->tuple);
+	*entry = hypertable_from_tuple(ti->tuple, ti->mctx);
 	return false;
 }
 
@@ -561,19 +570,41 @@ hypertable_get_by_id(int32 hypertable_id)
 								   &ht,
 								   1,
 								   AccessShareLock,
-								   false);
+								   false,
+								   CurrentMemoryContext);
 	return ht;
+}
+
+static ChunkStoreEntry *
+hypertable_chunk_store_add(Hypertable *h, Chunk *chunk)
+{
+	ChunkStoreEntry *cse;
+	MemoryContext old_mcxt,
+				chunk_mcxt;
+
+	chunk_mcxt = AllocSetContextCreate(subspace_store_mcxt(h->chunk_cache),
+									   "chunk cache entry memory context",
+									   ALLOCSET_SMALL_SIZES);
+
+	/* Add the chunk to the subspace store */
+	old_mcxt = MemoryContextSwitchTo(chunk_mcxt);
+	cse = palloc(sizeof(ChunkStoreEntry));
+	cse->mcxt = chunk_mcxt;
+	cse->chunk = chunk;
+	subspace_store_add(h->chunk_cache, chunk->cube, cse, chunk_subspace_store_entry_free);
+	MemoryContextSwitchTo(old_mcxt);
+
+	return cse;
 }
 
 Chunk *
 hypertable_get_chunk(Hypertable *h, Point *point)
 {
-	ChunkCacheEntry *cce = subspace_store_get(h->chunk_cache, point);
+	ChunkStoreEntry *cse = subspace_store_get(h->chunk_cache, point);
 
-	if (NULL == cce)
+	if (NULL == cse)
 	{
-		MemoryContext old_mcxt,
-					chunk_mcxt;
+		Cache	   *ccache = chunk_cache_pin();
 		Chunk	   *chunk;
 
 		/*
@@ -590,28 +621,22 @@ hypertable_get_chunk(Hypertable *h, Point *point)
 
 		Assert(chunk != NULL);
 
-		chunk_mcxt = AllocSetContextCreate(subspace_store_mcxt(h->chunk_cache),
-										   "chunk cache memory context",
-										   ALLOCSET_SMALL_SIZES);
+		/*
+		 * Make sure this chunk is in the cache. The returned chunk lives in
+		 * the cache's memory context.
+		 */
+		chunk = chunk_cache_get_or_add(ccache, chunk);
 
-		old_mcxt = MemoryContextSwitchTo(chunk_mcxt);
-
-		cce = palloc(sizeof(ChunkCacheEntry));
-		cce->mcxt = chunk_mcxt;
-
-		/* Make a copy which lives in the chunk cache's memory context */
-		chunk = cce->chunk = chunk_copy(chunk);
-
-		subspace_store_add(h->chunk_cache, chunk->cube, cce, chunk_cache_entry_free);
-		MemoryContextSwitchTo(old_mcxt);
+		/* Also add the chunk to the hypertable's chunk store */
+		cse = hypertable_chunk_store_add(h, chunk);
+		cache_release(ccache);
 	}
 
-	Assert(NULL != cce);
-	Assert(NULL != cce->chunk);
-	Assert(MemoryContextContains(cce->mcxt, cce));
-	Assert(MemoryContextContains(cce->mcxt, cce->chunk));
+	Assert(NULL != cse);
+	Assert(NULL != cse->chunk);
+	Assert(MemoryContextContains(cse->mcxt, cse));
 
-	return cce->chunk;
+	return cse->chunk;
 }
 
 bool

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -27,8 +27,8 @@ extern Hypertable *hypertable_get_by_id(int32 hypertable_id);
 extern Hypertable *hypertable_get_by_name(char *schema, char *name);
 extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
 extern Oid	hypertable_permissions_check(Oid hypertable_oid, Oid userid);
-extern Hypertable *hypertable_from_tuple(HeapTuple tuple);
-extern int	hypertable_scan(const char *schema, const char *table, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock);
+extern Hypertable *hypertable_from_tuple(HeapTuple tuple, MemoryContext mctx);
+extern int	hypertable_scan_with_memory_context(const char *schema, const char *table, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock, MemoryContext mctx);
 extern int	hypertable_scan_relid(Oid table_relid, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock);
 extern HTSU_Result hypertable_lock_tuple(Oid table_relid);
 extern bool hypertable_lock_tuple_simple(Oid table_relid);
@@ -47,5 +47,8 @@ extern Tablespace *hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
 extern char *hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
 extern Tablespace *hypertable_get_tablespace_at_offset_from(Hypertable *ht, Oid tablespace_oid, int16 offset);
 extern bool hypertable_has_tuples(Oid table_relid, LOCKMODE lockmode);
+
+#define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock) \
+	hypertable_scan_with_memory_context(schema, table, tuple_found, data, lockmode, tuplock, CurrentMemoryContext)
 
 #endif							/* TIMESCALEDB_HYPERTABLE_H */

--- a/src/init.c
+++ b/src/init.c
@@ -21,6 +21,9 @@ extern void _chunk_dispatch_info_fini(void);
 extern void _hypertable_cache_init(void);
 extern void _hypertable_cache_fini(void);
 
+extern void _chunk_cache_init(void);
+extern void _chunk_cache_fini(void);
+
 extern void _cache_invalidate_init(void);
 extern void _cache_invalidate_fini(void);
 
@@ -54,6 +57,7 @@ _PG_init(void)
 	_chunk_dispatch_info_init();
 	_cache_init();
 	_hypertable_cache_init();
+	_chunk_cache_init();
 	_cache_invalidate_init();
 	_planner_init();
 	_event_trigger_init();
@@ -76,6 +80,7 @@ _PG_fini(void)
 	_planner_fini();
 	_cache_invalidate_fini();
 	_hypertable_cache_fini();
+	_chunk_cache_fini();
 	_cache_fini();
 	_chunk_dispatch_info_fini();
 }

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -140,6 +140,7 @@ partitioning_info_create(const char *schema,
 						 Oid relid)
 {
 	PartitioningInfo *pinfo;
+	TypeCacheEntry *tce;
 	Oid			columntype,
 				varcollid,
 				funccollid = InvalidOid;
@@ -160,9 +161,9 @@ partitioning_info_create(const char *schema,
 
 	/* Lookup the type cache entry to access the hash function for the type */
 	columntype = get_atttype(relid, pinfo->column_attnum);
-	pinfo->typcache_entry = lookup_type_cache(columntype, TYPECACHE_HASH_FLAGS);
+	tce = lookup_type_cache(columntype, TYPECACHE_HASH_FLAGS);
 
-	if (pinfo->typcache_entry->hash_proc == InvalidOid)
+	if (tce->hash_proc == InvalidOid)
 		elog(ERROR, "could not find hash function for type %u", columntype);
 
 	partitioning_func_set_func_fmgr(&pinfo->partfunc);

--- a/src/partitioning.h
+++ b/src/partitioning.h
@@ -34,7 +34,6 @@ typedef struct PartitioningInfo
 {
 	char		column[NAMEDATALEN];
 	AttrNumber	column_attnum;
-	TypeCacheEntry *typcache_entry;
 	PartitioningFunc partfunc;
 } PartitioningInfo;
 
@@ -46,7 +45,6 @@ extern PartitioningInfo *partitioning_info_create(const char *schema,
 						 const char *partfunc,
 						 const char *partcol,
 						 Oid relid);
-
 extern List *partitioning_func_qualified_name(PartitioningFunc *pf);
 extern int32 partitioning_func_apply(PartitioningInfo *pinfo, Datum value);
 extern int32 partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDesc desc);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -160,6 +160,9 @@ scanner_scan(ScannerCtx *ctx)
 		.sctx = ctx,
 	};
 
+	if (NULL == ctx->result_mctx)
+		ctx->result_mctx = CurrentMemoryContext;
+
 	if (OidIsValid(ctx->index))
 		scanner = &scanners[ScannerTypeIndex];
 	else
@@ -172,6 +175,7 @@ scanner_scan(ScannerCtx *ctx)
 
 	ictx.tinfo.scanrel = ictx.tablerel;
 	ictx.tinfo.desc = tuple_desc;
+	ictx.tinfo.mctx = ctx->result_mctx;
 
 	/* Call pre-scan handler, if any. */
 	if (ctx->prescan != NULL)

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -29,6 +29,12 @@ typedef struct TupleInfo
 	 */
 	HTSU_Result lockresult;
 	int			count;
+
+	/*
+	 * The memory context (optionally) set initially in the ScannerCtx. This
+	 * can be used to allocate data on in the tuple handle function.
+	 */
+	MemoryContext mctx;
 } TupleInfo;
 
 typedef bool (*tuple_found_func) (TupleInfo *ti, void *data);
@@ -45,6 +51,8 @@ typedef struct ScannerCtx
 								 * less means no limit */
 	bool		want_itup;
 	LOCKMODE	lockmode;
+	MemoryContext result_mctx;	/* The memory context to allocate the result
+								 * on */
 	struct
 	{
 		LockTupleMode lockmode;

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -1,4 +1,5 @@
 #include <postgres.h>
+#include <utils/memutils.h>
 
 #include "dimension.h"
 #include "dimension_slice.h"
@@ -66,7 +67,8 @@ subspace_store_internal_node_descendants(SubspaceStoreInternalNode *node, int in
 SubspaceStore *
 subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items)
 {
-	MemoryContext old = MemoryContextSwitchTo(mcxt);
+	MemoryContext storemctx = AllocSetContextCreate(mcxt, "chunk store memory context", ALLOCSET_DEFAULT_SIZES);
+	MemoryContext old = MemoryContextSwitchTo(storemctx);
 	SubspaceStore *sst = palloc(sizeof(SubspaceStore));
 
 	/*
@@ -78,7 +80,7 @@ subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items)
 	sst->origin = subspace_store_internal_node_create(space->num_dimensions == 1);
 	sst->num_dimensions = space->num_dimensions;
 	sst->max_items = max_items;
-	sst->mcxt = mcxt;
+	sst->mcxt = storemctx;
 	MemoryContextSwitchTo(old);
 	return sst;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,22 +11,6 @@
  */
 extern int64 time_value_to_internal(Datum time_val, Oid type);
 
-#if 0
-#define CACHE1_elog(a,b)				elog(a,b)
-#define CACHE2_elog(a,b,c)				elog(a,b,c)
-#define CACHE3_elog(a,b,c,d)			elog(a,b,c,d)
-#define CACHE4_elog(a,b,c,d,e)			elog(a,b,c,d,e)
-#define CACHE5_elog(a,b,c,d,e,f)		elog(a,b,c,d,e,f)
-#define CACHE6_elog(a,b,c,d,e,f,g)		elog(a,b,c,d,e,f,g)
-#else
-#define CACHE1_elog(a,b)
-#define CACHE2_elog(a,b,c)
-#define CACHE3_elog(a,b,c,d)
-#define CACHE4_elog(a,b,c,d,e)
-#define CACHE5_elog(a,b,c,d,e,f)
-#define CACHE6_elog(a,b,c,d,e,f,g)
-#endif
-
 extern FmgrInfo *create_fmgr(char *schema, char *function_name, int num_args);
 extern RangeVar *makeRangeVarFromRelid(Oid relid);
 extern int	int_cmp(const void *a, const void *b);

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -53,7 +53,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    93
+    94
 (1 row)
 
 SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');
@@ -239,7 +239,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    93
+    94
 (1 row)
 
 --main table and chunk schemas should be the same
@@ -421,6 +421,7 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         AND objid NOT IN (select unnest(extconfig) from pg_extension where extname='timescaledb')
                  objid                  
 ----------------------------------------
+ _timescaledb_cache.cache_inval_chunk
  _timescaledb_catalog.tablespace_id_seq
-(1 row)
+(2 rows)
 


### PR DESCRIPTION
This adds a chunk cache on relation ID, similar to the hypertable
cache. Changes have also been made to improve memory allocation during
cache lookups, to avoid having transient memory being allocated on
cache memory context during, e.g., metadata table scans. The new chunk
cache improves chunk lookup times, in particular for some
planner/optimizer tasks that involve chunks.

For consistency, the principle going forward should be to allocate
chunks on the chunk cache's memory context. For instance, a
hypertable's own chunk store allocates chunks in the global chunk
cache instead of its own store memory context. A slight downside of
this is that it creates a dependency between the hypertable cache and
the chunk cache, forcing us to also invalidate the hypertable cache
whenever the chunk cache is invalidated.