### PR TITLE
Fix bug with extension loader when DISCARD ALL is executed

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -48,11 +48,9 @@ static enum ExtensionState extstate = EXTENSION_STATE_UNKNOWN;
 static bool
 extension_loader_present()
 {
-	char	   *guc_value = GetConfigOptionByName(GUC_LOADER_PRESENT_NAME, NULL, true);
+	void	  **presentptr = find_rendezvous_variable(RENDEZVOUS_LOADER_PRESENT_NAME);
 
-	if (guc_value != NULL && strcmp(guc_value, "on") == 0)
-		return true;
-	return false;
+	return (*presentptr != NULL && *((bool *) *presentptr));
 }
 
 void

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -26,7 +26,7 @@
 #define CACHE_SCHEMA_NAME "_timescaledb_cache"
 #define MAX_SO_NAME_LEN NAMEDATALEN+NAMEDATALEN+1+1 /* extname+"-"+version */
 
-#define GUC_LOADER_PRESENT_NAME "timescaledb.loader_present"
+#define RENDEZVOUS_LOADER_PRESENT_NAME "timescaledb.loader_present"
 
 enum ExtensionState
 {

--- a/test/expected/loader.out
+++ b/test/expected/loader.out
@@ -520,3 +520,22 @@ WARNING:  mock post_analyze_hook "mock-2"
  timescaledb | mock-2  | public     | Enables scalable inserts and complex queries for time-series data
 (2 rows)
 
+--make sure parallel workers started after a 'DISCARD ALL' work
+CREATE TABLE test (i int, j double precision);
+WARNING:  mock post_analyze_hook "mock-2"
+INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
+WARNING:  mock post_analyze_hook "mock-2"
+DISCARD ALL;
+WARNING:  mock post_analyze_hook "mock-2"
+SET force_parallel_mode = 'on';
+WARNING:  mock post_analyze_hook "mock-2"
+SET max_parallel_workers_per_gather = 1;
+WARNING:  mock post_analyze_hook "mock-2"
+SELECT count(*) FROM test;
+WARNING:  mock post_analyze_hook "mock-2"
+WARNING:  mock init "mock-2"
+ count 
+-------
+   100
+(1 row)
+

--- a/test/loader-mock/src/init.c
+++ b/test/loader-mock/src/init.c
@@ -7,6 +7,7 @@
 #include <utils/inval.h>
 #include <parser/analyze.h>
 #include <nodes/print.h>
+#include <access/parallel.h>
 
 #define STR_EXPAND(x) #x
 #define STR(x) STR_EXPAND(x)
@@ -39,7 +40,7 @@ post_analyze_hook(ParseState *pstate, Query *query)
 {
 	if (extension_is_loaded())
 		elog(WARNING, "mock post_analyze_hook " STR(TIMESCALEDB_VERSION_MOD));
-	if (prev_post_parse_analyze_hook != NULL)
+	if (prev_post_parse_analyze_hook != NULL && !IsParallelWorker())
 		elog(ERROR, "The extension called with a loader should always have a NULL prev hook");
 	if (BROKEN && !creating_extension)
 		elog(ERROR, "mock broken " STR(TIMESCALEDB_VERSION_MOD));
@@ -55,7 +56,7 @@ _PG_init(void)
 	extension_check_version(TIMESCALEDB_VERSION_MOD);
 	elog(WARNING, "mock init " STR(TIMESCALEDB_VERSION_MOD));
 	prev_post_parse_analyze_hook = post_parse_analyze_hook;
-	if (prev_post_parse_analyze_hook != NULL)
+	if (prev_post_parse_analyze_hook != NULL && !IsParallelWorker())
 		elog(ERROR, "The extension loaded with a loader should always have a NULL prev hook");
 	post_parse_analyze_hook = post_analyze_hook;
 	CacheRegisterRelcacheCallback(cache_invalidate_callback, PointerGetDatum(NULL));

--- a/test/sql/loader.sql
+++ b/test/sql/loader.sql
@@ -196,3 +196,12 @@ CREATE EXTENSION timescaledb VERSION 'mock-2';
 \c single :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-2';
 \dx
+
+--make sure parallel workers started after a 'DISCARD ALL' work
+CREATE TABLE test (i int, j double precision);
+INSERT INTO test SELECT x, x+0.1 FROM generate_series(1,100) AS x;
+
+DISCARD ALL;
+SET force_parallel_mode = 'on';
+SET max_parallel_workers_per_gather = 1;
+SELECT count(*) FROM test;


### PR DESCRIPTION
Previously, the GUC to let the versioned-extension know that
the loader was present was incorrectly reset during DISCARD ALL.
This caused newly minted parallel workers to throw an error
about the extension not being preloaded since it did not
know that a loader was, in fact, preloaded. This PR
fixes that by setting the correct default value for the GUC.

It also disables the loader in parallel workers since the loading
should have been handled in the parallel leader and the worker
start-up logic. Fixes #496 