### PR TITLE
Fix a compilation issue on pre 9.6.3 versions

### DIFF
--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -282,7 +282,7 @@ revoke_role_tuple_found(TupleInfo *ti, void *data)
 
 	foreach(lc_role, stmt->grantee_roles)
 	{
-		RoleSpec   *rolespec = lfirst_node(RoleSpec, lc_role);
+		RoleSpec   *rolespec = lfirst(lc_role);
 #if PG96
 		Oid			grantee = get_rolespec_oid((Node *) rolespec, true);
 #else


### PR DESCRIPTION
Macros that provide type assertion, like castNode() and lfirst_node()
were introduced in PG 9.6.3 and cannot be used if we want to support
the entire 9.6 series of releases. This change fixes usage of such
macros that was introduced as part of the 0.9.2 release of
TimescaleDB.