### PR TITLE
Improve memory allocation during cache lookups

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -6,6 +6,7 @@
 /* List of pinned caches. A cache occurs once in this list for every pin
  * taken */
 static List *pinned_caches = NIL;
+
 typedef struct CachePin
 {
 	Cache	   *cache;
@@ -17,7 +18,7 @@ cache_init(Cache *cache)
 {
 	if (cache->htab != NULL)
 	{
-		elog(ERROR, "Cache %s is already initialized", cache->name);
+		elog(ERROR, "cache %s is already initialized", cache->name);
 		return;
 	}
 
@@ -144,9 +145,7 @@ cache_fetch(Cache *cache, CacheQuery *query)
 	HASHACTION	action = cache->create_entry == NULL ? HASH_FIND : HASH_ENTER;
 
 	if (cache->htab == NULL)
-	{
-		elog(ERROR, "Hash %s not initialized", cache->name);
-	}
+		elog(ERROR, "hash %s is not initialized", cache->name);
 
 	query->result = hash_search(cache->htab, cache->get_key(query), action, &found);
 
@@ -155,12 +154,7 @@ cache_fetch(Cache *cache, CacheQuery *query)
 		cache->stats.hits++;
 
 		if (cache->update_entry != NULL)
-		{
-			MemoryContext old = cache_switch_to_memory_context(cache);
-
 			query->result = cache->update_entry(cache, query);
-			MemoryContextSwitchTo(old);
-		}
 	}
 	else
 	{
@@ -168,11 +162,8 @@ cache_fetch(Cache *cache, CacheQuery *query)
 
 		if (cache->create_entry != NULL)
 		{
-			MemoryContext old = cache_switch_to_memory_context(cache);
-
-			query->result = cache->create_entry(cache, query);
-			MemoryContextSwitchTo(old);
 			cache->stats.numelements++;
+			query->result = cache->create_entry(cache, query);
 		}
 	}
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -38,7 +38,7 @@ typedef struct Cache
 
 extern void cache_init(Cache *cache);
 extern void cache_invalidate(Cache *cache);
-extern void *cache_fetch(Cache *cache, CacheQuery *ctx);
+extern void *cache_fetch(Cache *cache, CacheQuery *query);
 extern bool cache_remove(Cache *cache, void *key);
 
 extern MemoryContext cache_memory_ctx(Cache *cache);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -104,22 +104,6 @@ chunk_fill(Chunk *chunk, HeapTuple tuple)
 	chunk->hypertable_relid = parent_relid(chunk->table_id);
 }
 
-Chunk *
-chunk_create_from_tuple(HeapTuple tuple, int16 num_constraints)
-{
-	Chunk	   *chunk = palloc0(sizeof(Chunk));
-
-	chunk_fill(chunk, tuple);
-
-	if (num_constraints > 0)
-	{
-		chunk->constraints = chunk_constraint_scan_by_chunk_id(chunk->fd.id, num_constraints);
-		chunk->cube = hypercube_from_constraints(chunk->constraints);
-	}
-
-	return chunk;
-}
-
 /*-
  * Align a chunk's hypercube in 'aligned' dimensions.
  *
@@ -532,7 +516,7 @@ chunk_create_stub(int32 id, int16 num_constraints)
 	chunk->fd.id = id;
 
 	if (num_constraints > 0)
-		chunk->constraints = chunk_constraints_alloc(num_constraints);
+		chunk->constraints = chunk_constraints_alloc(num_constraints, CurrentMemoryContext);
 
 	return chunk;
 }
@@ -590,7 +574,7 @@ chunk_fill_stub(Chunk *chunk_stub, bool tuplock)
 		elog(ERROR, "No chunk found with ID %d", chunk_stub->fd.id);
 
 	if (NULL == chunk_stub->cube)
-		chunk_stub->cube = hypercube_from_constraints(chunk_stub->constraints);
+		chunk_stub->cube = hypercube_from_constraints(chunk_stub->constraints, CurrentMemoryContext);
 	else
 
 		/*
@@ -842,7 +826,8 @@ chunk_find(Hyperspace *hs, Point *p)
 		 * constraints to also get the inherited constraints.
 		 */
 		chunk->constraints = chunk_constraint_scan_by_chunk_id(chunk->fd.id,
-															   hs->num_dimensions);
+															   hs->num_dimensions,
+															   CurrentMemoryContext);
 	}
 
 	return chunk;
@@ -919,7 +904,8 @@ chunk_scan_internal(int indexid,
 					tuple_found_func tuple_found,
 					void *data,
 					int limit,
-					LOCKMODE lockmode)
+					LOCKMODE lockmode,
+					MemoryContext mctx)
 {
 	Catalog    *catalog = catalog_get();
 	ScannerCtx	ctx = {
@@ -932,6 +918,7 @@ chunk_scan_internal(int indexid,
 		.limit = limit,
 		.lockmode = lockmode,
 		.scandirection = ForwardScanDirection,
+		.result_mctx = mctx,
 	};
 
 	return scanner_scan(&ctx);
@@ -942,9 +929,10 @@ chunk_scan_find(int indexid,
 				ScanKeyData scankey[],
 				int nkeys,
 				int16 num_constraints,
+				MemoryContext mctx,
 				bool fail_if_not_found)
 {
-	Chunk	   *chunk = palloc0(sizeof(Chunk));
+	Chunk	   *chunk = MemoryContextAllocZero(mctx, sizeof(Chunk));
 	int			num_found;
 
 	num_found = chunk_scan_internal(indexid,
@@ -953,7 +941,8 @@ chunk_scan_find(int indexid,
 									chunk_tuple_found,
 									chunk,
 									num_constraints,
-									AccessShareLock);
+									AccessShareLock,
+									mctx);
 
 	switch (num_found)
 	{
@@ -966,8 +955,8 @@ chunk_scan_find(int indexid,
 		case 1:
 			if (num_constraints > 0)
 			{
-				chunk->constraints = chunk_constraint_scan_by_chunk_id(chunk->fd.id, num_constraints);
-				chunk->cube = hypercube_from_constraints(chunk->constraints);
+				chunk->constraints = chunk_constraint_scan_by_chunk_id(chunk->fd.id, num_constraints, mctx);
+				chunk->cube = hypercube_from_constraints(chunk->constraints, mctx);
 			}
 			break;
 		default:
@@ -978,8 +967,11 @@ chunk_scan_find(int indexid,
 }
 
 Chunk *
-chunk_get_by_name(const char *schema_name, const char *table_name,
-				  int16 num_constraints, bool fail_if_not_found)
+chunk_get_by_name_with_memory_context(const char *schema_name,
+									  const char *table_name,
+									  int16 num_constraints,
+									  MemoryContext mctx,
+									  bool fail_if_not_found)
 {
 	NameData	schema,
 				table;
@@ -997,7 +989,7 @@ chunk_get_by_name(const char *schema_name, const char *table_name,
 				F_NAMEEQ, NameGetDatum(&table));
 
 	return chunk_scan_find(CHUNK_SCHEMA_NAME_INDEX, scankey, 2,
-						   num_constraints, fail_if_not_found);
+						   num_constraints, mctx, fail_if_not_found);
 }
 
 Chunk *
@@ -1025,8 +1017,12 @@ chunk_get_by_id(int32 id, int16 num_constraints, bool fail_if_not_found)
 	ScanKeyInit(&scankey[0], Anum_chunk_idx_id, BTEqualStrategyNumber,
 				F_INT4EQ, id);
 
-	return chunk_scan_find(CHUNK_ID_INDEX, scankey, 1,
-						   num_constraints, fail_if_not_found);
+	return chunk_scan_find(CHUNK_ID_INDEX,
+						   scankey,
+						   1,
+						   num_constraints,
+						   CurrentMemoryContext,
+						   fail_if_not_found);
 }
 
 bool
@@ -1046,7 +1042,7 @@ chunk_tuple_delete(TupleInfo *ti, void *data)
 {
 	FormData_chunk *form = (FormData_chunk *) GETSTRUCT(ti->tuple);
 	CatalogSecurityContext sec_ctx;
-	ChunkConstraints *ccs = chunk_constraints_alloc(2);
+	ChunkConstraints *ccs = chunk_constraints_alloc(2, ti->mctx);
 	int			i;
 
 	chunk_constraint_delete_by_chunk_id(form->id, ccs);
@@ -1085,7 +1081,8 @@ chunk_delete_by_name(const char *schema, const char *table)
 
 	return chunk_scan_internal(CHUNK_SCHEMA_NAME_INDEX, scankey, 2,
 							   chunk_tuple_delete, NULL, 0,
-							   RowExclusiveLock);
+							   RowExclusiveLock,
+							   CurrentMemoryContext);
 }
 
 int
@@ -1107,7 +1104,8 @@ chunk_delete_by_hypertable_id(int32 hypertable_id)
 
 	return chunk_scan_internal(CHUNK_HYPERTABLE_ID_INDEX, scankey, 1,
 							   chunk_tuple_delete, NULL, 0,
-							   RowExclusiveLock);
+							   RowExclusiveLock,
+							   CurrentMemoryContext);
 }
 
 static bool

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -62,14 +62,13 @@ typedef struct ChunkScanEntry
 	Chunk	   *chunk;
 } ChunkScanEntry;
 
-extern Chunk *chunk_create_from_tuple(HeapTuple tuple, int16 num_constraints);
 extern Chunk *chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
 extern Chunk *chunk_create_stub(int32 id, int16 num_constraints);
 extern void chunk_free(Chunk *chunk);
 extern Chunk *chunk_find(Hyperspace *hs, Point *p);
 extern List *chunk_find_all_oids(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode);
 extern Chunk *chunk_copy(Chunk *chunk);
-extern Chunk *chunk_get_by_name(const char *schema_name, const char *table_name, int16 num_constraints, bool fail_if_not_found);
+extern Chunk *chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name, int16 num_constraints, MemoryContext mctx, bool fail_if_not_found);
 extern Chunk *chunk_get_by_relid(Oid relid, int16 num_constraints, bool fail_if_not_found);
 extern Chunk *chunk_get_by_id(int32 id, int16 num_constraints, bool fail_if_not_found);
 extern bool chunk_exists(const char *schema_name, const char *table_name);
@@ -78,5 +77,9 @@ extern void chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 d
 extern int	chunk_delete_by_relid(Oid chunk_oid);
 extern int	chunk_delete_by_hypertable_id(int32 hypertable_id);
 extern int	chunk_delete_by_name(const char *schema, const char *table);
+
+#define chunk_get_by_name(schema_name, table_name, num_constraints, fail_if_not_found) \
+	chunk_get_by_name_with_memory_context(schema_name, table_name, num_constraints, \
+										  CurrentMemoryContext, fail_if_not_found)
 
 #endif							/* TIMESCALEDB_CHUNK_H */

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -15,6 +15,7 @@ typedef struct ChunkConstraint
 
 typedef struct ChunkConstraints
 {
+	MemoryContext mctx;
 	int16		capacity;
 	int16		num_constraints;
 	int16		num_dimension_constraints;
@@ -33,8 +34,8 @@ typedef struct DimensionSlice DimensionSlice;
 typedef struct Hypercube Hypercube;
 typedef struct ChunkScanCtx ChunkScanCtx;
 
-extern ChunkConstraints *chunk_constraints_alloc(int size_hint);
-extern ChunkConstraints *chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint);
+extern ChunkConstraints *chunk_constraints_alloc(int size_hint, MemoryContext mctx);
+extern ChunkConstraints *chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint, MemoryContext mctx);
 extern ChunkConstraints *chunk_constraints_copy(ChunkConstraints *constraints);
 extern int	chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx *ctx);
 extern int	chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkConstraints *ccs);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -94,7 +94,7 @@ typedef struct DimensionInfo
 	 (di)->colname != NULL &&											\
 	 ((di)->num_slices_is_set || OidIsValid((di)->interval_datum)))
 
-extern Hyperspace *dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension);
+extern Hyperspace *dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension, MemoryContext mctx);
 extern DimensionSlice *dimension_calculate_default_slice(Dimension *dim, int64 value);
 extern Point *hyperspace_calculate_point(Hyperspace *h, HeapTuple tuple, TupleDesc tupdesc);
 extern Dimension *hyperspace_get_dimension_by_id(Hyperspace *hs, int32 id);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -29,7 +29,7 @@ extern DimensionVec *dimension_slice_scan_range_limit(int32 dimension_id, Strate
 extern DimensionVec *dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, int64 range_end, int limit);
 extern Hypercube *dimension_slice_point_scan(Hyperspace *space, int64 point[]);
 extern DimensionSlice *dimension_slice_scan_for_existing(DimensionSlice *slice);
-extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id);
+extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
 extern DimensionVec *dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
 extern int	dimension_slice_delete_by_dimension_id(int32 dimension_id, bool delete_constraints);
 extern int	dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraints);

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -130,10 +130,15 @@ hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id)
  * Given a set of constraints, build the corresponding hypercube.
  */
 Hypercube *
-hypercube_from_constraints(ChunkConstraints *constraints)
+hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx)
 {
-	Hypercube  *hc = hypercube_alloc(constraints->num_dimension_constraints);
+	Hypercube  *hc;
 	int			i;
+	MemoryContext old;
+
+	old = MemoryContextSwitchTo(mctx);
+	hc = hypercube_alloc(constraints->num_dimension_constraints);
+	MemoryContextSwitchTo(old);
 
 	for (i = 0; i < constraints->num_constraints; i++)
 	{
@@ -144,7 +149,7 @@ hypercube_from_constraints(ChunkConstraints *constraints)
 			DimensionSlice *slice;
 
 			Assert(hc->num_slices < constraints->num_dimension_constraints);
-			slice = dimension_slice_scan_by_id(cc->fd.dimension_slice_id);
+			slice = dimension_slice_scan_by_id(cc->fd.dimension_slice_id, mctx);
 			Assert(slice != NULL);
 			hc->slices[hc->num_slices++] = slice;
 		}

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -25,7 +25,7 @@ typedef struct Hypercube
 extern Hypercube *hypercube_alloc(int16 num_dimensions);
 extern void hypercube_free(Hypercube *hc);
 extern void hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
-extern Hypercube *hypercube_from_constraints(ChunkConstraints *constraints);
+extern Hypercube *hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
 extern Hypercube *hypercube_calculate_from_point(Hyperspace *hs, Point *p);
 extern bool hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
 extern DimensionSlice *hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id);

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -27,8 +27,8 @@ extern Hypertable *hypertable_get_by_id(int32 hypertable_id);
 extern Hypertable *hypertable_get_by_name(char *schema, char *name);
 extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
 extern Oid	hypertable_permissions_check(Oid hypertable_oid, Oid userid);
-extern Hypertable *hypertable_from_tuple(HeapTuple tuple);
-extern int	hypertable_scan(const char *schema, const char *table, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock);
+extern Hypertable *hypertable_from_tuple(HeapTuple tuple, MemoryContext mctx);
+extern int	hypertable_scan_with_memory_context(const char *schema, const char *table, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock, MemoryContext mctx);
 extern int	hypertable_scan_relid(Oid table_relid, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock);
 extern HTSU_Result hypertable_lock_tuple(Oid table_relid);
 extern bool hypertable_lock_tuple_simple(Oid table_relid);
@@ -47,5 +47,8 @@ extern Tablespace *hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
 extern char *hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
 extern Tablespace *hypertable_get_tablespace_at_offset_from(Hypertable *ht, Oid tablespace_oid, int16 offset);
 extern bool hypertable_has_tuples(Oid table_relid, LOCKMODE lockmode);
+
+#define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock) \
+	hypertable_scan_with_memory_context(schema, table, tuple_found, data, lockmode, tuplock, CurrentMemoryContext)
 
 #endif							/* TIMESCALEDB_HYPERTABLE_H */

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -140,6 +140,7 @@ partitioning_info_create(const char *schema,
 						 Oid relid)
 {
 	PartitioningInfo *pinfo;
+	TypeCacheEntry *tce;
 	Oid			columntype,
 				varcollid,
 				funccollid = InvalidOid;
@@ -160,9 +161,9 @@ partitioning_info_create(const char *schema,
 
 	/* Lookup the type cache entry to access the hash function for the type */
 	columntype = get_atttype(relid, pinfo->column_attnum);
-	pinfo->typcache_entry = lookup_type_cache(columntype, TYPECACHE_HASH_FLAGS);
+	tce = lookup_type_cache(columntype, TYPECACHE_HASH_FLAGS);
 
-	if (pinfo->typcache_entry->hash_proc == InvalidOid)
+	if (tce->hash_proc == InvalidOid)
 		elog(ERROR, "could not find hash function for type %u", columntype);
 
 	partitioning_func_set_func_fmgr(&pinfo->partfunc);

--- a/src/partitioning.h
+++ b/src/partitioning.h
@@ -34,7 +34,6 @@ typedef struct PartitioningInfo
 {
 	char		column[NAMEDATALEN];
 	AttrNumber	column_attnum;
-	TypeCacheEntry *typcache_entry;
 	PartitioningFunc partfunc;
 } PartitioningInfo;
 
@@ -46,7 +45,6 @@ extern PartitioningInfo *partitioning_info_create(const char *schema,
 						 const char *partfunc,
 						 const char *partcol,
 						 Oid relid);
-
 extern List *partitioning_func_qualified_name(PartitioningFunc *pf);
 extern int32 partitioning_func_apply(PartitioningInfo *pinfo, Datum value);
 extern int32 partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDesc desc);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -172,6 +172,7 @@ scanner_scan(ScannerCtx *ctx)
 
 	ictx.tinfo.scanrel = ictx.tablerel;
 	ictx.tinfo.desc = tuple_desc;
+	ictx.tinfo.mctx = ctx->result_mctx == NULL ? CurrentMemoryContext : ctx->result_mctx;
 
 	/* Call pre-scan handler, if any. */
 	if (ctx->prescan != NULL)

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -29,6 +29,12 @@ typedef struct TupleInfo
 	 */
 	HTSU_Result lockresult;
 	int			count;
+
+	/*
+	 * The memory context (optionally) set initially in the ScannerCtx. This
+	 * can be used to allocate data on in the tuple handle function.
+	 */
+	MemoryContext mctx;
 } TupleInfo;
 
 typedef bool (*tuple_found_func) (TupleInfo *ti, void *data);
@@ -45,6 +51,8 @@ typedef struct ScannerCtx
 								 * less means no limit */
 	bool		want_itup;
 	LOCKMODE	lockmode;
+	MemoryContext result_mctx;	/* The memory context to allocate the result
+								 * on */
 	struct
 	{
 		LockTupleMode lockmode;

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -1,4 +1,5 @@
 #include <postgres.h>
+#include <utils/memutils.h>
 
 #include "dimension.h"
 #include "dimension_slice.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,22 +24,6 @@ extern int64 date_trunc_interval_period_approx(text *units);
  */
 extern int64 get_interval_period_approx(Interval *interval);
 
-#if 0
-#define CACHE1_elog(a,b)				elog(a,b)
-#define CACHE2_elog(a,b,c)				elog(a,b,c)
-#define CACHE3_elog(a,b,c,d)			elog(a,b,c,d)
-#define CACHE4_elog(a,b,c,d,e)			elog(a,b,c,d,e)
-#define CACHE5_elog(a,b,c,d,e,f)		elog(a,b,c,d,e,f)
-#define CACHE6_elog(a,b,c,d,e,f,g)		elog(a,b,c,d,e,f,g)
-#else
-#define CACHE1_elog(a,b)
-#define CACHE2_elog(a,b,c)
-#define CACHE3_elog(a,b,c,d)
-#define CACHE4_elog(a,b,c,d,e)
-#define CACHE5_elog(a,b,c,d,e,f)
-#define CACHE6_elog(a,b,c,d,e,f,g)
-#endif
-
 extern FmgrInfo *create_fmgr(char *schema, char *function_name, int num_args);
 extern RangeVar *makeRangeVarFromRelid(Oid relid);
 extern int	int_cmp(const void *a, const void *b);


### PR DESCRIPTION
Previously, cache lookups were run on the cache's memory
context. While simple, this risked allocating transient (work) data on
that memory context, e.g., when scanning for new cache data during
cache misses.

This change makes scan functions take a memory context, which the
found data should be allocated on. All other data is allocated on the
current memory (typically the transaction's memory context). With this
functionality, a cache can pass its memory context to the scan, thus
avoiding taking on unnecessary memory allocations.