### PR TITLE
Fix static analyzer warning when checking for index attributes

### DIFF
--- a/src/indexing.c
+++ b/src/indexing.c
@@ -23,7 +23,7 @@ index_has_attribute(List *indexelems, const char *attrname)
 	foreach(lc, indexelems)
 	{
 		Node	   *node = lfirst(lc);
-		const char *colname;
+		const char *colname = NULL;
 
 		/*
 		 * The type of the element varies depending on whether the list is
@@ -53,7 +53,7 @@ index_has_attribute(List *indexelems, const char *attrname)
 				elog(ERROR, "unsupported index list element");
 		}
 
-		if (strncmp(colname, attrname, NAMEDATALEN) == 0)
+		if (colname != NULL && strncmp(colname, attrname, NAMEDATALEN) == 0)
 			return true;
 	}
 


### PR DESCRIPTION
This fixes a static analyzer warning about using an unititalized
pointer. The analyzer doesn't realize that elog() will generate an
exception, so that the unitialized NULL check will never occur. This
change will clarify the code and silence the static analyzer.