### PR TITLE
Add support for changing chunk schema and name

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -77,6 +77,8 @@ extern void chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 d
 extern int	chunk_delete_by_relid(Oid chunk_oid);
 extern int	chunk_delete_by_hypertable_id(int32 hypertable_id);
 extern int	chunk_delete_by_name(const char *schema, const char *table);
+extern bool chunk_set_name(Chunk *chunk, const char *newname);
+extern bool chunk_set_schema(Chunk *chunk, const char *newschema);
 
 #define chunk_get_by_name(schema_name, table_name, num_constraints, fail_if_not_found) \
 	chunk_get_by_name_with_memory_context(schema_name, table_name, num_constraints, \

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -130,3 +130,32 @@ SELECT * FROM alter_after;
  Tue Aug 22 09:19:14 2017 | 12.5 |       3 |  7
 (7 rows)
 
+-- Need superuser to ALTER chunks in _timescaledb_internal schema
+\c single :ROLE_SUPERUSER
+SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id |      schema_name      |    table_name    
+----+---------------+-----------------------+------------------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk
+(1 row)
+
+-- Rename chunk
+ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
+SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id |      schema_name      |   table_name   
+----+---------------+-----------------------+----------------
+  2 |             2 | _timescaledb_internal | new_chunk_name
+(1 row)
+
+-- Set schema
+ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
+SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+ id | hypertable_id | schema_name |   table_name   
+----+---------------+-------------+----------------
+  2 |             2 | public      | new_chunk_name
+(1 row)
+
+-- Test that we cannot rename chunk columns
+\set ON_ERROR_STOP 0
+ALTER TABLE public.new_chunk_name RENAME COLUMN time TO newtime;
+ERROR:  cannot rename column "time" of hypertable chunk "new_chunk_name"
+\set ON_ERROR_STOP 1

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -56,3 +56,20 @@ AND a.attnum > 0
 ORDER BY c.relname, a.attnum;
 
 SELECT * FROM alter_after;
+
+-- Need superuser to ALTER chunks in _timescaledb_internal schema
+\c single :ROLE_SUPERUSER
+SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+
+-- Rename chunk
+ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
+SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+
+-- Set schema
+ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
+SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
+
+-- Test that we cannot rename chunk columns
+\set ON_ERROR_STOP 0
+ALTER TABLE public.new_chunk_name RENAME COLUMN time TO newtime;
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Previously, chunks could be renamed and have their schema changed, but
the metadata in the TimescaleDB catalog was not updated in a
corresponding way. Further, renaming a chunk column was possible,
which could break functionality on the hypertable.

Then catalog metadata is now properly updated on name and schema
changes applied to chunks. Renaming chunk columns have been blocked
with an informational error message.