### PR TITLE
Helpful runtime error message in pgindent target when there's no objdump

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -8,7 +8,7 @@ endif (APPLE)
 
 if (OBJDUMP)
   message(STATUS "Using objdump ${OBJDUMP}")
-  configure_file(generate_typedefs.sh.in generate_typedefs.sh @ONLY)
 else ()
   message(STATUS "Install objdump or gobjdump to be able to run pgindent")
 endif (OBJDUMP)
+configure_file(generate_typedefs.sh.in generate_typedefs.sh @ONLY)

--- a/scripts/generate_typedefs.sh.in
+++ b/scripts/generate_typedefs.sh.in
@@ -1,16 +1,21 @@
 #!/bin/bash
 
+if [ ! -x "@OBJDUMP@" ];
+then
+  echo "Cannot generate typedefs.list for pgindent because objdump is not installed" >&2
+  exit 1
+fi
 TMPDIR=${TMPDIR:-$(mktemp -d 2>/dev/null || mktemp -d -t 'timescaledb_typedef')}
 
 trap cleanup EXIT
 
 cleanup() {
-    rm -rf ${TMPDIR}
+  rm -rf ${TMPDIR}
 }
 
 @OBJDUMP@ -W @CMAKE_BINARY_DIR@/src/CMakeFiles/timescaledb.dir/*.o |egrep -A3 DW_TAG_typedef |perl -e 'while (<>) { chomp; @flds = split;next unless (1 < @flds);\
-     next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
-     next if $flds[-1] =~ /^DW_FORM_str/;\
-     print $flds[-1],"\n"; }' |sort |uniq > ${TMPDIR}/typedefs.list.local
+   next if $flds[0]  ne "DW_AT_name" && $flds[1] ne "DW_AT_name";\
+   next if $flds[-1] =~ /^DW_FORM_str/;\
+   print $flds[-1],"\n"; }' |sort |uniq > ${TMPDIR}/typedefs.list.local
 wget -q -O - "http://www.pgbuildfarm.org/cgi-bin/typedefs.pl?branch=HEAD" |\
- cat - ${TMPDIR}/typedefs.list.local | sort | uniq
+  cat - ${TMPDIR}/typedefs.list.local | sort | uniq

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,14 +153,14 @@ else ()
 endif (PGINDENT)
 
 # Configuration for running pgindent
-if (OBJDUMP AND PGINDENT)
+if (PGINDENT)
   add_custom_command(OUTPUT typedefs.list
     DEPENDS ${PROJECT_NAME}
     COMMAND sh ${CMAKE_BINARY_DIR}/scripts/generate_typedefs.sh > typedefs.list)
   add_custom_target(pgindent
     COMMAND ${PGINDENT} -typedefs typedefs.list -code-base ${CMAKE_SOURCE_DIR}/src
     DEPENDS typedefs.list)
-endif (OBJDUMP AND PGINDENT)
+endif (PGINDENT)
 
 add_library(${PROJECT_NAME} MODULE ${SOURCES} ${HEADERS} ${GITCOMMIT_H})
 


### PR DESCRIPTION
Trying to run `make pgindent` should result in runtime error if OBJDUMP not installed. This is in contrast to the current error message, which is easily missed during compile-time.