### PR TITLE
Improve version checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 env:
   # PG_VERSION (docker) and PG_GIT_TAG (Git) should be the same
   - PG_VERSION=9.6.6 PG_GIT_TAG=REL9_6_6
-  - PG_VERSION=10.0 PG_GIT_TAG=REL_10_0
+  - PG_VERSION=10.2 PG_GIT_TAG=REL_10_2
 before_install:
   # We need the PostgreSQL source for running the standard PostgreSQL
   # regression tests

--- a/src/compat.h
+++ b/src/compat.h
@@ -1,8 +1,12 @@
 #ifndef TIMESCALEDB_COMPAT_H
 #define TIMESCALEDB_COMPAT_H
 
-#define PG96 ((PG_VERSION_NUM >= 90600) && (PG_VERSION_NUM < 100000))
-#define PG10 ((PG_VERSION_NUM >= 100000) && (PG_VERSION_NUM < 110000))
+#define is_supported_pg_version_96(version) ((version >= 90603) && (version < 100000))
+#define is_supported_pg_version_10(version) ((version >= 100002) && (version < 110000))
+#define is_supported_pg_version(version) (is_supported_pg_version_96(version) || is_supported_pg_version_10(version))
+
+#define PG96 is_supported_pg_version_96(PG_VERSION_NUM)
+#define PG10 is_supported_pg_version_10(PG_VERSION_NUM)
 
 #if PG10
 

--- a/src/extension.h
+++ b/src/extension.h
@@ -7,6 +7,7 @@
 bool		extension_invalidate(Oid relid);
 bool		extension_is_loaded(void);
 void		extension_check_version(const char *so_version);
+void		extension_check_server_version(void);
 Oid			extension_schema_oid(void);
 
 #endif							/* TIMESCALEDB_EXTENSION_H */

--- a/src/init.c
+++ b/src/init.c
@@ -47,6 +47,7 @@ _PG_init(void)
 	 * functions defined on the wrong extension version
 	 */
 	extension_check_version(TIMESCALEDB_VERSION_MOD);
+	extension_check_server_version();
 
 	_chunk_dispatch_info_init();
 	_cache_init();


### PR DESCRIPTION
This PR adds a load-time check to the versioned extension for the
expected Postgres versions. This better handles the case where the
extension is distributed as a binary and compiled on a different
Postgres version than the one it is running on.

We also change the versioning to require:
PG >= 9.6.3 to avoid issues with missing functions in previous versions
OR
PG >= 10.2 to avoid issues with ABI incompatibility at PG 10.0 and 10.1