### PR TITLE
Fix formatting to comply with pgindent

### DIFF
--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -284,7 +284,7 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig)
 		if (transformed_expr != ec_mem->em_expr)
 		{
 			EquivalenceMember *em;
-			Oid			type = exprType((Node *) transformed_expr);
+			Oid			type_oid = exprType((Node *) transformed_expr);
 			List	   *opfamilies = list_copy(orig->ec_opfamilies);
 
 			/*
@@ -293,7 +293,7 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig)
 			 */
 			EquivalenceClass *exist =
 			get_eclass_for_sort_expr(root, transformed_expr, ec_mem->em_nullable_relids,
-									 opfamilies, type,
+									 opfamilies, type_oid,
 									 orig->ec_collation, orig->ec_sortref,
 									 ec_mem->em_relids, false);
 
@@ -309,7 +309,7 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig)
 			em->em_nullable_relids = bms_copy(ec_mem->em_nullable_relids);
 			em->em_is_const = ec_mem->em_is_const;
 			em->em_is_child = ec_mem->em_is_child;
-			em->em_datatype = type;
+			em->em_datatype = type_oid;
 
 			if (newec == NULL)
 			{

--- a/src/utils.c
+++ b/src/utils.c
@@ -167,9 +167,10 @@ time_to_internal(PG_FUNCTION_ARGS)
 int64
 time_value_to_internal(Datum time_val, Oid type_oid, bool failure_ok)
 {
-	Datum res, tz;
+	Datum		res,
+				tz;
 
-	switch(type_oid)
+	switch (type_oid)
 	{
 		case INT8OID:
 			return DatumGetInt64(time_val);
@@ -178,10 +179,11 @@ time_value_to_internal(Datum time_val, Oid type_oid, bool failure_ok)
 		case INT2OID:
 			return (int64) DatumGetInt16(time_val);
 		case TIMESTAMPOID:
+
 			/*
-			* for timestamps, ignore timezones, make believe the timestamp is at
-			* UTC
-			*/
+			 * for timestamps, ignore timezones, make believe the timestamp is
+			 * at UTC
+			 */
 			res = DirectFunctionCall1(pg_timestamp_to_unix_microseconds, time_val);
 
 			return DatumGetInt64(res);
@@ -425,7 +427,7 @@ date_trunc_interval_period_approx(text *units)
 		case DTK_YEAR:
 			return 1 * DAYS_PER_YEAR * USECS_PER_DAY;
 		case DTK_QUARTER:
-			return  DAYS_PER_QUARTER * USECS_PER_DAY;
+			return DAYS_PER_QUARTER * USECS_PER_DAY;
 		case DTK_MONTH:
 			return DAYS_PER_MONTH * USECS_PER_DAY;
 		case DTK_DAY:


### PR DESCRIPTION
This PR fixes all the formatting to be inline with the latest version of
pgindent. Since pgindent does not like variables named `type`, those
have been appropriately renamed.