### PR TITLE
Update statistics on parent table when doing ANALYZE

### DIFF
--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -21,6 +21,13 @@ ORDER BY schemaname, tablename;
 -----------+---------+------------------+------------
 (0 rows)
 
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
+ORDER BY schemaname, tablename;
+ tablename | attname | histogram_bounds | n_distinct 
+-----------+---------+------------------+------------
+(0 rows)
+
 VACUUM (VERBOSE, ANALYZE) vacuum_test;
 INFO:  vacuuming "_timescaledb_internal._hyper_1_1_chunk"
 INFO:  index "_hyper_1_1_chunk_vacuum_test_time_idx" now contains 2 row versions in 2 pages
@@ -37,6 +44,15 @@ INFO:  index "_hyper_1_3_chunk_vacuum_test_time_idx" now contains 2 row versions
 INFO:  "_hyper_1_3_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
 INFO:  analyzing "_timescaledb_internal._hyper_1_3_chunk"
 INFO:  "_hyper_1_3_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  vacuuming "public.vacuum_test"
+INFO:  index "vacuum_test_time_idx" now contains 0 row versions in 1 pages
+INFO:  "vacuum_test": found 0 removable, 0 nonremovable row versions in 0 out of 0 pages
+INFO:  analyzing "public.vacuum_test"
+INFO:  "vacuum_test": scanned 0 of 0 pages, containing 0 live rows and 0 dead rows; 0 rows in sample, 0 estimated total rows
+INFO:  analyzing "public.vacuum_test" inheritance tree
+INFO:  "_hyper_1_1_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  "_hyper_1_2_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  "_hyper_1_3_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
@@ -50,6 +66,84 @@ ORDER BY schemaname, tablename;
  _hyper_1_3_chunk | time    | {"Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
  _hyper_1_3_chunk | temp    | {11,18.5}                                               |         -1
 (6 rows)
+
+-- stats should exist on parent hypertable
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
+ORDER BY schemaname, tablename;
+  tablename  | attname |                                                                          histogram_bounds                                                                           | n_distinct 
+-------------+---------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------
+ vacuum_test | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017","Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017","Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
+ vacuum_test | temp    | {11,17.1,17.5,18.5,19.1,89.5}                                                                                                                                       |         -1
+(2 rows)
+
+DROP TABLE vacuum_test;
+--test plain analyze (no_vacuum)
+CREATE TABLE analyze_test(time timestamp, temp float);
+SELECT create_hypertable('analyze_test', 'time', chunk_time_interval => 2628000000000);
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO analyze_test VALUES ('2017-01-20T16:00:01', 17.5),
+                               ('2017-01-21T16:00:01', 19.1),
+                               ('2017-04-20T16:00:01', 89.5),
+                               ('2017-04-21T16:00:01', 17.1),
+                               ('2017-06-20T16:00:01', 18.5),
+                               ('2017-06-21T16:00:01', 11.0);
+-- no stats
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
+ORDER BY schemaname, tablename;
+ tablename | attname | histogram_bounds | n_distinct 
+-----------+---------+------------------+------------
+(0 rows)
+
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
+ORDER BY schemaname, tablename;
+ tablename | attname | histogram_bounds | n_distinct 
+-----------+---------+------------------+------------
+(0 rows)
+
+ANALYZE VERBOSE analyze_test;
+INFO:  analyzing "_timescaledb_internal._hyper_2_4_chunk"
+INFO:  "_hyper_2_4_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  analyzing "_timescaledb_internal._hyper_2_5_chunk"
+INFO:  "_hyper_2_5_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  analyzing "_timescaledb_internal._hyper_2_6_chunk"
+INFO:  "_hyper_2_6_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  analyzing "public.analyze_test"
+INFO:  "analyze_test": scanned 0 of 0 pages, containing 0 live rows and 0 dead rows; 0 rows in sample, 0 estimated total rows
+INFO:  analyzing "public.analyze_test" inheritance tree
+INFO:  "_hyper_2_4_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  "_hyper_2_5_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+INFO:  "_hyper_2_6_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+-- stats should exist for all three chunks
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
+ORDER BY schemaname, tablename;
+    tablename     | attname |                    histogram_bounds                     | n_distinct 
+------------------+---------+---------------------------------------------------------+------------
+ _hyper_2_4_chunk | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017"} |         -1
+ _hyper_2_4_chunk | temp    | {17.5,19.1}                                             |         -1
+ _hyper_2_5_chunk | time    | {"Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017"} |         -1
+ _hyper_2_5_chunk | temp    | {17.1,89.5}                                             |         -1
+ _hyper_2_6_chunk | time    | {"Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
+ _hyper_2_6_chunk | temp    | {11,18.5}                                               |         -1
+(6 rows)
+
+-- stats should exist on parent hypertable
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
+ORDER BY schemaname, tablename;
+  tablename   | attname |                                                                          histogram_bounds                                                                           | n_distinct 
+--------------+---------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------
+ analyze_test | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017","Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017","Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
+ analyze_test | temp    | {11,17.1,17.5,18.5,19.1,89.5}                                                                                                                                       |         -1
+(2 rows)
 
 -- Run vacuum on a normal (non-hypertable) table
 CREATE TABLE vacuum_norm(time timestamp, temp float);

--- a/test/sql/vacuum.sql
+++ b/test/sql/vacuum.sql
@@ -15,11 +15,55 @@ SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
 ORDER BY schemaname, tablename;
 
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
+ORDER BY schemaname, tablename;
+
 VACUUM (VERBOSE, ANALYZE) vacuum_test;
 
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
+ORDER BY schemaname, tablename;
+
+-- stats should exist on parent hypertable
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
+ORDER BY schemaname, tablename;
+
+DROP TABLE vacuum_test;
+
+--test plain analyze (no_vacuum)
+CREATE TABLE analyze_test(time timestamp, temp float);
+
+SELECT create_hypertable('analyze_test', 'time', chunk_time_interval => 2628000000000);
+
+INSERT INTO analyze_test VALUES ('2017-01-20T16:00:01', 17.5),
+                               ('2017-01-21T16:00:01', 19.1),
+                               ('2017-04-20T16:00:01', 89.5),
+                               ('2017-04-21T16:00:01', 17.1),
+                               ('2017-06-20T16:00:01', 18.5),
+                               ('2017-06-21T16:00:01', 11.0);
+
+-- no stats
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
+ORDER BY schemaname, tablename;
+
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
+ORDER BY schemaname, tablename;
+
+ANALYZE VERBOSE analyze_test;
+
+-- stats should exist for all three chunks
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
+ORDER BY schemaname, tablename;
+
+-- stats should exist on parent hypertable
+SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
+WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
 ORDER BY schemaname, tablename;
 
 -- Run vacuum on a normal (non-hypertable) table


### PR DESCRIPTION
Previously, when running a VACUUM ANALYZE or ANALYZE on
a hypertable the statics on the parent table (hypertable)
were not correctly updated. This fixes that problem
and adds tests.