### PR TITLE
Fix some ALTER TABLE corner case bugs on hypertables

### DIFF
--- a/src/dimension.h
+++ b/src/dimension.h
@@ -34,6 +34,15 @@ typedef struct Dimension
 #define IS_CLOSED_DIMENSION(d)					\
 	((d)->type == DIMENSION_TYPE_CLOSED)
 
+#define IS_INTEGER_TYPE(type)							\
+	(type == INT2OID || type == INT4OID || type == INT8OID)
+
+#define IS_TIMESTAMP_TYPE(type)									\
+	(type == TIMESTAMPOID || type == TIMESTAMPTZOID || type == DATEOID)
+
+#define IS_VALID_OPEN_DIM_TYPE(type)					\
+	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type))
+
 /*
  * A hyperspace defines how to partition in a N-dimensional space.
  */

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -220,6 +220,13 @@ ERROR:  duplicate key value violates unique constraint "4_6_hyper_unique_with_lo
 ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
 ADD CONSTRAINT hyper_unique_invalid UNIQUE (device_id);
 ERROR:  cannot create a unique index without the column "time" (used in partitioning)
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+ADD COLUMN new_device_id int UNIQUE;
+ERROR:  cannot create a unique index without the column "time" (used in partitioning)
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+DROP COLUMN device_id,
+ADD COLUMN new_device_id int UNIQUE;
+ERROR:  cannot create a unique index without the column "time" (used in partitioning)
 \set ON_ERROR_STOP 1
 ----------------------- RENAME CONSTRAINT  ------------------
 ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
@@ -310,6 +317,9 @@ INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_pk ADD CONSTRAINT hyper_pk_pkey PRIMARY KEY (time);
 ERROR:  could not create unique index "6_15_hyper_pk_pkey"
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+ADD COLUMN new_device_id int PRIMARY KEY;
+ERROR:  cannot create a unique index without the column "time" (used in partitioning)
 \set ON_ERROR_STOP 1
 DELETE FROM hyper_pk WHERE device_id = 'dev3';
 --cannot create pk constraint on non-partition column

--- a/test/expected/ddl_alter_column.out
+++ b/test/expected/ddl_alter_column.out
@@ -123,9 +123,31 @@ ERROR:  cannot change the type of a hash-partitioned column
 -- conversion that messes up partitioning fails
 ALTER TABLE alter_test ALTER COLUMN time_us TYPE timestamptz USING time_us::timestamptz+INTERVAL '1 year';
 ERROR:  check constraint "constraint_1" is violated by some row
+-- dropping column that messes up partiitoning fails
+ALTER TABLE alter_test DROP COLUMN colorname;
+ERROR:  cannot drop column named in partition key
 --ONLY blocked
 ALTER TABLE ONLY alter_test RENAME COLUMN colorname TO colorname2;
 ERROR:  inherited column "colorname" must be renamed in child tables too
 ALTER TABLE ONLY alter_test ALTER COLUMN colorname TYPE varchar(10);
 ERROR:  ONLY option not supported on hypertable operations
+\set ON_ERROR_STOP 1
+CREATE TABLE alter_test_bigint(time bigint, temp float);
+SELECT create_hypertable('alter_test_bigint', 'time', chunk_time_interval => 2628000000000);
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- Changing type of time dimension to a non-supported type
+-- shall not be allowed
+ALTER TABLE alter_test_bigint
+ALTER COLUMN time TYPE TEXT;
+ERROR:  cannot change data type of hypertable column "time" from bigint to text
+-- dropping open time dimension shall not be allowed.
+ALTER TABLE alter_test_bigint
+DROP COLUMN time;
+ERROR:  cannot drop column named in partition key
 \set ON_ERROR_STOP 1

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -131,6 +131,13 @@ VALUES (1257987700000000000, 'dev2', 11);
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
 ADD CONSTRAINT hyper_unique_invalid UNIQUE (device_id);
+
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+ADD COLUMN new_device_id int UNIQUE;
+
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+DROP COLUMN device_id,
+ADD COLUMN new_device_id int UNIQUE;
 \set ON_ERROR_STOP 1
 
 ----------------------- RENAME CONSTRAINT  ------------------
@@ -193,6 +200,9 @@ INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
 --shouldn't be able to create pk
 \set ON_ERROR_STOP 0
 ALTER TABLE hyper_pk ADD CONSTRAINT hyper_pk_pkey PRIMARY KEY (time);
+
+ALTER TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+ADD COLUMN new_device_id int PRIMARY KEY;
 \set ON_ERROR_STOP 1
 
 DELETE FROM hyper_pk WHERE device_id = 'dev3';

--- a/test/sql/ddl_alter_column.sql
+++ b/test/sql/ddl_alter_column.sql
@@ -45,7 +45,22 @@ SELECT * FROM alter_test WHERE time_us > '2017-05-20T10:00:01';
 ALTER TABLE alter_test ALTER COLUMN colorname TYPE varchar(3);
 -- conversion that messes up partitioning fails
 ALTER TABLE alter_test ALTER COLUMN time_us TYPE timestamptz USING time_us::timestamptz+INTERVAL '1 year';
+-- dropping column that messes up partiitoning fails
+ALTER TABLE alter_test DROP COLUMN colorname;
 --ONLY blocked
 ALTER TABLE ONLY alter_test RENAME COLUMN colorname TO colorname2;
 ALTER TABLE ONLY alter_test ALTER COLUMN colorname TYPE varchar(10);
+\set ON_ERROR_STOP 1
+
+CREATE TABLE alter_test_bigint(time bigint, temp float);
+SELECT create_hypertable('alter_test_bigint', 'time', chunk_time_interval => 2628000000000);
+
+\set ON_ERROR_STOP 0
+-- Changing type of time dimension to a non-supported type
+-- shall not be allowed
+ALTER TABLE alter_test_bigint
+ALTER COLUMN time TYPE TEXT;
+-- dropping open time dimension shall not be allowed.
+ALTER TABLE alter_test_bigint
+DROP COLUMN time;
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
Previously the following commands would not through
an error on hypertables and this PR makes sure that
they do in order to avoid hypertable internals'
corruption:

* ALTER TABLE hypertable
  ADD COLUMN new_device_id int UNIQUE;
* ALTER TABLE hypertable DROP COLUMN partitioning_column;
* ALTER TABLE hypertable DROP COLUMN time_open_dim;
* ALTER TABLE hypertable
  ALTER COLUMN time_open_dim TYPE TEXT;

This pull request resolves the last comment of #536 by @soccerdroid