### PR TITLE
Block NO INHERIT constraints on hypertables

### DIFF
--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -581,13 +581,6 @@ chunk_constraint_need_on_chunk(Form_pg_constraint conform)
 		 * of constraints (unique, primary key, and foreign key constraints)
 		 * are not inherited."
 		 */
-		if (conform->connoinherit)
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_IO_OPERATION_NOT_SUPPORTED),
-					 errmsg("NO INHERIT option not supported on hypertables: %s", conform->conname.data)
-					 ));
-		}
 		return false;
 	}
 	return true;

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -918,6 +918,13 @@ verify_constraint_hypertable(Hypertable *ht, Node *constr_node)
 		contype = constr->contype;
 		keys = (contype == CONSTR_EXCLUSION) ? constr->exclusions : constr->keys;
 		indexname = constr->indexname;
+
+		/* NO INHERIT constraints do not really make sense on a hypertable */
+		if (constr->is_no_inherit)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+					 errmsg("cannot have NO INHERIT constraints on hypertable \"%s\"",
+							get_rel_name(ht->main_table_relid))));
 	}
 	else if (IsA(constr_node, IndexStmt))
 	{

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -545,3 +545,33 @@ SELECT * FROM create_hypertable('hyper_ex_invalid', 'time', chunk_time_interval=
 NOTICE:  adding not-null constraint to column "time"
 ERROR:  cannot create a unique index without the column "time" (used in partitioning)
 \set ON_ERROR_STOP 1
+--- NO INHERIT constraints (not allowed) ----
+CREATE TABLE hyper_noinherit (
+    time BIGINT,
+    sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 0) NO INHERIT
+);
+SELECT * FROM test.show_constraints('hyper_noinherit');
+           Constraint           | Type |  Columns   | Index |           Expr            
+--------------------------------+------+------------+-------+---------------------------
+ hyper_noinherit_sensor_1_check | c    | {sensor_1} | -     | (sensor_1 > (0)::numeric)
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable('hyper_noinherit', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+ERROR:  cannot have NO INHERIT constraints on hypertable "hyper_noinherit"
+\set ON_ERROR_STOP 1
+CREATE TABLE hyper_noinherit_alter (
+    time BIGINT,
+    sensor_1 NUMERIC NULL DEFAULT 1
+);
+SELECT * FROM create_hypertable('hyper_noinherit_alter', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+ALTER TABLE hyper_noinherit_alter ADD CONSTRAINT check_noinherit CHECK (sensor_1 > 0) NO INHERIT;
+ERROR:  cannot have NO INHERIT constraints on hypertable "hyper_noinherit_alter"
+\set ON_ERROR_STOP 1

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -398,3 +398,27 @@ CREATE TABLE hyper_ex_invalid (
 \set ON_ERROR_STOP 0
 SELECT * FROM create_hypertable('hyper_ex_invalid', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 \set ON_ERROR_STOP 1
+
+
+--- NO INHERIT constraints (not allowed) ----
+CREATE TABLE hyper_noinherit (
+    time BIGINT,
+    sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 0) NO INHERIT
+);
+
+SELECT * FROM test.show_constraints('hyper_noinherit');
+
+\set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable('hyper_noinherit', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+\set ON_ERROR_STOP 1
+
+CREATE TABLE hyper_noinherit_alter (
+    time BIGINT,
+    sensor_1 NUMERIC NULL DEFAULT 1
+);
+
+SELECT * FROM create_hypertable('hyper_noinherit_alter', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+
+\set ON_ERROR_STOP 0
+ALTER TABLE hyper_noinherit_alter ADD CONSTRAINT check_noinherit CHECK (sensor_1 > 0) NO INHERIT;
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Constraints with the NO INHERIT option does not make sense on a
hypertable's root table since these will not be enforced.

Previously, NO INHERIT constraints were blocked on chunks, and were
thus not enforced until chunk creation time, allowing creation of NO
INHERIT constraints on empty hypertables, but then causing failure at
chunk-creation time. Instead, NO INHERIT constraints are now properly
blocked at the hypertable level.