### PR TITLE
Add pg_isolation_regress support to the timescale build system.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,17 @@ before_install:
 install:
   - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake bison flex curl git openssl-dev && mkdir -p /build/debug"
   - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted lcov"
-  # We only need to build the regress stuff
-  - docker exec -it pgbuild /bin/sh -c "cd /postgres && ./configure  CPPFLAGS=\"$EXEC_BACKEND\" --enable-coverage --enable-debug --enable-cassert --without-readline --without-zlib && make -C /postgres/src/test/regress"
-  - docker exec -it pgbuild /bin/sh -c "cd /build/debug && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres && make install && chown -R postgres:postgres /build/"
+  # We set /usr/local as prefix so the regression tools will be able to find
+  # initdb, psql, and postgres
+  - docker exec -it pgbuild /bin/sh -c "cd /postgres && ./configure CPPFLAGS=\"$EXEC_BACKEND\" --prefix=/usr/local --enable-coverage --enable-debug --enable-cassert --without-readline --without-zlib"
+  # We only need to build the regress and isolation stuff
+  - docker exec -it pgbuild /bin/sh -c "make -C /postgres/src/test/regress"
+  - docker exec -it pgbuild /bin/sh -c "make -C /postgres/src/test/isolation"
+
+  - docker exec -it pgbuild /bin/sh -c "cd /build/debug && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres && make install"
+  - docker exec -it pgbuild /bin/bash -c "chown -R postgres:postgres /build/"
 script:
+  - docker exec -it pgbuild /bin/bash -c "chown -R postgres:postgres /postgres/"
   - docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug installcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
   # some of the postgres tests don't pass with EXEC_BACKEND,
   # since this is merely a windows canary, not a real platform,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,14 @@ find_program(PG_REGRESS pg_regress
 
 message(STATUS "Using pg_regress ${PG_REGRESS}")
 
+find_program(PG_ISOLATION_REGRESS pg_isolation_regress
+  HINTS
+  ${PG_PKGLIBDIR}/pgxs/src/test/isolation/
+  ${PG_SOURCE_DIR}/src/test/isolation
+  REQUIRED)
+
+message(STATUS "Using pg_isolation_regress ${PG_ISOLATION_REGRESS}")
+
 set(TEST_ROLE_SUPERUSER super_user)
 set(TEST_ROLE_DEFAULT_PERM_USER default_perm_user)
 set(TEST_ROLE_DEFAULT_PERM_USER_2 default_perm_user_2)
@@ -31,9 +39,18 @@ set(PG_REGRESS_OPTS_EXTRA
   --dbname=${TEST_DBNAME}
   --launcher=${TEST_INPUT_DIR}/runner.sh)
 
+  set(PG_ISOLATION_REGRESS_OPTS_EXTRA
+  --create-role=${TEST_ROLE_SUPERUSER},${TEST_ROLE_DEFAULT_PERM_USER},${TEST_ROLE_DEFAULT_PERM_USER_2}
+  --dbname=${TEST_DBNAME})
+
 set(PG_REGRESS_OPTS_INOUT
   --inputdir=${TEST_INPUT_DIR}
   --outputdir=${TEST_OUTPUT_DIR})
+
+set(PG_ISOLATION_REGRESS_OPTS_INOUT
+  --inputdir=${TEST_INPUT_DIR}/isolation
+  --outputdir=${TEST_OUTPUT_DIR}/isolation
+  --load-extension=timescaledb)
 
 set(PG_REGRESS_OPTS_TEMP_INSTANCE
   --port=${TEST_PGPORT_TEMP_INSTANCE}
@@ -56,8 +73,23 @@ set(PG_REGRESS_ENV
   PG_BINDIR=${PG_BINDIR}
   PG_REGRESS=${PG_REGRESS})
 
+# at some point we may want to add an ISOLATION_TEST_SCHEDULE analogous to
+# TEST_SCHEDULE
+set(PG_ISOLATION_REGRESS_ENV
+  TEST_PGUSER=${TEST_PGUSER}
+  TEST_ROLE_SUPERUSER=${TEST_ROLE_SUPERUSER}
+  TEST_ROLE_DEFAULT_PERM_USER=${TEST_ROLE_DEFAULT_PERM_USER}
+  TEST_ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2}
+  TEST_DBNAME=${TEST_DBNAME}
+  TEST_INPUT_DIR=${TEST_INPUT_DIR}
+  TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR}
+  PG_ISOLATION_REGRESS=${PG_ISOLATION_REGRESS})
+
 # installcheck starts up new temporary instances for testing code
 add_custom_target(installcheck
+  DEPENDS regresscheck isolationcheck)
+
+add_custom_target(regresscheck
   COMMAND ${CMAKE_COMMAND} -E env
   ${PG_REGRESS_ENV}
   ${CMAKE_CURRENT_SOURCE_DIR}/pg_regress.sh
@@ -67,8 +99,21 @@ add_custom_target(installcheck
   ${PG_REGRESS_OPTS_TEMP_INSTANCE}
   USES_TERMINAL)
 
+add_custom_target(isolationcheck
+  COMMAND ${CMAKE_COMMAND} -E env
+  ${PG_ISOLATION_REGRESS_ENV}
+  ${CMAKE_CURRENT_SOURCE_DIR}/pg_isolation_regress.sh
+  ${PG_REGRESS_OPTS_BASE}
+  ${PG_ISOLATION_REGRESS_OPTS_EXTRA}
+  ${PG_ISOLATION_REGRESS_OPTS_INOUT}
+  ${PG_REGRESS_OPTS_TEMP_INSTANCE}
+  USES_TERMINAL)
+
 # installchecklocal tests against an existing postgres instance
 add_custom_target(installchecklocal
+  DEPENDS regresschecklocal isolationchecklocal)
+
+add_custom_target(regresschecklocal
   COMMAND ${CMAKE_COMMAND} -E env
   ${PG_REGRESS_ENV}
   ${CMAKE_CURRENT_SOURCE_DIR}/pg_regress.sh
@@ -77,8 +122,19 @@ add_custom_target(installchecklocal
   ${PG_REGRESS_OPTS_INOUT}
   ${PG_REGRESS_OPTS_LOCAL_INSTANCE}
   USES_TERMINAL)
-  
+
+add_custom_target(isolationchecklocal
+  COMMAND ${CMAKE_COMMAND} -E env
+  ${PG_ISOLATION_REGRESS_ENV}
+  ${CMAKE_CURRENT_SOURCE_DIR}/pg_isolation_regress.sh
+  ${PG_REGRESS_OPTS_BASE}
+  ${PG_ISOLATION_REGRESS_OPTS_EXTRA}
+  ${PG_ISOLATION_REGRESS_OPTS_INOUT}
+  ${PG_REGRESS_OPTS_LOCAL_INSTANCE}
+  USES_TERMINAL)
+
 add_subdirectory(sql)
+add_subdirectory(isolation)
 
 if (PG_SOURCE_DIR)
   add_subdirectory(pgtest)

--- a/test/isolation/CMakeLists.txt
+++ b/test/isolation/CMakeLists.txt
@@ -1,0 +1,1 @@
+#dummy file to ensure isolation output is created correctly

--- a/test/isolation/expected/isolation_nop.out
+++ b/test/isolation/expected/isolation_nop.out
@@ -1,0 +1,10 @@
+Parsed test spec with 1 sessions
+
+starting permutation: s1a
+create_hypertable
+
+               
+step s1a: SELECT pg_sleep(0);
+pg_sleep       
+
+               

--- a/test/isolation/expected/read_committed_insert.out
+++ b/test/isolation/expected/read_committed_insert.out
@@ -1,0 +1,61 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1a s1c s2a s2b
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s1c: COMMIT;
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s2b: COMMIT;
+
+starting permutation: s1a s2a s1c s2b
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
+step s1c: COMMIT;
+step s2a: <... completed>
+step s2b: COMMIT;
+
+starting permutation: s1a s2a s2b s1c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
+step s2a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s2b: COMMIT;
+step s1c: COMMIT;
+
+starting permutation: s2a s1a s1c s2b
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
+step s1a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s1c: COMMIT;
+step s2b: COMMIT;
+
+starting permutation: s2a s1a s2b s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
+step s2b: COMMIT;
+step s1a: <... completed>
+step s1c: COMMIT;
+
+starting permutation: s2a s2b s1a s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s2b: COMMIT;
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s1c: COMMIT;

--- a/test/isolation/expected/read_uncommitted_insert.out
+++ b/test/isolation/expected/read_uncommitted_insert.out
@@ -1,0 +1,61 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1a s1c s2a s2b
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s1c: COMMIT;
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s2b: COMMIT;
+
+starting permutation: s1a s2a s1c s2b
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
+step s1c: COMMIT;
+step s2a: <... completed>
+step s2b: COMMIT;
+
+starting permutation: s1a s2a s2b s1c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
+step s2a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s2b: COMMIT;
+step s1c: COMMIT;
+
+starting permutation: s2a s1a s1c s2b
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
+step s1a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s1c: COMMIT;
+step s2b: COMMIT;
+
+starting permutation: s2a s1a s2b s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
+step s2b: COMMIT;
+step s1a: <... completed>
+step s1c: COMMIT;
+
+starting permutation: s2a s2b s1a s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s2b: COMMIT;
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s1c: COMMIT;

--- a/test/isolation/expected/repeatable_read_insert.out
+++ b/test/isolation/expected/repeatable_read_insert.out
@@ -1,0 +1,61 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1a s1c s2a s2b
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s1c: COMMIT;
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s2b: COMMIT;
+
+starting permutation: s1a s2a s1c s2b
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
+step s1c: COMMIT;
+step s2a: <... completed>
+step s2b: COMMIT;
+
+starting permutation: s1a s2a s2b s1c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
+step s2a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s2b: COMMIT;
+step s1c: COMMIT;
+
+starting permutation: s2a s1a s1c s2b
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
+step s1a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s1c: COMMIT;
+step s2b: COMMIT;
+
+starting permutation: s2a s1a s2b s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
+step s2b: COMMIT;
+step s1a: <... completed>
+step s1c: COMMIT;
+
+starting permutation: s2a s2b s1a s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
+step s2b: COMMIT;
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
+step s1c: COMMIT;

--- a/test/isolation/expected/serializable_insert.out
+++ b/test/isolation/expected/serializable_insert.out
@@ -1,0 +1,61 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1a s1c s2a s2c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s1c: COMMIT;
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s2c: COMMIT;
+
+starting permutation: s1a s2a s1c s2c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1); <waiting ...>
+step s1c: COMMIT;
+step s2a: <... completed>
+step s2c: COMMIT;
+
+starting permutation: s1a s2a s2c s1c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1); <waiting ...>
+step s2a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s2c: COMMIT;
+step s1c: COMMIT;
+
+starting permutation: s2a s1a s1c s2c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1); <waiting ...>
+step s1a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s1c: COMMIT;
+step s2c: COMMIT;
+
+starting permutation: s2a s1a s2c s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1); <waiting ...>
+step s2c: COMMIT;
+step s1a: <... completed>
+step s1c: COMMIT;
+
+starting permutation: s2a s2c s1a s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s2c: COMMIT;
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s1c: COMMIT;

--- a/test/isolation/expected/serializable_insert_rollback.out
+++ b/test/isolation/expected/serializable_insert_rollback.out
@@ -1,0 +1,61 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1a s1c s2a s2c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s1c: ROLLBACK;
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s2c: COMMIT;
+
+starting permutation: s1a s2a s1c s2c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1); <waiting ...>
+step s1c: ROLLBACK;
+step s2a: <... completed>
+step s2c: COMMIT;
+
+starting permutation: s1a s2a s2c s1c
+create_hypertable
+
+               
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1); <waiting ...>
+step s2a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s2c: COMMIT;
+step s1c: ROLLBACK;
+
+starting permutation: s2a s1a s1c s2c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1); <waiting ...>
+step s1a: <... completed>
+ERROR:  canceling statement due to lock timeout
+step s1c: ROLLBACK;
+step s2c: COMMIT;
+
+starting permutation: s2a s1a s2c s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1); <waiting ...>
+step s2c: COMMIT;
+step s1a: <... completed>
+step s1c: ROLLBACK;
+
+starting permutation: s2a s2c s1a s1c
+create_hypertable
+
+               
+step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1);
+step s2c: COMMIT;
+step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1);
+step s1c: ROLLBACK;

--- a/test/isolation/specs/isolation_nop.spec
+++ b/test/isolation/specs/isolation_nop.spec
@@ -1,0 +1,11 @@
+setup{
+    CREATE TABLE ts_cluster_test(time timestamptz, temp float, location int);
+    SELECT create_hypertable('ts_cluster_test', 'time', chunk_time_interval => interval '1 day');
+}
+
+teardown {
+    DROP TABLE ts_cluster_test;
+}
+
+session "s1"
+step "s1a"	{ SELECT pg_sleep(0); }

--- a/test/isolation/specs/read_committed_insert.spec
+++ b/test/isolation/specs/read_committed_insert.spec
@@ -1,0 +1,18 @@
+setup
+{
+ CREATE TABLE ts_cluster_test(time timestamptz, temp float, location int);
+ SELECT create_hypertable('ts_cluster_test', 'time', chunk_time_interval => interval '1 day');
+}
+
+teardown { DROP TABLE ts_cluster_test; }
+
+session "s1"
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s1a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); }
+step "s1c"	{ COMMIT; }
+
+session "s2"
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s2a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); }
+step "s2b"	{ COMMIT; }
+

--- a/test/isolation/specs/read_uncommitted_insert.spec
+++ b/test/isolation/specs/read_uncommitted_insert.spec
@@ -1,0 +1,18 @@
+setup
+{
+ CREATE TABLE ts_cluster_test(time timestamptz, temp float, location int);
+ SELECT create_hypertable('ts_cluster_test', 'time', chunk_time_interval => interval '1 day');
+}
+
+teardown { DROP TABLE ts_cluster_test; }
+
+session "s1"
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s1a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); }
+step "s1c"	{ COMMIT; }
+
+session "s2"
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s2a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); }
+step "s2b"	{ COMMIT; }
+

--- a/test/isolation/specs/repeatable_read_insert.spec
+++ b/test/isolation/specs/repeatable_read_insert.spec
@@ -1,0 +1,18 @@
+setup
+{
+ CREATE TABLE ts_cluster_test(time timestamptz, temp float, location int);
+ SELECT create_hypertable('ts_cluster_test', 'time', chunk_time_interval => interval '1 day');
+}
+
+teardown { DROP TABLE ts_cluster_test; }
+
+session "s1"
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s1a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); }
+step "s1c"	{ COMMIT; }
+
+session "s2"
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s2a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); }
+step "s2b"	{ COMMIT; }
+

--- a/test/isolation/specs/serializable_insert.spec
+++ b/test/isolation/specs/serializable_insert.spec
@@ -1,0 +1,17 @@
+setup
+{
+ CREATE TABLE ts_cluster_test(time timestamptz, temp float, location int);
+ SELECT create_hypertable('ts_cluster_test', 'time', chunk_time_interval => interval '1 day');
+}
+
+teardown { DROP TABLE ts_cluster_test; }
+
+session "s1"
+setup	    { BEGIN; SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s1a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1); }
+step "s1c"	{ COMMIT; }
+
+session "s2"
+setup	    { BEGIN; SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s2a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1); }
+step "s2c"	{ COMMIT; }

--- a/test/isolation/specs/serializable_insert_rollback.spec
+++ b/test/isolation/specs/serializable_insert_rollback.spec
@@ -1,0 +1,17 @@
+setup
+{
+ CREATE TABLE ts_cluster_test(time timestamptz, temp float, location int);
+ SELECT create_hypertable('ts_cluster_test', 'time', chunk_time_interval => interval '1 day');
+}
+
+teardown { DROP TABLE ts_cluster_test; }
+
+session "s1"
+setup	    { BEGIN; SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s1a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:01', 23.4, 1); }
+step "s1c"	{ ROLLBACK; }
+
+session "s2"
+setup	    { BEGIN; SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
+step "s2a"	{ INSERT INTO ts_cluster_test VALUES ('2017-01-20T09:00:02', 0.72, 1); }
+step "s2c"	{ COMMIT; }

--- a/test/pg_isolation_regress.sh
+++ b/test/pg_isolation_regress.sh
@@ -3,34 +3,34 @@
 # Wrapper around pg_regress to be able to override the tests to run via the
 # TESTS environment variable
 
-# NB this script mirrors the adjacent pg_isolation_regress.sh, and they should
+# NB this script mirrors the adjacent pg_regress.sh, and they should
 #    kept in synch
 
 EXE_DIR=$(dirname $0)
-PG_REGRESS=${PG_REGRESS:-pg_regress}
-TEST_SCHEDULE=${TEST_SCHEDULE:-}
+PG_ISOLATION_REGRESS=${PG_ISOLATION_REGRESS:-pg_isolation_regress}
+ISOLATION_TEST_SCHEDULE=${ISOLATION_TEST_SCHEDULE:-}
 TESTS=${TESTS:-}
 
 if [[ -z ${TESTS} ]]; then
-    if [[ -z ${TEST_SCHEDULE} ]]; then
-        for t in ${EXE_DIR}/sql/*.sql; do
-            t=${t##${EXE_DIR}/sql/}
-            t=${t%.sql}
+    if [[ -z ${ISOLATION_TEST_SCHEDULE} ]]; then
+        for t in ${EXE_DIR}/isolation/specs/*.spec; do
+            t=${t##${EXE_DIR}/isolation/specs/}
+            t=${t%.spec}
             TESTS="${TESTS} $t"
         done
     else
-        PG_REGRESS_OPTS="${PG_REGRESS_OPTS} --schedule=${TEST_SCHEDULE}"
+        PG_ISOLATION_REGRESS_OPTS="${PG_ISOLATION_REGRESS_OPTS} --schedule=${ISOLATION_TEST_SCHEDULE}"
     fi
 else
-    # Both this and pg_isolation_regress.sh use the same TESTS env var to decide which tests to run.
+    # Both this and pg_regress.sh use the same TESTS env var to decide which tests to run.
     # Since we only want to pass the test runner the kind of tests it can understand,
     # and only those which actually exist, we use TESTS as a filter for the test folder,
     # passing in only those tests from the directory which are found in TESTS
     FILTER=${TESTS}
     TESTS=
-    for t in ${EXE_DIR}/sql/*.sql; do
-        t=${t##${EXE_DIR}/sql/}
-        t=${t%.sql}
+    for t in ${EXE_DIR}/isolation/specs/*.spec; do
+        t=${t##${EXE_DIR}/isolation/specs/}
+        t=${t%.spec}
         # we use the following chain of comparisons to properly handle the case
         # where a test name is a substring of another
         if [[ $FILTER = "$t" ]]; then # one test
@@ -45,4 +45,4 @@ else
     done
 fi
 
-${PG_REGRESS} $@ ${PG_REGRESS_OPTS} ${TESTS}
+${PG_ISOLATION_REGRESS} $@ ${PG_ISOLATION_REGRESS_OPTS} ${TESTS}


### PR DESCRIPTION
This commit adds the ability to run `pg_isolation_regress`  tests from  `make installcheck[local]`. This tool allows us to test what happens when various commands interleave (a description can be found [here](https://github.com/postgres/postgres/blob/master/src/test/isolation/README)).

I also two additional commands `make regresscheck` and `make isocheck` for testing only the `pg_regress` or `pg_isolation_regress` tests. All commands function like the original `make installcheck` with the `TESTS` env var specifying only specific tests are run.

Isolation tests are found in `test/isolation`. This commit adds tests for the behavior of concurrent inserts to a hypertable.