### PR TITLE
Fix and improve show_indexes test support function

### DIFF
--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -269,10 +269,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -291,10 +291,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -313,10 +313,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -334,9 +334,9 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                       Index                        | Columns | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------------------+---------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx" | {Time}  | f      | f       | f         | 
+                       Index                        | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------------------+---------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx" | {Time}  |      | f      | f       | f         | 
 (1 row)
 
 ROLLBACK;
@@ -354,8 +354,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
- Index | Columns | Unique | Primary | Exclusion | Tablespace 
--------+---------+--------+---------+-----------+------------
+ Index | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+-------+---------+------+--------+---------+-----------+------------
 (0 rows)
 
 ROLLBACK;

--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -8,9 +8,9 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Show default indexes
 SELECT * FROM test.show_indexes('cluster_test');
-         Index         | Columns | Unique | Primary | Exclusion | Tablespace 
------------------------+---------+--------+---------+-----------+------------
- cluster_test_time_idx | {time}  | f      | f       | f         | 
+         Index         | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+-----------------------+---------+------+--------+---------+-----------+------------
+ cluster_test_time_idx | {time}  |      | f      | f       | f         | 
 (1 row)
 
 -- Create two chunks

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -166,10 +166,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -188,10 +188,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -210,10 +210,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -231,9 +231,9 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                       Index                        | Columns | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------------------+---------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx" | {Time}  | f      | f       | f         | 
+                       Index                        | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------------------+---------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx" | {Time}  |      | f      | f       | f         | 
 (1 row)
 
 ROLLBACK;
@@ -251,8 +251,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
- Index | Columns | Unique | Primary | Exclusion | Tablespace 
--------+---------+--------+---------+-----------+------------
+ Index | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+-------+---------+------+--------+---------+-----------+------------
 (0 rows)
 
 ROLLBACK;

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -166,10 +166,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -188,10 +188,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -210,10 +210,10 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                            Index                             |     Columns      | Unique | Primary | Exclusion | Tablespace 
---------------------------------------------------------------+------------------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           | f      | f       | f         | 
- "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} | f      | f       | f         | 
+                            Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
+--------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -231,9 +231,9 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
-                       Index                        | Columns | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------------------+---------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx" | {Time}  | f      | f       | f         | 
+                       Index                        | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------------------+---------+------+--------+---------+-----------+------------
+ "Hypertable_1_with_default_index_enabled_Time_idx" | {Time}  |      | f      | f       | f         | 
 (1 row)
 
 ROLLBACK;
@@ -251,8 +251,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
- Index | Columns | Unique | Primary | Exclusion | Tablespace 
--------+---------+--------+---------+-----------+------------
+ Index | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+-------+---------+------+--------+---------+-----------+------------
 (0 rows)
 
 ROLLBACK;

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -8,9 +8,9 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Default indexes created
 SELECT * FROM test.show_indexes('index_test');
-        Index        | Columns | Unique | Primary | Exclusion | Tablespace 
----------------------+---------+--------+---------+-----------+------------
- index_test_time_idx | {time}  | f      | f       | f         | 
+        Index        | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------+---------+------+--------+---------+-----------+------------
+ index_test_time_idx | {time}  |      | f      | f       | f         | 
 (1 row)
 
 DROP TABLE index_test;
@@ -35,15 +35,15 @@ NOTICE:  adding not-null constraint to column "time"
 INSERT INTO index_test VALUES ('2017-01-20T09:00:01', 1, 17.5);
 -- Check that index is also created on chunk
 SELECT * FROM test.show_indexes('index_test');
-        Index        | Columns | Unique | Primary | Exclusion | Tablespace 
----------------------+---------+--------+---------+-----------+------------
- index_test_time_idx | {time}  | t      | f       | f         | 
+        Index        | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------+---------+------+--------+---------+-----------+------------
+ index_test_time_idx | {time}  |      | t      | f       | f         | 
 (1 row)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                           Index                            |      Columns       | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+------------------------------------------------------------+--------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal._hyper_3_1_chunk_index_test_time_idx | {time,device,temp} | t      | f       | f         | 
+                 Table                  |                           Index                            | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+------------------------------------------------------------+---------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal._hyper_3_1_chunk_index_test_time_idx | {time}  |      | t      | f       | f         | 
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk_index;
@@ -55,10 +55,10 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
 -- Create another chunk
 INSERT INTO index_test VALUES ('2017-05-20T09:00:01', 3, 17.5);
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                           Index                            |      Columns       | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+------------------------------------------------------------+--------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal._hyper_3_1_chunk_index_test_time_idx | {time,device,temp} | t      | f       | f         | 
- _timescaledb_internal._hyper_3_2_chunk | _timescaledb_internal._hyper_3_2_chunk_index_test_time_idx | {time,device,temp} | t      | f       | f         | 
+                 Table                  |                           Index                            | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+------------------------------------------------------------+---------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_3_1_chunk | _timescaledb_internal._hyper_3_1_chunk_index_test_time_idx | {time}  |      | t      | f       | f         | 
+ _timescaledb_internal._hyper_3_2_chunk | _timescaledb_internal._hyper_3_2_chunk_index_test_time_idx | {time}  |      | t      | f       | f         | 
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_index;
@@ -71,9 +71,9 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
 -- Delete the index on only one chunk
 DROP INDEX _timescaledb_internal._hyper_3_1_chunk_index_test_time_idx;
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                           Index                            |      Columns       | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+------------------------------------------------------------+--------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_3_2_chunk | _timescaledb_internal._hyper_3_2_chunk_index_test_time_idx | {time,device,temp} | t      | f       | f         | 
+                 Table                  |                           Index                            | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+------------------------------------------------------------+---------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_3_2_chunk | _timescaledb_internal._hyper_3_2_chunk_index_test_time_idx | {time}  |      | t      | f       | f         | 
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk_index;
@@ -126,25 +126,25 @@ CREATE INDEX ON index_test (time, temp);
 INSERT INTO index_test VALUES ('2017-04-20T09:00:01', 1, 17.5);
 -- New index should have been recursed to chunks
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace 
-----------------------------+---------------+--------+---------+-----------+------------
- index_test_time_idx        | {time}        | f      | f       | f         | 
- index_test_device_time_idx | {device,time} | f      | f       | f         | 
- index_test_time_device_idx | {time,device} | t      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   | f      | f       | f         | 
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------+---------------+------+--------+---------+-----------+------------
+ index_test_time_idx        | {time}        |      | f      | f       | f         | 
+ index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_device_idx | {time,device,temp} | t      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_device_idx | {time,device,temp} | t      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,device,temp} | f      | f       | f         | 
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (8 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_index;
@@ -163,25 +163,25 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
 ALTER INDEX index_test_time_idx RENAME TO index_test_time_idx2;
 -- Metadata and index should have changed name
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace 
-----------------------------+---------------+--------+---------+-----------+------------
- index_test_time_idx2       | {time}        | f      | f       | f         | 
- index_test_device_time_idx | {device,time} | f      | f       | f         | 
- index_test_time_device_idx | {time,device} | t      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   | f      | f       | f         | 
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------+---------------+------+--------+---------+-----------+------------
+ index_test_time_idx2       | {time}        |      | f      | f       | f         | 
+ index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx2       | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_device_idx | {time,device,temp} | t      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx2       | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_device_idx | {time,device,temp} | t      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,device,temp} | f      | f       | f         | 
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx2       | {time}        |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx2       | {time}        |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (8 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_index;
@@ -201,19 +201,19 @@ DROP INDEX index_test_time_idx2;
 DROP INDEX index_test_time_device_idx;
 -- Index should have been dropped
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace 
-----------------------------+---------------+--------+---------+-----------+------------
- index_test_device_time_idx | {device,time} | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   | f      | f       | f         | 
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------+---------------+------+--------+---------+-----------+------------
+ index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (2 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,device,temp} | f      | f       | f         | 
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_index;
@@ -229,25 +229,25 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
 CREATE INDEX a_hypertable_index_with_a_very_very_long_name_that_truncates ON index_test (time, temp);
 CREATE INDEX a_hypertable_index_with_a_very_very_long_name_that_truncates_2 ON index_test (time, temp);
 SELECT * FROM test.show_indexes('index_test');
-                             Index                              |    Columns    | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------------------------------+---------------+--------+---------+-----------+------------
- index_test_device_time_idx                                     | {device,time} | f      | f       | f         | 
- index_test_time_temp_idx                                       | {time,temp}   | f      | f       | f         | 
- a_hypertable_index_with_a_very_very_long_name_that_truncates   | {time,temp}   | f      | f       | f         | 
- a_hypertable_index_with_a_very_very_long_name_that_truncates_2 | {time,temp}   | f      | f       | f         | 
+                             Index                              |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
+ index_test_device_time_idx                                     | {device,time} |      | f      | f       | f         | 
+ index_test_time_temp_idx                                       | {time,temp}   |      | f      | f       | f         | 
+ a_hypertable_index_with_a_very_very_long_name_that_truncates   | {time,temp}   |      | f      | f       | f         | 
+ a_hypertable_index_with_a_very_very_long_name_that_truncates_2 | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                                         Index                                         |      Columns       | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+---------------------------------------------------------------------------------------+--------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx                     | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx                                  | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_a_hypertable_index_with_a_very_very_long_name_ | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_a_hypertable_index_with_a_very_very_long_nam_1 | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx                     | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx                       | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_a_hypertable_index_with_a_very_very_long_name_ | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_a_hypertable_index_with_a_very_very_long_nam_1 | {time,device,temp} | f      | f       | f         | 
+                 Table                  |                                         Index                                         |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+---------------------------------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx                     | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx                                  | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_a_hypertable_index_with_a_very_very_long_name_ | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_a_hypertable_index_with_a_very_very_long_nam_1 | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx                     | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx                       | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_a_hypertable_index_with_a_very_very_long_name_ | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_a_hypertable_index_with_a_very_very_long_nam_1 | {time,temp}   |      | f      | f       | f         | 
 (8 rows)
 
 DROP INDEX a_hypertable_index_with_a_very_very_long_name_that_truncates;
@@ -268,22 +268,22 @@ CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 \c single :ROLE_DEFAULT_PERM_USER
 CREATE INDEX index_test_time_idx ON index_test (time) TABLESPACE tablespace1;
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace  
-----------------------------+---------------+--------+---------+-----------+-------------
- index_test_device_time_idx | {device,time} | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   | f      | f       | f         | 
- index_test_time_idx        | {time}        | f      | f       | f         | tablespace1
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------+---------------+------+--------+---------+-----------+-------------
+ index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
 (3 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace  
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | tablespace1
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
 (6 rows)
 
 \c single :ROLE_SUPERUSER
@@ -291,46 +291,46 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 \c single :ROLE_DEFAULT_PERM_USER
 ALTER INDEX index_test_time_idx SET TABLESPACE tablespace2;
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace  
-----------------------------+---------------+--------+---------+-----------+-------------
- index_test_device_time_idx | {device,time} | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   | f      | f       | f         | 
- index_test_time_idx        | {time}        | f      | f       | f         | tablespace2
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------+---------------+------+--------+---------+-----------+-------------
+ index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
 (3 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace  
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | tablespace2
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
 (6 rows)
 
 -- Add constraint index
 ALTER TABLE index_test ADD UNIQUE (time, device);
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace  
-----------------------------+---------------+--------+---------+-----------+-------------
- index_test_device_time_idx | {device,time} | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   | f      | f       | f         | 
- index_test_time_idx        | {time}        | f      | f       | f         | tablespace2
- index_test_time_device_key | {time,device} | t      | f       | f         | 
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------+---------------+------+--------+---------+-----------+-------------
+ index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
+ index_test_time_device_key | {time,device} |      | t      | f       | f         | 
 (4 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace  
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal."3_1_index_test_time_device_key"            | {time,device,temp} | t      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,device,temp} | f      | f       | f         | 
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time,device,temp} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal."4_2_index_test_time_device_key"            | {time,device,temp} | t      | f       | f         | 
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal."3_1_index_test_time_device_key"            | {time,device} |      | t      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal."4_2_index_test_time_device_key"            | {time,device} |      | t      | f       | f         | 
 (8 rows)
 
 -- Constraint indexes are added to chunk_index table.
@@ -386,40 +386,40 @@ INSERT INTO index_test VALUES ('2017-01-20T09:00:01', 17.5);
 -- Check that the tablespaces of chunk indexes match the tablespace of
 -- the main index
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace  
-----------------------------+---------------+--------+---------+-----------+-------------
- index_test_time_idx        | {time}        | f      | f       | f         | tablespace1
- index_test_time_device_idx | {time,device} | f      | f       | f         | tablespace2
- index_test_device_idx      | {device}      | f      | f       | f         | 
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------+---------------+------+--------+---------+-----------+-------------
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
+ index_test_device_idx      | {device}      |      | f      | f       | f         | 
 (3 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace  
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_device_idx | {time,temp,device} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {time,temp,device} | f      | f       | f         | tablespace1
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {device}      |      | f      | f       | f         | tablespace1
 (3 rows)
 
 -- Creating a new index should propagate to existing chunks, including
 -- the given tablespace
 CREATE INDEX ON index_test (time, temp) TABLESPACE tablespace2;
 SELECT * FROM test.show_indexes('index_test');
-           Index            |    Columns    | Unique | Primary | Exclusion | Tablespace  
-----------------------------+---------------+--------+---------+-----------+-------------
- index_test_time_idx        | {time}        | f      | f       | f         | tablespace1
- index_test_time_device_idx | {time,device} | f      | f       | f         | tablespace2
- index_test_device_idx      | {device}      | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   | f      | f       | f         | tablespace2
+           Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------+---------------+------+--------+---------+-----------+-------------
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
+ index_test_device_idx      | {device}      |      | f      | f       | f         | 
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | tablespace2
 (4 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                               |      Columns       | Unique | Primary | Exclusion | Tablespace  
-----------------------------------------+-------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_device_idx | {time,temp,device} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_time_temp_idx              | {time,temp,device} | f      | f       | f         | tablespace2
+                 Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {device}      |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | tablespace2
 (4 rows)
 
 -- Cleanup

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -119,36 +119,36 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal.%');
 (76 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal.%');
-                 Table                  |                                       Index                                        |                            Columns                            | Unique | Primary | Exclusion | Tablespace 
-----------------------------------------+------------------------------------------------------------------------------------+---------------------------------------------------------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_device_id_timeCustom_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_device_id_timeCustom_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_idx"             | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_device_id_timeCustom_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_idx"             | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
- _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom,device_id,series_0,series_1,series_2,series_bool} | f      | f       | f         | 
+                 Table                  |                                       Index                                        |         Columns          | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+------------------------------------------------------------------------------------+--------------------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal."_hyper_1_2_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_3_chunk | _timescaledb_internal."_hyper_1_3_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}    |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_4_chunk | _timescaledb_internal."_hyper_1_4_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}             |      | f      | f       | f         | 
 (28 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -79,29 +79,29 @@ SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
 (6 rows)
 
 SELECT * FROM test.show_indexes('"test_schema"."two_Partitions"');
-                          Index                          |             Columns             | Unique | Primary | Exclusion | Tablespace 
----------------------------------------------------------+---------------------------------+--------+---------+-----------+------------
- test_schema."two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_idx"             | {timeCustom}                    | f      | f       | f         | 
- test_schema.timecustom_device_id_series_2_key           | {timeCustom,device_id,series_2} | t      | f       | f         | 
+                          Index                          |             Columns             | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------+---------------------------------+------+--------+---------+-----------+------------
+ test_schema."two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
+ test_schema.timecustom_device_id_series_2_key           | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
 (8 rows)
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
-                                       Index                                        |             Columns             | Unique | Primary | Exclusion | Tablespace 
-------------------------------------------------------------------------------------+---------------------------------+--------+---------+-----------+------------
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}                    | f      | f       | f         | 
- _timescaledb_internal."1_1_timecustom_device_id_series_2_key"                      | {timeCustom,device_id,series_2} | t      | f       | f         | 
+                                       Index                                        |             Columns             | Expr | Unique | Primary | Exclusion | Tablespace 
+------------------------------------------------------------------------------------+---------------------------------+------+--------+---------+-----------+------------
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
+ _timescaledb_internal."1_1_timecustom_device_id_series_2_key"                      | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
 (8 rows)
 
 SELECT * FROM test.show_constraints('"test_schema"."two_Partitions"');
@@ -266,29 +266,29 @@ SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
 (6 rows)
 
 SELECT * FROM test.show_indexes('"test_schema"."two_Partitions"');
-                          Index                          |             Columns             | Unique | Primary | Exclusion | Tablespace 
----------------------------------------------------------+---------------------------------+--------+---------+-----------+------------
- test_schema."two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_idx"             | {timeCustom}                    | f      | f       | f         | 
- test_schema.timecustom_device_id_series_2_key           | {timeCustom,device_id,series_2} | t      | f       | f         | 
+                          Index                          |             Columns             | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------+---------------------------------+------+--------+---------+-----------+------------
+ test_schema."two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
+ test_schema.timecustom_device_id_series_2_key           | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
 (8 rows)
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
-                                       Index                                        |             Columns             | Unique | Primary | Exclusion | Tablespace 
-------------------------------------------------------------------------------------+---------------------------------+--------+---------+-----------+------------
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}                    | f      | f       | f         | 
- _timescaledb_internal."1_1_timecustom_device_id_series_2_key"                      | {timeCustom,device_id,series_2} | t      | f       | f         | 
+                                       Index                                        |             Columns             | Expr | Unique | Primary | Exclusion | Tablespace 
+------------------------------------------------------------------------------------+---------------------------------+------+--------+---------+-----------+------------
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
+ _timescaledb_internal."1_1_timecustom_device_id_series_2_key"                      | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
 (8 rows)
 
 SELECT * FROM test.show_constraints('"test_schema"."two_Partitions"');

--- a/test/expected/plain.out
+++ b/test/expected/plain.out
@@ -17,9 +17,9 @@ SELECT * FROM test.show_columns('regular_table');
 (4 rows)
 
 SELECT * FROM test.show_indexes('regular_table');
-      Index      |   Columns    | Unique | Primary | Exclusion | Tablespace 
------------------+--------------+--------+---------+-----------+------------
- time_color_idx2 | {time,color} | f      | f       | f         | 
+      Index      |   Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+-----------------+--------------+------+--------+---------+-----------+------------
+ time_color_idx2 | {time,color} |      | f      | f       | f         | 
 (1 row)
 
 -- Renaming types should work

--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -88,10 +88,10 @@ SELECT * FROM reindex_norm;
 (6 rows)
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
-                                Index                                |   Columns   | Unique | Primary | Exclusion | Tablespace 
----------------------------------------------------------------------+-------------+--------+---------+-----------+------------
- _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} | t      | t       | f         | 
- _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      | t      | f       | f         | 
+                                Index                                |   Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------------------+-------------+------+--------+---------+-----------+------------
+ _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} |      | t      | t       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      |      | t      | f       | f         | 
 (2 rows)
 
 SELECT chunk_index_clone::regclass::text
@@ -102,11 +102,11 @@ FROM _timescaledb_internal.chunk_index_clone('_timescaledb_internal."1_1_reindex
 (1 row)
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
-                                Index                                |   Columns   | Unique | Primary | Exclusion | Tablespace 
----------------------------------------------------------------------+-------------+--------+---------+-----------+------------
- _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} | t      | t       | f         | 
- _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      | t      | f       | f         | 
- _timescaledb_internal._hyper_1_1_chunk_1_1_reindex_test_pkey        | {time,temp} | t      | t       | f         | 
+                                Index                                |   Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------------------+-------------+------+--------+---------+-----------+------------
+ _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} |      | t      | t       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      |      | t      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk_1_1_reindex_test_pkey        | {time,temp} |      | t      | t       | f         | 
 (3 rows)
 
 SELECT * FROM _timescaledb_internal.chunk_index_replace('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass, '_timescaledb_internal."_hyper_1_1_chunk_1_1_reindex_test_pkey"'::regclass);
@@ -116,9 +116,9 @@ SELECT * FROM _timescaledb_internal.chunk_index_replace('_timescaledb_internal."
 (1 row)
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
-                                Index                                |   Columns   | Unique | Primary | Exclusion | Tablespace 
----------------------------------------------------------------------+-------------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      | t      | f       | f         | 
- _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} | t      | t       | f         | 
+                                Index                                |   Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------------------------------------------------------+-------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      |      | t      | f       | f         | 
+ _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} |      | t      | t       | f         | 
 (2 rows)
 

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -94,12 +94,12 @@ SELECT * FROM test.show_subtables('tspace_2dim');
 
 --indexes should inherit the tablespace of their chunk
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                                |      Columns       | Unique | Primary | Exclusion | Tablespace  
-----------------------------------------+--------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
+                 Table                  |                               Index                                |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+--------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_device_time_idx | {device,time} |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_device_time_idx | {device,time} |      | f      | f       | f         | tablespace1
 (4 rows)
 
 --
@@ -167,14 +167,14 @@ SELECT * FROM test.show_subtablesp('tspace_%');
 --created with a tablespace, because then default indexes will be
 --created in that tablespace too.
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
-                 Table                  |                               Index                                |      Columns       | Unique | Primary | Exclusion | Tablespace  
-----------------------------------------+--------------------------------------------------------------------+--------------------+--------+---------+-----------+-------------
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_device_time_idx | {time,temp,device} | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_2_3_chunk | _timescaledb_internal._hyper_2_3_chunk_tspace_1dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace2
- _timescaledb_internal._hyper_2_4_chunk | _timescaledb_internal._hyper_2_4_chunk_tspace_1dim_time_idx        | {time,temp,device} | f      | f       | f         | tablespace1
+                 Table                  |                               Index                                |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+--------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_tspace_2dim_device_time_idx | {device,time} |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_tspace_2dim_device_time_idx | {device,time} |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_2_3_chunk | _timescaledb_internal._hyper_2_3_chunk_tspace_1dim_time_idx        | {time}        |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_2_4_chunk | _timescaledb_internal._hyper_2_4_chunk_tspace_1dim_time_idx        | {time}        |      | f      | f       | f         | tablespace1
 (6 rows)
 
 --detach tablespace1 from tspace_2dim should fail due to lack of permissions

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -54,13 +54,15 @@ $BODY$;
 CREATE OR REPLACE FUNCTION test.show_indexes(rel regclass)
 RETURNS TABLE("Index" regclass,
               "Columns" name[],
+              "Expr" text,
               "Unique" boolean,
               "Primary" boolean,
               "Exclusion" boolean,
               "Tablespace" name) LANGUAGE SQL STABLE AS
 $BODY$
     SELECT c.oid::regclass,
-    array(SELECT "Column" FROM test.show_columns(c.oid)),
+    array(SELECT "Column" FROM test.show_columns(i.indexrelid)),
+    pg_get_expr(i.indexprs, c.oid, true),
     i.indisunique,
     i.indisprimary,
     i.indisexclusion,
@@ -74,6 +76,7 @@ CREATE OR REPLACE FUNCTION test.show_indexesp(pattern text)
 RETURNS TABLE("Table" regclass,
               "Index" regclass,
               "Columns" name[],
+              "Expr" text,
               "Unique" boolean,
               "Primary" boolean,
               "Exclusion" boolean,
@@ -91,7 +94,8 @@ BEGIN
     RETURN QUERY
     SELECT c.oid::regclass,
     i.indexrelid::regclass,
-    array(SELECT "Column" FROM test.show_columns(c.oid)),
+    array(SELECT "Column" FROM test.show_columns(i.indexrelid)),
+    pg_get_expr(i.indexprs, c.oid, true),
     i.indisunique,
     i.indisprimary,
     i.indisexclusion,


### PR DESCRIPTION
This fixes the show_indexes test support function to properly show the
columns of the indexes instead of the table. The function now also
shows the expressions of expression indexes.