### PR TITLE
Enforce IMMUTABLE partitioning functions

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -897,7 +897,9 @@ dimension_validate_info(DimensionInfo *info)
 		else if (!partitioning_func_is_valid(info->partitioning_func))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
-					 errmsg("invalid partitioning function: must have the signature (anyelement) -> integer")));
+					 errmsg("invalid partitioning function"),
+					 errhint("A valid partitioning function for closed (space) dimensions must be IMMUTABLE "
+							 "and have the signature (anyelement) -> integer.")));
 
 		if (!IS_VALID_NUM_SLICES(info->num_slices))
 			ereport(ERROR,

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -28,6 +28,7 @@
 
 #define IS_VALID_PARTITIONING_FUNC(proform)							\
 	((proform)->prorettype == INT4OID &&							\
+	 ((proform)->provolatile == PROVOLATILE_IMMUTABLE) &&			\
 	 (proform)->pronargs == 1 &&									\
 	 (proform)->proargtypes.values[0] == ANYELEMENTOID)
 /*
@@ -101,7 +102,9 @@ partitioning_func_set_func_fmgr(PartitioningFunc *pf)
 
 	if (!OidIsValid(funcoid))
 		ereport(ERROR,
-				(errmsg("invalid partitioning function: must have the signature (anyelement) -> integer")));
+				(errmsg("invalid partitioning function"),
+				 errhint("A partitioning function for a closed (space) dimension "
+						 "must be IMMUTABLE and have the signature (anyelement) -> integer")));
 
 	fmgr_info_cxt(funcoid, &pf->func_fmgr, CurrentMemoryContext);
 }

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -375,3 +375,76 @@ NOTICE:  adding not-null constraint to column "time"
 -- Reset GRANTS
 \c single :ROLE_SUPERUSER
 REVOKE :ROLE_DEFAULT_PERM_USER FROM :ROLE_DEFAULT_PERM_USER_2;
+-- Test custom partitioning functions
+CREATE OR REPLACE FUNCTION partfunc_not_immutable(source anyelement)
+    RETURNS INTEGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+    RETURN _timescaledb_internal.get_partition_hash(source);
+END
+$BODY$;
+CREATE OR REPLACE FUNCTION partfunc_bad_return_type(source anyelement)
+    RETURNS BIGINT LANGUAGE PLPGSQL IMMUTABLE AS
+$BODY$
+BEGIN
+    RETURN _timescaledb_internal.get_partition_hash(source);
+END
+$BODY$;
+CREATE OR REPLACE FUNCTION partfunc_bad_arg_type(source text)
+    RETURNS INTEGER LANGUAGE PLPGSQL IMMUTABLE AS
+$BODY$
+BEGIN
+    RETURN _timescaledb_internal.get_partition_hash(source);
+END
+$BODY$;
+CREATE OR REPLACE FUNCTION partfunc_bad_multi_arg(source anyelement, extra_arg integer)
+    RETURNS INTEGER LANGUAGE PLPGSQL IMMUTABLE AS
+$BODY$
+BEGIN
+    RETURN _timescaledb_internal.get_partition_hash(source);
+END
+$BODY$;
+CREATE OR REPLACE FUNCTION partfunc_valid(source anyelement)
+    RETURNS INTEGER LANGUAGE PLPGSQL IMMUTABLE AS
+$BODY$
+BEGIN
+    RETURN _timescaledb_internal.get_partition_hash(source);
+END
+$BODY$;
+create table test_schema.test_partfunc(time timestamptz, temp float, device int);
+-- Test that create_hypertable fails due to invalid partitioning function
+\set ON_ERROR_STOP 0
+select create_hypertable('test_schema.test_partfunc', 'time', 'device', 2, partitioning_func => 'partfunc_not_immutable');
+ERROR:  invalid partitioning function
+select create_hypertable('test_schema.test_partfunc', 'time', 'device', 2, partitioning_func => 'partfunc_bad_return_type');
+ERROR:  invalid partitioning function
+select create_hypertable('test_schema.test_partfunc', 'time', 'device', 2, partitioning_func => 'partfunc_bad_arg_type');
+ERROR:  invalid partitioning function
+select create_hypertable('test_schema.test_partfunc', 'time', 'device', 2, partitioning_func => 'partfunc_bad_multi_arg');
+ERROR:  invalid partitioning function
+\set ON_ERROR_STOP 1
+-- Test that add_dimension fails due to invalid partitioning function
+select create_hypertable('test_schema.test_partfunc', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_not_immutable');
+ERROR:  invalid partitioning function
+select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_bad_return_type');
+ERROR:  invalid partitioning function
+select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_bad_arg_type');
+ERROR:  invalid partitioning function
+select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_bad_multi_arg');
+ERROR:  invalid partitioning function
+\set ON_ERROR_STOP 1
+-- A valid function should work:
+select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_valid');
+ add_dimension 
+---------------
+ 
+(1 row)
+

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -145,7 +145,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
 -- that our native partitioning function handles function expressions
 -- as argument
 CREATE OR REPLACE FUNCTION custom_partfunc(source anyelement)
-    RETURNS INTEGER LANGUAGE PLPGSQL AS
+    RETURNS INTEGER LANGUAGE PLPGSQL IMMUTABLE AS
 $BODY$
 DECLARE
     retval INTEGER;

--- a/test/sql/partitioning.sql
+++ b/test/sql/partitioning.sql
@@ -61,7 +61,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
 -- that our native partitioning function handles function expressions
 -- as argument
 CREATE OR REPLACE FUNCTION custom_partfunc(source anyelement)
-    RETURNS INTEGER LANGUAGE PLPGSQL AS
+    RETURNS INTEGER LANGUAGE PLPGSQL IMMUTABLE AS
 $BODY$
 DECLARE
     retval INTEGER;


### PR DESCRIPTION
This adds a simple check to enforce that partitioning functions
are IMMUTABLE. This is a requirement since a partitioning function
must always return the same value given the same input.