### PR TITLE
Fix segfault with custom partition types.

### DIFF
--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -112,62 +112,6 @@ chunk_insert_state_convert_tuple(ChunkInsertState *state,
 	return tuple;
 }
 
-/* Just like ExecPrepareExpr except that it doesn't switch to the query memory context */
-static inline ExprState *
-prepare_constr_expr(Expr *node)
-{
-	ExprState  *result;
-
-	node = expression_planner(node);
-	result = ExecInitExpr(node, NULL);
-
-	return result;
-}
-
-/*
- * Create the constraint exprs inside the current memory context. If this
- * is not done here, then ExecRelCheck will do it for you but put it into
- * the query memory context, which will cause a memory leak.
- */
-static inline void
-create_chunk_rri_constraint_expr(ResultRelInfo *rri, Relation rel)
-{
-	int			ncheck,
-				i;
-	ConstrCheck *check;
-
-	Assert(rel->rd_att->constr != NULL &&
-		   rri->ri_ConstraintExprs == NULL);
-
-	ncheck = rel->rd_att->constr->num_check;
-	check = rel->rd_att->constr->check;
-
-#if PG10
-	rri->ri_ConstraintExprs =
-		(ExprState **) palloc(ncheck * sizeof(ExprState *));
-
-	for (i = 0; i < ncheck; i++)
-	{
-		Expr	   *checkconstr = stringToNode(check[i].ccbin);
-
-		rri->ri_ConstraintExprs[i] =
-			prepare_constr_expr(checkconstr);
-	}
-#elif PG96
-	rri->ri_ConstraintExprs =
-		(List **) palloc(ncheck * sizeof(List *));
-
-	for (i = 0; i < ncheck; i++)
-	{
-		/* ExecQual wants implicit-AND form */
-		List	   *qual = make_ands_implicit(stringToNode(check[i].ccbin));
-
-		rri->ri_ConstraintExprs[i] = (List *)
-			prepare_constr_expr((Expr *) qual);
-	}
-#endif
-}
-
 /*
  * Create a new ResultRelInfo for a chunk.
  *
@@ -201,7 +145,15 @@ create_chunk_result_relation_info(ChunkDispatch *dispatch, Relation rel, Index r
 	rri->ri_onConflictSetProj = rri_orig->ri_onConflictSetProj;
 	rri->ri_onConflictSetWhere = rri_orig->ri_onConflictSetWhere;
 
-	create_chunk_rri_constraint_expr(rri, rel);
+	/*
+	 * We do not create the actual constraint exprs here, leaving it for
+	 * ExecRelCheck to create them in the query memory context. While it might
+	 * be more memory efficient to create them in the chunk insert memory
+	 * context, postgres expects these expr to live for the entire duration of
+	 * the SQL expression we are running, and will happily store pointers into
+	 * it for later; this has caused segfualts in the past. Additionally, memory
+	 * savings for shorter allocation seems minimal.
+	 */
 
 	return rri;
 }


### PR DESCRIPTION
Postgres assumes that exprs will live for the entire duration of the SQL expression that they are created from and stores pointers into them based on that assumption. On `INSERT` Our dynamically created chunk constraints currently live only for an individual chunk insert, causing segfaults when postgres tries to read through the cleaned up memory. We do this as a memory size optimization, partly due to #284. It looks like this optimization is no longer effective, and that there is no noticable difference in memory gain from using the default behavior. Therefore this commit removes our allocation so as to fix the segfault. 

After @Ngalstyan4's partition on custom type patch #636 the following SQL will cause a segfault:
<details>

```SQL

CREATE TYPE simpl AS (val1 int4);

CREATE OR REPLACE FUNCTION simpl_type_hash(ANYELEMENT) RETURNS int4 AS $$
    SELECT $1.val1 AS resut;
$$ LANGUAGE SQL STABLE;

CREATE TABLE simpl_partition ("timestamp" TIMESTAMPTZ, object simpl);

SELECT create_hypertable(
    'simpl_partition',
    'timestamp',
    'object',
    1000,
    chunk_time_interval => interval '1 day',
    partitioning_func=>'simpl_type_hash');

INSERT INTO simpl_partition VALUES ('2017-03-22T09:18:23', ROW(1)::simpl);

SELECT * from simpl_partition;
```

</detaills>