### PR TITLE
Create aggregate functions only once to avoid dependency issues

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -6,6 +6,13 @@ set(CATALOG_SOURCE_FILES
   tables.sql
 )
 
+# Things like aggregate functions cannot be REPLACEd and really
+# need to be created just once(like CATALOG_SOURCE_FILES)
+# but unlike CATALOG_SOURCE_FILES these have to be loaded
+# after everything else is loaded.
+set(IMMUTABLE_API_SOURCE_FILES
+  aggregates.sql
+)
 # The rest of the source files defining mostly functions
 set(SOURCE_FILES
   chunk.sql
@@ -78,6 +85,7 @@ endfunction()
 # directory of all our source files
 version_files("${PRE_UPDATE_FILES}" PRE_UPDATE_FILES_VERSIONED)
 version_files("${CATALOG_SOURCE_FILES}" CATALOG_SOURCE_FILES_VERSIONED)
+version_files("${IMMUTABLE_API_SOURCE_FILES}" IMMUTABLE_API_SOURCE_FILES_VERSIONED)
 version_files("${SOURCE_FILES}" SOURCE_FILES_VERSIONED)
 version_files("${MOD_FILES}" MOD_FILES_VERSIONED)
 
@@ -106,7 +114,10 @@ function(cat_files SRC_FILE_LIST OUTPUT_FILE)
 endfunction()
 
 # Generate the extension file used with CREATE EXTENSION
-cat_files("${CATALOG_SOURCE_FILES_VERSIONED};${SOURCE_FILES_VERSIONED}" ${CMAKE_CURRENT_BINARY_DIR}/${INSTALL_FILE})
+cat_files(
+  "${CATALOG_SOURCE_FILES_VERSIONED};${SOURCE_FILES_VERSIONED};${IMMUTABLE_API_SOURCE_FILES_VERSIONED}"
+  ${CMAKE_CURRENT_BINARY_DIR}/${INSTALL_FILE}
+)
 add_custom_target(sqlfile ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${INSTALL_FILE})
 
 # Generate the update files used with ALTER EXTENSION <name> UPDATE

--- a/sql/aggregates.sql
+++ b/sql/aggregates.sql
@@ -1,0 +1,48 @@
+-- This file is meant to contain aggregate functions that need to be created only
+-- once and not recreated during updates.
+-- There is no CREATE OR REPLACE AGGREGATE which means that the only way to replace
+-- an aggregate is to DROP then CREATE which is problematic as it will fail
+-- if the previous version of the aggregate has dependencies.
+-- NOTE that WHEN CREATING NEW FUNCTIONS HERE you should also make sure they are
+-- created in an update script so that both new users and people updating from a
+-- previous version get the new function
+
+
+--This aggregate returns the "first" element of the first argument when ordered by the second argument.
+--Ex. first(temp, time) returns the temp value for the row with the lowest time
+CREATE AGGREGATE first(anyelement, "any") (
+    SFUNC = _timescaledb_internal.first_sfunc,
+    STYPE = internal,
+    COMBINEFUNC = _timescaledb_internal.first_combinefunc,
+    SERIALFUNC = _timescaledb_internal.bookend_serializefunc,
+    DESERIALFUNC = _timescaledb_internal.bookend_deserializefunc,
+    PARALLEL = SAFE,
+    FINALFUNC = _timescaledb_internal.bookend_finalfunc,
+    FINALFUNC_EXTRA
+);
+
+--This aggregate returns the "last" element of the first argument when ordered by the second argument.
+--Ex. last(temp, time) returns the temp value for the row with highest time
+CREATE AGGREGATE last(anyelement, "any") (
+    SFUNC = _timescaledb_internal.last_sfunc,
+    STYPE = internal,
+    COMBINEFUNC = _timescaledb_internal.last_combinefunc,
+    SERIALFUNC = _timescaledb_internal.bookend_serializefunc,
+    DESERIALFUNC = _timescaledb_internal.bookend_deserializefunc,
+    PARALLEL = SAFE,
+    FINALFUNC = _timescaledb_internal.bookend_finalfunc,
+    FINALFUNC_EXTRA
+);
+
+-- This aggregate partitions the dataset into a specified number of buckets (nbuckets) ranging
+-- from the inputted min to max values.
+CREATE AGGREGATE histogram (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, INTEGER) (
+    SFUNC = _timescaledb_internal.hist_sfunc,
+    STYPE = INTERNAL,
+    COMBINEFUNC = _timescaledb_internal.hist_combinefunc,
+    SERIALFUNC = _timescaledb_internal.hist_serializefunc,
+    DESERIALFUNC = _timescaledb_internal.hist_deserializefunc,
+    PARALLEL = SAFE,
+    FINALFUNC = _timescaledb_internal.hist_finalfunc,
+    FINALFUNC_EXTRA
+);

--- a/sql/bookend.sql
+++ b/sql/bookend.sql
@@ -32,31 +32,3 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.bookend_deserializefunc(bytea, 
 RETURNS internal
 AS '@MODULE_PATHNAME@', 'bookend_deserializefunc'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
---This aggregate returns the "first" element of the first argument when ordered by the second argument.
---Ex. first(temp, time) returns the temp value for the row with the lowest time
-DROP AGGREGATE IF EXISTS first(anyelement, "any");
-CREATE AGGREGATE first(anyelement, "any") (
-    SFUNC = _timescaledb_internal.first_sfunc,
-    STYPE = internal,
-    COMBINEFUNC = _timescaledb_internal.first_combinefunc,
-    SERIALFUNC = _timescaledb_internal.bookend_serializefunc,
-    DESERIALFUNC = _timescaledb_internal.bookend_deserializefunc,
-    PARALLEL = SAFE,
-    FINALFUNC = _timescaledb_internal.bookend_finalfunc,
-    FINALFUNC_EXTRA
-);
-
---This aggregate returns the "last" element of the first argument when ordered by the second argument.
---Ex. last(temp, time) returns the temp value for the row with highest time
-DROP AGGREGATE IF EXISTS last(anyelement, "any");
-CREATE AGGREGATE last(anyelement, "any") (
-    SFUNC = _timescaledb_internal.last_sfunc,
-    STYPE = internal,
-    COMBINEFUNC = _timescaledb_internal.last_combinefunc,
-    SERIALFUNC = _timescaledb_internal.bookend_serializefunc,
-    DESERIALFUNC = _timescaledb_internal.bookend_deserializefunc,
-    PARALLEL = SAFE,
-    FINALFUNC = _timescaledb_internal.bookend_finalfunc,
-    FINALFUNC_EXTRA
-);

--- a/sql/histogram.sql
+++ b/sql/histogram.sql
@@ -22,16 +22,3 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_finalfunc(state INTERNAL, 
 RETURNS INTEGER[]
 AS '@MODULE_PATHNAME@', 'hist_finalfunc'
 LANGUAGE C IMMUTABLE PARALLEL SAFE;
-
--- Tell Postgres how to use the new function
-DROP AGGREGATE IF EXISTS histogram (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, INTEGER);
-CREATE AGGREGATE histogram (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, INTEGER) (
-    SFUNC = _timescaledb_internal.hist_sfunc,
-    STYPE = INTERNAL,
-    COMBINEFUNC = _timescaledb_internal.hist_combinefunc,
-    SERIALFUNC = _timescaledb_internal.hist_serializefunc,
-    DESERIALFUNC = _timescaledb_internal.hist_deserializefunc,
-    PARALLEL = SAFE,
-    FINALFUNC = _timescaledb_internal.hist_finalfunc,
-    FINALFUNC_EXTRA
-);

--- a/sql/updates/0.4.2--0.5.0.sql
+++ b/sql/updates/0.4.2--0.5.0.sql
@@ -246,3 +246,42 @@ DROP FUNCTION IF EXISTS _timescaledb_internal.drop_trigger_on_all_chunks(INTEGER
 DROP FUNCTION IF EXISTS _timescaledb_internal.get_general_trigger_definition(regclass);
 DROP FUNCTION IF EXISTS _timescaledb_internal.get_trigger_definition_for_table(INTEGER, text);
 DROP FUNCTION IF EXISTS _timescaledb_internal.need_chunk_trigger(int, oid);
+
+-- Adding this in the update script because aggregates.sql is not rerun in case of an update
+CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_sfunc (state INTERNAL, val DOUBLE PRECISION, MIN DOUBLE PRECISION, MAX DOUBLE PRECISION, nbuckets INTEGER)
+RETURNS INTERNAL
+AS '@MODULE_PATHNAME@', 'hist_sfunc'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_combinefunc(state1 INTERNAL, state2 INTERNAL)
+RETURNS INTERNAL
+AS '@MODULE_PATHNAME@', 'hist_combinefunc'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_serializefunc(INTERNAL)
+RETURNS bytea
+AS '@MODULE_PATHNAME@', 'hist_serializefunc'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_deserializefunc(bytea, INTERNAL)
+RETURNS INTERNAL
+AS '@MODULE_PATHNAME@', 'hist_deserializefunc'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.hist_finalfunc(state INTERNAL, val DOUBLE PRECISION, MIN DOUBLE PRECISION, MAX DOUBLE PRECISION, nbuckets INTEGER)
+RETURNS INTEGER[]
+AS '@MODULE_PATHNAME@', 'hist_finalfunc'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- This aggregate partitions the dataset into a specified number of buckets (nbuckets) ranging
+-- from the inputted min to max values.
+CREATE AGGREGATE histogram (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, INTEGER) (
+    SFUNC = _timescaledb_internal.hist_sfunc,
+    STYPE = INTERNAL,
+    COMBINEFUNC = _timescaledb_internal.hist_combinefunc,
+    SERIALFUNC = _timescaledb_internal.hist_serializefunc,
+    DESERIALFUNC = _timescaledb_internal.hist_deserializefunc,
+    PARALLEL = SAFE,
+    FINALFUNC = _timescaledb_internal.hist_finalfunc,
+    FINALFUNC_EXTRA
+);

--- a/sql/updates/README.md
+++ b/sql/updates/README.md
@@ -28,7 +28,7 @@ to consider.
    commands that change or remove objects. In some cases,
    modifications of metadata are also necessary.
 2. `DROP FUNCTION` needs to be idempotent. In most cases that means
-   commands should have an `IF NOT EXISTS` clause. The reason is that
+   commands should have an `IF EXISTS` clause. The reason is that
    some modfiles might try to, e.g., `DROP` functions that aren't
    present because they only exist in an intermediate version of the
    database, which is skipped over.
@@ -39,6 +39,11 @@ to consider.
 4. The creation of new metadata tables need to be part of modfiles,
    similar to `ALTER`s of such tables. Otherwise, later modfiles
    cannot rely on those tables being present.
+5. When creating a new aggregate, the `CREATE` statement should be
+   added to both aggregate.sql AND an update file. aggregate.sql is
+   run once when TimescaleDB is installed so adding a definition in
+   an update file is the only way to ensure that upgrading users get
+   the new function.
 
 Note that modfiles that contain no changes need not exist as a
 file. Transition modfiles must, however, be listed in the


### PR DESCRIPTION
There is no CREATE OR REPLACE AGGREGATE which means that the only way to replace
an aggregate is to DROP then CREATE which is problematic as it will fail
if the previous version of the aggregate has dependencies.
NOTE that WHEN CREATING NEW FUNCTIONS in sql/aggregates.sql you should also make
sure they are created in an update script so that both new users and people
updating from a previous version get the new function.
Fixes #612 