### PR TITLE
Implement show_chunks in C and have drop_chunks use it

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -83,6 +83,7 @@ set(MOD_FILES
   updates/1.0.0-rc2--1.0.0-rc3.sql
   updates/1.0.0-rc3--1.0.0.sql
   updates/1.0.0--1.0.1-dev.sql
+  updates/1.0.1--1.1.0.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/sql/updates/1.0.1--1.1.0.sql
+++ b/sql/updates/1.0.1--1.1.0.sql
@@ -1,0 +1,5 @@
+DROP FUNCTION IF EXISTS drop_chunks(INTERVAL, NAME, NAME, BOOLEAN);
+DROP FUNCTION IF EXISTS drop_chunks(ANYELEMENT, NAME, NAME, BOOLEAN);
+DROP FUNCTION IF EXISTS _timescaledb_internal.drop_chunks_impl(BIGINT, NAME, NAME, BOOLEAN, BOOLEAN);
+DROP FUNCTION IF EXISTS _timescaledb_internal.drop_chunks_type_check(REGTYPE, NAME, NAME);
+DROP FUNCTION IF EXISTS _timescaledb_internal.dimension_get_time(INTEGER);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
   chunk_dispatch_state.c
   chunk_index.c
   chunk_insert_state.c
+  compat.c
   constraint_aware_append.c
   copy.c
   dimension.c

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -17,7 +17,6 @@
 #include <miscadmin.h>
 #include <commands/dbcommands.h>
 #include <commands/sequence.h>
-#include <access/xact.h>
 
 #include "compat.h"
 #include "catalog.h"

--- a/src/compat.c
+++ b/src/compat.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-2018  Timescale, Inc. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License,
+ * see LICENSE-APACHE at the top level directory.
+ */
+#include "compat.h"
+
+#if PG96
+/* this was statically defined in pg_enum.c but was moved to
+ buitlins.c in March 2017 and exposed in buitlins.h in PG10.
+ This makes sure that we can use oid_cmp in PG96
+ The change in postgres happened here:
+ https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=20f6d74242b3c9c84924e890248d027d30283e21
+ */
+/* qsort comparison function for Oids */
+int
+oid_cmp(const void *p1, const void *p2)
+{
+	Oid			v1 = *((const Oid *) p1);
+	Oid			v2 = *((const Oid *) p2);
+
+	if (v1 < v2)
+		return -1;
+	if (v1 > v2)
+		return 1;
+	return 0;
+}
+
+#endif

--- a/src/compat.h
+++ b/src/compat.h
@@ -71,6 +71,9 @@
 	 ExecBuildProjectionInfo((List *)ExecInitExpr((Expr *) tl, NULL), exprContext, slot, inputdesc)
 #define WaitLatchCompat(latch, wakeEvents, timeout) \
 	WaitLatch(latch, wakeEvents, timeout)
+
+extern int	oid_cmp(const void *p1, const void *p2);
+
 #else
 
 #error "Unsupported PostgreSQL version"

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -764,6 +764,54 @@ ts_dimension_interval_to_internal_test(PG_FUNCTION_ARGS)
 	PG_RETURN_INT64(dimension_interval_to_internal("testcol", coltype, valuetype, value, false));
 }
 
+/* A utility function to check that the argument type passed to be
+ * used/compared with a hypertable time column is valid
+ * The argument is valid if
+ * 	-	it is an INTEGER type and time column of hypertable is also INTEGER
+ * 	-	it is an INTERVAL and time column of hypertable is time or date
+ * 	-	it is the same as time column of hypertable
+ */
+void
+dimension_open_typecheck(Oid arg_type, Oid time_column_type, char *caller_name)
+{
+	AssertArg(arg_type != InvalidOid);
+	AssertArg(IS_VALID_OPEN_DIM_TYPE(time_column_type));
+
+	if (IS_INTEGER_TYPE(time_column_type) && IS_INTEGER_TYPE(arg_type))
+		return;
+
+	if (arg_type == INTERVALOID)
+	{
+		if (IS_INTEGER_TYPE(time_column_type))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("can only use \"%s\" with an INTERVAL"
+							" for TIMESTAMP, TIMESTAMPTZ, and DATE types",
+							caller_name)
+					 ));
+		return;
+	}
+
+	if (!IS_VALID_OPEN_DIM_TYPE(arg_type))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("time constraint arguments of \"%s\" should "
+						"have one of acceptable time column types: "
+						"SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE",
+						caller_name)
+				 ));
+	}
+
+	if (arg_type != time_column_type)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("time constraint arguments of \"%s\" should "
+						"have same type as time column of the hypertable",
+						caller_name)
+				 ));
+}
+
 static void
 dimension_add_not_null_on_column(Oid table_relid, char *colname)
 {
@@ -1115,11 +1163,17 @@ ts_dimension_add(PG_FUNCTION_ARGS)
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(info.table_relid))));
 
-	if ((!info.num_slices_is_set && !OidIsValid(info.interval_type)) ||
-		(info.num_slices_is_set && OidIsValid(info.interval_type)))
+	if (info.num_slices_is_set && OidIsValid(info.interval_type))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("cannot specify both the number of partitions and an interval")));
+				 errmsg("cannot specify both the number of partitions and an interval")
+				 ));
+
+	if (!info.num_slices_is_set && !OidIsValid(info.interval_type))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("cannot omit both the number of partitions and the interval")
+				 ));
 
 	dimension_validate_info(&info);
 

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -141,6 +141,7 @@ extern int	dimension_set_name(Dimension *dim, const char *newname);
 extern int	dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
 extern int	dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete_slices);
 extern void dimension_validate_info(DimensionInfo *info);
+extern void dimension_open_typecheck(Oid arg_type, Oid time_column_type, char *caller_name);
 extern void dimension_add_from_info(DimensionInfo *info);
 extern void dimensions_rename_schema_name(char *oldname, char *newname);
 

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -202,7 +202,7 @@ dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit)
 }
 
 /*
- * Look for all ranges where value > lower_bound and value < upper_bound
+ * Look for all dimension slices where (lower_bound, upper_bound) of the dimension_slice contains the given (start_value, end_value) range
  *
  */
 DimensionVec *

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -33,7 +33,6 @@ typedef struct Hypercube Hypercube;
 extern DimensionVec *dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit);
 extern DimensionVec *dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy, int64 start_value, StrategyNumber end_strategy, int64 end_value, int limit);
 extern DimensionVec *dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, int64 range_end, int limit);
-extern Hypercube *dimension_slice_point_scan(Hyperspace *space, int64 point[]);
 extern DimensionSlice *dimension_slice_scan_for_existing(DimensionSlice *slice);
 extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
 extern DimensionVec *dimension_slice_scan_by_dimension(int32 dimension_id, int limit);

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -16,7 +16,6 @@
 #include <utils/lsyscache.h>
 #include <miscadmin.h>
 #include <parser/analyze.h>
-#include <commands/extension.h>
 #include <access/relscan.h>
 #include <catalog/pg_extension.h>
 #include <catalog/pg_authid.h>

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -214,6 +214,34 @@ number_of_hypertables()
 }
 
 static ScanTupleResult
+hypertable_tuple_append(TupleInfo *ti, void *data)
+{
+	List	  **hypertables = data;
+
+	*hypertables = lappend(*hypertables, hypertable_from_tuple(ti->tuple, ti->mctx));
+
+	return SCAN_CONTINUE;
+}
+
+List *
+hypertable_get_all(void)
+{
+	List	   *result = NIL;
+
+	hypertable_scan_limit_internal(NULL,
+								   0,
+								   InvalidOid,
+								   hypertable_tuple_append,
+								   &result,
+								   -1,
+								   LockTupleKeyShare,
+								   false,
+								   CurrentMemoryContext);
+
+	return result;
+}
+
+static ScanTupleResult
 hypertable_tuple_update(TupleInfo *ti, void *data)
 {
 	Hypertable *ht = data;

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -20,7 +20,6 @@
 
 typedef struct SubspaceStore SubspaceStore;
 typedef struct Chunk Chunk;
-typedef struct HeapTupleData *HeapTuple;
 
 typedef struct Hypertable
 {
@@ -47,6 +46,7 @@ enum Anum_create_hypertable
 extern int	number_of_hypertables(void);
 
 extern Oid	rel_get_owner(Oid relid);
+extern List *hypertable_get_all(void);
 extern Hypertable *hypertable_get_by_id(int32 hypertable_id);
 extern Hypertable *hypertable_get_by_name(char *schema, char *name);
 extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);

--- a/src/plan_add_hashagg.c
+++ b/src/plan_add_hashagg.c
@@ -35,7 +35,6 @@
 #include "hypertable_insert.h"
 #include "constraint_aware_append.h"
 #include "compat.h"
-#include "extension.h"
 
 #define INVALID_ESTIMATE (-1)
 #define IS_VALID_ESTIMATE(est) ((est) >= 0)

--- a/src/planner.c
+++ b/src/planner.c
@@ -22,7 +22,6 @@
 #include <utils/lsyscache.h>
 #include <executor/nodeAgg.h>
 #include <utils/timestamp.h>
-#include <utils/lsyscache.h>
 #include <utils/selfuncs.h>
 
 #include "compat-msvc-enter.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,6 +22,11 @@ extern bool type_is_int8_binary_compatible(Oid sourcetype);
 extern int64 time_value_to_internal(Datum time_val, Oid type, bool failure_ok);
 
 /*
+ * Convert the difference of interval and current timestamp to internal representation
+ */
+extern int64 interval_from_now_to_internal(Datum time_val, Oid type);
+
+/*
  * Return the period in microseconds of the first argument to date_trunc.
  * This is approximate -- to be used for planning;
  */

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -2,10 +2,26 @@
 --
 -- This file is licensed under the Apache License,
 -- see LICENSE-APACHE at the top level directory.
+CREATE OR REPLACE FUNCTION dimension_get_time(
+    hypertable_id INT
+)
+    RETURNS _timescaledb_catalog.dimension LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT *
+    FROM _timescaledb_catalog.dimension d
+    WHERE d.hypertable_id = dimension_get_time.hypertable_id AND
+          d.interval_length IS NOT NULL
+$BODY$;
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test3(time bigint, temp float8, device_id text);
 CREATE INDEX ON drop_chunk_test1(time DESC);
+-- show_chunks() returns 0 rows when there are no hypertables
+SELECT show_chunks();
+ show_chunks 
+-------------
+(0 rows)
+
 SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
@@ -46,10 +62,16 @@ SELECT add_dimension('public.drop_chunk_test3', 'device_id', 2);
  (6,public,drop_chunk_test3,device_id,t)
 (1 row)
 
+--should work becasue so far all tables have time column type of bigint
+SELECT show_chunks();
+ show_chunks 
+-------------
+(0 rows)
+
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -96,7 +118,7 @@ INSERT INTO PUBLIC.drop_chunk_test3 VALUES(6, 6.0, 'dev7');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -140,15 +162,104 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
  _timescaledb_internal | _hyper_3_18_chunk | table | default_perm_user
 (18 rows)
 
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(6 rows)
+
+SELECT * FROM show_chunks('drop_chunk_test2');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(6 rows)
+
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chunk;
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(2);
 ERROR:  cannot drop table _timescaledb_internal._hyper_1_1_chunk because other objects depend on it
 SELECT drop_chunks(NULL::interval);
-ERROR:  can only use drop_chunks with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
+ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
 SELECT drop_chunks(NULL::int);
-ERROR:  the timestamp provided to drop_chunks cannot be NULL
+ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
+-- error messages were refactored in postgres between 9.6 and 10 because of
+-- which direct comparison of error messages fails.
+-- The change in postgres happened here:
+-- https://github.com/postgres/postgres/commit/9a34123bc315e55b33038464422ef1cd2b67dab2
+SET client_min_messages TO FATAL;
+-- error message is suppressed for the reason above but this test should still make sure
+-- this causes an error. Not returning # rows below can be used as an indication that
+-- this did cause an error.
+-- should error because not a time type
+SELECT drop_chunks('haha', 'drop_chunk_test3');
+SET client_min_messages TO DEFAULT;
+SELECT show_chunks('drop_chunk_test3', 'haha');
+ERROR:  time constraint arguments of "show_chunks" should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
+-- should error because wrong time type
+SELECT drop_chunks(now(), 'drop_chunk_test3');
+ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
+SELECT show_chunks('drop_chunk_test3', now());
+ERROR:  time constraint arguments of "show_chunks" should have same type as time column of the hypertable
+-- should error because of wrong relative order of time constraints
+SELECT show_chunks('drop_chunk_test1', older_than=>3, newer_than=>4);
+ERROR:  When both older_than and newer_than are specified, older_than must come after newer_than
 \set ON_ERROR_STOP 1
+--should always work regardless of time column types of hypertables
+SELECT show_chunks();
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+ _timescaledb_internal._hyper_3_13_chunk
+ _timescaledb_internal._hyper_3_14_chunk
+ _timescaledb_internal._hyper_3_15_chunk
+ _timescaledb_internal._hyper_3_16_chunk
+ _timescaledb_internal._hyper_3_17_chunk
+ _timescaledb_internal._hyper_3_18_chunk
+(18 rows)
+
+-- should work vecause so far all tables have time column type of bigint
+SELECT show_chunks(newer_than => 2);
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+ _timescaledb_internal._hyper_3_14_chunk
+ _timescaledb_internal._hyper_3_15_chunk
+ _timescaledb_internal._hyper_3_16_chunk
+ _timescaledb_internal._hyper_3_17_chunk
+ _timescaledb_internal._hyper_3_18_chunk
+(15 rows)
+
 -- show created constraints and dimension slices for each chunk
 SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
@@ -375,7 +486,7 @@ SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -392,6 +503,27 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
        11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (10 rows)
+
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(5 rows)
+
+SELECT * FROM show_chunks('drop_chunk_test2');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(5 rows)
 
 \dt "_timescaledb_internal"._hyper*
                            List of relations
@@ -423,7 +555,7 @@ SELECT drop_chunks(3, 'drop_chunk_test1');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -461,6 +593,26 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
  _timescaledb_internal | bgw_job_stat      | table | super_user
 (15 rows)
 
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(4 rows)
+
+SELECT * FROM show_chunks('drop_chunk_test2');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(5 rows)
+
 -- 2,147,483,647 is the largest int so this tests that BIGINTs work
 SELECT drop_chunks(2147483648, 'drop_chunk_test3');
  drop_chunks 
@@ -471,7 +623,7 @@ SELECT drop_chunks(2147483648, 'drop_chunk_test3');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2' OR h.table_name = 'drop_chunk_test3');
@@ -503,16 +655,26 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
  _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
 (9 rows)
 
--- should error because no hypertable
 \set ON_ERROR_STOP 0
+-- should fail because too dangerous to assume anything
+-- Note that currently this failure is triggered by SQL typecheker when it tries and fails to resolve
+-- ANYELEMENT args to a concrete type. Explicit error checking may be necessary if drop_chunks implementation
+-- is fully ported to C.
+-- commented out because there is discrepancy between postgres 9.6 and postgres 10 error messages for this case
+-- SELECT drop_chunks();
+-- should error because no hypertable
 SELECT drop_chunks(5, 'drop_chunk_test4');
-ERROR:  no hypertables found
+ERROR:  hypertable "drop_chunk_test4" does not exist
+SELECT show_chunks('drop_chunk_test4');
+ERROR:  relation "drop_chunk_test4" does not exist at character 20
+SELECT show_chunks('drop_chunk_test4', 5);
+ERROR:  relation "drop_chunk_test4" does not exist at character 20
 \set ON_ERROR_STOP 1
 DROP TABLE _timescaledb_internal._hyper_1_6_chunk;
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -541,6 +703,119 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
  _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
  _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
 (8 rows)
+
+-- newer_than tests
+SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5);
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1');
+ chunk_id | hypertable_id |     chunk_schema      |   chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+------------------+-------------+-----------
+        3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |           3 |         4
+        4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |           4 |         5
+(2 rows)
+
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(2 rows)
+
+\dt "_timescaledb_internal"._hyper*
+                           List of relations
+        Schema         |       Name        | Type  |       Owner       
+-----------------------+-------------------+-------+-------------------
+ _timescaledb_internal | _hyper_1_3_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_1_4_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_10_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
+(7 rows)
+
+SELECT drop_chunks(table_name=>'drop_chunk_test1', older_than=>4, newer_than=>3);
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1');
+ chunk_id | hypertable_id |     chunk_schema      |   chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+------------------+-------------+-----------
+        4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |           4 |         5
+(1 row)
+
+-- the call of show_chunks should give same set of chunks as above
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_4_chunk
+(1 row)
+
+-- testing drop_chunks when only schema is specified.
+\set ON_ERROR_STOP 0
+-- error messages were refactored in postgres between 9.6 and 10 because of
+-- which direct comparison of error messages fails.
+SET client_min_messages TO FATAL;
+SELECT drop_chunks(schema_name=>'public');
+SET client_min_messages TO DEFAULT;
+SELECT drop_chunks(null::bigint, schema_name=>'public');
+ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
+\set ON_ERROR_STOP 1
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public';
+ chunk_id | hypertable_id |     chunk_schema      |    chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+-------------------+-------------+-----------
+        4 |             1 | _timescaledb_internal | _hyper_1_4_chunk  |           4 |         5
+        8 |             2 | _timescaledb_internal | _hyper_2_8_chunk  |           2 |         3
+        9 |             2 | _timescaledb_internal | _hyper_2_9_chunk  |           3 |         4
+       10 |             2 | _timescaledb_internal | _hyper_2_10_chunk |           4 |         5
+       11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
+       12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
+(6 rows)
+
+SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public';
+ chunk_id | hypertable_id |     chunk_schema      |    chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+-------------------+-------------+-----------
+        8 |             2 | _timescaledb_internal | _hyper_2_8_chunk  |           2 |         3
+        9 |             2 | _timescaledb_internal | _hyper_2_9_chunk  |           3 |         4
+       11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
+       12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
+(4 rows)
 
 CREATE TABLE PUBLIC.drop_chunk_test_ts(time timestamp, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_ts', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
@@ -573,6 +848,96 @@ SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
  _timescaledb_internal._hyper_5_20_chunk | 
 (1 row)
 
+BEGIN;
+    SELECT show_chunks('drop_chunk_test_ts');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_4_19_chunk
+(1 row)
+
+    SELECT show_chunks('drop_chunk_test_ts', now()::timestamp-interval '1 minute');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_4_19_chunk
+(1 row)
+
+    SELECT drop_chunks(newer_than => interval '1 minute', table_name => 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT drop_chunks(older_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+                  Child                  | Tablespace 
+-----------------------------------------+------------
+ _timescaledb_internal._hyper_4_19_chunk | 
+(1 row)
+
+    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+    SELECT show_chunks('drop_chunk_test_tstz');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_5_20_chunk
+(1 row)
+
+    SELECT show_chunks('drop_chunk_test_tstz', now() - interval '1 minute', now() - interval '6 minute');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_5_20_chunk
+(1 row)
+
+    SELECT show_chunks('drop_chunk_test_tstz', newer_than => now() - interval '1 minute');
+ show_chunks 
+-------------
+(0 rows)
+
+    SELECT show_chunks('drop_chunk_test_tstz', older_than => now() - interval '1 minute');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_5_20_chunk
+(1 row)
+
+    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_tstz');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+ROLLBACK;
+BEGIN;
+    SELECT drop_chunks(newer_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+ROLLBACK;
 BEGIN;
     SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
  drop_chunks 
@@ -621,16 +986,57 @@ BEGIN;
 (0 rows)
 
 ROLLBACK;
+\dt "_timescaledb_internal"._hyper*
+                           List of relations
+        Schema         |       Name        | Type  |       Owner       
+-----------------------+-------------------+-------+-------------------
+ _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_4_19_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_5_20_chunk | table | default_perm_user
+(6 rows)
+
+SELECT show_chunks();
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+ _timescaledb_internal._hyper_4_19_chunk
+ _timescaledb_internal._hyper_5_20_chunk
+(6 rows)
+
 \set ON_ERROR_STOP 0
+SELECT show_chunks(older_than=>4);
+ERROR:  cannot call "show_chunks" on all hypertables when all hypertables do not have the same time dimension type
+SELECT drop_chunks(4);
+ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
 SELECT drop_chunks(interval '1 minute');
-ERROR:  cannot use drop_chunks on multiple tables with different time types
+ERROR:  can only use "drop_chunks" with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
 SELECT drop_chunks(interval '1 minute', 'drop_chunk_test3');
-ERROR:  can only use drop_chunks with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
+ERROR:  can only use "drop_chunks" with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
 SELECT drop_chunks(now()-interval '1 minute', 'drop_chunk_test_ts');
-ERROR:  cannot call drop_chunks with a timestamp with time zone on hypertables with a time type of: timestamp without time zone
+ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
 SELECT drop_chunks(now()::timestamp-interval '1 minute', 'drop_chunk_test_tstz');
-ERROR:  cannot call drop_chunks with a timestamp without time zone on hypertables with a time type of: timestamp with time zone
+ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
+SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
+ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
 \set ON_ERROR_STOP 1
+\dt "_timescaledb_internal"._hyper*
+                           List of relations
+        Schema         |       Name        | Type  |       Owner       
+-----------------------+-------------------+-------+-------------------
+ _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_4_19_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_5_20_chunk | table | default_perm_user
+(6 rows)
+
 CREATE TABLE PUBLIC.drop_chunk_test_date(time date, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_date', 'time', chunk_time_interval => interval '1 day', create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -37,7 +37,8 @@ ORDER BY proname;
  set_adaptive_chunking
  set_chunk_time_interval
  set_number_partitions
+ show_chunks
  show_tablespaces
  time_bucket
-(24 rows)
+(25 rows)
 

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_FILES
   append_unoptimized.sql
   append_x_diff.sql
   chunk_adaptive.sql
+  chunk_utils.sql
   chunks.sql
   cluster.sql
   constraint.sql
@@ -21,7 +22,6 @@ set(TEST_FILES
   delete.sql
   drop_schema.sql
   drop_owned.sql
-  drop_chunks.sql
   drop_extension.sql
   drop_hypertable.sql
   drop_rename_hypertable.sql

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -3,10 +3,25 @@
 -- This file is licensed under the Apache License,
 -- see LICENSE-APACHE at the top level directory.
 
+CREATE OR REPLACE FUNCTION dimension_get_time(
+    hypertable_id INT
+)
+    RETURNS _timescaledb_catalog.dimension LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT *
+    FROM _timescaledb_catalog.dimension d
+    WHERE d.hypertable_id = dimension_get_time.hypertable_id AND
+          d.interval_length IS NOT NULL
+$BODY$;
+
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test3(time bigint, temp float8, device_id text);
 CREATE INDEX ON drop_chunk_test1(time DESC);
+
+-- show_chunks() returns 0 rows when there are no hypertables
+SELECT show_chunks();
+
 SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 SELECT create_hypertable('public.drop_chunk_test3', 'time', chunk_time_interval => 1, create_default_indexes=>false);
@@ -16,10 +31,13 @@ SELECT add_dimension('public.drop_chunk_test1', 'device_id', 2);
 SELECT add_dimension('public.drop_chunk_test2', 'device_id', 2);
 SELECT add_dimension('public.drop_chunk_test3', 'device_id', 2);
 
+--should work becasue so far all tables have time column type of bigint
+SELECT show_chunks();
+
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -53,11 +71,15 @@ INSERT INTO PUBLIC.drop_chunk_test3 VALUES(6, 6.0, 'dev7');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
 \dt "_timescaledb_internal"._hyper*
+
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+SELECT * FROM show_chunks('drop_chunk_test2');
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chunk;
 
@@ -65,7 +87,34 @@ CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chu
 SELECT drop_chunks(2);
 SELECT drop_chunks(NULL::interval);
 SELECT drop_chunks(NULL::int);
+-- error messages were refactored in postgres between 9.6 and 10 because of
+-- which direct comparison of error messages fails.
+-- The change in postgres happened here:
+-- https://github.com/postgres/postgres/commit/9a34123bc315e55b33038464422ef1cd2b67dab2
+SET client_min_messages TO FATAL;
+-- error message is suppressed for the reason above but this test should still make sure
+-- this causes an error. Not returning # rows below can be used as an indication that
+-- this did cause an error.
+-- should error because not a time type
+SELECT drop_chunks('haha', 'drop_chunk_test3');
+SET client_min_messages TO DEFAULT;
+
+SELECT show_chunks('drop_chunk_test3', 'haha');
+
+-- should error because wrong time type
+SELECT drop_chunks(now(), 'drop_chunk_test3');
+SELECT show_chunks('drop_chunk_test3', now());
+
+-- should error because of wrong relative order of time constraints
+SELECT show_chunks('drop_chunk_test1', older_than=>3, newer_than=>4);
+
 \set ON_ERROR_STOP 1
+
+--should always work regardless of time column types of hypertables
+SELECT show_chunks();
+
+-- should work vecause so far all tables have time column type of bigint
+SELECT show_chunks(newer_than => 2);
 
 -- show created constraints and dimension slices for each chunk
 SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
@@ -100,10 +149,14 @@ SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
+
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+SELECT * FROM show_chunks('drop_chunk_test2');
 
 \dt "_timescaledb_internal"._hyper*
 
@@ -112,12 +165,16 @@ SELECT drop_chunks(3, 'drop_chunk_test1');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
 
 \dt "_timescaledb_internal".*
+
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+SELECT * FROM show_chunks('drop_chunk_test2');
 
 -- 2,147,483,647 is the largest int so this tests that BIGINTs work
 SELECT drop_chunks(2147483648, 'drop_chunk_test3');
@@ -125,16 +182,25 @@ SELECT drop_chunks(2147483648, 'drop_chunk_test3');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2' OR h.table_name = 'drop_chunk_test3');
 
 \dt "_timescaledb_internal"._hyper*
+\set ON_ERROR_STOP 0
+-- should fail because too dangerous to assume anything
+-- Note that currently this failure is triggered by SQL typecheker when it tries and fails to resolve
+-- ANYELEMENT args to a concrete type. Explicit error checking may be necessary if drop_chunks implementation
+-- is fully ported to C.
+-- commented out because there is discrepancy between postgres 9.6 and postgres 10 error messages for this case
+-- SELECT drop_chunks();
+
 
 -- should error because no hypertable
-\set ON_ERROR_STOP 0
 SELECT drop_chunks(5, 'drop_chunk_test4');
+SELECT show_chunks('drop_chunk_test4');
+SELECT show_chunks('drop_chunk_test4', 5);
 \set ON_ERROR_STOP 1
 
 DROP TABLE _timescaledb_internal._hyper_1_6_chunk;
@@ -142,12 +208,68 @@ DROP TABLE _timescaledb_internal._hyper_1_6_chunk;
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
 
 \dt "_timescaledb_internal"._hyper*
+
+-- newer_than tests
+SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5);
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1');
+
+SELECT show_chunks('drop_chunk_test1');
+
+\dt "_timescaledb_internal"._hyper*
+
+SELECT drop_chunks(table_name=>'drop_chunk_test1', older_than=>4, newer_than=>3);
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1');
+
+-- the call of show_chunks should give same set of chunks as above
+SELECT show_chunks('drop_chunk_test1');
+
+-- testing drop_chunks when only schema is specified.
+\set ON_ERROR_STOP 0
+-- error messages were refactored in postgres between 9.6 and 10 because of
+-- which direct comparison of error messages fails.
+SET client_min_messages TO FATAL;
+SELECT drop_chunks(schema_name=>'public');
+SET client_min_messages TO DEFAULT;
+SELECT drop_chunks(null::bigint, schema_name=>'public');
+\set ON_ERROR_STOP 1
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public';
+
+SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public';
 
 CREATE TABLE PUBLIC.drop_chunk_test_ts(time timestamp, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_ts', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
@@ -163,6 +285,29 @@ SELECT * FROM test.show_subtables('drop_chunk_test_ts');
 SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
 
 BEGIN;
+    SELECT show_chunks('drop_chunk_test_ts');
+    SELECT show_chunks('drop_chunk_test_ts', now()::timestamp-interval '1 minute');
+    SELECT drop_chunks(newer_than => interval '1 minute', table_name => 'drop_chunk_test_ts');
+    SELECT drop_chunks(older_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+    SELECT show_chunks('drop_chunk_test_tstz');
+    SELECT show_chunks('drop_chunk_test_tstz', now() - interval '1 minute', now() - interval '6 minute');
+    SELECT show_chunks('drop_chunk_test_tstz', newer_than => now() - interval '1 minute');
+    SELECT show_chunks('drop_chunk_test_tstz', older_than => now() - interval '1 minute');
+
+    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_tstz');
+    SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
+ROLLBACK;
+
+BEGIN;
+    SELECT drop_chunks(newer_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+ROLLBACK;
+
+BEGIN;
     SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
     SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_tstz');
@@ -176,13 +321,20 @@ BEGIN;
     SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
 ROLLBACK;
 
+\dt "_timescaledb_internal"._hyper*
+SELECT show_chunks();
+
 \set ON_ERROR_STOP 0
+SELECT show_chunks(older_than=>4);
+SELECT drop_chunks(4);
 SELECT drop_chunks(interval '1 minute');
 SELECT drop_chunks(interval '1 minute', 'drop_chunk_test3');
 SELECT drop_chunks(now()-interval '1 minute', 'drop_chunk_test_ts');
 SELECT drop_chunks(now()::timestamp-interval '1 minute', 'drop_chunk_test_tstz');
+SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
 \set ON_ERROR_STOP 1
 
+\dt "_timescaledb_internal"._hyper*
 
 CREATE TABLE PUBLIC.drop_chunk_test_date(time date, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_date', 'time', chunk_time_interval => interval '1 day', create_default_indexes=>false);


### PR DESCRIPTION
Timescale provides an efficient and easy to use api to drop individual
chunks from timescale database through drop_chunks. This PR builds on
that functionality and through a new show_chunks function gives the
opportunity to see the chunks that would be dropped if drop_chunks was run.
Additionally, it adds a newer_than option to drop_chunks (also supported
by show_chunks) that allows to see/drop chunks in an interval or newer
than a point in time.

This commit includes:
    - Implementation of show_chunks in C
    - Additional helper functions to work with chunks
    - New version of drop_chunks in sql that uses show_chunks. This
      	  also adds a newer_than option to drop_chunks
    - More enhanced tests of drop_chunks and new tests for show_chunks

Among other reasons, show_chunks was implemented in C in order
to be able to have both older_than and newer_than arguments be null. This
was not possible in SQL because the arguments had to have polymorphic types
and whether they are used in function body or not, PL/pgSQL requires these
arguments to typecheck.
Implements and resolves #572