### PR TITLE
Fix segfault with custom partition types V2.

### DIFF
--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -1,6 +1,7 @@
 #ifndef TIMESCALEDB_CHUNK_INSERT_STATE_H
 #define TIMESCALEDB_CHUNK_INSERT_STATE_H
 
+#include <nodes/execnodes.h>
 #include <postgres.h>
 #include <funcapi.h>
 #include <access/tupconvert.h>
@@ -18,6 +19,8 @@ typedef struct ChunkInsertState
 	TupleConversionMap *tup_conv_map;
 	TupleTableSlot *slot;
 	MemoryContext mctx;
+
+	EState	   *estate;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -194,6 +194,54 @@ SELECT * FROM test.show_subtables('part_custom_func');
  _timescaledb_internal._hyper_5_7_chunk | 
 (2 rows)
 
+-- This first test is slightly trivial, but segfaulted in old versions
+CREATE TYPE simpl AS (val1 int4);
+CREATE OR REPLACE FUNCTION simpl_type_hash(ANYELEMENT) RETURNS int4 AS $$
+    SELECT $1.val1;
+$$ LANGUAGE SQL IMMUTABLE;
+CREATE TABLE simpl_partition ("timestamp" TIMESTAMPTZ, object simpl);
+SELECT create_hypertable(
+    'simpl_partition',
+    'timestamp',
+    'object',
+    1000,
+    chunk_time_interval => interval '1 day',
+    partitioning_func=>'simpl_type_hash');
+NOTICE:  adding not-null constraint to column "timestamp"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO simpl_partition VALUES ('2017-03-22T09:18:23', ROW(1)::simpl);
+SELECT * from simpl_partition;
+          timestamp           | object 
+------------------------------+--------
+ Wed Mar 22 09:18:23 2017 PDT | (1)
+(1 row)
+
+-- Also test that the fix works when we have more chunks than allowed at once
+SET timescaledb.max_open_chunks_per_insert=1;
+INSERT INTO simpl_partition VALUES
+    ('2017-03-22T10:18:23', ROW(0)::simpl),
+    ('2017-03-22T10:18:23', ROW(1)::simpl),
+    ('2017-03-22T10:18:23', ROW(2)::simpl),
+    ('2017-03-22T10:18:23', ROW(3)::simpl),
+    ('2017-03-22T10:18:23', ROW(4)::simpl),
+    ('2017-03-22T10:18:23', ROW(5)::simpl);
+SET timescaledb.max_open_chunks_per_insert=default;
+SELECT * from simpl_partition;
+          timestamp           | object 
+------------------------------+--------
+ Wed Mar 22 09:18:23 2017 PDT | (1)
+ Wed Mar 22 10:18:23 2017 PDT | (0)
+ Wed Mar 22 10:18:23 2017 PDT | (1)
+ Wed Mar 22 10:18:23 2017 PDT | (2)
+ Wed Mar 22 10:18:23 2017 PDT | (3)
+ Wed Mar 22 10:18:23 2017 PDT | (4)
+ Wed Mar 22 10:18:23 2017 PDT | (5)
+(7 rows)
+
 -- Test that index creation is handled correctly.
 CREATE TABLE hyper_with_index(time timestamptz, temp float, device int);
 CREATE UNIQUE INDEX temp_index ON hyper_with_index(temp);


### PR DESCRIPTION
Postgres assumes that exprs will live for the entire duration of the SQL expression that they are created from and stores pointers into them based on that assumption. As a memory usage optimization our INSERT dynamically creates chunk constraints which live for only an individual chunk insert, causing segfaults when postgres tries to read through the cleaned up memory. As we consider the constraint optimization critical, to fix this we now free the `per_tuple_exprcontext` _before_ deleting a chunk insert state memory context, ensuring the segfaulting callback is called on a valid state.

Supersedes #635 and #645.

Segfaulting code:

```SQL
CREATE TYPE simpl AS (val1 int4);

CREATE OR REPLACE FUNCTION simpl_type_hash(ANYELEMENT) RETURNS int4 AS $$
    SELECT $1.val1 AS resut;
$$ LANGUAGE SQL STABLE;

CREATE TABLE simpl_partition ("timestamp" TIMESTAMPTZ, object simpl);

SELECT create_hypertable(
    'simpl_partition',
    'timestamp',
    'object',
    1000,
    chunk_time_interval => interval '1 day',
    partitioning_func=>'simpl_type_hash');

INSERT INTO simpl_partition VALUES ('2017-03-22T09:18:23', ROW(1)::simpl);

SELECT * from simpl_partition;
```