### PR TITLE
Change default chunk size to one week

### DIFF
--- a/src/dimension.h
+++ b/src/dimension.h
@@ -74,7 +74,7 @@ typedef struct Point
 #define POINT_SIZE(cardinality)							\
 	(sizeof(Point) + (sizeof(int64) * (cardinality)))
 
-#define DEFAULT_CHUNK_TIME_INTERVAL (USECS_PER_DAY * 30)	/* 1 month */
+#define DEFAULT_CHUNK_TIME_INTERVAL (USECS_PER_DAY * 7)	/* 7 days w/o adaptive */
 #define DEFAULT_CHUNK_TIME_INTERVAL_ADAPTIVE (USECS_PER_DAY)	/* 1 day with adaptive
 																 * chunking enabled */
 

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -266,9 +266,9 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_internal.get_create_command('test_1dim');
-                                                        get_create_command                                                         
------------------------------------------------------------------------------------------------------------------------------------
- SELECT create_hypertable('test_schema.test_1dim', '"time"', chunk_time_interval => 2592000000000, create_default_indexes=>FALSE);
+                                                        get_create_command                                                        
+----------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_1dim', '"time"', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
 (1 row)
 
 \dt "test_schema".*

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -78,7 +78,7 @@ SELECT * from _timescaledb_catalog.hypertable;
 SELECT * from _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
 ----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------
-  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |   2592000000000
+  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000
 (1 row)
 
 DROP TABLE should_drop;
@@ -100,6 +100,6 @@ SELECT * from _timescaledb_catalog.hypertable;
 SELECT * from _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
 ----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------
-  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |   2592000000000
+  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000
 (1 row)
 

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -260,7 +260,7 @@ SELECT * FROM _timescaledb_catalog.dimension_slice;
   1 |            1 | 1257892416000000000 | 1257895008000000000
   2 |            1 | 1257897600000000000 | 1257900192000000000
   3 |            1 | 1257985728000000000 | 1257988320000000000
-  4 |            2 |    1482624000000000 |    1485216000000000
+  4 |            2 |    1484784000000000 |    1485388800000000
   5 |            3 |      -5184000000000 |      -2592000000000
   6 |            3 |      -2592000000000 |                   0
   7 |            3 |                   0 |       2592000000000
@@ -295,7 +295,7 @@ INSERT INTO "3dim" VALUES('2017-01-20T09:00:47', 25.1, 'yellow', 'la');
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_7_16_chunk');
   Constraint   | Type |  Columns   | Index |                                                                     Expr                                                                     | Deferrable | Deferred | Validated 
 ---------------+------+------------+-------+----------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
- constraint_16 | c    | {time}     | -     | (("time" >= 'Sun Dec 25 00:00:00 2016'::timestamp without time zone) AND ("time" < 'Tue Jan 24 00:00:00 2017'::timestamp without time zone)) | f          | f        | t
+ constraint_16 | c    | {time}     | -     | (("time" >= 'Thu Jan 19 00:00:00 2017'::timestamp without time zone) AND ("time" < 'Thu Jan 26 00:00:00 2017'::timestamp without time zone)) | f          | f        | t
  constraint_17 | c    | {device}   | -     | (_timescaledb_internal.get_partition_hash(device) < 1073741823)                                                                              | f          | f        | t
  constraint_18 | c    | {location} | -     | (_timescaledb_internal.get_partition_hash(location) >= 1073741823)                                                                           | f          | f        | t
 (3 rows)
@@ -432,7 +432,7 @@ INSERT INTO "test_tz" VALUES('2017-09-21 19:01:00', 21.2);
 SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_10_20_chunk');
   Constraint   | Type | Columns | Index |                                Expr                                | Deferrable | Deferred | Validated 
 ---------------+------+---------+-------+--------------------------------------------------------------------+------------+----------+-----------
- constraint_23 | c    | {time}  | -     | (("time" >= '01-26-2011'::date) AND ("time" < '02-25-2011'::date)) | f          | f        | t
+ constraint_23 | c    | {time}  | -     | (("time" >= '01-20-2011'::date) AND ("time" < '01-27-2011'::date)) | f          | f        | t
 (1 row)
 
 SELECT * FROM test_tz;

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -10,7 +10,7 @@ NOTICE:  adding not-null constraint to column "time"
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
 ----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |   2592000000000
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000
   2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
 (2 rows)
 
@@ -21,9 +21,9 @@ VACUUM part_legacy;
 SELECT * FROM test.show_constraintsp('_timescaledb_internal._hyper_1_%_chunk');
                  Table                  |  Constraint  | Type | Columns  | Index |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
 ----------------------------------------+--------------+------+----------+-------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
- _timescaledb_internal._hyper_1_1_chunk | constraint_1 | c    | {time}   | -     | (("time" >= 'Wed Feb 22 16:00:00 2017 PST'::timestamp with time zone) AND ("time" < 'Fri Mar 24 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
+ _timescaledb_internal._hyper_1_1_chunk | constraint_1 | c    | {time}   | -     | (("time" >= 'Wed Mar 15 17:00:00 2017 PDT'::timestamp with time zone) AND ("time" < 'Wed Mar 22 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
  _timescaledb_internal._hyper_1_1_chunk | constraint_2 | c    | {device} | -     | (_timescaledb_internal.get_partition_for_key(device) >= 1073741823)                                                                            | f          | f        | t
- _timescaledb_internal._hyper_1_2_chunk | constraint_1 | c    | {time}   | -     | (("time" >= 'Wed Feb 22 16:00:00 2017 PST'::timestamp with time zone) AND ("time" < 'Fri Mar 24 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
+ _timescaledb_internal._hyper_1_2_chunk | constraint_1 | c    | {time}   | -     | (("time" >= 'Wed Mar 15 17:00:00 2017 PDT'::timestamp with time zone) AND ("time" < 'Wed Mar 22 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
  _timescaledb_internal._hyper_1_2_chunk | constraint_3 | c    | {device} | -     | (_timescaledb_internal.get_partition_for_key(device) < 1073741823)                                                                             | f          | f        | t
 (4 rows)
 
@@ -52,9 +52,9 @@ NOTICE:  adding not-null constraint to column "time"
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
 ----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |   2592000000000
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000
   2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
-  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |   2592000000000
+  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000
   4 |             2 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
 (4 rows)
 
@@ -65,9 +65,9 @@ VACUUM part_new;
 SELECT * FROM test.show_constraintsp('_timescaledb_internal._hyper_2_%_chunk');
                  Table                  |  Constraint  | Type | Columns  | Index |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
 ----------------------------------------+--------------+------+----------+-------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
- _timescaledb_internal._hyper_2_3_chunk | constraint_4 | c    | {time}   | -     | (("time" >= 'Wed Feb 22 16:00:00 2017 PST'::timestamp with time zone) AND ("time" < 'Fri Mar 24 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
+ _timescaledb_internal._hyper_2_3_chunk | constraint_4 | c    | {time}   | -     | (("time" >= 'Wed Mar 15 17:00:00 2017 PDT'::timestamp with time zone) AND ("time" < 'Wed Mar 22 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
  _timescaledb_internal._hyper_2_3_chunk | constraint_5 | c    | {device} | -     | (_timescaledb_internal.get_partition_hash(device) < 1073741823)                                                                                | f          | f        | t
- _timescaledb_internal._hyper_2_4_chunk | constraint_4 | c    | {time}   | -     | (("time" >= 'Wed Feb 22 16:00:00 2017 PST'::timestamp with time zone) AND ("time" < 'Fri Mar 24 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
+ _timescaledb_internal._hyper_2_4_chunk | constraint_4 | c    | {time}   | -     | (("time" >= 'Wed Mar 15 17:00:00 2017 PDT'::timestamp with time zone) AND ("time" < 'Wed Mar 22 17:00:00 2017 PDT'::timestamp with time zone)) | f          | f        | t
  _timescaledb_internal._hyper_2_4_chunk | constraint_6 | c    | {device} | -     | (_timescaledb_internal.get_partition_hash(device) >= 1073741823)                                                                               | f          | f        | t
 (4 rows)
 
@@ -130,13 +130,13 @@ SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => '_times
 SELECT * FROM _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
 ----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |   2592000000000
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000
   2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
-  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |   2592000000000
+  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000
   4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
   6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
-  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |   2592000000000
-  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |   2592000000000
+  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000
+  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000
   8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
   9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
 (9 rows)

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -104,15 +104,15 @@ INSERT INTO timestamp_partitioned VALUES('2004-12-19 10:23:54', '30');
 SELECT * FROM chunk_relation_size('timestamp_partitioned');
  chunk_id |              chunk_table               | partitioning_columns |      partitioning_column_types       |           partitioning_hash_functions           |                                   ranges                                   | table_bytes | index_bytes | toast_bytes | total_bytes 
 ----------+----------------------------------------+----------------------+--------------------------------------+-------------------------------------------------+----------------------------------------------------------------------------+-------------+-------------+-------------+-------------
-        5 | _timescaledb_internal._hyper_2_5_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1096416000000000,1099008000000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |        8192 |       49152
-        6 | _timescaledb_internal._hyper_2_6_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1101600000000000,1104192000000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |        8192 |       49152
+        5 | _timescaledb_internal._hyper_2_5_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1097712000000000,1098316800000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |        8192 |       49152
+        6 | _timescaledb_internal._hyper_2_6_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1103155200000000,1103760000000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |        8192 |       49152
 (2 rows)
 
 SELECT * FROM chunk_relation_size_pretty('timestamp_partitioned');
  chunk_id |              chunk_table               | partitioning_columns |      partitioning_column_types       |           partitioning_hash_functions           |                                       ranges                                        | table_size | index_size | toast_size | total_size 
 ----------+----------------------------------------+----------------------+--------------------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+------------+------------+------------+------------
-        5 | _timescaledb_internal._hyper_2_5_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Tue Sep 28 17:00:00 2004 PDT','Thu Oct 28 17:00:00 2004 PDT')","[1073741823,)"} | 8192 bytes | 32 kB      | 8192 bytes | 48 kB
-        6 | _timescaledb_internal._hyper_2_6_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Sat Nov 27 16:00:00 2004 PST','Mon Dec 27 16:00:00 2004 PST')","[1073741823,)"} | 8192 bytes | 32 kB      | 8192 bytes | 48 kB
+        5 | _timescaledb_internal._hyper_2_5_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Wed Oct 13 17:00:00 2004 PDT','Wed Oct 20 17:00:00 2004 PDT')","[1073741823,)"} | 8192 bytes | 32 kB      | 8192 bytes | 48 kB
+        6 | _timescaledb_internal._hyper_2_6_chunk | {time,value}         | {"timestamp without time zone",text} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Wed Dec 15 16:00:00 2004 PST','Wed Dec 22 16:00:00 2004 PST')","[1073741823,)"} | 8192 bytes | 32 kB      | 8192 bytes | 48 kB
 (2 rows)
 
 CREATE TABLE timestamp_partitioned_2(time TIMESTAMP, value CHAR(9));
@@ -128,15 +128,15 @@ INSERT INTO timestamp_partitioned_2 VALUES('2004-12-19 10:23:54', '30');
 SELECT * FROM chunk_relation_size('timestamp_partitioned_2');
  chunk_id |              chunk_table               | partitioning_columns |         partitioning_column_types         |           partitioning_hash_functions           |                                   ranges                                   | table_bytes | index_bytes | toast_bytes | total_bytes 
 ----------+----------------------------------------+----------------------+-------------------------------------------+-------------------------------------------------+----------------------------------------------------------------------------+-------------+-------------+-------------+-------------
-        7 | _timescaledb_internal._hyper_3_7_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1096416000000000,1099008000000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |             |       40960
-        8 | _timescaledb_internal._hyper_3_8_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1101600000000000,1104192000000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |             |       40960
+        7 | _timescaledb_internal._hyper_3_7_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1097712000000000,1098316800000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |             |       40960
+        8 | _timescaledb_internal._hyper_3_8_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1103155200000000,1103760000000000)","[1073741823,9223372036854775807)"} |        8192 |       32768 |             |       40960
 (2 rows)
 
 SELECT * FROM chunk_relation_size_pretty('timestamp_partitioned_2');
  chunk_id |              chunk_table               | partitioning_columns |         partitioning_column_types         |           partitioning_hash_functions           |                                       ranges                                        | table_size | index_size | toast_size | total_size 
 ----------+----------------------------------------+----------------------+-------------------------------------------+-------------------------------------------------+-------------------------------------------------------------------------------------+------------+------------+------------+------------
-        7 | _timescaledb_internal._hyper_3_7_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Tue Sep 28 17:00:00 2004 PDT','Thu Oct 28 17:00:00 2004 PDT')","[1073741823,)"} | 8192 bytes | 32 kB      |            | 40 kB
-        8 | _timescaledb_internal._hyper_3_8_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Sat Nov 27 16:00:00 2004 PST','Mon Dec 27 16:00:00 2004 PST')","[1073741823,)"} | 8192 bytes | 32 kB      |            | 40 kB
+        7 | _timescaledb_internal._hyper_3_7_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Wed Oct 13 17:00:00 2004 PDT','Wed Oct 20 17:00:00 2004 PDT')","[1073741823,)"} | 8192 bytes | 32 kB      |            | 40 kB
+        8 | _timescaledb_internal._hyper_3_8_chunk | {time,value}         | {"timestamp without time zone",character} | {NULL,_timescaledb_internal.get_partition_hash} | {"['Wed Dec 15 16:00:00 2004 PST','Wed Dec 22 16:00:00 2004 PST')","[1073741823,)"} | 8192 bytes | 32 kB      |            | 40 kB
 (2 rows)
 
 CREATE TABLE toast_test(time TIMESTAMP, value TEXT);
@@ -156,13 +156,13 @@ $$);
 SELECT * FROM chunk_relation_size('toast_test');
  chunk_id |              chunk_table               | partitioning_columns |    partitioning_column_types    | partitioning_hash_functions |                 ranges                  | table_bytes | index_bytes | toast_bytes | total_bytes 
 ----------+----------------------------------------+----------------------+---------------------------------+-----------------------------+-----------------------------------------+-------------+-------------+-------------+-------------
-        9 | _timescaledb_internal._hyper_4_9_chunk | {time}               | {"timestamp without time zone"} | {NULL}                      | {"[1096416000000000,1099008000000000)"} |        8192 |       16384 |       24576 |       49152
+        9 | _timescaledb_internal._hyper_4_9_chunk | {time}               | {"timestamp without time zone"} | {NULL}                      | {"[1097712000000000,1098316800000000)"} |        8192 |       16384 |       24576 |       49152
 (1 row)
 
 SELECT * FROM chunk_relation_size_pretty('toast_test');
  chunk_id |              chunk_table               | partitioning_columns |    partitioning_column_types    | partitioning_hash_functions |                               ranges                                | table_size | index_size | toast_size | total_size 
 ----------+----------------------------------------+----------------------+---------------------------------+-----------------------------+---------------------------------------------------------------------+------------+------------+------------+------------
-        9 | _timescaledb_internal._hyper_4_9_chunk | {time}               | {"timestamp without time zone"} | {NULL}                      | {"['Tue Sep 28 17:00:00 2004 PDT','Thu Oct 28 17:00:00 2004 PDT')"} | 8192 bytes | 16 kB      | 24 kB      | 48 kB
+        9 | _timescaledb_internal._hyper_4_9_chunk | {time}               | {"timestamp without time zone"} | {NULL}                      | {"['Wed Oct 13 17:00:00 2004 PDT','Wed Oct 20 17:00:00 2004 PDT')"} | 8192 bytes | 16 kB      | 24 kB      | 48 kB
 (1 row)
 
 CREATE TABLE approx_count(time TIMESTAMP, value int);

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -626,7 +626,7 @@ HINT:  The interval is specified in microseconds
 SELECT test.interval_to_internal('TIMESTAMP'::regtype);
  interval_to_internal 
 ----------------------
-        2592000000000
+         604800000000
 (1 row)
 
 SELECT test.interval_to_internal('BIGINT'::regtype, 2147483649::bigint);


### PR DESCRIPTION
The previous default of 30 days was typically too long for most
starting use cases, which would lead users to have one large
chunk that lacked some of the benefits of using TimescaleDB, at
least for the initial chunk. This chunk size should be more
reasonable, especially for initial workloads.