### PR TITLE
Fix SubspaceStore to ensure max_open_chunks_per_insert is obeyed

### DIFF
--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -86,7 +86,7 @@ dimension_vec_remove_slice(DimensionVec **vecptr, int32 index)
 	DimensionVec *vec = *vecptr;
 
 	dimension_slice_free(vec->slices[index]);
-	memcpy(vec->slices + index, vec->slices + (index + 1), sizeof(DimensionSlice *) * (vec->num_slices - index - 1));
+	memmove(vec->slices + index, vec->slices + (index + 1), sizeof(DimensionSlice *) * (vec->num_slices - index - 1));
 	vec->num_slices--;
 }
 

--- a/src/subspace_store.README.md
+++ b/src/subspace_store.README.md
@@ -1,0 +1,59 @@
+A subspace store allows you to save data associated with a
+multidimensional-subspace. We use this to cache per-chunk values, such as
+`chunk`s or `chunk_insert_state`. Subspaces are defined conceptually via a
+Hypercube (that is a collection of slices -- one for each dimension). Thus, a
+subspace is a "rectangular" cutout in a multidimensional space.
+
+that is given a hypertable with (ts Timestamp, i int) with intervals of one hour
+and 2 hash-partitions the subspaces could be:
+
+```
+     00:00   01:00   02:00   03:00
+---|-------|-------|-------|-------|--- - -
+ 1 |       |       |       |       |
+---|-------|-------|-------|-------|--- - -
+ 2 |       |       |       |       |
+---|-------|-------|-------|-------|--- - -
+ 3 |       |       |       |       |
+---|-------|-------|-------|-------|--- - -
+```
+
+Each subspace is cached in a tree structure, with each level of the tree
+corresponding to a dimension the hypertable is partitioned on, with the first
+level always being an open (time) dimension time dimension. Thus, the
+aforementioned hypertable will have the following tree:
+
+```
+SubspaceStore
+    |
+    V
+SubspaceStoreInternalNode (time)
+       | (.vector)
+       V
+  |  o  | ... | ... | ... |
+     |
+     V
+  DimensionSlice (00:00 - 01:00)
+     |
+     V
+    SubspaceStoreInternalNode (dim 1)
+     |
+     V
+     .
+     .
+     .
+     |
+     V
+    ChunkInsertState (or other leaf object)
+```
+
+Each `SubspaceStoreInternalNode` has a field `descendants` storing a count of
+the number of leaf objects for that subtree, which we used to ensure
+`SubspaceStore`s don't grow beyond their maximum size. Currently our strategy
+when adding to a full `SubspaceStore` is to evict the all elements referenced
+from the first entry of the top-most vector. The assumption is that the topmost
+vector indexes based on time, and that the first element stores state for those
+chunks with the earliest time. If we usually perform operations in time-order,
+these are the elements least likely to be reused. This eviction-strategy is the
+only reason that the first level of a `SubspaceStore` is always a open (time)
+dimension.

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -668,6 +668,28 @@ INSERT INTO many_partitions_test_1m(time, temp, device)
 SELECT time_bucket('1 minute', time) AS period, avg(temp), device
 FROM many_partitions_test
 GROUP BY period, device;
+-- Out-of-order insertion regression test.
+-- this used to trip an assert in subspace_store.c checking that
+-- max_open_chunks_per_insert was obeyed
+set timescaledb.max_open_chunks_per_insert=1;
+CREATE TABLE chunk_assert_fail(i bigint, j bigint);
+SELECT create_hypertable('chunk_assert_fail', 'i', 'j', 1000, chunk_time_interval=>1);
+NOTICE:  adding not-null constraint to column "i"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+insert into chunk_assert_fail values (1, 1), (1, 2), (2,1);
+select * from chunk_assert_fail;
+ i | j 
+---+---
+ 1 | 1
+ 1 | 2
+ 2 | 1
+(3 rows)
+
+set timescaledb.max_open_chunks_per_insert=default;
 SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
            time           | temp | device 
 --------------------------+------+--------


### PR DESCRIPTION
SubspaceStore keeps a running count of the number of objects added to
it called `descendants`. This patch fixes that count, so that it always
keeps track of the number of objects sitting at the leaves of the
SubspaceStore. (The current version treats `descendants` as keeping
track of the number of leaves at some places, and the number of objects
sitting at the next level at others, resulting in the counter containing
neither.

Adds documentation about the layout of, and insertion to, `SubspaceStore`.

Also fixes UB in dimension vector: `memcpy` cannot be used on overlapping memory.

This reduces memory usage of #643 by ~200MB.