### PR TITLE
Use AttrNumberGetAttrOffset instead of Anum_name - 1 for array indexing

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -51,10 +51,10 @@ chunk_insert_relation(Relation rel, Chunk *chunk)
 	CatalogSecurityContext sec_ctx;
 
 	memset(values, 0, sizeof(values));
-	values[Anum_chunk_id - 1] = Int32GetDatum(chunk->fd.id);
-	values[Anum_chunk_hypertable_id - 1] = Int32GetDatum(chunk->fd.hypertable_id);
-	values[Anum_chunk_schema_name - 1] = NameGetDatum(&chunk->fd.schema_name);
-	values[Anum_chunk_table_name - 1] = NameGetDatum(&chunk->fd.table_name);
+	values[AttrNumberGetAttrOffset(Anum_chunk_id)] = Int32GetDatum(chunk->fd.id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_hypertable_id)] = Int32GetDatum(chunk->fd.hypertable_id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_schema_name)] = NameGetDatum(&chunk->fd.schema_name);
+	values[AttrNumberGetAttrOffset(Anum_chunk_table_name)] = NameGetDatum(&chunk->fd.table_name);
 
 	catalog_become_owner(catalog_get(), &sec_ctx);
 	catalog_insert_values(rel, desc, values, nulls);

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -318,11 +318,11 @@ chunk_index_insert_relation(Relation rel,
 	bool		nulls[Natts_chunk_index] = {false};
 	CatalogSecurityContext sec_ctx;
 
-	values[Anum_chunk_index_chunk_id - 1] = Int32GetDatum(chunk_id);
-	values[Anum_chunk_index_index_name - 1] =
+	values[AttrNumberGetAttrOffset(Anum_chunk_index_chunk_id)] = Int32GetDatum(chunk_id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_index_index_name)] =
 		DirectFunctionCall1(namein, CStringGetDatum(chunk_index));
-	values[Anum_chunk_index_hypertable_id - 1] = Int32GetDatum(hypertable_id);
-	values[Anum_chunk_index_hypertable_index_name - 1] =
+	values[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_id)] = Int32GetDatum(hypertable_id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_index_name)] =
 		DirectFunctionCall1(namein, CStringGetDatum(parent_index));
 
 	catalog_become_owner(catalog_get(), &sec_ctx);

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -594,10 +594,10 @@ dimension_slice_insert_relation(Relation rel, DimensionSlice *slice)
 	catalog_become_owner(catalog_get(), &sec_ctx);
 	memset(values, 0, sizeof(values));
 	slice->fd.id = catalog_table_next_seq_id(catalog_get(), DIMENSION_SLICE);
-	values[Anum_dimension_slice_id - 1] = Int32GetDatum(slice->fd.id);
-	values[Anum_dimension_slice_dimension_id - 1] = Int32GetDatum(slice->fd.dimension_id);
-	values[Anum_dimension_slice_range_start - 1] = Int64GetDatum(slice->fd.range_start);
-	values[Anum_dimension_slice_range_end - 1] = Int64GetDatum(slice->fd.range_end);
+	values[AttrNumberGetAttrOffset(Anum_dimension_slice_id)] = Int32GetDatum(slice->fd.id);
+	values[AttrNumberGetAttrOffset(Anum_dimension_slice_dimension_id)] = Int32GetDatum(slice->fd.dimension_id);
+	values[AttrNumberGetAttrOffset(Anum_dimension_slice_range_start)] = Int64GetDatum(slice->fd.range_start);
+	values[AttrNumberGetAttrOffset(Anum_dimension_slice_range_end)] = Int64GetDatum(slice->fd.range_end);
 
 	catalog_insert_values(rel, desc, values, nulls);
 	catalog_restore_user(&sec_ctx);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -213,12 +213,12 @@ hypertable_tuple_update(TupleInfo *ti, void *data)
 
 	heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
 
-	values[Anum_hypertable_schema_name - 1] = NameGetDatum(&ht->fd.schema_name);
-	values[Anum_hypertable_table_name - 1] = NameGetDatum(&ht->fd.table_name);
-	values[Anum_hypertable_associated_schema_name - 1] = NameGetDatum(&ht->fd.associated_schema_name);
-	values[Anum_hypertable_associated_table_prefix - 1] = NameGetDatum(&ht->fd.associated_table_prefix);
-	values[Anum_hypertable_num_dimensions - 1] = Int16GetDatum(ht->fd.num_dimensions);
-	values[Anum_hypertable_chunk_target_size - 1] = Int64GetDatum(ht->fd.chunk_target_size);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_schema_name)] = NameGetDatum(&ht->fd.schema_name);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_table_name)] = NameGetDatum(&ht->fd.table_name);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_associated_schema_name)] = NameGetDatum(&ht->fd.associated_schema_name);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_associated_table_prefix)] = NameGetDatum(&ht->fd.associated_table_prefix);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_num_dimensions)] = Int16GetDatum(ht->fd.num_dimensions);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_chunk_target_size)] = Int64GetDatum(ht->fd.chunk_target_size);
 
 	memset(nulls, 0, sizeof(nulls));
 
@@ -236,15 +236,15 @@ hypertable_tuple_update(TupleInfo *ti, void *data)
 		namestrcpy(&ht->fd.chunk_sizing_func_schema, NameStr(info.func_schema));
 		namestrcpy(&ht->fd.chunk_sizing_func_name, NameStr(info.func_name));
 
-		values[Anum_hypertable_chunk_sizing_func_schema - 1] =
+		values[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_schema)] =
 			NameGetDatum(&ht->fd.chunk_sizing_func_schema);
-		values[Anum_hypertable_chunk_sizing_func_name - 1] =
+		values[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_name)] =
 			NameGetDatum(&ht->fd.chunk_sizing_func_name);
 	}
 	else
 	{
-		nulls[Anum_hypertable_chunk_sizing_func_schema - 1] = true;
-		nulls[Anum_hypertable_chunk_sizing_func_name - 1] = true;
+		nulls[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_schema)] = true;
+		nulls[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_name)] = true;
 	}
 
 	copy = heap_form_tuple(ti->desc, values, nulls);
@@ -546,40 +546,40 @@ hypertable_insert_relation(Relation rel,
 	NameData	default_associated_table_prefix;
 	CatalogSecurityContext sec_ctx;
 
-	values[Anum_hypertable_schema_name - 1] = NameGetDatum(schema_name);
-	values[Anum_hypertable_table_name - 1] = NameGetDatum(table_name);
-	values[Anum_hypertable_associated_schema_name - 1] = NameGetDatum(associated_schema_name);
-	values[Anum_hypertable_num_dimensions - 1] = Int16GetDatum(num_dimensions);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_schema_name)] = NameGetDatum(schema_name);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_table_name)] = NameGetDatum(table_name);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_associated_schema_name)] = NameGetDatum(associated_schema_name);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_num_dimensions)] = Int16GetDatum(num_dimensions);
 
 	if (NULL != chunk_sizing_func_schema && NULL != chunk_sizing_func_name)
 	{
-		values[Anum_hypertable_chunk_sizing_func_schema - 1] = NameGetDatum(chunk_sizing_func_schema);
-		values[Anum_hypertable_chunk_sizing_func_name - 1] = NameGetDatum(chunk_sizing_func_name);
+		values[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_schema)] = NameGetDatum(chunk_sizing_func_schema);
+		values[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_name)] = NameGetDatum(chunk_sizing_func_name);
 	}
 	else
 	{
-		nulls[Anum_hypertable_chunk_sizing_func_schema - 1] = true;
-		nulls[Anum_hypertable_chunk_sizing_func_name - 1] = true;
+		nulls[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_schema)] = true;
+		nulls[AttrNumberGetAttrOffset(Anum_hypertable_chunk_sizing_func_name)] = true;
 	}
 
 	if (chunk_target_size < 0)
 		chunk_target_size = 0;
 
-	values[Anum_hypertable_chunk_target_size - 1] = Int64GetDatum(chunk_target_size);
+	values[AttrNumberGetAttrOffset(Anum_hypertable_chunk_target_size)] = Int64GetDatum(chunk_target_size);
 
 	catalog_become_owner(catalog_get(), &sec_ctx);
-	values[Anum_hypertable_id - 1] = Int32GetDatum(catalog_table_next_seq_id(catalog_get(), HYPERTABLE));
+	values[AttrNumberGetAttrOffset(Anum_hypertable_id)] = Int32GetDatum(catalog_table_next_seq_id(catalog_get(), HYPERTABLE));
 
 	if (NULL != associated_table_prefix)
-		values[Anum_hypertable_associated_table_prefix - 1] = NameGetDatum(associated_table_prefix);
+		values[AttrNumberGetAttrOffset(Anum_hypertable_associated_table_prefix)] = NameGetDatum(associated_table_prefix);
 	else
 	{
 		memset(NameStr(default_associated_table_prefix), '\0', NAMEDATALEN);
 		snprintf(NameStr(default_associated_table_prefix),
 				 NAMEDATALEN,
 				 DEFAULT_ASSOCIATED_TABLE_PREFIX_FORMAT,
-				 DatumGetInt32(values[Anum_hypertable_id - 1]));
-		values[Anum_hypertable_associated_table_prefix - 1] =
+				 DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_hypertable_id)]));
+		values[AttrNumberGetAttrOffset(Anum_hypertable_associated_table_prefix)] =
 			NameGetDatum(&default_associated_table_prefix);
 	}
 

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -321,9 +321,9 @@ tablespace_insert_relation(Relation rel, int32 hypertable_id, const char *tspcna
 
 	memset(values, 0, sizeof(values));
 	id = catalog_table_next_seq_id(catalog_get(), TABLESPACE);
-	values[Anum_tablespace_id - 1] = Int32GetDatum(id);
-	values[Anum_tablespace_hypertable_id - 1] = Int32GetDatum(hypertable_id);
-	values[Anum_tablespace_tablespace_name - 1] =
+	values[AttrNumberGetAttrOffset(Anum_tablespace_id)] = Int32GetDatum(id);
+	values[AttrNumberGetAttrOffset(Anum_tablespace_hypertable_id)] = Int32GetDatum(hypertable_id);
+	values[AttrNumberGetAttrOffset(Anum_tablespace_tablespace_name)] =
 		DirectFunctionCall1(namein, CStringGetDatum(tspcname));
 
 	catalog_insert_values(rel, desc, values, nulls);


### PR DESCRIPTION
Use the postgres macro instead of manual subtraction everywhere to be more readable, and gain the `Assert`.

This was done with `find ./src -type f -exec sed -i -e 's/\[Anum_\(.*\) - 1\]/\[AttrNumberGetAttrOffset(Anum_\1)\]/' {} \;`