### PR TITLE
Add job for telemetry

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -31,7 +31,7 @@ else
 fi
 
 # Build and install the extension with debug symbols and assertions
-docker exec -u root -it ${BUILD_CONTAINER_NAME} /bin/bash -c "cp -a /src/{src,sql,test,scripts,version.config,CMakeLists.txt,timescaledb.control.in} /build/ && cd build/debug && cmake -DCMAKE_BUILD_TYPE=Debug .. && make && make install && echo \"shared_preload_libraries = 'timescaledb'\" >> /usr/local/share/postgresql/postgresql.conf.sample && cd / && rm -rf /build"
+docker exec -u root -it ${BUILD_CONTAINER_NAME} /bin/bash -c "cp -a /src/{src,sql,test,scripts,version.config,CMakeLists.txt,timescaledb.control.in} /build/ && cd build/debug && cmake -DCMAKE_BUILD_TYPE=Debug .. && make && make install && echo \"shared_preload_libraries = 'timescaledb'\" >> /usr/local/share/postgresql/postgresql.conf.sample && echo \"timescaledb.telemetry_level=off\" >> /usr/local/share/postgresql/postgresql.conf.sample && cd / && rm -rf /build"
 
 docker commit -a $USER -m "TimescaleDB development image" ${BUILD_CONTAINER_NAME} ${IMAGE_NAME}:${TAG_NAME}
 

--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -1,16 +1,20 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.restart_background_workers()
-RETURNS BOOL 
+RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_restart'
 LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.stop_background_workers()
-RETURNS BOOL 
+RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_stop'
 LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.start_background_workers()
-RETURNS BOOL 
+RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_start'
 LANGUAGE C VOLATILE;
 
 SELECT _timescaledb_internal.start_background_workers();
+
+INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+(1, 'Telemetry Reporter', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h')
+ON CONFLICT (id) DO NOTHING;

--- a/sql/updates/0.11.0--0.11.1-dev.sql
+++ b/sql/updates/0.11.0--0.11.1-dev.sql
@@ -14,18 +14,22 @@ DROP FUNCTION _timescaledb_internal.insert_blocker_trigger_add(REGCLASS);
 CREATE SCHEMA IF NOT EXISTS _timescaledb_config;
 GRANT USAGE ON SCHEMA _timescaledb_config TO PUBLIC;
 
+CREATE SEQUENCE IF NOT EXISTS _timescaledb_config.bgw_job_id_seq MINVALUE 1000;
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_job_id_seq', '');
+
 CREATE TABLE IF NOT EXISTS _timescaledb_config.bgw_job (
-    id                  SERIAL      PRIMARY KEY,
+    id                  INTEGER PRIMARY KEY DEFAULT nextval('_timescaledb_config.bgw_job_id_seq'),
     application_name    NAME        NOT NULL,
     job_type            NAME        NOT NULL,
     schedule_interval   INTERVAL    NOT NULL,
     max_runtime         INTERVAL    NOT NULL,
     max_retries         INT         NOT NULL,
     retry_period        INTERVAL    NOT NULL,
-    CONSTRAINT  valid_job_type CHECK (job_type IN ('update_check'))
+    CONSTRAINT  valid_job_type CHECK (job_type IN ('telemetry_and_version_check_if_enabled'))
 );
-SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_job', '');
-SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_config.bgw_job','id'), '');
+ALTER SEQUENCE _timescaledb_config.bgw_job_id_seq OWNED BY _timescaledb_config.bgw_job.id;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_job', 'WHERE id >= 1000');
 
 CREATE TABLE IF NOT EXISTS _timescaledb_internal.bgw_job_stat (
     job_id                  INT         PRIMARY KEY REFERENCES _timescaledb_config.bgw_job(id) ON DELETE CASCADE,

--- a/sql/version.sql
+++ b/sql/version.sql
@@ -4,5 +4,5 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_os_info() RETURNS TABLE(sysname TEXT, version TEXT, release TEXT)
     AS '@MODULE_PATHNAME@', 'ts_get_os_info' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION get_report() RETURNS TEXT
+CREATE OR REPLACE FUNCTION get_telemetry_report() RETURNS TEXT
     AS '@MODULE_PATHNAME@', 'ts_get_telemetry_report' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -14,7 +14,7 @@
 #include "telemetry/telemetry.h"
 
 const char *job_type_names[_MAX_JOB_TYPE] = {
-	[JOB_TYPE_VERSION_CHECK] = "check_for_update_if_enabled",
+	[JOB_TYPE_VERSION_CHECK] = "telemetry_and_version_check_if_enabled",
 	[JOB_TYPE_UNKNOWN] = "unknown"
 };
 

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -209,16 +209,18 @@ build_version_body(void)
 	JsonbValue *result;
 	Jsonb	   *jb;
 	StringInfo	jtext;
-	JsonbParseState *parseState = NULL;
 	VersionOSInfo osinfo;
+	JsonbParseState *parseState = NULL;
 
 	pushJsonbValue(&parseState, WJB_BEGIN_OBJECT, NULL);
+
 	jsonb_add_pair(parseState, REQ_DB_UUID,
 				   DatumGetCString(DirectFunctionCall1(uuid_out, metadata_get_uuid())));
 	jsonb_add_pair(parseState, REQ_EXPORTED_DB_UUID,
 				   DatumGetCString(DirectFunctionCall1(uuid_out, metadata_get_exported_uuid())));
 	jsonb_add_pair(parseState, REQ_INSTALL_TIME,
 				   DatumGetCString(DirectFunctionCall1(timestamptz_out, metadata_get_install_timestamp())));
+
 	jsonb_add_pair(parseState, REQ_INSTALL_METHOD, TIMESCALEDB_INSTALL_METHOD);
 
 	if (version_get_os_info(&osinfo))
@@ -310,9 +312,16 @@ telemetry_main()
 	Connection *conn;
 	HttpRequest *req;
 	HttpResponseState *rsp;
+	bool		started = false;
 
 	if (!telemetry_on())
 		return;
+
+	if (!IsTransactionOrTransactionBlock())
+	{
+		started = true;
+		StartTransactionCommand();
+	}
 
 	conn = telemetry_connect();
 
@@ -339,6 +348,10 @@ telemetry_main()
 	process_response(http_response_state_body_start(rsp));
 
 	http_response_state_destroy(rsp);
+
+	if (started)
+		CommitTransactionCommand();
+	return;
 }
 
 TS_FUNCTION_INFO_V1(ts_get_telemetry_report);

--- a/src/telemetry/uuid.c
+++ b/src/telemetry/uuid.c
@@ -41,7 +41,7 @@ uuid_create(void)
 	{
 		TimestampTz ts = GetCurrentTimestamp();
 
-		memcpy(&gen_uuid[9], &ts, sizeof(TimestampTz));
+		memcpy(&gen_uuid[8], &ts, sizeof(TimestampTz));
 	}
 
 	gen_uuid[6] = (gen_uuid[6] & 0x0f) | 0x40;	/* "version" field */

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -41,6 +41,21 @@ BEGIN
     RETURN NULL;
 END
 $BODY$;
+-- Remove any default jobs, e.g., telemetry
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+SELECT _timescaledb_internal.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+(1 row)
+
 \c single :ROLE_DEFAULT_PERM_USER
 CREATE TABLE public.bgw_log(
     msg_no INT,
@@ -94,9 +109,9 @@ SELECT ts_bgw_params_reset_time();
 INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
 ('test_job_1', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
 select * from _timescaledb_config.bgw_job;
- id | application_name |    job_type    | schedule_interval |   max_runtime   | max_retries | retry_period 
-----+------------------+----------------+-------------------+-----------------+-------------+--------------
-  1 | test_job_1       | bgw_test_job_1 | @ 0.1 secs        | @ 1 min 40 secs |           3 | @ 1 sec
+  id  | application_name |    job_type    | schedule_interval |   max_runtime   | max_retries | retry_period 
+------+------------------+----------------+-------------------+-----------------+-------------+--------------
+ 1000 | test_job_1       | bgw_test_job_1 | @ 0.1 secs        | @ 1 min 40 secs |           3 | @ 1 sec
 (1 row)
 
 \c single :ROLE_DEFAULT_PERM_USER
@@ -111,7 +126,7 @@ SELECT job_id, next_start, last_finish as until_next, last_run_success, total_ru
 FROM _timescaledb_internal.bgw_job_stat;
  job_id |           next_start           |          until_next          | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+--------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------
-      1 | Fri Dec 31 16:00:00.1 1999 PST | Fri Dec 31 16:00:00 1999 PST | t                |          1 |               1 |              0 |             0
+   1000 | Fri Dec 31 16:00:00.1 1999 PST | Fri Dec 31 16:00:00 1999 PST | t                |          1 |               1 |              0 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -133,7 +148,7 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      1 | @ 0.1 secs | t                |          1 |               1 |              0 |             0
+   1000 | @ 0.1 secs | t                |          1 |               1 |              0 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -156,7 +171,7 @@ SELECT job_id, next_start, last_finish, last_run_success, total_runs, total_succ
 FROM _timescaledb_internal.bgw_job_stat;
  job_id |           next_start           |          last_finish           | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+--------------------------------+--------------------------------+------------------+------------+-----------------+----------------+---------------
-      1 | Fri Dec 31 16:00:00.2 1999 PST | Fri Dec 31 16:00:00.1 1999 PST | t                |          2 |               2 |              0 |             0
+   1000 | Fri Dec 31 16:00:00.2 1999 PST | Fri Dec 31 16:00:00.1 1999 PST | t                |          2 |               2 |              0 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -183,7 +198,7 @@ SELECT job_id, next_start, last_finish, last_run_success, total_runs, total_succ
 FROM _timescaledb_internal.bgw_job_stat;
  job_id |           next_start           |          last_finish           | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+--------------------------------+--------------------------------+------------------+------------+-----------------+----------------+---------------
-      1 | Fri Dec 31 16:00:00.3 1999 PST | Fri Dec 31 16:00:00.2 1999 PST | t                |          3 |               3 |              0 |             0
+   1000 | Fri Dec 31 16:00:00.3 1999 PST | Fri Dec 31 16:00:00.2 1999 PST | t                |          3 |               3 |              0 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -230,7 +245,7 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      2 | @ 0.1 secs | f                |          1 |               0 |              1 |             0
+   1001 | @ 0.1 secs | f                |          1 |               0 |              1 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -252,7 +267,7 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      2 | @ 0.2 secs | f                |          2 |               0 |              2 |             0
+   1001 | @ 0.2 secs | f                |          2 |               0 |              2 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -278,7 +293,7 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      2 | @ 0.4 secs | f                |          3 |               0 |              3 |             0
+   1001 | @ 0.4 secs | f                |          3 |               0 |              3 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -307,7 +322,7 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      2 | @ 0.5 secs | f                |          4 |               0 |              4 |             0
+   1001 | @ 0.5 secs | f                |          4 |               0 |              4 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -341,7 +356,7 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      2 | @ 0.5 secs | f                |          5 |               0 |              5 |             0
+   1001 | @ 0.5 secs | f                |          5 |               0 |              5 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -402,7 +417,7 @@ SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_succ
 FROM _timescaledb_internal.bgw_job_stat;
  job_id |          last_finish           |           next_start            | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
 --------+--------------------------------+---------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
-      3 | Fri Dec 31 16:00:00.2 1999 PST | Fri Dec 31 16:00:00.25 1999 PST | f                |          1 |               0 |              1 |             0 |                   0
+   1002 | Fri Dec 31 16:00:00.2 1999 PST | Fri Dec 31 16:00:00.25 1999 PST | f                |          1 |               0 |              1 |             0 |                   0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -439,7 +454,7 @@ SELECT job_id, last_finish-next_start as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id |  until_next  | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
 --------+--------------+------------------+------------+-----------------+----------------+---------------+---------------------
-      4 | @ 5 secs ago | t                |          1 |               1 |              0 |             0 |                   0
+   1003 | @ 5 secs ago | t                |          1 |               1 |              0 |             0 |                   0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -508,7 +523,7 @@ SELECT job_id, next_start - last_finish as until_next, last_run_success, total_r
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      5 | @ 0.5 secs | f                |          1 |               0 |              1 |             0
+   1004 | @ 0.5 secs | f                |          1 |               0 |              1 |             0
 (1 row)
 
 -- Test that the job is able to run again and succeed
@@ -522,7 +537,7 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
 --------+------------+------------------+------------+-----------------+----------------+---------------
-      5 | @ 5 secs   | t                |          2 |               1 |              1 |             0
+   1004 | @ 5 secs   | t                |          2 |               1 |              1 |             0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -584,7 +599,7 @@ SELECT job_id, last_finish, last_run_success, total_runs, total_successes, total
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | last_finish | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
 --------+-------------+------------------+------------+-----------------+----------------+---------------+---------------------
-      6 | -infinity   | f                |          1 |               0 |              0 |             1 |                   1
+   1005 | -infinity   | f                |          1 |               0 |              0 |             1 |                   1
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -610,7 +625,7 @@ SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_succ
 FROM _timescaledb_internal.bgw_job_stat;
  job_id | last_finish | next_start | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
 --------+-------------+------------+------------------+------------+-----------------+----------------+---------------+---------------------
-      6 | -infinity   | -infinity  | f                |          1 |               0 |              0 |             1 |                   1
+   1005 | -infinity   | -infinity  | f                |          1 |               0 |              0 |             1 |                   1
 (1 row)
 
 --But after the 5 min period the job is again run
@@ -624,7 +639,7 @@ SELECT job_id, last_finish, next_start, last_run_success, total_runs, total_succ
 FROM _timescaledb_internal.bgw_job_stat;
  job_id |          last_finish           |           next_start           | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
 --------+--------------------------------+--------------------------------+------------------+------------+-----------------+----------------+---------------+---------------------
-      6 | Fri Dec 31 16:05:00.5 1999 PST | Fri Dec 31 16:05:05.5 1999 PST | t                |          2 |               1 |              0 |             1 |                   0
+   1005 | Fri Dec 31 16:05:00.5 1999 PST | Fri Dec 31 16:05:05.5 1999 PST | t                |          2 |               1 |              0 |             1 |                   0
 (1 row)
 
 SELECT * FROM bgw_log;
@@ -679,25 +694,25 @@ FROM _timescaledb_internal.bgw_job_stat
 ORDER BY job_id;
  job_id | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
 --------+------------------+------------+-----------------+----------------+---------------+---------------------
-      7 | t                |          1 |               1 |              0 |             0 |                   0
-      8 | t                |          1 |               1 |              0 |             0 |                   0
-      9 | t                |          1 |               1 |              0 |             0 |                   0
-     10 | t                |          1 |               1 |              0 |             0 |                   0
-     11 | t                |          1 |               1 |              0 |             0 |                   0
-     12 | t                |          1 |               1 |              0 |             0 |                   0
-     13 | t                |          2 |               1 |              1 |             0 |                   0
+   1006 | t                |          1 |               1 |              0 |             0 |                   0
+   1007 | t                |          1 |               1 |              0 |             0 |                   0
+   1008 | t                |          1 |               1 |              0 |             0 |                   0
+   1009 | t                |          1 |               1 |              0 |             0 |                   0
+   1010 | t                |          1 |               1 |              0 |             0 |                   0
+   1011 | t                |          1 |               1 |              0 |             0 |                   0
+   1012 | t                |          2 |               1 |              1 |             0 |                   0
 (7 rows)
 
 SELECT * FROM bgw_log WHERE application_name = 'DB Scheduler' ORDER BY mock_time, application_name, msg_no;
- msg_no | mock_time | application_name |                                  msg                                   
---------+-----------+------------------+------------------------------------------------------------------------
+ msg_no | mock_time | application_name |                                   msg                                    
+--------+-----------+------------------+--------------------------------------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       2 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       3 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       4 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       5 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      6 |         0 | DB Scheduler     | failed to launch job 13 "test_job_3_long_7": out of background workers
+      6 |         0 | DB Scheduler     | failed to launch job 1012 "test_job_3_long_7": out of background workers
       7 |         0 | DB Scheduler     | [TESTING] Wait until 10000, started at 0
       8 |     10000 | DB Scheduler     | [TESTING] Registered new background worker
       9 |     10000 | DB Scheduler     | [TESTING] Wait until 500000, started at 10000

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -200,10 +200,10 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (8 rows)
 
 \dt+ "_timescaledb_internal".*
-                                 List of relations
-        Schema         |     Name     | Type  |   Owner    |  Size   | Description 
------------------------+--------------+-------+------------+---------+-------------
- _timescaledb_internal | bgw_job_stat | table | super_user | 0 bytes | 
+                                  List of relations
+        Schema         |     Name     | Type  |   Owner    |    Size    | Description 
+-----------------------+--------------+-------+------------+------------+-------------
+ _timescaledb_internal | bgw_job_stat | table | super_user | 8192 bytes | 
 (1 row)
 
 -- Test that renaming ordinary table works

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -20,7 +20,7 @@ ORDER BY proname;
  detach_tablespaces
  drop_chunks
  first
- get_report
+ get_telemetry_report
  histogram
  hypertable_approximate_row_count
  hypertable_relation_size

--- a/test/expected/privacy.out
+++ b/test/expected/privacy.out
@@ -2,10 +2,11 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_privacy() RETURNS VOID
     AS :MODULE_PATHNAME, 'test_privacy' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 \c single :ROLE_DEFAULT_PERM_USER
+-- Should be off be default in tests
 SHOW timescaledb.telemetry_level;
  timescaledb.telemetry_level 
 -----------------------------
- basic
+ off
 (1 row)
 
 SET timescaledb.telemetry_level=off;

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -1,2 +1,3 @@
 shared_preload_libraries=timescaledb
 max_worker_processes=16
+timescaledb.telemetry_level=off

--- a/test/sql/bgw_db_scheduler.sql
+++ b/test/sql/bgw_db_scheduler.sql
@@ -51,6 +51,12 @@ BEGIN
 END
 $BODY$;
 
+-- Remove any default jobs, e.g., telemetry
+SELECT _timescaledb_internal.stop_background_workers();
+DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+SELECT _timescaledb_internal.start_background_workers();
+
 \c single :ROLE_DEFAULT_PERM_USER
 
 CREATE TABLE public.bgw_log(

--- a/test/sql/privacy.sql
+++ b/test/sql/privacy.sql
@@ -3,6 +3,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_privacy() RETURNS VOID
     AS :MODULE_PATHNAME, 'test_privacy' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 \c single :ROLE_DEFAULT_PERM_USER
 
+-- Should be off be default in tests
 SHOW timescaledb.telemetry_level;
 SET timescaledb.telemetry_level=off;
 SHOW timescaledb.telemetry_level;

--- a/test/sql/updates/post.post_insert.sql
+++ b/test/sql/updates/post.post_insert.sql
@@ -64,3 +64,6 @@ END;
 $BODY$;
 
 SELECT timescaledb_integrity_test();
+
+-- Verify that the default jobs are the same in bgw_job
+SELECT * FROM _timescaledb_config.bgw_job;


### PR DESCRIPTION
This adds the telemetry job to the job scheduler. Telemetry is
scheduled to run every 24 hours with a 1 hour exponential backoff
retry period.