### PR TITLE
Note how to recreate templated files

### DIFF
--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -76,7 +76,9 @@ set(TEST_TEMPLATES
 
 # Regression tests that vary with PostgreSQL version. Generated test
 # files are put in the original source directory since all tests must
-# be in the same directory.
+# be in the same directory. These files are updated when the template
+# is edited, but not when the output file is deleted. If the output is
+# deleted either recreate it manually, or rerun cmake on the root dir.
 if (${PG_VERSION_MAJOR} EQUAL "10")
     set(TEST_VERSION_SUFFIX ${PG_VERSION_MAJOR})
 else ()


### PR DESCRIPTION
Our files generated from templates do not get recreated by `make` when
they get deleted, and have to be recreated manually or by rerunning
cmake. This commit adds a note to the CMakeLists.txt to that effect.