### PR TITLE
Add loader API version function

### DIFF
--- a/src/bgw/launcher_interface.c
+++ b/src/bgw/launcher_interface.c
@@ -4,7 +4,9 @@
 
 #include "extension.h"
 #include "launcher_interface.h"
+#include "compat.h"
 
+#define MIN_LOADER_API_VERSION 1
 
 extern bool
 bgw_worker_reserve(void)
@@ -28,4 +30,26 @@ bgw_num_unreserved(void)
 	PGFunction	unreserved = load_external_function(EXTENSION_NAME, "ts_bgw_num_unreserved", true, NULL);
 
 	return DatumGetInt32(DirectFunctionCall1(unreserved, BoolGetDatum(false))); /* no function call zero */
+}
+
+extern int
+bgw_loader_api_version(void)
+{
+	void	  **versionptr = find_rendezvous_variable(RENDEZVOUS_BGW_LOADER_API_VERSION);
+
+	if (*versionptr == NULL)
+		return 0;
+	return *((int32 *) *versionptr);
+}
+
+extern void
+bgw_check_loader_api_version()
+{
+	int			version = bgw_loader_api_version();
+
+	if (version < MIN_LOADER_API_VERSION)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("loader version out-of-date"),
+				 errhint("Please restart the database to upgrade the loader version.")));
 }

--- a/src/bgw/launcher_interface.h
+++ b/src/bgw/launcher_interface.h
@@ -6,5 +6,6 @@
 extern bool bgw_worker_reserve(void);
 extern void bgw_worker_release(void);
 extern int	bgw_num_unreserved(void);
-
+extern int	bgw_loader_api_version(void);
+extern void bgw_check_loader_api_version(void);
 #endif							/* TIMESCALEDB_BGW_LAUNCHER_INTERFACE_H */

--- a/src/extension_constants.h
+++ b/src/extension_constants.h
@@ -11,6 +11,7 @@
 #define INTERNAL_SCHEMA_NAME "_timescaledb_internal"
 #define CACHE_SCHEMA_NAME "_timescaledb_cache"
 #define CONFIG_SCHEMA_NAME "_timescaledb_config"
+#define RENDEZVOUS_BGW_LOADER_API_VERSION "timescaledb.bgw_loader_api_version"
 
 
 #endif							/* TIMESCALEDB_EXTENSION_CONSTANTS_H */

--- a/src/init.c
+++ b/src/init.c
@@ -6,6 +6,7 @@
 #include <utils/guc.h>
 
 #include "extension.h"
+#include "bgw/launcher_interface.h"
 #include "guc.h"
 #include "catalog.h"
 #include "version.h"
@@ -62,6 +63,7 @@ _PG_init(void)
 	 */
 	extension_check_version(TIMESCALEDB_VERSION_MOD);
 	extension_check_server_version();
+	bgw_check_loader_api_version();
 
 	_chunk_dispatch_info_init();
 	_cache_init();

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -2,7 +2,6 @@ set(HEADERS
   bgw_message_queue.h
   bgw_counter.h
   bgw_launcher.h
-  bgw_interface.h
   loader.h
   ../compat.h
   ../extension_constants.h

--- a/src/loader/bgw_interface.c
+++ b/src/loader/bgw_interface.c
@@ -2,20 +2,35 @@
 
 #include <miscadmin.h>
 #include <fmgr.h>
+
+#include "bgw_interface.h"
 #include "../compat.h"
 #include "bgw_counter.h"
 #include "bgw_message_queue.h"
-#include "bgw_interface.h"
+#include "../extension_constants.h"
 
 
 /* This is where versioned-extension facing functions live. They shouldn't live anywhere else. */
 
+const int32 ts_bgw_loader_api_version = 1;
 
+TS_FUNCTION_INFO_V1(ts_bgw_worker_reserve);
+TS_FUNCTION_INFO_V1(ts_bgw_worker_release);
+TS_FUNCTION_INFO_V1(ts_bgw_num_unreserved);
 TS_FUNCTION_INFO_V1(ts_bgw_db_workers_start);
 
 TS_FUNCTION_INFO_V1(ts_bgw_db_workers_stop);
 
 TS_FUNCTION_INFO_V1(ts_bgw_db_workers_restart);
+
+void
+bgw_interface_register_api_version()
+{
+	void	  **versionptr = find_rendezvous_variable(RENDEZVOUS_BGW_LOADER_API_VERSION);
+
+	/* Cast away the const to store in the rendezvous variable */
+	*versionptr = (void *) &ts_bgw_loader_api_version;
+}
 
 Datum
 ts_bgw_worker_reserve(PG_FUNCTION_ARGS)

--- a/src/loader/bgw_interface.h
+++ b/src/loader/bgw_interface.h
@@ -2,13 +2,8 @@
 #define TIMESCALEDB_BGW_INTERFACE_H
 
 #include <postgres.h>
-#include <fmgr.h>
 
-/* This is where versioned-extension facing functions live. It shouldn't live anywhere else */
+extern void bgw_interface_register_api_version(void);
+extern const int32 ts_bgw_loader_api_version;
 
-PGDLLEXPORT extern Datum ts_bgw_worker_reserve(PG_FUNCTION_ARGS);
-PGDLLEXPORT extern Datum ts_bgw_worker_release(PG_FUNCTION_ARGS);
-PGDLLEXPORT extern Datum ts_bgw_num_unreserved(PG_FUNCTION_ARGS);
-
-
-#endif							/* TIMESCALEDB_BGW_INTERFACE_H */
+#endif

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -27,6 +27,7 @@
 #include "bgw_counter.h"
 #include "bgw_launcher.h"
 #include "bgw_message_queue.h"
+#include "bgw_interface.h"
 
 /*
  * Some notes on design:
@@ -315,6 +316,7 @@ _PG_init(void)
 	bgw_message_queue_alloc();
 	bgw_cluster_launcher_register();
 	bgw_counter_setup_gucs();
+	bgw_interface_register_api_version();
 
 	/* This is a safety-valve variable to prevent loading the full extension */
 	DefineCustomBoolVariable(GUC_DISABLE_LOAD_NAME, "Disable the loading of the actual extension",


### PR DESCRIPTION
A loader API version is added for future-proofing. It will allow
versioned-extension to figure out the version of the loader API that
is installed. For example, if a future versioned extension uses new
functions made available by a new loader version it could use the loader
API version number to figure out if this new capability is actually
available in the installed loader (note a loader could be older than
the versioned-extension if the database was not restarted).