### PR TITLE
Add travis format checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,22 @@ jobs:
       script:
         - PGTEST_TMPDIR=/tmp/ bash -x ./scripts/test_updates_with_constraints.sh
 
+    # this tests the formatting of a PR.
+    - stage: test
+      env:
+        - PG_VERSION=10.2 PG_GIT_TAG=REL_10_2
+      before_install:
+        - git clone --branch ${PG_GIT_TAG} --depth 1 https://github.com/postgres/postgres.git /tmp/postgres
+        - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres timescaledev/pgindent:10-alpine
+      after_failure:
+        - docker exec -it pgbuild /bin/bash -c 'diff -r /build/src /tmp/timescale_src'
+        - docker exec -it pgbuild /bin/bash -c 'diff -r /build/test/src /tmp/timescale_test_src'
+      script:
+        - docker exec -it pgbuild /bin/bash -c 'cp -R /build/src/ /tmp/timescale_src && cp -R /build/test/src/ /tmp/timescale_test_src'
+        - docker exec -it pgbuild /bin/bash -c 'cd /build/debug && make pgindent'
+        - docker exec -it pgbuild /bin/bash -c 'diff -r -q /build/src /tmp/timescale_src'
+        - docker exec -it pgbuild /bin/bash -c 'diff -r -q /build/test/src /tmp/timescale_test_src'
+
     - if: type = cron
       stage: test
       script:


### PR DESCRIPTION
We currently check code formatting and remind people to obey style by hand. Github's [unusual rendering](https://github.com/timescale/timescaledb/blob/0e4fce5dad1c307669fbe68bcb720c6f34421f98/src/net/conn.h#L24-L25), makes this tedious and error-prone, since it is difficult to be certain if some formatting is incorrect, or just strangely rendered. This commit adds a travis job which checks PRs for correct formatting by running `pgident` on each PR, and outputting the diff if one exists. Hopefully this will prevent incorrectly formatted code from merging into master with minimal overhead.