### PR TITLE
Fix issues when OpenSSL is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
   # Therefore, we only set these flags if the configuration-time CMAKE_BUILD_TYPE is set to
   # Debug. Then Debug enabled builds will only happen on Windows if both the configuration-
   # and build-time settings are Debug.
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DUSE_ASSERT_CHECKING=1 -DDEBUG=1")
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DUSE_ASSERT_CHECKING=1 -DDEBUG=1 -DTS_DEBUG=1")
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 set(SUPPORTED_COMPILERS "GNU" "Clang" "AppleClang" "MSVC")
@@ -269,3 +269,14 @@ if (PGINDENT)
 else ()
   message(STATUS "Install pgindent to be able to format C code: https://github.com/postgres/postgres/tree/master/src/tools/pgindent")
 endif (PGINDENT)
+
+option(USE_OPENSSL "Enable use of OpenSSL if available" ON)
+
+if (USE_OPENSSL)
+  # Try to find a local OpenSSL installation
+  include(FindOpenSSL)
+
+  if (NOT OPENSSL_FOUND)
+    message(FATAL_ERROR "TimescaleDB requires OpenSSL but it wasn't found")
+  endif(NOT OPENSSL_FOUND)
+endif (USE_OPENSSL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,3 @@
-# Check if PostgreSQL has OpenSSL enabled
-file(STRINGS ${PG_INCLUDEDIR}/pg_config.h PG_USE_OPENSSL REGEX "#define USE_OPENSSL [01]")
-string(REGEX REPLACE "#define USE_OPENSSL ([01])" "\\1" USE_OPENSSL ${PG_USE_OPENSSL})
-
-# If OpenSSL couldn't be found, we need to disable usage of OpenSSL
-if (USE_OPENSSL)
-  # Try to find a local OpenSSL installation
-  include(FindOpenSSL)
-
-  if (NOT OPENSSL_FOUND)
-    message(FATAL_ERROR "PostgreSQL was compiled with SSL support, but OpenSSL was not found")
-  endif (NOT OPENSSL_FOUND)
-
-  include_directories(${OPENSSL_INCLUDE_DIR})
-endif (USE_OPENSSL)
-
 if (UNIX)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${PG_LIBDIR}")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -L${PG_LIBDIR}")
@@ -146,6 +130,8 @@ set(GITCOMMIT_H ${CMAKE_CURRENT_BINARY_DIR}/gitcommit.h)
 # Add test source code in Debug builds
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   set(TEST_SOURCES ../test/src/symbol_conflict.c)
+  set(TS_DEBUG 1)
+  set(DEBUG 1)
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 if (WIN32)
@@ -168,16 +154,7 @@ endif (WIN32)
 
 add_library(${PROJECT_NAME} MODULE ${SOURCES} ${TEST_SOURCES} ${GITCOMMIT_H})
 
-if (OPENSSL_FOUND AND USE_OPENSSL)
-    target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
-endif (OPENSSL_FOUND AND USE_OPENSSL)
-
-if (OPENSSL_FOUND AND USE_OPENSSL)
-  target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
-endif (OPENSSL_FOUND AND USE_OPENSSL)
-
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  set(DEBUG 1)
   add_subdirectory(../test/src "${CMAKE_CURRENT_BINARY_DIR}/test/src")
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
@@ -193,6 +170,10 @@ endif (CMAKE_BUILD_TYPE MATCHES Debug)
 install(
   TARGETS ${PROJECT_NAME}
   DESTINATION ${PG_PKGLIBDIR})
+
+if (USE_OPENSSL)
+  set(TS_USE_OPENSSL ${USE_OPENSSL})
+endif (USE_OPENSSL)
 
 configure_file(config.h.in config.h)
 

--- a/src/bgw/timer.c
+++ b/src/bgw/timer.c
@@ -13,11 +13,9 @@
 #include <access/xact.h>
 #include <pgstat.h>
 
-
 #include "timer.h"
 #include "compat.h"
-
-
+#include "config.h"
 
 #define MAX_TIMEOUT (5*1000L)
 #define MILLISECS_PER_SEC 1000L
@@ -104,7 +102,7 @@ timer_get_current_timestamp()
 	return timer_get()->get_current_timestamp();
 }
 
-#ifdef DEBUG
+#ifdef TS_DEBUG
 void
 timer_set(const Timer *timer)
 {

--- a/src/bgw/timer.h
+++ b/src/bgw/timer.h
@@ -4,6 +4,8 @@
 #include <postgres.h>
 #include <utils/timestamp.h>
 
+#include "config.h"
+
 typedef struct Timer
 {
 	TimestampTz (*get_current_timestamp) ();
@@ -14,7 +16,7 @@ typedef struct Timer
 extern bool timer_wait(TimestampTz until);
 extern TimestampTz timer_get_current_timestamp(void);
 
-#ifdef DEBUG
+#ifdef TS_DEBUG
 extern void timer_set(const Timer *timer);
 #endif
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -34,4 +34,11 @@
 #cmakedefine DEBUG
 #endif
 
+#ifndef TS_DEBUG
+#cmakedefine TS_DEBUG
+#endif
+
+/* Avoid conflicts with USE_OPENSSL defined by PostgreSQL */
+#cmakedefine TS_USE_OPENSSL
+
 #endif /* TIMESCALEDB_CONFIG_H */

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1091,7 +1091,7 @@ old_insert_blocker_trigger_get(Oid relid)
 		Form_pg_trigger trig = (Form_pg_trigger) GETSTRUCT(tuple);
 
 		if (TRIGGER_TYPE_MATCHES(trig->tgtype, TRIGGER_TYPE_ROW, TRIGGER_TYPE_BEFORE, TRIGGER_TYPE_INSERT) &&
-			strncmp(OLD_INSERT_BLOCKER_NAME, NameStr(trig->tgname), strlen(OLD_INSERT_BLOCKER_NAME)) == 0  && trig->tgisinternal)
+			strncmp(OLD_INSERT_BLOCKER_NAME, NameStr(trig->tgname), strlen(OLD_INSERT_BLOCKER_NAME)) == 0 && trig->tgisinternal)
 		{
 			tgoid = HeapTupleGetOid(tuple);
 			break;
@@ -1130,8 +1130,8 @@ insert_blocker_trigger_add(Oid relid)
 
 	/*
 	 * We create a user-visible trigger, so that it will get pg_dump'd with
-	 * the hypertable. This call will error out if a trigger with the same name already exists.
-     * (This is the desired behavior.)
+	 * the hypertable. This call will error out if a trigger with the same
+	 * name already exists. (This is the desired behavior.)
 	 */
 	objaddr = CreateTrigger(&stmt, NULL, relid, InvalidOid, InvalidOid, InvalidOid, false);
 

--- a/src/init.c
+++ b/src/init.c
@@ -16,7 +16,6 @@
 PG_MODULE_MAGIC;
 #endif
 
-
 extern void _chunk_dispatch_info_init(void);
 extern void _chunk_dispatch_info_fini(void);
 
@@ -41,12 +40,12 @@ extern void _event_trigger_fini(void);
 extern void _conn_plain_init();
 extern void _conn_plain_fini();
 
-#ifdef USE_OPENSSL
+#ifdef TS_USE_OPENSSL
 extern void _conn_ssl_init();
 extern void _conn_ssl_fini();
 #endif
 
-#ifdef DEBUG
+#ifdef TS_DEBUG
 extern void _conn_mock_init();
 extern void _conn_mock_fini();
 #endif
@@ -73,10 +72,10 @@ _PG_init(void)
 	_process_utility_init();
 	_guc_init();
 	_conn_plain_init();
-#ifdef USE_OPENSSL
+#ifdef TS_USE_OPENSSL
 	_conn_ssl_init();
 #endif
-#ifdef DEBUG
+#ifdef TS_DEBUG
 	_conn_mock_init();
 #endif
 }
@@ -88,10 +87,10 @@ _PG_fini(void)
 	 * Order of items should be strict reverse order of _PG_init. Please
 	 * document any exceptions.
 	 */
-#ifdef DEBUG
+#ifdef TS_DEBUG
 	_conn_mock_fini();
 #endif
-#ifdef USE_OPENSSL
+#ifdef TS_USE_OPENSSL
 	_conn_ssl_fini();
 #endif
 	_conn_plain_fini();

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -38,7 +38,7 @@
 #define ACK_SUCCESS true
 #define ACK_FAILURE false
 
-#ifdef DEBUG
+#ifdef TS_DEBUG
 #define BGW_LAUNCHER_RESTART_TIME 0
 #else
 #define BGW_LAUNCHER_RESTART_TIME 60
@@ -337,8 +337,8 @@ start_db_schedulers(HTAB *db_htab)
 						  errhint("%d schedulers have been started, %d databases remain without scheduler. Increase max_worker_processes and restart the server.", nstarted, (ndatabases - nstarted))));
 
 			/*
-			 * We incremented total workers, but we don't need to decrement
-			 * as that will be handled by the stopped workers check.
+			 * We incremented total workers, but we don't need to decrement as
+			 * that will be handled by the stopped workers check.
 			 */
 			break;
 		}

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -1,11 +1,16 @@
 set(SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/conn.c
   ${CMAKE_CURRENT_SOURCE_DIR}/conn_plain.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/conn_ssl.c
   ${CMAKE_CURRENT_SOURCE_DIR}/utils.c
   ${CMAKE_CURRENT_SOURCE_DIR}/http.c
   ${CMAKE_CURRENT_SOURCE_DIR}/http_response.c
   ${CMAKE_CURRENT_SOURCE_DIR}/http_request.c
 )
+
+if (USE_OPENSSL)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/conn_ssl.c)
+  target_include_directories(${PROJECT_NAME} PUBLIC ${OPENSSL_INCLUDE_DIR})
+  target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
+endif (USE_OPENSSL)
 
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})

--- a/test/expected/privacy.out
+++ b/test/expected/privacy.out
@@ -22,45 +22,10 @@ SELECT _timescaledb_internal.test_privacy();
 (1 row)
 
 -- To make sure nothing was sent, we check the UUID table to make sure no exported UUID row was created
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata;
- count 
--------
-     2
-(1 row)
-
--- Now try to send something
-RESET timescaledb.telemetry_level;
--- We don't care about the output of the version checker
-SET client_min_messages=error;
-SELECT _timescaledb_internal.test_privacy();
- test_privacy 
---------------
- 
-(1 row)
-
-RESET client_min_messages;
--- We know it attempted to send if there generated UUIDs
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata where key='uuid';
- count 
--------
-     1
-(1 row)
-
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata where key='exported_uuid';
- count 
--------
-     1
-(1 row)
-
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata where key='install_timestamp';
- count 
--------
-     1
-(1 row)
-
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata;
- count 
--------
-     3
-(1 row)
+SELECT key from _timescaledb_catalog.installation_metadata;
+        key        
+-------------------
+ uuid
+ install_timestamp
+(2 rows)
 

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -64,8 +64,11 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
     loader.sql
     symbol_conflict.sql
     net.sql
-    telemetry.sql
-    privacy.sql)
+    telemetry.sql)
+  if (USE_OPENSSL)
+    list(APPEND TEST_FILES
+      privacy.sql)
+  endif (USE_OPENSSL)
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 set(TEST_TEMPLATES

--- a/test/sql/privacy.sql
+++ b/test/sql/privacy.sql
@@ -8,16 +8,4 @@ SET timescaledb.telemetry_level=off;
 SHOW timescaledb.telemetry_level;
 SELECT _timescaledb_internal.test_privacy();
 -- To make sure nothing was sent, we check the UUID table to make sure no exported UUID row was created
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata;
-
--- Now try to send something
-RESET timescaledb.telemetry_level;
--- We don't care about the output of the version checker
-SET client_min_messages=error;
-SELECT _timescaledb_internal.test_privacy();
-RESET client_min_messages;
--- We know it attempted to send if there generated UUIDs
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata where key='uuid';
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata where key='exported_uuid';
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata where key='install_timestamp';
-SELECT COUNT(*) from _timescaledb_catalog.installation_metadata;
+SELECT key from _timescaledb_catalog.installation_metadata;

--- a/test/src/net/test_conn.c
+++ b/test/src/net/test_conn.c
@@ -4,6 +4,7 @@
 #include <fmgr.h>
 
 #include "compat.h"
+#include "config.h"
 #include "net/conn.h"
 
 #define MAX_RESULT_SIZE	2048
@@ -17,7 +18,7 @@ test_conn(PG_FUNCTION_ARGS)
 	Connection *conn;
 	bool		should_fail = false;
 	int			port = 80;
-#if USE_OPENSSL
+#ifdef TS_USE_OPENSSL
 	int			ssl_port = 443;
 #endif
 	char	   *host = "postman-echo.com";
@@ -50,7 +51,7 @@ test_conn(PG_FUNCTION_ARGS)
 	connection_close(conn);
 	connection_destroy(conn);
 
-#if USE_OPENSSL
+#ifdef TS_USE_OPENSSL
 	/* Now test ssl_ops */
 	conn = connection_create(CONNECTION_SSL);
 	Assert(connection_connect(conn, host, NULL, ssl_port) >= 0);


### PR DESCRIPTION
This fixes a number of compilation and test issues when OpenSSL is not
available. While we still default to OpenSSL enabled, we allow
explicitly setting -DUSE_OPENSSL=false to compile and run tests
without OpenSSL installed. But if not specified, CMake will fail if
OpenSSL is not available on the system.