### PR TITLE
Make pg_dump test work on remote and Windows

### DIFF
--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -271,8 +271,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
                             Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
 --------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
  "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -315,8 +315,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
                             Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
 --------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
  "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -168,8 +168,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
                             Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
 --------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
  "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -212,8 +212,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
                             Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
 --------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
  "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -168,8 +168,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
                             Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
 --------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
  "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;
@@ -212,8 +212,8 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabl
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
                             Index                             |     Columns      | Expr | Unique | Primary | Exclusion | Tablespace 
 --------------------------------------------------------------+------------------+------+--------+---------+-----------+------------
- "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
  "Hypertable_1_with_default_index_enabled_Device_id_Time_idx" | {Device_id,Time} |      | f      | f       | f         | 
+ "Hypertable_1_with_default_index_enabled_Time_idx"           | {Time}           |      | f      | f       | f         | 
 (2 rows)
 
 ROLLBACK;

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -128,9 +128,9 @@ INSERT INTO index_test VALUES ('2017-04-20T09:00:01', 1, 17.5);
 SELECT * FROM test.show_indexes('index_test');
            Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
 ----------------------------+---------------+------+--------+---------+-----------+------------
- index_test_time_idx        | {time}        |      | f      | f       | f         | 
  index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ index_test_time_idx        | {time}        |      | f      | f       | f         | 
  index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
@@ -165,9 +165,9 @@ ALTER INDEX index_test_time_idx RENAME TO index_test_time_idx2;
 SELECT * FROM test.show_indexes('index_test');
            Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
 ----------------------------+---------------+------+--------+---------+-----------+------------
- index_test_time_idx2       | {time}        |      | f      | f       | f         | 
  index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
+ index_test_time_idx2       | {time}        |      | f      | f       | f         | 
  index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
@@ -231,10 +231,10 @@ CREATE INDEX a_hypertable_index_with_a_very_very_long_name_that_truncates_2 ON i
 SELECT * FROM test.show_indexes('index_test');
                              Index                              |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
 ----------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
- index_test_device_time_idx                                     | {device,time} |      | f      | f       | f         | 
- index_test_time_temp_idx                                       | {time,temp}   |      | f      | f       | f         | 
  a_hypertable_index_with_a_very_very_long_name_that_truncates   | {time,temp}   |      | f      | f       | f         | 
  a_hypertable_index_with_a_very_very_long_name_that_truncates_2 | {time,temp}   |      | f      | f       | f         | 
+ index_test_device_time_idx                                     | {device,time} |      | f      | f       | f         | 
+ index_test_time_temp_idx                                       | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
@@ -271,8 +271,8 @@ SELECT * FROM test.show_indexes('index_test');
            Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------+---------------+------+--------+---------+-----------+-------------
  index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (3 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
@@ -294,8 +294,8 @@ SELECT * FROM test.show_indexes('index_test');
            Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------+---------------+------+--------+---------+-----------+-------------
  index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (3 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
@@ -315,9 +315,9 @@ SELECT * FROM test.show_indexes('index_test');
            Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------+---------------+------+--------+---------+-----------+-------------
  index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
- index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
- index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
  index_test_time_device_key | {time,device} |      | t      | f       | f         | 
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
+ index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
@@ -388,9 +388,9 @@ INSERT INTO index_test VALUES ('2017-01-20T09:00:01', 17.5);
 SELECT * FROM test.show_indexes('index_test');
            Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------+---------------+------+--------+---------+-----------+-------------
- index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
- index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
  index_test_device_idx      | {device}      |      | f      | f       | f         | 
+ index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
 (3 rows)
 
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
@@ -407,9 +407,9 @@ CREATE INDEX ON index_test (time, temp) TABLESPACE tablespace2;
 SELECT * FROM test.show_indexes('index_test');
            Index            |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------+---------------+------+--------+---------+-----------+-------------
- index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
- index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
  index_test_device_idx      | {device}      |      | f      | f       | f         | 
+ index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
+ index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
  index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | tablespace2
 (4 rows)
 

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -256,12 +256,12 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 (12 rows)
 
 \c postgres :ROLE_SUPERUSER
--- NOTE: This section does _not_ work when server is remote, i.e. not localhost
-\! pg_dump -h localhost -U super_user -Fc single > dump/single.sql
-\! dropdb -h localhost -U super_user single
-\! createdb -h localhost -U super_user single
+-- We shell out to a script in order to grab the correct hostname from the
+-- environmental variables that originally called this psql command. Sadly
+-- vars passed to psql do not work in \! commands so we can't do it that way.
+\! utils/pg_dump_aux_dump.sh
 ALTER DATABASE single SET timescaledb.restoring='on';
-\! pg_restore -h localhost -U super_user -d single dump/single.sql
+\! utils/pg_dump_aux_restore.sh
 \c single
 -- Set to OFF for future DB sessions.
 ALTER DATABASE single SET timescaledb.restoring='off';

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -115,27 +115,27 @@ SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
 SELECT * FROM test.show_indexes('"test_schema"."two_Partitions"');
                           Index                          |             Columns             | Expr | Unique | Primary | Exclusion | Tablespace 
 ---------------------------------------------------------+---------------------------------+------+--------+---------+-----------+------------
+ test_schema.timecustom_device_id_series_2_key           | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
  test_schema."two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
+ test_schema."two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
  test_schema."two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           |      | f      | f       | f         | 
  test_schema."two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           |      | f      | f       | f         | 
  test_schema."two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           |      | f      | f       | f         | 
  test_schema."two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        |      | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
- test_schema."two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
- test_schema.timecustom_device_id_series_2_key           | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
 (8 rows)
 
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
                                        Index                                        |             Columns             | Expr | Unique | Primary | Exclusion | Tablespace 
 ------------------------------------------------------------------------------------+---------------------------------+------+--------+---------+-----------+------------
+ _timescaledb_internal."1_1_timecustom_device_id_series_2_key"                      | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
  _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_device_id_timeCustom_idx"   | {device_id,timeCustom}          |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
+ _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
  _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_0_idx"    | {timeCustom,series_0}           |      | f      | f       | f         | 
  _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx"    | {timeCustom,series_1}           |      | f      | f       | f         | 
  _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_2_idx"    | {timeCustom,series_2}           |      | f      | f       | f         | 
  _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_series_bool_idx" | {timeCustom,series_bool}        |      | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx"   | {timeCustom,device_id}          |      | f      | f       | f         | 
- _timescaledb_internal."_hyper_1_1_chunk_two_Partitions_timeCustom_idx"             | {timeCustom}                    |      | f      | f       | f         | 
- _timescaledb_internal."1_1_timecustom_device_id_series_2_key"                      | {timeCustom,device_id,series_2} |      | t      | f       | f         | 
 (8 rows)
 
 SELECT * FROM test.show_constraints('"test_schema"."two_Partitions"');
@@ -256,6 +256,7 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 (12 rows)
 
 \c postgres :ROLE_SUPERUSER
+-- NOTE: This section does _not_ work when server is remote, i.e. not localhost
 \! pg_dump -h localhost -U super_user -Fc single > dump/single.sql
 \! dropdb -h localhost -U super_user single
 \! createdb -h localhost -U super_user single

--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -105,8 +105,8 @@ SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
                                 Index                                |   Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
 ---------------------------------------------------------------------+-------------+------+--------+---------+-----------+------------
  _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} |      | t      | t       | f         | 
- _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      |      | t      | f       | f         | 
  _timescaledb_internal._hyper_1_1_chunk_1_1_reindex_test_pkey        | {time,temp} |      | t      | t       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      |      | t      | f       | f         | 
 (3 rows)
 
 SELECT * FROM _timescaledb_internal.chunk_index_replace('_timescaledb_internal."1_1_reindex_test_pkey"'::regclass, '_timescaledb_internal."_hyper_1_1_chunk_1_1_reindex_test_pkey"'::regclass);
@@ -118,7 +118,7 @@ SELECT * FROM _timescaledb_internal.chunk_index_replace('_timescaledb_internal."
 SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
                                 Index                                |   Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
 ---------------------------------------------------------------------+-------------+------+--------+---------+-----------+------------
- _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      |      | t      | f       | f         | 
  _timescaledb_internal."1_1_reindex_test_pkey"                       | {time,temp} |      | t      | t       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk_reindex_test_time_unique_idx | {time}      |      | t      | f       | f         | 
 (2 rows)
 

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -69,6 +69,7 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 
 \c postgres :ROLE_SUPERUSER
 
+-- NOTE: This section does _not_ work when server is remote, i.e. not localhost
 \! pg_dump -h localhost -U super_user -Fc single > dump/single.sql
 \! dropdb -h localhost -U super_user single
 \! createdb -h localhost -U super_user single

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -69,12 +69,12 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 
 \c postgres :ROLE_SUPERUSER
 
--- NOTE: This section does _not_ work when server is remote, i.e. not localhost
-\! pg_dump -h localhost -U super_user -Fc single > dump/single.sql
-\! dropdb -h localhost -U super_user single
-\! createdb -h localhost -U super_user single
+-- We shell out to a script in order to grab the correct hostname from the
+-- environmental variables that originally called this psql command. Sadly
+-- vars passed to psql do not work in \! commands so we can't do it that way.
+\! utils/pg_dump_aux_dump.sh
 ALTER DATABASE single SET timescaledb.restoring='on';
-\! pg_restore -h localhost -U super_user -d single dump/single.sql
+\! utils/pg_dump_aux_restore.sh
 \c single
 
 -- Set to OFF for future DB sessions.

--- a/test/sql/utils/pg_dump_aux_dump.sh
+++ b/test/sql/utils/pg_dump_aux_dump.sh
@@ -1,0 +1,3 @@
+pg_dump -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -Fc single > dump/single.sql
+dropdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} single
+createdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} single

--- a/test/sql/utils/pg_dump_aux_restore.sh
+++ b/test/sql/utils/pg_dump_aux_restore.sh
@@ -1,0 +1,1 @@
+pg_restore -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -d single dump/single.sql

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -69,7 +69,7 @@ $BODY$
     (SELECT t.spcname FROM pg_tablespace t WHERE t.oid = c.reltablespace)
     FROM pg_class c, pg_index i
     WHERE c.oid = i.indexrelid AND i.indrelid = rel
-    ORDER BY c.oid;
+    ORDER BY c.relname;
 $BODY$;
 
 CREATE OR REPLACE FUNCTION test.show_indexesp(pattern text)


### PR DESCRIPTION
Windows and Unix platforms had different orderings
for some tests in pg_dump. Now we order by Index
name collated as a byte string so that we get the
same ordering regardless of platform.