### PR TITLE
Fix symbol_conflict test on Windows

### DIFF
--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -24,12 +24,14 @@ add_library(${PROJECT_NAME}-loader MODULE ${SOURCES} ${TEST_SOURCES} ${HEADERS})
 
 # Do not compile mock extensions on Windows due to missing exported symbol
 # in IsParallelWorker macro
-if (CMAKE_BUILD_TYPE MATCHES Debug AND NOT WIN32)
-  add_subdirectory(../../test/loader-mock/ "${CMAKE_CURRENT_BINARY_DIR}/mock")
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+  if (NOT WIN32)
+    add_subdirectory(../../test/loader-mock/ "${CMAKE_CURRENT_BINARY_DIR}/mock")
+  endif (NOT WIN32)
 
   # This define generates extension-specific code for symbol conflict testing
   target_compile_definitions(${PROJECT_NAME}-loader PUBLIC MODULE_NAME=loader)
-endif (CMAKE_BUILD_TYPE MATCHES Debug AND NOT WIN32)
+endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 set_target_properties(${PROJECT_NAME}-loader PROPERTIES
     OUTPUT_NAME ${PROJECT_NAME}


### PR DESCRIPTION
The symbol_conflict test failed on Windows because the CMake build
script accidentally did not include the required code in the loader
during Debug builds. This change fixes the CMake script so that the
code is included in the laoder.