### PR TITLE
Testing: use pg_config bindir directory for pg executables.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,7 @@ set(PG_REGRESS_ENV
   TEST_INPUT_DIR=${TEST_INPUT_DIR}
   TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR}
   TEST_SCHEDULE=${TEST_SCHEDULE}
+  PG_BINDIR=${PG_BINDIR}
   PG_REGRESS=${PG_REGRESS})
 
 # installcheck starts up new temporary instances for testing code

--- a/test/sql/utils/pg_dump_aux_dump.sh
+++ b/test/sql/utils/pg_dump_aux_dump.sh
@@ -1,3 +1,3 @@
-pg_dump -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -Fc single > dump/single.sql
-dropdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} single
-createdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} single
+${PG_BINDIR}/pg_dump -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -Fc single > dump/single.sql
+${PG_BINDIR}/dropdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} single
+${PG_BINDIR}/createdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} single

--- a/test/sql/utils/pg_dump_aux_restore.sh
+++ b/test/sql/utils/pg_dump_aux_restore.sh
@@ -1,1 +1,1 @@
-pg_restore -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -d single dump/single.sql
+${PG_BINDIR}/pg_restore -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -d single dump/single.sql


### PR DESCRIPTION
Hi,

Trivial but If pg_dump, createdb, dropdb and pg_restore aren't in system default path 'make installcheck' test pg_dump fails.

pg_config output is already used for pg_regress.

Regards
Didier