### PR TITLE
Remove NOTICE in debug mode

### DIFF
--- a/test/expected/installation_metadata.out
+++ b/test/expected/installation_metadata.out
@@ -80,25 +80,8 @@ SELECT _timescaledb_internal.test_install_timestamp() = :'timestamp_1' as timest
 \! dropdb -h localhost -U super_user single
 \! createdb -h localhost -U super_user single
 ALTER DATABASE single SET timescaledb.restoring='on';
-\! pg_restore -h localhost -U super_user -d single dump/single.sql
-pg_restore: WARNING:  
-WELCOME TO
- _____ _                               _     ____________  
-|_   _(_)                             | |    |  _  \ ___ \ 
-  | |  _ _ __ ___   ___  ___  ___ __ _| | ___| | | | |_/ / 
-  | | | |  _ ` _ \ / _ \/ __|/ __/ _` | |/ _ \ | | | ___ \ 
-  | | | | | | | | |  __/\__ \ (_| (_| | |  __/ |/ /| |_/ /
-  |_| |_|_| |_| |_|\___||___/\___\__,_|_|\___|___/ \____/
-               Running version 0.11.1-dev
-For more information on TimescaleDB, please visit the following links:
-
- 1. Getting started: https://docs.timescale.com/getting-started
- 2. API reference documentation: https://docs.timescale.com/api
- 3. How TimescaleDB is designed: https://docs.timescale.com/introduction/architecture
-
-Note: TimescaleDB collects anonymous reports to better understand and assist our users.
-For more information and how to disable, please see our docs https://docs.timescaledb.com/using-timescaledb/telemetry.
-
+-- Redirect to /dev/null to suppress NOTICE
+\! pg_restore -h localhost -U super_user -d single dump/single.sql > /dev/null 2>&1
 ALTER DATABASE single SET timescaledb.restoring='off';
 \c single :ROLE_DEFAULT_PERM_USER
 -- Should have all 3 row, because pg_dump includes the insertion of uuid and timestamp.

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -262,24 +262,6 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 \! utils/pg_dump_aux_dump.sh
 ALTER DATABASE single SET timescaledb.restoring='on';
 \! utils/pg_dump_aux_restore.sh
-pg_restore: WARNING:  
-WELCOME TO
- _____ _                               _     ____________  
-|_   _(_)                             | |    |  _  \ ___ \ 
-  | |  _ _ __ ___   ___  ___  ___ __ _| | ___| | | | |_/ / 
-  | | | |  _ ` _ \ / _ \/ __|/ __/ _` | |/ _ \ | | | ___ \ 
-  | | | | | | | | |  __/\__ \ (_| (_| | |  __/ |/ /| |_/ /
-  |_| |_|_| |_| |_|\___||___/\___\__,_|_|\___|___/ \____/
-               Running version 0.12.1-dev
-For more information on TimescaleDB, please visit the following links:
-
- 1. Getting started: https://docs.timescale.com/getting-started
- 2. API reference documentation: https://docs.timescale.com/api
- 3. How TimescaleDB is designed: https://docs.timescale.com/introduction/architecture
-
-Note: TimescaleDB collects anonymous reports to better understand and assist our users.
-For more information and how to disable, please see our docs https://docs.timescaledb.com/using-timescaledb/telemetry.
-
 \c single
 -- Set to OFF for future DB sessions.
 ALTER DATABASE single SET timescaledb.restoring='off';

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -61,9 +61,10 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES
     bgw_launcher.sql
     bgw_db_scheduler.sql
+    installation_metadata.sql
     loader.sql
-    symbol_conflict.sql
     net.sql
+    symbol_conflict.sql
     telemetry.sql)
   if (USE_OPENSSL)
     list(APPEND TEST_FILES

--- a/test/sql/installation_metadata.sql
+++ b/test/sql/installation_metadata.sql
@@ -36,7 +36,8 @@ SELECT _timescaledb_internal.test_install_timestamp() = :'timestamp_1' as timest
 \! dropdb -h localhost -U super_user single
 \! createdb -h localhost -U super_user single
 ALTER DATABASE single SET timescaledb.restoring='on';
-\! pg_restore -h localhost -U super_user -d single dump/single.sql
+-- Redirect to /dev/null to suppress NOTICE
+\! pg_restore -h localhost -U super_user -d single dump/single.sql > /dev/null 2>&1
 ALTER DATABASE single SET timescaledb.restoring='off';
 
 \c single :ROLE_DEFAULT_PERM_USER

--- a/test/sql/utils/pg_dump_aux_restore.sh
+++ b/test/sql/utils/pg_dump_aux_restore.sh
@@ -1,1 +1,2 @@
-${PG_BINDIR}/pg_restore -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -d single dump/single.sql
+# Redirect output to /dev/null to suppress NOTICE
+${PG_BINDIR}/pg_restore -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -d single dump/single.sql > /dev/null 2>&1


### PR DESCRIPTION
Removed NOTICE from extension file when in Debug mode, so we don't have to keep removing it from and fixing the version number in *.out files. Also added installation_metadata test back into CMakeList.