### PR TITLE
Don't start schedulers for template databases.

### DIFF
--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -1,4 +1,5 @@
 \c single_2 :ROLE_SUPERUSER
+\ir include/bgw_launcher_utils.sql
 /*
  * Note on testing: need a couple wrappers that pg_sleep in a loop to wait for changes
  * to appear in pg_stat_activity.
@@ -8,9 +9,10 @@
  */
 CREATE VIEW worker_counts as SELECT count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Launcher') as launcher,
 count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single') as single_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single_2') as single_2_scheduler
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single_2') as single_2_scheduler, 
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
 FROM pg_stat_activity;
-CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER, template1_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE
 r INTEGER;
@@ -18,7 +20,7 @@ BEGIN
 FOR i in 1..10
 LOOP
 SELECT COUNT(*) from worker_counts where (launcher = launcher_ct OR current_setting('server_version_num')::int < 100000) 
-	AND single_scheduler = scheduler1_ct AND single_2_scheduler=scheduler2_ct into r;
+	AND single_scheduler = scheduler1_ct AND single_2_scheduler = scheduler2_ct and template1_scheduler = template1_ct into r;
 if(r < 1) THEN
   PERFORM pg_sleep(0.1);
   PERFORM pg_stat_clear_snapshot();
@@ -35,33 +37,17 @@ $BODY$;
  * and the scheduler for single in pg_stat_activity
  * but single_2 shouldn't have a scheduler because ext not created yet 
  */
-SELECT wait_worker_counts(1,1,0);
+SELECT wait_worker_counts(1,1,0,0);
  wait_worker_counts 
 --------------------
  t
 (1 row)
 
 /*Now create the extension in single_2*/
+SET client_min_messages = ERROR;
 CREATE EXTENSION timescaledb CASCADE;
-WARNING:  
-WELCOME TO
- _____ _                               _     ____________  
-|_   _(_)                             | |    |  _  \ ___ \ 
-  | |  _ _ __ ___   ___  ___  ___ __ _| | ___| | | | |_/ / 
-  | | | |  _ ` _ \ / _ \/ __|/ __/ _` | |/ _ \ | | | ___ \ 
-  | | | | | | | | |  __/\__ \ (_| (_| | |  __/ |/ /| |_/ /
-  |_| |_|_| |_| |_|\___||___/\___\__,_|_|\___|___/ \____/
-               Running version 0.12.1-dev
-For more information on TimescaleDB, please visit the following links:
-
- 1. Getting started: https://docs.timescale.com/getting-started
- 2. API reference documentation: https://docs.timescale.com/api
- 3. How TimescaleDB is designed: https://docs.timescale.com/introduction/architecture
-
-Note: TimescaleDB collects anonymous reports to better understand and assist our users.
-For more information and how to disable, please see our docs https://docs.timescaledb.com/using-timescaledb/telemetry.
-
-SELECT wait_worker_counts(1,1,1);
+RESET client_min_messages;
+SELECT wait_worker_counts(1,1,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -69,7 +55,7 @@ SELECT wait_worker_counts(1,1,1);
 
 DROP DATABASE single;
 /* Now the db_scheduler for single should have disappeared*/
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -88,7 +74,7 @@ SELECT _timescaledb_internal.restart_background_workers();
  t
 (1 row)
 
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -105,7 +91,7 @@ AND datname = 'single_2';
 (1 row)
 
 COMMIT;
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -127,7 +113,7 @@ SELECT _timescaledb_internal.stop_background_workers();
  t
 (1 row)
 
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
  wait_worker_counts 
 --------------------
  t
@@ -140,7 +126,7 @@ SELECT _timescaledb_internal.stop_background_workers();
  t
 (1 row)
 
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
  wait_worker_counts 
 --------------------
  t
@@ -153,7 +139,7 @@ SELECT _timescaledb_internal.start_background_workers();
  t
 (1 row)
 
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -227,7 +213,7 @@ SELECT _timescaledb_internal.stop_background_workers();
  t
 (1 row)
 
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
  wait_worker_counts 
 --------------------
  t
@@ -239,7 +225,7 @@ SELECT _timescaledb_internal.restart_background_workers();
  t
 (1 row)
 
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -253,7 +239,7 @@ WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2' \gset
 BEGIN;
 DROP EXTENSION timescaledb;
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -300,7 +286,7 @@ SELECT coalesce(
  t
 (1 row)
 
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------
  t
@@ -316,9 +302,68 @@ SELECT ((current_setting('server_version_num')::int < 100000) OR wait_greater(:'
 BEGIN;
 DROP EXTENSION timescaledb;
 COMMIT;
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
  wait_worker_counts 
 --------------------
  t
 (1 row)
 
+/* Connect to the template1 database */ 
+\c template1
+\ir include/bgw_launcher_utils.sql
+/*
+ * Note on testing: need a couple wrappers that pg_sleep in a loop to wait for changes
+ * to appear in pg_stat_activity.
+ * Further Note: PG 9.6 changed what appeared in pg_stat_activity, so the launcher doesn't actually show up. 
+ * we can still test its interactions with its children, but can't test some of the things specific to the launcher. 
+ * So we've added some bits about the version number as needed. 
+ */
+CREATE VIEW worker_counts as SELECT count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Launcher') as launcher,
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single') as single_scheduler,
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single_2') as single_2_scheduler, 
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
+FROM pg_stat_activity;
+CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER, template1_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+r INTEGER;
+BEGIN
+FOR i in 1..10
+LOOP
+SELECT COUNT(*) from worker_counts where (launcher = launcher_ct OR current_setting('server_version_num')::int < 100000) 
+	AND single_scheduler = scheduler1_ct AND single_2_scheduler = scheduler2_ct and template1_scheduler = template1_ct into r;
+if(r < 1) THEN
+  PERFORM pg_sleep(0.1);
+  PERFORM pg_stat_clear_snapshot();
+ELSE
+	--We have the correct counts!
+  RETURN TRUE;
+END IF;
+END LOOP;
+RETURN FALSE;
+END
+$BODY$;
+BEGIN;
+/* Then create extension there in a txn and make sure we see a scheduler start */
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb CASCADE;
+RESET client_min_messages;
+SELECT wait_worker_counts(1,0,0,1);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+COMMIT;
+/* End our transaction and it should immediately exit because it's a template database.*/
+SELECT wait_worker_counts(1,0,0,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+/* Clean up after ourselves */
+\ir include/bgw_launcher_utils_cleanup.sql
+DROP FUNCTION wait_worker_counts(integer, integer, integer, integer);
+DROP VIEW worker_counts;
+DROP EXTENSION timescaledb;

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -1,55 +1,24 @@
 \c single_2 :ROLE_SUPERUSER
 
-
-/*
- * Note on testing: need a couple wrappers that pg_sleep in a loop to wait for changes
- * to appear in pg_stat_activity.
- * Further Note: PG 9.6 changed what appeared in pg_stat_activity, so the launcher doesn't actually show up. 
- * we can still test its interactions with its children, but can't test some of the things specific to the launcher. 
- * So we've added some bits about the version number as needed. 
- */
-
-CREATE VIEW worker_counts as SELECT count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Launcher') as launcher,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single') as single_scheduler,
-count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single_2') as single_2_scheduler
-FROM pg_stat_activity;
-
-CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
-$BODY$
-DECLARE
-r INTEGER;
-BEGIN
-FOR i in 1..10
-LOOP
-SELECT COUNT(*) from worker_counts where (launcher = launcher_ct OR current_setting('server_version_num')::int < 100000) 
-	AND single_scheduler = scheduler1_ct AND single_2_scheduler=scheduler2_ct into r;
-if(r < 1) THEN
-  PERFORM pg_sleep(0.1);
-  PERFORM pg_stat_clear_snapshot();
-ELSE
-	--We have the correct counts!
-  RETURN TRUE;
-END IF;
-END LOOP;
-RETURN FALSE;
-END
-$BODY$;
+\ir include/bgw_launcher_utils.sql
 
 /* 
  * When we've connected to single_2, we should be able to see the cluster launcher 
  * and the scheduler for single in pg_stat_activity
  * but single_2 shouldn't have a scheduler because ext not created yet 
  */
-SELECT wait_worker_counts(1,1,0);
+SELECT wait_worker_counts(1,1,0,0);
 
 /*Now create the extension in single_2*/
+SET client_min_messages = ERROR;
 CREATE EXTENSION timescaledb CASCADE;
-SELECT wait_worker_counts(1,1,1);
+RESET client_min_messages;
+SELECT wait_worker_counts(1,1,1,0);
 
 DROP DATABASE single;
 
 /* Now the db_scheduler for single should have disappeared*/
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
 
 /*Now let's restart the scheduler and make sure our backend_start changed */
 SELECT backend_start as orig_backend_start 
@@ -59,7 +28,7 @@ AND datname = 'single_2' \gset
 /* We'll do this in a txn so that we can see that the worker locks on our txn before continuing*/
 BEGIN;
 SELECT _timescaledb_internal.restart_background_workers();
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
 
 SELECT (backend_start > :'orig_backend_start'::timestamptz) backend_start_changed, 
 (wait_event = 'virtualxid') wait_event_changed
@@ -68,7 +37,7 @@ WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2';
 COMMIT;
 
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
 SELECT (wait_event IS DISTINCT FROM 'virtualxid') wait_event_changed
 FROM pg_stat_activity
 WHERE application_name = 'TimescaleDB Background Worker Scheduler'
@@ -76,15 +45,15 @@ AND datname = 'single_2';
 
 /*Test stop*/
 SELECT _timescaledb_internal.stop_background_workers();
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
 
 /*Make sure it doesn't break if we stop twice in a row*/
 SELECT _timescaledb_internal.stop_background_workers();
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
 
 /*test start*/
 SELECT _timescaledb_internal.start_background_workers();
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
 
 /*make sure start is idempotent*/
 SELECT backend_start as orig_backend_start
@@ -122,9 +91,9 @@ select wait_equals(:'orig_backend_start');
 
 /*Make sure restart works from stopped worker state*/
 SELECT _timescaledb_internal.stop_background_workers();
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
 SELECT _timescaledb_internal.restart_background_workers();
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
 
 /*Make sure drop extension statement restarts the worker and on rollback it keeps running*/
 /*Now let's restart the scheduler and make sure our backend_start changed */
@@ -135,7 +104,7 @@ AND datname = 'single_2' \gset
 
 BEGIN;
 DROP EXTENSION timescaledb;
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
 ROLLBACK;
 
 CREATE FUNCTION wait_greater(TIMESTAMPTZ) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
@@ -171,7 +140,7 @@ SELECT coalesce(
   (SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher'), 
   (SELECT current_setting('server_version_num')::int < 100000));
 
-SELECT wait_worker_counts(1,0,1);
+SELECT wait_worker_counts(1,0,1,0);
 
 SELECT ((current_setting('server_version_num')::int < 100000) OR wait_greater(:'orig_backend_start')) as wait_greater;
 
@@ -180,4 +149,22 @@ SELECT ((current_setting('server_version_num')::int < 100000) OR wait_greater(:'
 BEGIN;
 DROP EXTENSION timescaledb;
 COMMIT;
-SELECT wait_worker_counts(1,0,0);
+SELECT wait_worker_counts(1,0,0,0);
+
+/* Connect to the template1 database */ 
+\c template1
+\ir include/bgw_launcher_utils.sql
+BEGIN;
+/* Then create extension there in a txn and make sure we see a scheduler start */
+
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb CASCADE;
+RESET client_min_messages;
+SELECT wait_worker_counts(1,0,0,1);
+COMMIT;
+/* End our transaction and it should immediately exit because it's a template database.*/
+SELECT wait_worker_counts(1,0,0,0);
+
+/* Clean up after ourselves */
+\ir include/bgw_launcher_utils_cleanup.sql
+DROP EXTENSION timescaledb;

--- a/test/sql/include/bgw_launcher_utils.sql
+++ b/test/sql/include/bgw_launcher_utils.sql
@@ -1,0 +1,34 @@
+/*
+ * Note on testing: need a couple wrappers that pg_sleep in a loop to wait for changes
+ * to appear in pg_stat_activity.
+ * Further Note: PG 9.6 changed what appeared in pg_stat_activity, so the launcher doesn't actually show up. 
+ * we can still test its interactions with its children, but can't test some of the things specific to the launcher. 
+ * So we've added some bits about the version number as needed. 
+ */
+
+CREATE VIEW worker_counts as SELECT count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Launcher') as launcher,
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single') as single_scheduler,
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'single_2') as single_2_scheduler, 
+count(*) filter (WHERE application_name = 'TimescaleDB Background Worker Scheduler' AND datname = 'template1') as template1_scheduler
+FROM pg_stat_activity;
+
+CREATE FUNCTION wait_worker_counts(launcher_ct INTEGER,  scheduler1_ct INTEGER, scheduler2_ct INTEGER, template1_ct INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+r INTEGER;
+BEGIN
+FOR i in 1..10
+LOOP
+SELECT COUNT(*) from worker_counts where (launcher = launcher_ct OR current_setting('server_version_num')::int < 100000) 
+	AND single_scheduler = scheduler1_ct AND single_2_scheduler = scheduler2_ct and template1_scheduler = template1_ct into r;
+if(r < 1) THEN
+  PERFORM pg_sleep(0.1);
+  PERFORM pg_stat_clear_snapshot();
+ELSE
+	--We have the correct counts!
+  RETURN TRUE;
+END IF;
+END LOOP;
+RETURN FALSE;
+END
+$BODY$;

--- a/test/sql/include/bgw_launcher_utils_cleanup.sql
+++ b/test/sql/include/bgw_launcher_utils_cleanup.sql
@@ -1,0 +1,3 @@
+
+DROP FUNCTION wait_worker_counts(integer, integer, integer, integer);
+DROP VIEW worker_counts;


### PR DESCRIPTION
Avoid starting schedulers for template databases as connections to them (including from background workers) mean that they cannot be used as templates. 