### PR TITLE
Fix build on FreeBSD wrt sockets

### DIFF
--- a/src/net/conn_plain.c
+++ b/src/net/conn_plain.c
@@ -4,6 +4,7 @@
 
 #ifndef WIN32
 #include <sys/socket.h>
+#include <sys/time.h>
 #endif
 
 #include "conn_internal.h"

--- a/src/net/conn_plain.c
+++ b/src/net/conn_plain.c
@@ -2,6 +2,10 @@
 #include <postgres.h>
 #include <pg_config.h>
 
+#ifndef WIN32
+#include <sys/socket.h>
+#endif
+
 #include "conn_internal.h"
 #include "conn_plain.h"
 
@@ -25,7 +29,7 @@ plain_connect(Connection *conn, const char *host, const char *servname, int port
 	char		strport[6];
 	struct addrinfo *ainfo,
 				hints = {
-		.ai_family = PF_UNSPEC,
+		.ai_family = AF_UNSPEC,
 		.ai_socktype = SOCK_STREAM,
 	};
 	int			ret;

--- a/src/net/conn_plain.c
+++ b/src/net/conn_plain.c
@@ -1,11 +1,8 @@
 #include <unistd.h>
 #include <postgres.h>
 #include <pg_config.h>
-
-#ifndef WIN32
 #include <sys/socket.h>
 #include <sys/time.h>
-#endif
 
 #include "conn_internal.h"
 #include "conn_plain.h"


### PR DESCRIPTION
AF_UNSPEC is in SUS, postgres uses similar convention.  FreeBSD seems to lack whatever was implicitly importing sys/socket.h, so specify it here for !win32.