### PR TITLE
Fix custom error handling callbacks in scheduler test code

### DIFF
--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -196,7 +196,13 @@ static bool
 test_job_3_long()
 {
 	BackgroundWorkerBlockSignals();
-	prev_signal_func = pqsignal(SIGTERM, log_terminate_signal);
+
+	/*
+	 * Only set prev_signal_func once to prevent it from being set to
+	 * log_terminate_signal.
+	 */
+	if (prev_signal_func == NULL)
+		prev_signal_func = pqsignal(SIGTERM, log_terminate_signal);
 	/* Setup any signal handlers here */
 	BackgroundWorkerUnblockSignals();
 


### PR DESCRIPTION
There was a Valgrind stack overflow bug that occurred occassionally inside the bgw_db_scheduler test.
This led us to identify several places in the scheduler test code in which infinite recursion could occur.
The biggest source of a potential stack overflow is inside the emit_log_hook_callback. In particular, if the
callback encounters an error, the code that throws the error will be trying to write a log message, which
will trigger a call to the log_hook_callback. If this error persists (ie is encountered on every subsequent
call to the callback), then the log_hook_callback will
infinitely loop on itself, thereby causing a stack overflow.

Another potential source of infinite recursion are the static variables, prev_emit_log_hook and
prev_signal_func, that preserve Postgres' default handlers. If the setter functions for these variables
are called more than once (which appears possible in the test code), then they will invariably be
set to our custom callbacks. Because these static variables are functions that are called within
our callback functions, then our callback functions will end up calling themselves ad infinitem.

To eliminate this possibility, I have removed prev_emit_log_hook (emit_log_hook == NULL in Postgres, so
really this was supposed to be a no-op) and made sure prev_signal_func is only set if it is NULL (the first time).