### PR TITLE
Add support for pre-release version checks

### DIFF
--- a/sql/version.sql
+++ b/sql/version.sql
@@ -1,8 +1,13 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
     AS '@MODULE_PATHNAME@', 'get_git_commit' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.get_os_info() RETURNS TABLE(sysname TEXT, version TEXT, release TEXT)
+CREATE OR REPLACE FUNCTION _timescaledb_internal.get_os_info()
+    RETURNS TABLE(sysname TEXT, version TEXT, release TEXT)
     AS '@MODULE_PATHNAME@', 'ts_get_os_info' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.get_version()
+    RETURNS TABLE(major INTEGER, minor INTEGER, patch INTEGER, modtag TEXT)
+    AS '@MODULE_PATHNAME@', 'ts_version_get_info' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION get_telemetry_report() RETURNS TEXT
     AS '@MODULE_PATHNAME@', 'ts_get_telemetry_report' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -22,15 +22,15 @@
 
 typedef struct VersionResult
 {
+	VersionInfo vinfo;
 	const char *versionstr;
-	long		version[3];
 	bool		is_up_to_date;
 	const char *errhint;
 } VersionResult;
 
 HttpRequest *build_version_request(const char *host, const char *path);
 Connection *telemetry_connect(void);
-bool		telemetry_parse_version(const char *json, const long installed_version[3], VersionResult *result);
+bool		telemetry_parse_version(const char *json, VersionInfo *vinfo, VersionResult *result);
 
 /*
  *	This function is intended as the main function for a BGW.

--- a/src/version.c
+++ b/src/version.c
@@ -9,9 +9,151 @@
 #include "compat.h"
 #include "gitcommit.h"
 #include "version.h"
+#include "config.h"
 
 #define STR_EXPAND(x) #x
 #define STR(x) STR_EXPAND(x)
+
+void
+version_get_info(VersionInfo *vinfo)
+{
+	memset(vinfo, 0, sizeof(VersionInfo));
+	vinfo->version[0] = strtol(TIMESCALEDB_MAJOR_VERSION, NULL, 10);
+	vinfo->version[1] = strtol(TIMESCALEDB_MINOR_VERSION, NULL, 10);
+	vinfo->version[2] = strtol(TIMESCALEDB_PATCH_VERSION, NULL, 10);
+
+	if (strlen(TIMESCALEDB_MOD_VERSION) > 0)
+	{
+		StrNCpy(vinfo->version_mod, TIMESCALEDB_MOD_VERSION, sizeof(vinfo->version_mod));
+		vinfo->has_version_mod = true;
+	}
+}
+
+/*
+ * Compare two versions.
+ *
+ * It returns an integer less than, equal to, or greater than zero if version
+ * v1 is found, respectively, to be less than, to match, or be greater than
+ * version v2.
+ */
+int
+version_cmp(VersionInfo *v1, VersionInfo *v2)
+{
+	int			i;
+
+	for (i = 0; i < 3; i++)
+	{
+		if (v1->version[i] > v2->version[i])
+			return 1;
+
+		if (v1->version[i] < v2->version[i])
+			return -1;
+	}
+
+	/*
+	 * Note that the version mod signifies a pre-release version, so having a
+	 * version mod is "less" than not having one with otherwise identical
+	 * versions
+	 */
+	if (v1->has_version_mod && !v2->has_version_mod)
+		return -1;
+
+	if (!v1->has_version_mod && v2->has_version_mod)
+		return 1;
+
+	/* Compare the version mod lexicographically */
+	if (v1->has_version_mod && v2->has_version_mod)
+		return strncmp(v1->version_mod, v2->version_mod, sizeof(v1->version_mod));
+
+	return 0;
+}
+
+#define NUM_VERSION_DELIMS 4
+
+static const char *version_delimiter[NUM_VERSION_DELIMS] = {".", ".", "-", ""};
+
+bool
+version_parse(const char *version, VersionInfo *result)
+{
+	char	   *parse_version = pstrdup(version);
+	int			i;
+
+	memset(result, 0, sizeof(VersionInfo));
+
+	for (i = 0; i < NUM_VERSION_DELIMS; i++)
+	{
+		const char *subversion;
+
+		subversion = strtok(i == 0 ? parse_version : NULL, version_delimiter[i]);
+
+		if (subversion == NULL)
+			return i > 0;
+
+		/*
+		 * If we are past the '-' delimiter, we've found the mod/pre-release
+		 * tag
+		 */
+		if (i > 0 && version_delimiter[i - 1][0] == '-')
+		{
+			int			len = snprintf(result->version_mod, sizeof(result->version_mod) - 1, "%s", subversion);
+
+			if (len > (sizeof(result->version_mod) - 1))
+				return false;
+
+			if (len > 0)
+				result->has_version_mod = true;
+		}
+		else
+		{
+			char	   *endptr;
+
+			result->version[i] = strtol(subversion, &endptr, 10);
+
+			/*
+			 * We expect the parsing of the version num to end at a '\0' since
+			 * strtok() should have replaced the delimiter with a '\0' if the
+			 * delimiter was found
+			 */
+			if (endptr != NULL && *endptr != '\0')
+				return false;
+		}
+	}
+
+	return true;
+}
+
+TS_FUNCTION_INFO_V1(ts_version_get_info);
+
+Datum
+ts_version_get_info(PG_FUNCTION_ARGS)
+{
+	VersionInfo info;
+	TupleDesc	tupdesc;
+	Datum		values[4];
+	bool		nulls[4] = {false};
+	HeapTuple	tuple;
+
+	version_get_info(&info);
+
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("function returning record called in context "
+						"that cannot accept type record")));
+
+	values[0] = Int32GetDatum((int32) info.version[0]);
+	values[1] = Int32GetDatum((int32) info.version[1]);
+	values[2] = Int32GetDatum((int32) info.version[2]);
+
+	if (info.has_version_mod)
+		values[3] = CStringGetTextDatum(info.version_mod);
+	else
+		nulls[3] = true;
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+
+	return HeapTupleGetDatum(tuple);
+}
 
 const char *git_commit = STR(EXT_GIT_COMMIT);
 
@@ -59,9 +201,9 @@ version_get_os_info(VersionOSInfo *info)
 	if (!VerQueryValueA(buffer, TEXT("\\"), &vinfo, &vinfo_len))
 		goto error;
 
-	snprintf(info->sysname, VERSION_OS_INFO_LEN - 1, "Windows");
-	snprintf(info->version, VERSION_OS_INFO_LEN - 1, "%u", HIWORD(vinfo->dwProductVersionMS));
-	snprintf(info->release, VERSION_OS_INFO_LEN - 1, "%u", LOWORD(vinfo->dwProductVersionMS));
+	snprintf(info->sysname, VERSION_INFO_LEN - 1, "Windows");
+	snprintf(info->version, VERSION_INFO_LEN - 1, "%u", HIWORD(vinfo->dwProductVersionMS));
+	snprintf(info->release, VERSION_INFO_LEN - 1, "%u", LOWORD(vinfo->dwProductVersionMS));
 
 	pfree(buffer);
 
@@ -85,9 +227,9 @@ version_get_os_info(VersionOSInfo *info)
 	uname(&os_info);
 
 	memset(info, 0, sizeof(VersionOSInfo));
-	strncpy(info->sysname, os_info.sysname, VERSION_OS_INFO_LEN - 1);
-	strncpy(info->version, os_info.version, VERSION_OS_INFO_LEN - 1);
-	strncpy(info->release, os_info.release, VERSION_OS_INFO_LEN - 1);
+	strncpy(info->sysname, os_info.sysname, VERSION_INFO_LEN - 1);
+	strncpy(info->version, os_info.version, VERSION_INFO_LEN - 1);
+	strncpy(info->release, os_info.release, VERSION_INFO_LEN - 1);
 
 	return true;
 }

--- a/src/version.h
+++ b/src/version.h
@@ -1,14 +1,27 @@
 #ifndef TIMESCALEDB_VERSION_H
 #define TIMESCALEDB_VERSION_H
 
-#define VERSION_OS_INFO_LEN 128
+#include <postgres.h>
+
+#define VERSION_INFO_LEN 128
+
+typedef struct VersionInfo
+{
+	long		version[3];
+	char		version_mod[VERSION_INFO_LEN];
+	bool		has_version_mod;
+} VersionInfo;
 
 typedef struct VersionOSInfo
 {
-	char		sysname[VERSION_OS_INFO_LEN];
-	char		version[VERSION_OS_INFO_LEN];
-	char		release[VERSION_OS_INFO_LEN];
+	char		sysname[VERSION_INFO_LEN];
+	char		version[VERSION_INFO_LEN];
+	char		release[VERSION_INFO_LEN];
 } VersionOSInfo;
+
+extern void version_get_info(VersionInfo *vinfo);
+extern int	version_cmp(VersionInfo *v1, VersionInfo *v2);
+extern bool version_parse(const char *version, VersionInfo *result);
 
 extern bool version_get_os_info(VersionOSInfo *info);
 

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -87,7 +87,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   108
+   109
 (1 row)
 
 SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');
@@ -283,7 +283,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-   108
+   109
 (1 row)
 
 --main table and chunk schemas should be the same

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -5,9 +5,9 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_status_ssl(int) RETURNS JS
     AS :MODULE_PATHNAME, 'test_status_ssl' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_status_mock(text) RETURNS JSONB
     AS :MODULE_PATHNAME, 'test_status_mock' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_parse_version(response text, installed_major int, installed_minor int, installed_patch int)
-    RETURNS TABLE(version_string text, major int, minor int, patch int, up_to_date bool)
-    AS :MODULE_PATHNAME, 'test_telemetry_parse_version' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_parse_version(response text, installed_major int, installed_minor int, installed_patch int, installed_modtag text = NULL)
+    RETURNS TABLE(version_string text, major int, minor int, patch int, modtag text, up_to_date bool)
+    AS :MODULE_PATHNAME, 'test_telemetry_parse_version' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry(host text = NULL, servname text = NULL, port int = NULL) RETURNS JSONB AS :MODULE_PATHNAME, 'test_telemetry' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 \c single :ROLE_DEFAULT_PERM_USER
 SELECT _timescaledb_internal.test_status_ssl(200);
@@ -148,48 +148,114 @@ ERROR:  could not parse HTTP response
 \set ON_ERROR_STOP 1
 -- Test parsing version response
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"status": "200", "current_timescaledb_version": "10.1.0"}', 10, 1, 0);
- version_string | major | minor | patch | up_to_date 
-----------------+-------+-------+-------+------------
- 10.1.0         |    10 |     1 |     0 | t
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 10.1.0         |    10 |     1 |     0 |        | t
 (1 row)
 
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10.1"}', 10, 1, 0);
- version_string | major | minor | patch | up_to_date 
-----------------+-------+-------+-------+------------
- 10.1           |    10 |     1 |     0 | t
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 10.1           |    10 |     1 |     0 |        | t
 (1 row)
 
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10"}', 10, 1, 0);
- version_string | major | minor | patch | up_to_date 
-----------------+-------+-------+-------+------------
- 10             |    10 |     0 |     0 | t
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 10             |    10 |     0 |     0 |        | t
 (1 row)
 
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10"}', 9, 1, 1);
- version_string | major | minor | patch | up_to_date 
-----------------+-------+-------+-------+------------
- 10             |    10 |     0 |     0 | f
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 10             |    10 |     0 |     0 |        | f
 (1 row)
 
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "9.2.0"}', 9, 1, 1);
- version_string | major | minor | patch | up_to_date 
-----------------+-------+-------+-------+------------
- 9.2.0          |     9 |     2 |     0 | f
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 9.2.0          |     9 |     2 |     0 |        | f
 (1 row)
 
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "9.1.2"}', 9, 1, 1);
- version_string | major | minor | patch | up_to_date 
-----------------+-------+-------+-------+------------
- 9.1.2          |     9 |     1 |     2 | f
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 9.1.2          |     9 |     1 |     2 |        | f
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0"}', 1, 0, 0, 'rc1');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0          |     1 |     0 |     0 |        | f
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'rc1');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-rc1      |     1 |     0 |     0 | rc1    | t
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'rc2');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-rc1      |     1 |     0 |     0 | rc1    | t
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc2"}', 1, 0, 0, 'rc1');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-rc2      |     1 |     0 |     0 | rc2    | f
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'alpha');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-rc1      |     1 |     0 |     0 | rc1    | f
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-alpha"}', 1, 0, 0, 'rc1');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-alpha    |     1 |     0 |     0 | alpha  | t
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 1, 'rc1');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-rc1      |     1 |     0 |     0 | rc1    | t
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'beta');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-rc1      |     1 |     0 |     0 | rc1    | f
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-alpha"}', 1, 0, 0, 'beta');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-alpha    |     1 |     0 |     0 | alpha  | t
+(1 row)
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-alpha1"}', 1, 0, 0, 'alpha2');
+ version_string | major | minor | patch | modtag | up_to_date 
+----------------+-------+-------+-------+--------+------------
+ 1.0.0-alpha1   |     1 |     0 |     0 | alpha1 | t
 (1 row)
 
 \set ON_ERROR_STOP 0
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": " 10 "}', 10, 1, 0);
-ERROR:  could not parse version string
+ERROR:  parsing failed for version string " 10 "
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "a"}', 9, 1, 1);
-ERROR:  could not parse version string
+ERROR:  parsing failed for version string "a"
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "a.b.c"}', 9, 1, 1);
-ERROR:  could not parse version string
+ERROR:  parsing failed for version string "a.b.c"
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10.1.1a"}', 9, 1, 1);
-ERROR:  could not parse version string
+ERROR:  parsing failed for version string "10.1.1a"
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10.1.1+rc1"}', 10, 1, 1, 'rc1');
+ERROR:  parsing failed for version string "10.1.1+rc1"
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10.1.1.1"}', 10, 1, 1, 'rc1');
+ERROR:  parsing failed for version string "10.1.1.1"
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"}', 1, 0, 0, 'alpha2');
+ERROR:  parsing failed for version string "1.0.0-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 \set ON_ERROR_STOP 1

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -5,9 +5,9 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_status_ssl(int) RETURNS JS
     AS :MODULE_PATHNAME, 'test_status_ssl' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_status_mock(text) RETURNS JSONB
     AS :MODULE_PATHNAME, 'test_status_mock' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_parse_version(response text, installed_major int, installed_minor int, installed_patch int)
-    RETURNS TABLE(version_string text, major int, minor int, patch int, up_to_date bool)
-    AS :MODULE_PATHNAME, 'test_telemetry_parse_version' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_parse_version(response text, installed_major int, installed_minor int, installed_patch int, installed_modtag text = NULL)
+    RETURNS TABLE(version_string text, major int, minor int, patch int, modtag text, up_to_date bool)
+    AS :MODULE_PATHNAME, 'test_telemetry_parse_version' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry(host text = NULL, servname text = NULL, port int = NULL) RETURNS JSONB AS :MODULE_PATHNAME, 'test_telemetry' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 \c single :ROLE_DEFAULT_PERM_USER
@@ -93,10 +93,25 @@ SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_time
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10"}', 9, 1, 1);
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "9.2.0"}', 9, 1, 1);
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "9.1.2"}', 9, 1, 1);
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0"}', 1, 0, 0, 'rc1');
+
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'rc1');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'rc2');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc2"}', 1, 0, 0, 'rc1');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'alpha');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-alpha"}', 1, 0, 0, 'rc1');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 1, 'rc1');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-rc1"}', 1, 0, 0, 'beta');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-alpha"}', 1, 0, 0, 'beta');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-alpha1"}', 1, 0, 0, 'alpha2');
 
 \set ON_ERROR_STOP 0
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": " 10 "}', 10, 1, 0);
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "a"}', 9, 1, 1);
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "a.b.c"}', 9, 1, 1);
 SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10.1.1a"}', 9, 1, 1);
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10.1.1+rc1"}', 10, 1, 1, 'rc1');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "10.1.1.1"}', 10, 1, 1, 'rc1');
+SELECT * FROM _timescaledb_internal.test_telemetry_parse_version('{"current_timescaledb_version": "1.0.0-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"}', 1, 0, 0, 'alpha2');
+
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
Version checks fail on pre-release versions (e.g., `1.0.0-rc1`) since
the version parsing didn't expect a pre-release tag at the end.

This change adds support for pre-release tags, using lexicographical
comparison in case of pre-release tags. Note that having a pre-release
tag vs not having one makes the version strictly "smaller", given
otherwise identical versions.