### PR TITLE
Make sure DB schedulers are not decremented if they were never increm…

### DIFF
--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -206,19 +206,6 @@ select wait_equals(:'orig_backend_start');
  t
 (1 row)
 
-/*Make sure restart works from stopped worker state*/
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-SELECT wait_worker_counts(1,0,0,0);
- wait_worker_counts 
---------------------
- t
-(1 row)
-
 SELECT _timescaledb_internal.restart_background_workers();
  restart_background_workers 
 ----------------------------

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -89,9 +89,6 @@ END
 $BODY$;
 select wait_equals(:'orig_backend_start');
 
-/*Make sure restart works from stopped worker state*/
-SELECT _timescaledb_internal.stop_background_workers();
-SELECT wait_worker_counts(1,0,0,0);
 SELECT _timescaledb_internal.restart_background_workers();
 SELECT wait_worker_counts(1,0,1,0);
 


### PR DESCRIPTION
…ented

Previously, accounting for BGWs assigned to DB schedulers was incorrect, because NULL scheduler handlers were translating to BGW_STOPPED. This caused the accounter to decrement BGW_counter despite the counter never being incremented. We fix this by adding an explicit incremented boolean to each scheduler in the hash table. Also did some cleanup with respect to the message-handling functions.