### PR TITLE
Fix ordering of vacuum test output take 2

### DIFF
--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -16,14 +16,14 @@ INSERT INTO vacuum_test VALUES ('2017-01-20T16:00:01', 17.5),
 -- no stats
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
  tablename | attname | histogram_bounds | n_distinct 
 -----------+---------+------------------+------------
 (0 rows)
 
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
  tablename | attname | histogram_bounds | n_distinct 
 -----------+---------+------------------+------------
 (0 rows)
@@ -56,25 +56,25 @@ INFO:  "_hyper_1_3_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 de
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
     tablename     | attname |                    histogram_bounds                     | n_distinct 
 ------------------+---------+---------------------------------------------------------+------------
- _hyper_1_1_chunk | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017"} |         -1
  _hyper_1_1_chunk | temp    | {17.5,19.1}                                             |         -1
- _hyper_1_2_chunk | time    | {"Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017"} |         -1
  _hyper_1_2_chunk | temp    | {17.1,89.5}                                             |         -1
- _hyper_1_3_chunk | time    | {"Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
  _hyper_1_3_chunk | temp    | {11,18.5}                                               |         -1
+ _hyper_1_1_chunk | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017"} |         -1
+ _hyper_1_2_chunk | time    | {"Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017"} |         -1
+ _hyper_1_3_chunk | time    | {"Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
 (6 rows)
 
 -- stats should exist on parent hypertable
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
   tablename  | attname |                                                                          histogram_bounds                                                                           | n_distinct 
 -------------+---------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------
- vacuum_test | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017","Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017","Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
  vacuum_test | temp    | {11,17.1,17.5,18.5,19.1,89.5}                                                                                                                                       |         -1
+ vacuum_test | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017","Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017","Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
 (2 rows)
 
 DROP TABLE vacuum_test;
@@ -96,14 +96,14 @@ INSERT INTO analyze_test VALUES ('2017-01-20T16:00:01', 17.5),
 -- no stats
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
  tablename | attname | histogram_bounds | n_distinct 
 -----------+---------+------------------+------------
 (0 rows)
 
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
  tablename | attname | histogram_bounds | n_distinct 
 -----------+---------+------------------+------------
 (0 rows)
@@ -124,25 +124,25 @@ INFO:  "_hyper_2_6_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 de
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
     tablename     | attname |                    histogram_bounds                     | n_distinct 
 ------------------+---------+---------------------------------------------------------+------------
- _hyper_2_4_chunk | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017"} |         -1
  _hyper_2_4_chunk | temp    | {17.5,19.1}                                             |         -1
- _hyper_2_5_chunk | time    | {"Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017"} |         -1
  _hyper_2_5_chunk | temp    | {17.1,89.5}                                             |         -1
- _hyper_2_6_chunk | time    | {"Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
  _hyper_2_6_chunk | temp    | {11,18.5}                                               |         -1
+ _hyper_2_4_chunk | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017"} |         -1
+ _hyper_2_5_chunk | time    | {"Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017"} |         -1
+ _hyper_2_6_chunk | time    | {"Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
 (6 rows)
 
 -- stats should exist on parent hypertable
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
   tablename   | attname |                                                                          histogram_bounds                                                                           | n_distinct 
 --------------+---------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------
- analyze_test | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017","Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017","Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
  analyze_test | temp    | {11,17.1,17.5,18.5,19.1,89.5}                                                                                                                                       |         -1
+ analyze_test | time    | {"Fri Jan 20 16:00:01 2017","Sat Jan 21 16:00:01 2017","Thu Apr 20 16:00:01 2017","Fri Apr 21 16:00:01 2017","Tue Jun 20 16:00:01 2017","Wed Jun 21 16:00:01 2017"} |         -1
 (2 rows)
 
 -- Run vacuum on a normal (non-hypertable) table

--- a/test/sql/vacuum.sql
+++ b/test/sql/vacuum.sql
@@ -13,23 +13,23 @@ INSERT INTO vacuum_test VALUES ('2017-01-20T16:00:01', 17.5),
 -- no stats
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 VACUUM (VERBOSE, ANALYZE) vacuum_test;
 
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 -- stats should exist on parent hypertable
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 DROP TABLE vacuum_test;
 
@@ -48,23 +48,23 @@ INSERT INTO analyze_test VALUES ('2017-01-20T16:00:01', 17.5),
 -- no stats
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 ANALYZE VERBOSE analyze_test;
 
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 -- stats should exist on parent hypertable
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'analyze_test'
-ORDER BY schemaname, tablename, array_dims(histogram_bounds);
+ORDER BY attname, tablename, array_dims(histogram_bounds);
 
 -- Run vacuum on a normal (non-hypertable) table
 CREATE TABLE vacuum_norm(time timestamp, temp float);


### PR DESCRIPTION
Even after the last fix, vacuum still gives the wrong order on
EXEC_BACKEND. We're going to order based on every field we have, if this
doesn't work something is wrong.