### PR TITLE
Fix adaptive chunking so it chooses correct index

### DIFF
--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -342,6 +342,112 @@ SELECT * FROM chunk_relation_size('test_adaptive_no_index');
        38 | _timescaledb_internal._hyper_3_38_chunk | {time}               | {"timestamp with time zone"} | {NULL}                      | {"[1488770158695935,1491085508864980)"} |       90112 |           0 |             |       90112
 (16 rows)
 
+-- Test added to check that the correct index (i.e. time index) is being used
+-- to find the min and max. Previously a bug selected the first index listed,
+-- which in this case is location rather than time and therefore could return
+-- the wrong min and max if items at the start and end of the index did not have
+-- the correct min and max timestamps.
+--
+-- In this test, we create chunks with a lot of locations with only one reading
+-- that is at the beginning of the time frame, and then one location in the middle
+-- of the range that has two readings, one that is the same as the others and one
+-- that is larger. The algorithm should use these two readings for min & max; however,
+-- if it's broken (as it was before), it would choose just the reading that is common
+-- to all the locations.
+CREATE TABLE test_adaptive_correct_index(time timestamptz, temp float, location int);
+SELECT create_hypertable('test_adaptive_correct_index', 'time',
+                         chunk_target_size => '100MB',
+                         chunk_time_interval => 86400000000,
+                         create_default_indexes => false);
+WARNING:  no index on "time" found for adaptive chunking on hypertable "test_adaptive_correct_index"
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+CREATE INDEX ON test_adaptive_correct_index(location);
+CREATE INDEX ON test_adaptive_correct_index(time DESC);
+-- First chunk
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-01T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(1, 1000) as val;
+INSERT INTO test_adaptive_correct_index
+SELECT time, 0.0, '1500' FROM
+generate_series('2018-01-01T00:00:00+00'::timestamptz,
+                '2018-01-01T20:00:00+00'::timestamptz,
+                '10 hours') as time;
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-01T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(2001, 3000) as val;
+-- Second chunk
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-02T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(1, 1000) as val;
+INSERT INTO test_adaptive_correct_index
+SELECT time, 0.0, '1500' FROM
+generate_series('2018-01-02T00:00:00+00'::timestamptz,
+                '2018-01-02T20:00:00+00'::timestamptz,
+                '10 hours') as time;
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-02T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(2001, 3000) as val;
+-- Third chunk
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-03T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(1, 1000) as val;
+INSERT INTO test_adaptive_correct_index
+SELECT time, 0.0, '1500' FROM
+generate_series('2018-01-03T00:00:00+00'::timestamptz,
+                '2018-01-03T20:00:00+00'::timestamptz,
+                '10 hours') as time;
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-03T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(2001, 3000) as val;
+-- This should be the start of the fourth chunk
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-04T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(1, 1000) as val;
+INSERT INTO test_adaptive_correct_index
+SELECT time, 0.0, '1500' FROM
+generate_series('2018-01-04T00:00:00+00'::timestamptz,
+                '2018-01-04T20:00:00+00'::timestamptz,
+                '10 hours') as time;
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-04T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(2001, 3000) as val;
+-- If working correctly, this goes in the 4th chunk, otherwise its a separate 5th chunk
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-05T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(1, 1000) as val;
+INSERT INTO test_adaptive_correct_index
+SELECT time, 0.0, '1500' FROM
+generate_series('2018-01-05T00:00:00+00'::timestamptz,
+                '2018-01-05T20:00:00+00'::timestamptz,
+                '10 hours') as time;
+INSERT INTO test_adaptive_correct_index
+SELECT '2018-01-05T00:00:00+00'::timestamptz, val, val + 1 FROM
+generate_series(2001, 3000) as val;
+-- This should show 4 chunks, rather than 5
+SELECT COUNT(*) FROM chunk_relation_size_pretty('test_adaptive_correct_index');
+ count 
+-------
+     4
+(1 row)
+
+-- The interval_length should no longer be 86400000000 for our hypertable, so 3rd column so be true.
+-- Note: the exact interval_length is non-deterministic, so we can't use its actual value for tests
+SELECT id, hypertable_id, interval_length > 86400000000 FROM _timescaledb_catalog.dimension;
+ id | hypertable_id | ?column? 
+----+---------------+----------
+  2 |             2 | t
+  3 |             3 | t
+  4 |             4 | t
+(3 rows)
+
+-- Drop because it's size and estimated chunk_interval is non-deterministic so
+-- we don't want to make other tests flaky.
+DROP TABLE test_adaptive_correct_index;
 -- Test with space partitioning. This might affect the estimation
 -- since there are more chunks in the same time interval and space
 -- chunks might be unevenly filled.
@@ -361,8 +467,8 @@ SELECT id, hypertable_id, interval_length FROM _timescaledb_catalog.dimension;
 ----+---------------+-----------------
   2 |             2 |   1317108710139
   3 |             3 |   2315350169045
-  4 |             4 |     86400000000
-  5 |             4 |                
+  5 |             5 |     86400000000
+  6 |             5 |                
 (4 rows)
 
 INSERT INTO test_adaptive_space
@@ -373,44 +479,44 @@ generate_series('2017-03-07T18:18:03+00'::timestamptz - interval '175 days',
 SELECT * FROM chunk_relation_size('test_adaptive_space');
  chunk_id |               chunk_table               | partitioning_columns |      partitioning_column_types       |           partitioning_hash_functions           |                                   ranges                                    | table_bytes | index_bytes | toast_bytes | total_bytes 
 ----------+-----------------------------------------+----------------------+--------------------------------------+-------------------------------------------------+-----------------------------------------------------------------------------+-------------+-------------+-------------+-------------
-       39 | _timescaledb_internal._hyper_4_39_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473724800000000,1473811200000000)","[-9223372036854775808,1073741823)"} |        8192 |       32768 |             |       40960
-       40 | _timescaledb_internal._hyper_4_40_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473724800000000,1473811200000000)","[1073741823,9223372036854775807)"}  |        8192 |       32768 |             |       40960
-       41 | _timescaledb_internal._hyper_4_41_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473811200000000,1473897600000000)","[-9223372036854775808,1073741823)"} |       49152 |       57344 |             |      106496
-       42 | _timescaledb_internal._hyper_4_42_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473811200000000,1473897600000000)","[1073741823,9223372036854775807)"}  |       49152 |       57344 |             |      106496
-       43 | _timescaledb_internal._hyper_4_43_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473897600000000,1473965271473760)","[1073741823,9223372036854775807)"}  |       40960 |       49152 |             |       90112
-       44 | _timescaledb_internal._hyper_4_44_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473897600000000,1473965271473760)","[-9223372036854775808,1073741823)"} |       40960 |       32768 |             |       73728
-       45 | _timescaledb_internal._hyper_4_45_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473965271473760,1474105249182352)","[1073741823,9223372036854775807)"}  |       57344 |       81920 |             |      139264
-       46 | _timescaledb_internal._hyper_4_46_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473965271473760,1474105249182352)","[-9223372036854775808,1073741823)"} |       57344 |       81920 |             |      139264
-       47 | _timescaledb_internal._hyper_4_47_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474105249182352,1474245226890944)","[1073741823,9223372036854775807)"}  |       57344 |       81920 |             |      139264
-       48 | _timescaledb_internal._hyper_4_48_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474105249182352,1474245226890944)","[-9223372036854775808,1073741823)"} |       57344 |       81920 |             |      139264
-       49 | _timescaledb_internal._hyper_4_49_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474245226890944,1474256155676760)","[1073741823,9223372036854775807)"}  |        8192 |       32768 |             |       40960
-       50 | _timescaledb_internal._hyper_4_50_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474245226890944,1474256155676760)","[-9223372036854775808,1073741823)"} |        8192 |       32768 |             |       40960
-       51 | _timescaledb_internal._hyper_4_51_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474256155676760,1474422400168830)","[-9223372036854775808,1073741823)"} |       65536 |      106496 |             |      172032
-       52 | _timescaledb_internal._hyper_4_52_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474256155676760,1474422400168830)","[1073741823,9223372036854775807)"}  |       65536 |       90112 |             |      155648
-       53 | _timescaledb_internal._hyper_4_53_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474422400168830,1474970056929824)","[1073741823,9223372036854775807)"}  |      147456 |      196608 |             |      344064
-       54 | _timescaledb_internal._hyper_4_54_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474422400168830,1474970056929824)","[-9223372036854775808,1073741823)"} |      147456 |      221184 |             |      368640
-       55 | _timescaledb_internal._hyper_4_55_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474970056929824,1475036924131296)","[1073741823,9223372036854775807)"}  |       40960 |       32768 |             |       73728
-       56 | _timescaledb_internal._hyper_4_56_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474970056929824,1475036924131296)","[-9223372036854775808,1073741823)"} |       40960 |       32768 |             |       73728
-       57 | _timescaledb_internal._hyper_4_57_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1475036924131296,1476449794748280)","[1073741823,9223372036854775807)"}  |      335872 |      532480 |             |      868352
-       58 | _timescaledb_internal._hyper_4_58_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1475036924131296,1476449794748280)","[-9223372036854775808,1073741823)"} |      327680 |      532480 |             |      860160
-       59 | _timescaledb_internal._hyper_4_59_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476449794748280,1476912838462752)","[1073741823,9223372036854775807)"}  |      131072 |      180224 |             |      311296
-       60 | _timescaledb_internal._hyper_4_60_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476449794748280,1476912838462752)","[-9223372036854775808,1073741823)"} |      131072 |      180224 |             |      311296
-       61 | _timescaledb_internal._hyper_4_61_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476912838462752,1478576028596156)","[-9223372036854775808,1073741823)"} |      393216 |      581632 |             |      974848
-       62 | _timescaledb_internal._hyper_4_62_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476912838462752,1478576028596156)","[1073741823,9223372036854775807)"}  |      393216 |      581632 |             |      974848
-       63 | _timescaledb_internal._hyper_4_63_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1478576028596156,1480239218729560)","[1073741823,9223372036854775807)"}  |      385024 |      589824 |             |      974848
-       64 | _timescaledb_internal._hyper_4_64_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1478576028596156,1480239218729560)","[-9223372036854775808,1073741823)"} |      393216 |      589824 |             |      983040
-       65 | _timescaledb_internal._hyper_4_65_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1480239218729560,1481902408862964)","[-9223372036854775808,1073741823)"} |      393216 |      598016 |             |      991232
-       66 | _timescaledb_internal._hyper_4_66_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1480239218729560,1481902408862964)","[1073741823,9223372036854775807)"}  |      393216 |      606208 |             |      999424
-       67 | _timescaledb_internal._hyper_4_67_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1481902408862964,1483565598996368)","[-9223372036854775808,1073741823)"} |      385024 |      589824 |             |      974848
-       68 | _timescaledb_internal._hyper_4_68_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1481902408862964,1483565598996368)","[1073741823,9223372036854775807)"}  |      393216 |      589824 |             |      983040
-       69 | _timescaledb_internal._hyper_4_69_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1483565598996368,1485228789129772)","[-9223372036854775808,1073741823)"} |      393216 |      598016 |             |      991232
-       70 | _timescaledb_internal._hyper_4_70_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1483565598996368,1485228789129772)","[1073741823,9223372036854775807)"}  |      393216 |      589824 |             |      983040
-       71 | _timescaledb_internal._hyper_4_71_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1485228789129772,1486891979263176)","[-9223372036854775808,1073741823)"} |      393216 |      606208 |             |      999424
-       72 | _timescaledb_internal._hyper_4_72_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1485228789129772,1486891979263176)","[1073741823,9223372036854775807)"}  |      385024 |      598016 |             |      983040
-       73 | _timescaledb_internal._hyper_4_73_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1486891979263176,1488555169396580)","[-9223372036854775808,1073741823)"} |      393216 |      598016 |             |      991232
-       74 | _timescaledb_internal._hyper_4_74_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1486891979263176,1488555169396580)","[1073741823,9223372036854775807)"}  |      385024 |      581632 |             |      966656
-       75 | _timescaledb_internal._hyper_4_75_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1488555169396580,1490218359529984)","[1073741823,9223372036854775807)"}  |      106496 |      163840 |             |      270336
-       76 | _timescaledb_internal._hyper_4_76_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1488555169396580,1490218359529984)","[-9223372036854775808,1073741823)"} |      106496 |      155648 |             |      262144
+       43 | _timescaledb_internal._hyper_5_43_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473724800000000,1473811200000000)","[-9223372036854775808,1073741823)"} |        8192 |       32768 |             |       40960
+       44 | _timescaledb_internal._hyper_5_44_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473724800000000,1473811200000000)","[1073741823,9223372036854775807)"}  |        8192 |       32768 |             |       40960
+       45 | _timescaledb_internal._hyper_5_45_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473811200000000,1473897600000000)","[-9223372036854775808,1073741823)"} |       49152 |       57344 |             |      106496
+       46 | _timescaledb_internal._hyper_5_46_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473811200000000,1473897600000000)","[1073741823,9223372036854775807)"}  |       49152 |       57344 |             |      106496
+       47 | _timescaledb_internal._hyper_5_47_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473897600000000,1473965271473760)","[1073741823,9223372036854775807)"}  |       40960 |       49152 |             |       90112
+       48 | _timescaledb_internal._hyper_5_48_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473897600000000,1473965271473760)","[-9223372036854775808,1073741823)"} |       40960 |       32768 |             |       73728
+       49 | _timescaledb_internal._hyper_5_49_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473965271473760,1474105249182352)","[1073741823,9223372036854775807)"}  |       57344 |       81920 |             |      139264
+       50 | _timescaledb_internal._hyper_5_50_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1473965271473760,1474105249182352)","[-9223372036854775808,1073741823)"} |       57344 |       81920 |             |      139264
+       51 | _timescaledb_internal._hyper_5_51_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474105249182352,1474245226890944)","[1073741823,9223372036854775807)"}  |       57344 |       81920 |             |      139264
+       52 | _timescaledb_internal._hyper_5_52_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474105249182352,1474245226890944)","[-9223372036854775808,1073741823)"} |       57344 |       81920 |             |      139264
+       53 | _timescaledb_internal._hyper_5_53_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474245226890944,1474256155676760)","[1073741823,9223372036854775807)"}  |        8192 |       32768 |             |       40960
+       54 | _timescaledb_internal._hyper_5_54_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474245226890944,1474256155676760)","[-9223372036854775808,1073741823)"} |        8192 |       32768 |             |       40960
+       55 | _timescaledb_internal._hyper_5_55_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474256155676760,1474422400168830)","[-9223372036854775808,1073741823)"} |       65536 |      106496 |             |      172032
+       56 | _timescaledb_internal._hyper_5_56_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474256155676760,1474422400168830)","[1073741823,9223372036854775807)"}  |       65536 |       90112 |             |      155648
+       57 | _timescaledb_internal._hyper_5_57_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474422400168830,1474970056929824)","[1073741823,9223372036854775807)"}  |      147456 |      196608 |             |      344064
+       58 | _timescaledb_internal._hyper_5_58_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474422400168830,1474970056929824)","[-9223372036854775808,1073741823)"} |      147456 |      221184 |             |      368640
+       59 | _timescaledb_internal._hyper_5_59_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474970056929824,1475036924131296)","[1073741823,9223372036854775807)"}  |       40960 |       32768 |             |       73728
+       60 | _timescaledb_internal._hyper_5_60_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1474970056929824,1475036924131296)","[-9223372036854775808,1073741823)"} |       40960 |       32768 |             |       73728
+       61 | _timescaledb_internal._hyper_5_61_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1475036924131296,1476449794748280)","[1073741823,9223372036854775807)"}  |      335872 |      532480 |             |      868352
+       62 | _timescaledb_internal._hyper_5_62_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1475036924131296,1476449794748280)","[-9223372036854775808,1073741823)"} |      327680 |      532480 |             |      860160
+       63 | _timescaledb_internal._hyper_5_63_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476449794748280,1476912838462752)","[1073741823,9223372036854775807)"}  |      131072 |      180224 |             |      311296
+       64 | _timescaledb_internal._hyper_5_64_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476449794748280,1476912838462752)","[-9223372036854775808,1073741823)"} |      131072 |      180224 |             |      311296
+       65 | _timescaledb_internal._hyper_5_65_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476912838462752,1478576028596156)","[-9223372036854775808,1073741823)"} |      393216 |      581632 |             |      974848
+       66 | _timescaledb_internal._hyper_5_66_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1476912838462752,1478576028596156)","[1073741823,9223372036854775807)"}  |      393216 |      581632 |             |      974848
+       67 | _timescaledb_internal._hyper_5_67_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1478576028596156,1480239218729560)","[1073741823,9223372036854775807)"}  |      385024 |      589824 |             |      974848
+       68 | _timescaledb_internal._hyper_5_68_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1478576028596156,1480239218729560)","[-9223372036854775808,1073741823)"} |      393216 |      589824 |             |      983040
+       69 | _timescaledb_internal._hyper_5_69_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1480239218729560,1481902408862964)","[-9223372036854775808,1073741823)"} |      393216 |      598016 |             |      991232
+       70 | _timescaledb_internal._hyper_5_70_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1480239218729560,1481902408862964)","[1073741823,9223372036854775807)"}  |      393216 |      606208 |             |      999424
+       71 | _timescaledb_internal._hyper_5_71_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1481902408862964,1483565598996368)","[-9223372036854775808,1073741823)"} |      385024 |      589824 |             |      974848
+       72 | _timescaledb_internal._hyper_5_72_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1481902408862964,1483565598996368)","[1073741823,9223372036854775807)"}  |      393216 |      589824 |             |      983040
+       73 | _timescaledb_internal._hyper_5_73_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1483565598996368,1485228789129772)","[-9223372036854775808,1073741823)"} |      393216 |      598016 |             |      991232
+       74 | _timescaledb_internal._hyper_5_74_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1483565598996368,1485228789129772)","[1073741823,9223372036854775807)"}  |      393216 |      589824 |             |      983040
+       75 | _timescaledb_internal._hyper_5_75_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1485228789129772,1486891979263176)","[-9223372036854775808,1073741823)"} |      393216 |      606208 |             |      999424
+       76 | _timescaledb_internal._hyper_5_76_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1485228789129772,1486891979263176)","[1073741823,9223372036854775807)"}  |      385024 |      598016 |             |      983040
+       77 | _timescaledb_internal._hyper_5_77_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1486891979263176,1488555169396580)","[-9223372036854775808,1073741823)"} |      393216 |      598016 |             |      991232
+       78 | _timescaledb_internal._hyper_5_78_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1486891979263176,1488555169396580)","[1073741823,9223372036854775807)"}  |      385024 |      581632 |             |      966656
+       79 | _timescaledb_internal._hyper_5_79_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1488555169396580,1490218359529984)","[1073741823,9223372036854775807)"}  |      106496 |      163840 |             |      270336
+       80 | _timescaledb_internal._hyper_5_80_chunk | {time,location}      | {"timestamp with time zone",integer} | {NULL,_timescaledb_internal.get_partition_hash} | {"[1488555169396580,1490218359529984)","[-9223372036854775808,1073741823)"} |      106496 |      155648 |             |      262144
 (38 rows)
 
 SELECT id, hypertable_id, interval_length FROM _timescaledb_catalog.dimension;
@@ -418,7 +524,7 @@ SELECT id, hypertable_id, interval_length FROM _timescaledb_catalog.dimension;
 ----+---------------+-----------------
   2 |             2 |   1317108710139
   3 |             3 |   2315350169045
-  5 |             4 |                
-  4 |             4 |   1663190133404
+  6 |             5 |                
+  5 |             5 |   1663190133404
 (4 rows)
 


### PR DESCRIPTION
Previously we did not check that the type of the index was correct
so it would usually take the first default index, which actually
did not give the correct results for min and max and thus caused
adaptive chunking to potentially not work well.