### PR TITLE
Give a helpful build warning when Postgres does not have OpenSSL enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,12 +265,21 @@ endif (PGINDENT)
 
 option(USE_OPENSSL "Enable use of OpenSSL if available" ON)
 
+# Check if PostgreSQL has OpenSSL enabled.
+# Right now, a Postgres header will redefine an OpenSSL function if Postgres is not installed --with-openssl,
+# so in order for TimescaleDB to compile correctly with OpenSSL, Postgres must also have OpenSSL enabled.
+file(STRINGS ${PG_INCLUDEDIR}/pg_config.h PG_USE_OPENSSL REGEX "#define USE_OPENSSL [01]")
+
+if (USE_OPENSSL AND (NOT PG_USE_OPENSSL))
+    message(FATAL_ERROR "PostgreSQL was built without OpenSSL support, which TimescaleDB needs for full compatibility. Please rebuild PostgreSQL using `--with-openssl` or if you want to continue without OpenSSL, re-run bootstrap with `-DUSE_OPENSSL=0`")
+endif (USE_OPENSSL AND (NOT PG_USE_OPENSSL))
+
 if (USE_OPENSSL)
   # Try to find a local OpenSSL installation
   include(FindOpenSSL)
 
   if (NOT OPENSSL_FOUND)
-    message(FATAL_ERROR "TimescaleDB requires OpenSSL but it wasn't found")
+    message(FATAL_ERROR "TimescaleDB requires OpenSSL but it wasn't found. If you want to continue without OpenSSL, re-run bootstrap with `-DUSE_OPENSSL=0`")
   endif(NOT OPENSSL_FOUND)
 
   if (${OPENSSL_VERSION} VERSION_LESS "1.0")


### PR DESCRIPTION
Previously, whenever the underlying Postgres installation did not have OpenSSL enabled, but Timescale was trying to compile WITH OpenSSL, users would get a compile error because the Postgres header file include/pg_config.h tries to redefine an OpenSSL function. To prevent this compilation error, we have modified CMake to simply fail the build if Postgres is not OpenSSL-enabled, but the user is trying to compile WITH OpenSSL. CMake will now print a message with 2 actions the user can take to fix the error.