### PR TITLE
Add const qualifier to version_delimiter definition

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -70,7 +70,7 @@ version_cmp(VersionInfo *v1, VersionInfo *v2)
 
 #define NUM_VERSION_DELIMS 4
 
-static const char *version_delimiter[NUM_VERSION_DELIMS] = {".", ".", "-", ""};
+static const char *const version_delimiter[NUM_VERSION_DELIMS] = {".", ".", "-", ""};
 
 bool
 version_parse(const char *version, VersionInfo *result)
@@ -106,6 +106,8 @@ version_parse(const char *version, VersionInfo *result)
 		else
 		{
 			char	   *endptr;
+
+			Assert(i < VERSION_PARTS);
 
 			result->version[i] = strtol(subversion, &endptr, 10);
 

--- a/src/version.h
+++ b/src/version.h
@@ -4,10 +4,11 @@
 #include <postgres.h>
 
 #define VERSION_INFO_LEN 128
+#define VERSION_PARTS 3
 
 typedef struct VersionInfo
 {
-	long		version[3];
+	long		version[VERSION_PARTS];
 	char		version_mod[VERSION_INFO_LEN];
 	bool		has_version_mod;
 } VersionInfo;


### PR DESCRIPTION
This prevents a possible memory overflow bug.