### PR TITLE
Fix negative value handling in time_bucket

### DIFF
--- a/sql/time_bucket.sql
+++ b/sql/time_bucket.sql
@@ -11,6 +11,15 @@ CREATE OR REPLACE FUNCTION time_bucket(bucket_width INTERVAL, ts TIMESTAMPTZ) RE
 CREATE OR REPLACE FUNCTION time_bucket(bucket_width INTERVAL, ts DATE) RETURNS DATE
 	AS '@MODULE_PATHNAME@', 'date_bucket' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION time_bucket(bucket_width SMALLINT, ts SMALLINT) RETURNS SMALLINT
+	AS '@MODULE_PATHNAME@', 'ts_int16_bucket' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION time_bucket(bucket_width INT, ts INT) RETURNS INT
+	AS '@MODULE_PATHNAME@', 'ts_int32_bucket' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION time_bucket(bucket_width BIGINT, ts BIGINT) RETURNS BIGINT
+	AS '@MODULE_PATHNAME@', 'ts_int64_bucket' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
 -- If an interval is given as the third argument, the bucket alignment is offset by the interval.
 CREATE OR REPLACE FUNCTION time_bucket(bucket_width INTERVAL, ts TIMESTAMP, "offset" INTERVAL)
     RETURNS TIMESTAMP LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
@@ -30,39 +39,21 @@ $BODY$
     SELECT (@extschema@.time_bucket(bucket_width, ts-"offset")+"offset")::date;
 $BODY$;
 
-
-CREATE OR REPLACE FUNCTION time_bucket(bucket_width BIGINT, ts BIGINT)
-    RETURNS BIGINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
-$BODY$
-    SELECT (ts / bucket_width)*bucket_width;
-$BODY$;
-
-CREATE OR REPLACE FUNCTION time_bucket(bucket_width INT, ts INT)
-    RETURNS INT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
-$BODY$
-    SELECT (ts / bucket_width)*bucket_width;
-$BODY$;
-
-CREATE OR REPLACE FUNCTION time_bucket(bucket_width SMALLINT, ts SMALLINT)
+CREATE OR REPLACE FUNCTION time_bucket(bucket_width SMALLINT, ts SMALLINT, "offset" SMALLINT)
     RETURNS SMALLINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
 $BODY$
-    SELECT (ts / bucket_width)*bucket_width;
-$BODY$;
-
-CREATE OR REPLACE FUNCTION time_bucket(bucket_width BIGINT, ts BIGINT, "offset" BIGINT)
-    RETURNS BIGINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
-$BODY$
-    SELECT (((ts-"offset") / bucket_width)*bucket_width)+"offset";
+    SELECT @extschema@.time_bucket(bucket_width, ts-"offset")+"offset";
 $BODY$;
 
 CREATE OR REPLACE FUNCTION time_bucket(bucket_width INT, ts INT, "offset" INT)
     RETURNS INT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
 $BODY$
-    SELECT (((ts-"offset") / bucket_width)*bucket_width)+"offset";
+    SELECT @extschema@.time_bucket(bucket_width, ts-"offset")+"offset";
 $BODY$;
 
-CREATE OR REPLACE FUNCTION time_bucket(bucket_width SMALLINT, ts SMALLINT, "offset" SMALLINT)
-    RETURNS SMALLINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+CREATE OR REPLACE FUNCTION time_bucket(bucket_width BIGINT, ts BIGINT, "offset" BIGINT)
+    RETURNS BIGINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
 $BODY$
-    SELECT (((ts-"offset") / bucket_width)*bucket_width)+"offset";
+    SELECT @extschema@.time_bucket(bucket_width, ts-"offset")+"offset";
 $BODY$;
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,6 +121,7 @@ set(SOURCES
   sort_transform.c
   subspace_store.c
   tablespace.c
+  time_bucket.c
   trigger.c
   utils.c
   version.c)

--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -1,0 +1,58 @@
+#include <postgres.h>
+#include <fmgr.h>
+
+#include "compat.h"
+
+#define TIME_BUCKET(period, timestamp, min, result)			\
+	do															\
+	{															\
+		if (period <= 0) \
+			ereport(ERROR, \
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE), \
+				 errmsg("period must be greater then 0"))); \
+		*(result) = (timestamp / period) * period;				\
+		if (timestamp < 0)										\
+			if (timestamp % period)								\
+			{													\
+				if (*(result) < min + period)				\
+					ereport(ERROR, \
+						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE), \
+						 errmsg("timestamp out of range"))); \
+				else											\
+					*(result) = *(result) - period;				\
+			}													\
+	} while (0)
+
+
+TS_FUNCTION_INFO_V1(ts_int16_bucket);
+Datum
+ts_int16_bucket(PG_FUNCTION_ARGS)
+{
+	int16		result;
+
+	TIME_BUCKET(PG_GETARG_INT16(0), PG_GETARG_INT16(1), PG_INT16_MIN, &result);
+
+	PG_RETURN_INT16(result);
+}
+
+TS_FUNCTION_INFO_V1(ts_int32_bucket);
+Datum
+ts_int32_bucket(PG_FUNCTION_ARGS)
+{
+	int32		result;
+
+	TIME_BUCKET(PG_GETARG_INT32(0), PG_GETARG_INT32(1), PG_INT32_MIN, &result);
+
+	PG_RETURN_INT32(result);
+}
+
+TS_FUNCTION_INFO_V1(ts_int64_bucket);
+Datum
+ts_int64_bucket(PG_FUNCTION_ARGS)
+{
+	int64		result;
+
+	TIME_BUCKET(PG_GETARG_INT64(0), PG_GETARG_INT64(1), PG_INT64_MIN, &result);
+
+	PG_RETURN_INT64(result);
+}

--- a/test/expected/plan_hashagg_optimized-10.out
+++ b/test/expected/plan_hashagg_optimized-10.out
@@ -170,13 +170,13 @@ ORDER BY MetricMinuteTs DESC;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (((hyper.time_int / '60'::bigint) * '60'::bigint)) DESC
+   Sort Key: (time_bucket('60'::bigint, hyper.time_int)) DESC
    ->  Finalize HashAggregate
-         Group Key: (((hyper.time_int / '60'::bigint) * '60'::bigint))
+         Group Key: (time_bucket('60'::bigint, hyper.time_int))
          ->  Gather
                Workers Planned: 2
                ->  Partial HashAggregate
-                     Group Key: ((hyper.time_int / '60'::bigint) * '60'::bigint)
+                     Group Key: time_bucket('60'::bigint, hyper.time_int)
                      ->  Result
                            ->  Append
                                  ->  Parallel Seq Scan on hyper
@@ -193,13 +193,13 @@ ORDER BY MetricMinuteTs DESC;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (((((hyper.time_int - '10'::bigint) / '60'::bigint) * '60'::bigint) + '10'::bigint)) DESC
+   Sort Key: ((time_bucket('60'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint)) DESC
    ->  Finalize HashAggregate
-         Group Key: (((((hyper.time_int - '10'::bigint) / '60'::bigint) * '60'::bigint) + '10'::bigint))
+         Group Key: ((time_bucket('60'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint))
          ->  Gather
                Workers Planned: 2
                ->  Partial HashAggregate
-                     Group Key: ((((hyper.time_int - '10'::bigint) / '60'::bigint) * '60'::bigint) + '10'::bigint)
+                     Group Key: (time_bucket('60'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint)
                      ->  Result
                            ->  Append
                                  ->  Parallel Seq Scan on hyper
@@ -314,13 +314,13 @@ ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (((((hyper.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint)) DESC, metric.id
+   Sort Key: ((time_bucket('3600'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint)) DESC, metric.id
    ->  Finalize HashAggregate
-         Group Key: (((((hyper.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint)), metric.id
+         Group Key: ((time_bucket('3600'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint)), metric.id
          ->  Gather
                Workers Planned: 2
                ->  Partial HashAggregate
-                     Group Key: ((((hyper.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint), metric.id
+                     Group Key: (time_bucket('3600'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint), metric.id
                      ->  Hash Join
                            Hash Cond: (hyper.metricid = metric.id)
                            ->  Append
@@ -342,9 +342,9 @@ ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
-   Group Key: (((((regular.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint)), metric.id
+   Group Key: ((time_bucket('3600'::bigint, (regular.time_int - '10'::bigint)) + '10'::bigint)), metric.id
    ->  Sort
-         Sort Key: (((((regular.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint)) DESC, metric.id
+         Sort Key: ((time_bucket('3600'::bigint, (regular.time_int - '10'::bigint)) + '10'::bigint)) DESC, metric.id
          ->  Nested Loop
                Join Filter: (regular.metricid = metric.id)
                ->  Seq Scan on regular

--- a/test/expected/plan_hashagg_optimized-9.6.out
+++ b/test/expected/plan_hashagg_optimized-9.6.out
@@ -146,9 +146,9 @@ ORDER BY MetricMinuteTs DESC;
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (((hyper.time_int / '60'::bigint) * '60'::bigint)) DESC
+   Sort Key: (time_bucket('60'::bigint, hyper.time_int)) DESC
    ->  HashAggregate
-         Group Key: ((hyper.time_int / '60'::bigint) * '60'::bigint)
+         Group Key: time_bucket('60'::bigint, hyper.time_int)
          ->  Result
                ->  Append
                      ->  Seq Scan on hyper
@@ -165,9 +165,9 @@ ORDER BY MetricMinuteTs DESC;
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (((((hyper.time_int - '10'::bigint) / '60'::bigint) * '60'::bigint) + '10'::bigint)) DESC
+   Sort Key: ((time_bucket('60'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint)) DESC
    ->  HashAggregate
-         Group Key: ((((hyper.time_int - '10'::bigint) / '60'::bigint) * '60'::bigint) + '10'::bigint)
+         Group Key: (time_bucket('60'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint)
          ->  Result
                ->  Append
                      ->  Seq Scan on hyper
@@ -266,9 +266,9 @@ ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (((((hyper.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint)) DESC, metric.id
+   Sort Key: ((time_bucket('3600'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint)) DESC, metric.id
    ->  HashAggregate
-         Group Key: ((((hyper.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint), metric.id
+         Group Key: (time_bucket('3600'::bigint, (hyper.time_int - '10'::bigint)) + '10'::bigint), metric.id
          ->  Hash Join
                Hash Cond: (hyper.metricid = metric.id)
                ->  Append
@@ -290,9 +290,9 @@ ORDER BY MetricMinuteTs DESC, metric.id;
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate
-   Group Key: (((((regular.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint)), metric.id
+   Group Key: ((time_bucket('3600'::bigint, (regular.time_int - '10'::bigint)) + '10'::bigint)), metric.id
    ->  Sort
-         Sort Key: (((((regular.time_int - '10'::bigint) / '3600'::bigint) * '3600'::bigint) + '10'::bigint)) DESC, metric.id
+         Sort Key: ((time_bucket('3600'::bigint, (regular.time_int - '10'::bigint)) + '10'::bigint)) DESC, metric.id
          ->  Nested Loop
                Join Filter: (regular.metricid = metric.id)
                ->  Seq Scan on regular

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -373,10 +373,10 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
 ----------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (((hyper_1_int."time" / 10) * 10))
+         Group Key: (time_bucket(10, hyper_1_int."time"))
          ->  Result
                ->  Merge Append
-                     Sort Key: (((hyper_1_int."time" / 10) * 10)) DESC
+                     Sort Key: (time_bucket(10, hyper_1_int."time")) DESC
                      ->  Index Scan using time_plain_int on hyper_1_int
                      ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
                      ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk
@@ -397,10 +397,10 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
 ----------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (((((hyper_1_int."time" - 2) / 10) * 10) + 2))
+         Group Key: ((time_bucket(10, (hyper_1_int."time" - 2)) + 2))
          ->  Result
                ->  Merge Append
-                     Sort Key: (((((hyper_1_int."time" - 2) / 10) * 10) + 2)) DESC
+                     Sort Key: ((time_bucket(10, (hyper_1_int."time" - 2)) + 2)) DESC
                      ->  Index Scan using time_plain_int on hyper_1_int
                      ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
                      ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -380,13 +380,13 @@ FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
 
 EXPLAIN (costs off) SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (((hyper_1_int."time" / 10) * 10))
+         Group Key: (time_bucket(10, hyper_1_int."time"))
          ->  Sort
-               Sort Key: (((hyper_1_int."time" / 10) * 10)) DESC
+               Sort Key: (time_bucket(10, hyper_1_int."time")) DESC
                ->  Result
                      ->  Append
                            ->  Seq Scan on hyper_1_int
@@ -405,13 +405,13 @@ FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
 
 EXPLAIN (costs off) SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (((((hyper_1_int."time" - 2) / 10) * 10) + 2))
+         Group Key: ((time_bucket(10, (hyper_1_int."time" - 2)) + 2))
          ->  Sort
-               Sort Key: (((((hyper_1_int."time" - 2) / 10) * 10) + 2)) DESC
+               Sort Key: ((time_bucket(10, (hyper_1_int."time" - 2)) + 2)) DESC
                ->  Result
                      ->  Append
                            ->  Seq Scan on hyper_1_int

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -235,12 +235,12 @@
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
->                            QUERY PLAN                            
-> -----------------------------------------------------------------
+>                              QUERY PLAN                             
+> --------------------------------------------------------------------
 377,384c388,396
 <          ->  Result
 <                ->  Merge Append
-<                      Sort Key: (((hyper_1_int."time" / 10) * 10)) DESC
+<                      Sort Key: (time_bucket(10, hyper_1_int."time")) DESC
 <                      ->  Index Scan using time_plain_int on hyper_1_int
 <                      ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
 <                      ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk
@@ -248,7 +248,7 @@
 < (10 rows)
 ---
 >          ->  Sort
->                Sort Key: (((hyper_1_int."time" / 10) * 10)) DESC
+>                Sort Key: (time_bucket(10, hyper_1_int."time")) DESC
 >                ->  Result
 >                      ->  Append
 >                            ->  Seq Scan on hyper_1_int
@@ -260,12 +260,12 @@
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
->                                  QUERY PLAN                                  
-> -----------------------------------------------------------------------------
+>                                    QUERY PLAN                                   
+> --------------------------------------------------------------------------------
 401,408c413,421
 <          ->  Result
 <                ->  Merge Append
-<                      Sort Key: (((((hyper_1_int."time" - 2) / 10) * 10) + 2)) DESC
+<                      Sort Key: ((time_bucket(10, (hyper_1_int."time" - 2)) + 2)) DESC
 <                      ->  Index Scan using time_plain_int on hyper_1_int
 <                      ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
 <                      ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk
@@ -273,7 +273,7 @@
 < (10 rows)
 ---
 >          ->  Sort
->                Sort Key: (((((hyper_1_int."time" - 2) / 10) * 10) + 2)) DESC
+>                Sort Key: ((time_bucket(10, (hyper_1_int."time" - 2)) + 2)) DESC
 >                ->  Result
 >                      ->  Append
 >                            ->  Seq Scan on hyper_1_int

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -509,50 +509,161 @@ FROM unnest(ARRAY[
  Sun Nov 05 03:05:00 2017 EST | Sun Nov 05 02:00:00 2017
 (4 rows)
 
-SELECT time, time_bucket(10, time)
+SELECT time,
+    time_bucket(10::smallint, time) AS time_bucket_smallint,
+    time_bucket(10::int, time) AS time_bucket_int,
+    time_bucket(10::bigint, time) AS time_bucket_bigint
 FROM unnest(ARRAY[
-     '99',
+     '-11',
+     '-10',
+      '-9',
+      '-1',
+       '0',
+       '1',
+      '99',
      '100',
      '109',
      '110'
-    ]::int[]) AS time;
- time | time_bucket 
-------+-------------
-   99 |          90
-  100 |         100
-  109 |         100
-  110 |         110
-(4 rows)
+    ]::smallint[]) AS time;
+ time | time_bucket_smallint | time_bucket_int | time_bucket_bigint 
+------+----------------------+-----------------+--------------------
+  -11 |                  -20 |             -20 |                -20
+  -10 |                  -10 |             -10 |                -10
+   -9 |                  -10 |             -10 |                -10
+   -1 |                  -10 |             -10 |                -10
+    0 |                    0 |               0 |                  0
+    1 |                    0 |               0 |                  0
+   99 |                   90 |              90 |                 90
+  100 |                  100 |             100 |                100
+  109 |                  100 |             100 |                100
+  110 |                  110 |             110 |                110
+(10 rows)
 
-SELECT time, time_bucket(10, time,2)
+SELECT time,
+    time_bucket(10::smallint, time, 2::smallint) AS time_bucket_smallint,
+    time_bucket(10::int, time, 2::int) AS time_bucket_int,
+    time_bucket(10::bigint, time, 2::bigint) AS time_bucket_bigint
 FROM unnest(ARRAY[
+      '-9',
+      '-8',
+      '-7',
+       '1',
+       '2',
+       '3',
      '101',
      '102',
      '111',
      '112'
-    ]::int[]) AS time;
- time | time_bucket 
-------+-------------
-  101 |          92
-  102 |         102
-  111 |         102
-  112 |         112
-(4 rows)
+    ]::smallint[]) AS time;
+ time | time_bucket_smallint | time_bucket_int | time_bucket_bigint 
+------+----------------------+-----------------+--------------------
+   -9 |                  -18 |             -18 |                -18
+   -8 |                   -8 |              -8 |                 -8
+   -7 |                   -8 |              -8 |                 -8
+    1 |                   -8 |              -8 |                 -8
+    2 |                    2 |               2 |                  2
+    3 |                    2 |               2 |                  2
+  101 |                   92 |              92 |                 92
+  102 |                  102 |             102 |                102
+  111 |                  102 |             102 |                102
+  112 |                  112 |             112 |                112
+(10 rows)
 
-SELECT time, time_bucket(10, time, -2)
+SELECT time,
+    time_bucket(10::smallint, time, -2::smallint) AS time_bucket_smallint,
+    time_bucket(10::int, time, -2::int) AS time_bucket_int,
+    time_bucket(10::bigint, time, -2::bigint) AS time_bucket_bigint
 FROM unnest(ARRAY[
+    '-13',
+    '-12',
+    '-11',
+     '-3',
+     '-2',
+     '-1',
      '97',
      '98',
-     '107',
-     '108'
+    '107',
+    '108'
+    ]::smallint[]) AS time;
+ time | time_bucket_smallint | time_bucket_int | time_bucket_bigint 
+------+----------------------+-----------------+--------------------
+  -13 |                  -22 |             -22 |                -22
+  -12 |                  -12 |             -12 |                -12
+  -11 |                  -12 |             -12 |                -12
+   -3 |                  -12 |             -12 |                -12
+   -2 |                   -2 |              -2 |                 -2
+   -1 |                   -2 |              -2 |                 -2
+   97 |                   88 |              88 |                 88
+   98 |                   98 |              98 |                 98
+  107 |                   98 |              98 |                 98
+  108 |                  108 |             108 |                108
+(10 rows)
+
+\set ON_ERROR_STOP 0
+SELECT time_bucket(10::smallint, '-32768'::smallint);
+ERROR:  timestamp out of range
+SELECT time_bucket(10::smallint, '-32761'::smallint);
+ERROR:  timestamp out of range
+select time_bucket(10::smallint, '-32000'::smallint, 1000::smallint);
+ERROR:  smallint out of range
+CONTEXT:  SQL function "time_bucket" statement 1
+\set ON_ERROR_STOP 1
+SELECT time, time_bucket(10::smallint, time)
+FROM unnest(ARRAY[
+    '-32760',
+    '-32759',
+    '32767'
+    ]::smallint[]) AS time;
+  time  | time_bucket 
+--------+-------------
+ -32760 |      -32760
+ -32759 |      -32760
+  32767 |       32760
+(3 rows)
+
+\set ON_ERROR_STOP 0
+SELECT time_bucket(10::int, '-2147483648'::int);
+ERROR:  timestamp out of range
+SELECT time_bucket(10::int, '-2147483641'::int);
+ERROR:  timestamp out of range
+SELECT time_bucket(10::int, '-2147483000'::int, 1000::int);
+ERROR:  integer out of range
+CONTEXT:  SQL function "time_bucket" statement 1
+\set ON_ERROR_STOP 1
+SELECT time, time_bucket(10::int, time)
+FROM unnest(ARRAY[
+    '-2147483640',
+    '-2147483639',
+    '2147483647'
     ]::int[]) AS time;
- time | time_bucket 
-------+-------------
-   97 |          88
-   98 |          98
-  107 |          98
-  108 |         108
-(4 rows)
+    time     | time_bucket 
+-------------+-------------
+ -2147483640 | -2147483640
+ -2147483639 | -2147483640
+  2147483647 |  2147483640
+(3 rows)
+
+\set ON_ERROR_STOP 0
+SELECT time_bucket(10::bigint, '-9223372036854775808'::bigint);
+ERROR:  timestamp out of range
+SELECT time_bucket(10::bigint, '-9223372036854775801'::bigint);
+ERROR:  timestamp out of range
+SELECT time_bucket(10::bigint, '-9223372036854775000'::bigint, 1000::bigint);
+ERROR:  bigint out of range
+CONTEXT:  SQL function "time_bucket" statement 1
+\set ON_ERROR_STOP 1
+SELECT time, time_bucket(10::bigint, time)
+FROM unnest(ARRAY[
+    '-9223372036854775800',
+    '-9223372036854775799',
+    '9223372036854775807'
+    ]::bigint[]) AS time;
+         time         |     time_bucket      
+----------------------+----------------------
+ -9223372036854775800 | -9223372036854775800
+ -9223372036854775799 | -9223372036854775800
+  9223372036854775807 |  9223372036854775800
+(3 rows)
 
 SELECT time, time_bucket(INTERVAL '1 day', time::date)
 FROM unnest(ARRAY[

--- a/test/sql/timestamp.sql
+++ b/test/sql/timestamp.sql
@@ -302,30 +302,96 @@ FROM unnest(ARRAY[
     ]) AS time;
 
 
-SELECT time, time_bucket(10, time)
+SELECT time,
+    time_bucket(10::smallint, time) AS time_bucket_smallint,
+    time_bucket(10::int, time) AS time_bucket_int,
+    time_bucket(10::bigint, time) AS time_bucket_bigint
 FROM unnest(ARRAY[
-     '99',
+     '-11',
+     '-10',
+      '-9',
+      '-1',
+       '0',
+       '1',
+      '99',
      '100',
      '109',
      '110'
-    ]::int[]) AS time;
+    ]::smallint[]) AS time;
 
-SELECT time, time_bucket(10, time,2)
+SELECT time,
+    time_bucket(10::smallint, time, 2::smallint) AS time_bucket_smallint,
+    time_bucket(10::int, time, 2::int) AS time_bucket_int,
+    time_bucket(10::bigint, time, 2::bigint) AS time_bucket_bigint
 FROM unnest(ARRAY[
+      '-9',
+      '-8',
+      '-7',
+       '1',
+       '2',
+       '3',
      '101',
      '102',
      '111',
      '112'
-    ]::int[]) AS time;
+    ]::smallint[]) AS time;
 
-SELECT time, time_bucket(10, time, -2)
+SELECT time,
+    time_bucket(10::smallint, time, -2::smallint) AS time_bucket_smallint,
+    time_bucket(10::int, time, -2::int) AS time_bucket_int,
+    time_bucket(10::bigint, time, -2::bigint) AS time_bucket_bigint
 FROM unnest(ARRAY[
+    '-13',
+    '-12',
+    '-11',
+     '-3',
+     '-2',
+     '-1',
      '97',
      '98',
-     '107',
-     '108'
+    '107',
+    '108'
+    ]::smallint[]) AS time;
+
+
+\set ON_ERROR_STOP 0
+SELECT time_bucket(10::smallint, '-32768'::smallint);
+SELECT time_bucket(10::smallint, '-32761'::smallint);
+select time_bucket(10::smallint, '-32000'::smallint, 1000::smallint);
+\set ON_ERROR_STOP 1
+
+SELECT time, time_bucket(10::smallint, time)
+FROM unnest(ARRAY[
+    '-32760',
+    '-32759',
+    '32767'
+    ]::smallint[]) AS time;
+
+\set ON_ERROR_STOP 0
+SELECT time_bucket(10::int, '-2147483648'::int);
+SELECT time_bucket(10::int, '-2147483641'::int);
+SELECT time_bucket(10::int, '-2147483000'::int, 1000::int);
+\set ON_ERROR_STOP 1
+
+SELECT time, time_bucket(10::int, time)
+FROM unnest(ARRAY[
+    '-2147483640',
+    '-2147483639',
+    '2147483647'
     ]::int[]) AS time;
 
+\set ON_ERROR_STOP 0
+SELECT time_bucket(10::bigint, '-9223372036854775808'::bigint);
+SELECT time_bucket(10::bigint, '-9223372036854775801'::bigint);
+SELECT time_bucket(10::bigint, '-9223372036854775000'::bigint, 1000::bigint);
+\set ON_ERROR_STOP 1
+
+SELECT time, time_bucket(10::bigint, time)
+FROM unnest(ARRAY[
+    '-9223372036854775800',
+    '-9223372036854775799',
+    '9223372036854775807'
+    ]::bigint[]) AS time;
 
 SELECT time, time_bucket(INTERVAL '1 day', time::date)
 FROM unnest(ARRAY[


### PR DESCRIPTION
The integer variants of time_bucket don't handle negative time values properly and return the upper boundary of the interval instead of the lower boundary for negative time values.

Fixes #738 
