### PR TITLE
Fix adaptive chunking when hypertables have multiple dimensions

### DIFF
--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -427,7 +427,7 @@ calculate_chunk_interval(PG_FUNCTION_ARGS)
 	current_interval = dim->fd.interval_length;
 
 	/* Get a window of recent chunks */
-	chunks = chunk_get_window(hypertable_id,
+	chunks = chunk_get_window(dimension_id,
 							  dimension_coord,
 							  DEFAULT_CHUNK_WINDOW,
 							  CurrentMemoryContext);

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -528,3 +528,18 @@ SELECT id, hypertable_id, interval_length FROM _timescaledb_catalog.dimension;
   5 |             5 |   1663190133404
 (4 rows)
 
+-- A previous version stopped working as soon as hypertable_id stopped being
+-- equal to dimension_id (i.e., there was a hypertable with more than 1 dimension).
+-- This test comes after test_adaptive_space, which has 2 dimensions, and makes
+-- sure that it still works.
+CREATE TABLE test_adaptive_after_multiple_dims(time timestamptz, temp float, location int);
+SELECT create_hypertable('test_adaptive_after_multiple_dims', 'time',
+                         chunk_target_size => '100MB',
+                         create_default_indexes => true);
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ 
+(1 row)
+
+INSERT INTO test_adaptive_after_multiple_dims VALUES('2018-01-01T00:00:00+00'::timestamptz, 0.0, 5);

--- a/test/sql/chunk_adaptive.sql
+++ b/test/sql/chunk_adaptive.sql
@@ -251,3 +251,13 @@ generate_series('2017-03-07T18:18:03+00'::timestamptz - interval '175 days',
 
 SELECT * FROM chunk_relation_size('test_adaptive_space');
 SELECT id, hypertable_id, interval_length FROM _timescaledb_catalog.dimension;
+
+-- A previous version stopped working as soon as hypertable_id stopped being
+-- equal to dimension_id (i.e., there was a hypertable with more than 1 dimension).
+-- This test comes after test_adaptive_space, which has 2 dimensions, and makes
+-- sure that it still works.
+CREATE TABLE test_adaptive_after_multiple_dims(time timestamptz, temp float, location int);
+SELECT create_hypertable('test_adaptive_after_multiple_dims', 'time',
+                         chunk_target_size => '100MB',
+                         create_default_indexes => true);
+INSERT INTO test_adaptive_after_multiple_dims VALUES('2018-01-01T00:00:00+00'::timestamptz, 0.0, 5);


### PR DESCRIPTION
The use of the incorrect index to find the hypertable that a
dimension belongs to caused adaptive chunking to break whenever
dimension_id != hypertable_id, which happened with hypertables that
have multiple dimensions where time is not the first one.