### PR TITLE
Grant permissions to public for pg_dump to work

### DIFF
--- a/sql/cache.sql
+++ b/sql/cache.sql
@@ -14,3 +14,6 @@ CREATE TABLE IF NOT EXISTS  _timescaledb_cache.cache_inval_extension();
 -- not actually strictly needed but good for sanity as all tables should be dumped.
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_hypertable', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_extension', '');
+
+GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_cache TO PUBLIC;
+

--- a/sql/pre_install/schemas.sql
+++ b/sql/pre_install/schemas.sql
@@ -2,4 +2,4 @@ CREATE SCHEMA IF NOT EXISTS _timescaledb_catalog;
 CREATE SCHEMA IF NOT EXISTS _timescaledb_internal;
 CREATE SCHEMA IF NOT EXISTS _timescaledb_cache;
 CREATE SCHEMA IF NOT EXISTS _timescaledb_config;
-GRANT USAGE ON SCHEMA _timescaledb_catalog, _timescaledb_internal, _timescaledb_config TO PUBLIC;
+GRANT USAGE ON SCHEMA _timescaledb_cache, _timescaledb_catalog, _timescaledb_internal, _timescaledb_config TO PUBLIC;

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -189,6 +189,14 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.installation_metadata (
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.installation_metadata', $$WHERE key='exported_uuid'$$);
 
 -- Set table permissions
+-- We need to grant SELECT to PUBLIC for all tables even those not
+-- marked as being dumped because pg_dump will try to access all
+-- tables initially to detect inheritance chains and then decide
+-- which objects actually need to be dumped.
 GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_catalog TO PUBLIC;
 GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_config TO PUBLIC;
-GRANT SELECT ON _timescaledb_internal.bgw_job_stat TO PUBLIC;
+GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_internal TO PUBLIC;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA _timescaledb_catalog TO PUBLIC;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA _timescaledb_config TO PUBLIC;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA _timescaledb_internal TO PUBLIC;
+

--- a/test/expected/pg_dump_unprivileged.out
+++ b/test/expected/pg_dump_unprivileged.out
@@ -1,0 +1,13 @@
+\c template1 :ROLE_SUPERUSER
+SET client_min_messages TO ERROR;
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+RESET client_min_messages;
+CREATE USER dump_unprivileged CREATEDB;
+\c template1 dump_unprivileged
+CREATE database dump_unprivileged;
+\! utils/pg_dump_unprivileged.sh
+Database dumped successfully
+\c template1 :ROLE_SUPERUSER
+DROP EXTENSION timescaledb;
+DROP DATABASE dump_unprivileged;
+DROP USER dump_unprivileged;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_FILES
   lateral.sql
   partitioning.sql
   pg_dump.sql
+  pg_dump_unprivileged.sql
   plain.sql
   plan_expand_hypertable_optimized.sql
   plan_expand_hypertable_results_diff.sql

--- a/test/sql/pg_dump_unprivileged.sql
+++ b/test/sql/pg_dump_unprivileged.sql
@@ -1,0 +1,19 @@
+
+\c template1 :ROLE_SUPERUSER
+
+SET client_min_messages TO ERROR;
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+RESET client_min_messages;
+
+CREATE USER dump_unprivileged CREATEDB;
+
+\c template1 dump_unprivileged
+CREATE database dump_unprivileged;
+
+\! utils/pg_dump_unprivileged.sh
+
+\c template1 :ROLE_SUPERUSER
+DROP EXTENSION timescaledb;
+DROP DATABASE dump_unprivileged;
+DROP USER dump_unprivileged;
+

--- a/test/sql/utils/pg_dump_unprivileged.sh
+++ b/test/sql/utils/pg_dump_unprivileged.sh
@@ -1,0 +1,6 @@
+${PG_BINDIR}/pg_dump -h ${PGHOST} -U dump_unprivileged dump_unprivileged > /dev/null
+
+if [ $? -eq 0 ]; then
+  echo "Database dumped successfully"
+fi
+


### PR DESCRIPTION
When timescaledb is installed in template1 and a user with only createdb privileges creates a database, the user won't be able to dump the database because of lacking permissions. This PR grants the missing permissions to PUBLIC for pg_dump to succeed.

Fixes #720 
Fixes #605 