### PR TITLE
Modify telemetry BGW to run every hour the first 12 hours

### DIFF
--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -18,6 +18,7 @@ typedef struct BgwJob
 
 } BgwJob;
 
+typedef bool job_main_func (void);
 typedef bool (*unknown_job_type_hook_type) (BgwJob *job);
 
 BackgroundWorkerHandle *bgw_start_worker(const char *function, const char *name, const char *extra);
@@ -37,5 +38,6 @@ bool		bgw_job_execute(BgwJob *job);
 PGDLLEXPORT extern Datum ts_bgw_job_entrypoint(PG_FUNCTION_ARGS);
 extern void bgw_job_set_unknown_job_type_hook(unknown_job_type_hook_type hook);
 extern void bgw_job_set_job_entrypoint_function_name(char *func_name);
+extern bool bgw_job_run_and_set_next_start(BgwJob *job, job_main_func func, int64 initial_runs, Interval *next_interval);
 
 #endif							/* BGW_JOB_H */

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -17,7 +17,6 @@
 #include "extension.h"
 #include "net/http.h"
 
-
 #define TS_VERSION_JSON_FIELD "current_timescaledb_version"
 
 /*  HTTP request details */
@@ -279,7 +278,13 @@ telemetry_connect(const char *host, const char *service)
 	return conn;
 }
 
-void
+bool
+telemetry_main_wrapper()
+{
+	return telemetry_main(TELEMETRY_HOST, TELEMETRY_PATH, TELEMETRY_SCHEME);
+}
+
+bool
 telemetry_main(const char *host, const char *path, const char *service)
 {
 	HttpError	err;
@@ -289,7 +294,7 @@ telemetry_main(const char *host, const char *path, const char *service)
 	bool		started = false;
 
 	if (!telemetry_on())
-		return;
+		return true;
 
 	if (!IsTransactionOrTransactionBlock())
 	{
@@ -337,12 +342,12 @@ telemetry_main(const char *host, const char *path, const char *service)
 
 	if (started)
 		CommitTransactionCommand();
-	return;
+	return true;
 
 cleanup:
 	if (started)
 		AbortCurrentTransaction();
-	return;
+	return false;
 }
 
 TS_FUNCTION_INFO_V1(ts_get_telemetry_report);

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -32,6 +32,7 @@ bool		telemetry_parse_version(const char *json, VersionInfo *vinfo, VersionResul
  *  Its job is to send metrics and fetch the most up-to-date version of
  *  Timescale via HTTPS.
  */
-void		telemetry_main(const char *host, const char *path, const char *service);
+bool		telemetry_main(const char *host, const char *path, const char *service);
+bool		telemetry_main_wrapper(void);
 
 #endif							/* TIMESCALEDB_TELEMETRY_TELEMETRY_H */

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -728,3 +728,75 @@ SELECT ts_bgw_params_destroy();
  
 (1 row)
 
+--
+-- Test setting next_start time within a job
+--
+\c single :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+SELECT ts_bgw_params_reset_time();
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job;
+INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+('test_job_4', 'bgw_test_job_4', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+select * from _timescaledb_config.bgw_job;
+  id  | application_name |    job_type    | schedule_interval |   max_runtime   | max_retries | retry_period 
+------+------------------+----------------+-------------------+-----------------+-------------+--------------
+ 1013 | test_job_4       | bgw_test_job_4 | @ 0.1 secs        | @ 1 min 40 secs |           3 | @ 1 sec
+(1 row)
+
+\c single :ROLE_DEFAULT_PERM_USER
+-- Now run and make sure next_start is 200ms away, not 100ms
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT job_id, next_start - last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+FROM _timescaledb_internal.bgw_job_stat;
+ job_id | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------+------------------+------------+-----------------+----------------+---------------
+   1013 | @ 0.2 secs | t                |          1 |               1 |              0 |             0
+(1 row)
+
+SELECT * FROM bgw_log;
+ msg_no | mock_time | application_name |                    msg                     
+--------+-----------+------------------+--------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |         0 | test_job_4       | Execute job 4
+(3 rows)
+
+-- Now just make sure that the job actually runs in 200ms
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(200);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+-- Print next_start and last_finish explicitly, instead of the difference, to make sure the times have changed
+-- since the last run
+SELECT job_id, next_start, last_finish, last_run_success, total_runs, total_successes, total_failures, total_crashes
+FROM _timescaledb_internal.bgw_job_stat;
+ job_id |           next_start           |          last_finish           | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+--------------------------------+--------------------------------+------------------+------------+-----------------+----------------+---------------
+   1013 | Fri Dec 31 16:00:00.4 1999 PST | Fri Dec 31 16:00:00.2 1999 PST | t                |          2 |               2 |              0 |             0
+(1 row)
+
+SELECT * FROM bgw_log;
+ msg_no | mock_time | application_name |                      msg                       
+--------+-----------+------------------+------------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |         0 | test_job_4       | Execute job 4
+      0 |     25000 | DB Scheduler     | [TESTING] Wait until 200000, started at 25000
+      1 |    200000 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |    200000 | DB Scheduler     | [TESTING] Wait until 225000, started at 200000
+      0 |    200000 | test_job_4       | Execute job 4
+(7 rows)
+

--- a/test/expected/privacy.out
+++ b/test/expected/privacy.out
@@ -1,5 +1,5 @@
 \c single :ROLE_SUPERUSER
-CREATE OR REPLACE FUNCTION _timescaledb_internal.test_privacy() RETURNS VOID
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_privacy() RETURNS BOOLEAN
     AS :MODULE_PATHNAME, 'test_privacy' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 \c single :ROLE_DEFAULT_PERM_USER
 -- Should be off be default in tests
@@ -19,7 +19,7 @@ SHOW timescaledb.telemetry_level;
 SELECT _timescaledb_internal.test_privacy();
  test_privacy 
 --------------
- 
+ t
 (1 row)
 
 -- To make sure nothing was sent, we check the UUID table to make sure no exported UUID row was created

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_parse_version(re
     RETURNS TABLE(version_string text, major int, minor int, patch int, modtag text, up_to_date bool)
     AS :MODULE_PATHNAME, 'test_telemetry_parse_version' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_main_conn(text, text, text)
-RETURNS VOID AS :MODULE_PATHNAME, 'test_telemetry_main_conn' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+RETURNS BOOLEAN AS :MODULE_PATHNAME, 'test_telemetry_main_conn' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry(host text = NULL, servname text = NULL, port int = NULL) RETURNS JSONB AS :MODULE_PATHNAME, 'test_telemetry' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 \c single :ROLE_DEFAULT_PERM_USER
 SELECT _timescaledb_internal.test_status_ssl(200);
@@ -267,7 +267,7 @@ WARNING:  could not make a connection to http://timescale.com
 WARNING:  telemetry connect error: could not make connection
  test_telemetry_main_conn 
 --------------------------
- 
+ f
 (1 row)
 
 SELECT _timescaledb_internal.test_telemetry_main_conn('timescale.com', 'path', 'https');
@@ -275,7 +275,7 @@ WARNING:  could not make a connection to https://timescale.com
 WARNING:  telemetry connect error: could not make connection
  test_telemetry_main_conn 
 --------------------------
- 
+ f
 (1 row)
 
 SELECT _timescaledb_internal.test_telemetry_main_conn('telemetry.timescale.com', 'path', 'http');
@@ -283,7 +283,7 @@ WARNING:  could not make a connection to http://telemetry.timescale.com
 WARNING:  telemetry connect error: could not make connection
  test_telemetry_main_conn 
 --------------------------
- 
+ f
 (1 row)
 
 SET timescaledb.telemetry_level=off;

--- a/test/sql/privacy.sql
+++ b/test/sql/privacy.sql
@@ -1,5 +1,5 @@
 \c single :ROLE_SUPERUSER
-CREATE OR REPLACE FUNCTION _timescaledb_internal.test_privacy() RETURNS VOID
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_privacy() RETURNS BOOLEAN
     AS :MODULE_PATHNAME, 'test_privacy' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 \c single :ROLE_DEFAULT_PERM_USER
 

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_parse_version(re
     RETURNS TABLE(version_string text, major int, minor int, patch int, modtag text, up_to_date bool)
     AS :MODULE_PATHNAME, 'test_telemetry_parse_version' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_main_conn(text, text, text)
-RETURNS VOID AS :MODULE_PATHNAME, 'test_telemetry_main_conn' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+RETURNS BOOLEAN AS :MODULE_PATHNAME, 'test_telemetry_main_conn' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry(host text = NULL, servname text = NULL, port int = NULL) RETURNS JSONB AS :MODULE_PATHNAME, 'test_telemetry' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
 \c single :ROLE_DEFAULT_PERM_USER

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -36,6 +36,7 @@ typedef enum TestJobType
 	TEST_JOB_TYPE_JOB_1 = 0,
 	TEST_JOB_TYPE_JOB_2_ERROR,
 	TEST_JOB_TYPE_JOB_3_LONG,
+	TEST_JOB_TYPE_JOB_4,
 	_MAX_TEST_JOB_TYPE
 } TestJobType;
 
@@ -43,6 +44,7 @@ const char *test_job_type_names[_MAX_TEST_JOB_TYPE] = {
 	[TEST_JOB_TYPE_JOB_1] = "bgw_test_job_1",
 	[TEST_JOB_TYPE_JOB_2_ERROR] = "bgw_test_job_2_error",
 	[TEST_JOB_TYPE_JOB_3_LONG] = "bgw_test_job_3_long",
+	[TEST_JOB_TYPE_JOB_4] = "bgw_test_job_4",
 };
 
 static char *
@@ -157,6 +159,7 @@ ts_bgw_db_scheduler_test_wait_for_scheduler_finish(PG_FUNCTION_ARGS)
 	Assert(BGWH_STOPPED == WaitForBackgroundWorkerShutdown(current_handle));
 	PG_RETURN_VOID();
 }
+
 static bool
 test_job_1()
 {
@@ -214,6 +217,16 @@ test_job_3_long()
 	return true;
 }
 
+/* Exactly like job 1, except a wrapper will change its next_start. */
+static bool
+test_job_4()
+{
+	StartTransactionCommand();
+	elog(WARNING, "Execute job 4");
+	CommitTransactionCommand();
+	return true;
+}
+
 static TestJobType
 get_test_job_type_from_name(Name job_type_name)
 {
@@ -245,6 +258,13 @@ test_job_dispatcher(BgwJob *job)
 			return test_job_2_error();
 		case TEST_JOB_TYPE_JOB_3_LONG:
 			return test_job_3_long();
+		case TEST_JOB_TYPE_JOB_4:
+			{
+				/* Set next_start to 200ms */
+				Interval   *new_interval = DatumGetIntervalP(DirectFunctionCall7(make_interval, Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Float8GetDatum(0.2)));
+
+				return bgw_job_run_and_set_next_start(job, test_job_4, 3, new_interval);
+			}
 		case _MAX_TEST_JOB_TYPE:
 			elog(ERROR, "unrecognized test job type: %s", NameStr(job->fd.job_type));
 	}

--- a/test/src/telemetry/test_privacy.c
+++ b/test/src/telemetry/test_privacy.c
@@ -14,6 +14,5 @@ Datum
 test_privacy(PG_FUNCTION_ARGS)
 {
 	/* This test should only run when timescaledb.telemetry_level=off */
-	telemetry_main("", "", "");
-	PG_RETURN_NULL();
+	PG_RETURN_BOOL(telemetry_main("", "", ""));
 }

--- a/test/src/telemetry/test_telemetry.c
+++ b/test/src/telemetry/test_telemetry.c
@@ -202,8 +202,7 @@ test_telemetry_main_conn(PG_FUNCTION_ARGS)
 	text	   *path = PG_GETARG_TEXT_P(1);
 	text	   *service = PG_GETARG_TEXT_P(2);
 
-	telemetry_main(text_to_cstring(host), text_to_cstring(path), text_to_cstring(service));
-	PG_RETURN_NULL();
+	PG_RETURN_BOOL(telemetry_main(text_to_cstring(host), text_to_cstring(path), text_to_cstring(service)));
 }
 
 Datum


### PR DESCRIPTION
To distinguish short-running instances from long-running instances, we have the telemetry BGW run hourly for the first 12 hours.
After this initial period, the BGW will run the default once every 24 hours.

Also added a scheduler test that tests background jobs are able to set next_start time within the job itself. Also modified telemetry function to return a boolean so that the scheduler can properly account for failures.