### PR TITLE
 Stop background workers when extension is DROP OWNED

### DIFF
--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -295,6 +295,38 @@ SELECT wait_worker_counts(1,0,0,0);
  t
 (1 row)
 
+/* Test that background workers are stopped with DROP OWNED */
+ALTER ROLE :ROLE_DEFAULT_PERM_USER WITH SUPERUSER;
+\c single_2  :ROLE_DEFAULT_PERM_USER
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb CASCADE;
+RESET client_min_messages;
+/* Make sure there is 1 launcher and 1 bgw in single_2 */
+SELECT wait_worker_counts(launcher_ct=>1, scheduler1_ct=> 0, scheduler2_ct=>1, template1_ct=>0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+/* drop a non-owner of the extension results in no change to worker counts */
+DROP OWNED BY  :ROLE_DEFAULT_PERM_USER_2;
+SELECT wait_worker_counts(launcher_ct=>1, scheduler1_ct=> 0, scheduler2_ct=>1, template1_ct=>0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+/* drop of owner of extension results in extension drop and a stop to the bgw */
+DROP OWNED BY  :ROLE_DEFAULT_PERM_USER;
+/* The worker in single_2 is dead. Note that 0s are respected */
+SELECT wait_worker_counts(launcher_ct=>1, scheduler1_ct=>0, scheduler2_ct=>0, template1_ct=>0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+\c single_2  :ROLE_SUPERUSER
+ALTER ROLE :ROLE_DEFAULT_PERM_USER WITH NOSUPERUSER;
 /* Connect to the template1 database */
 \c template1
 \ir include/bgw_launcher_utils.sql

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -32,10 +32,10 @@ END LOOP;
 RETURN FALSE;
 END
 $BODY$;
-/* 
- * When we've connected to single_2, we should be able to see the cluster launcher 
+/*
+ * When we've connected to single_2, we should be able to see the cluster launcher
  * and the scheduler for single in pg_stat_activity
- * but single_2 shouldn't have a scheduler because ext not created yet 
+ * but single_2 shouldn't have a scheduler because ext not created yet
  */
 SELECT wait_worker_counts(1,1,0,0);
  wait_worker_counts 
@@ -62,9 +62,9 @@ SELECT wait_worker_counts(1,0,1,0);
 (1 row)
 
 /*Now let's restart the scheduler and make sure our backend_start changed */
-SELECT backend_start as orig_backend_start 
-FROM pg_stat_activity 
-WHERE application_name = 'TimescaleDB Background Worker Scheduler' 
+SELECT backend_start as orig_backend_start
+FROM pg_stat_activity
+WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2' \gset
 /* We'll do this in a txn so that we can see that the worker locks on our txn before continuing*/
 BEGIN;
@@ -80,10 +80,10 @@ SELECT wait_worker_counts(1,0,1,0);
  t
 (1 row)
 
-SELECT (backend_start > :'orig_backend_start'::timestamptz) backend_start_changed, 
+SELECT (backend_start > :'orig_backend_start'::timestamptz) backend_start_changed,
 (wait_event = 'virtualxid') wait_event_changed
-FROM pg_stat_activity 
-WHERE application_name = 'TimescaleDB Background Worker Scheduler' 
+FROM pg_stat_activity
+WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2';
  backend_start_changed | wait_event_changed 
 -----------------------+--------------------
@@ -176,9 +176,9 @@ SELECT _timescaledb_internal.start_background_workers() as start_background_work
  t                        |              20
 (20 rows)
 
-/*Here we're waiting to see if something shows up in pg_stat_activity, 
- * so we have to condition our loop in the opposite way. We'll only wait 
- * half a second in total as well so that tests don't take too long. */ 
+/*Here we're waiting to see if something shows up in pg_stat_activity,
+ * so we have to condition our loop in the opposite way. We'll only wait
+ * half a second in total as well so that tests don't take too long. */
 CREATE FUNCTION wait_equals(TIMESTAMPTZ) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE
@@ -266,7 +266,7 @@ FROM pg_stat_activity
 WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2' \gset
 SELECT coalesce(
-  (SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher'), 
+  (SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher'),
   (SELECT current_setting('server_version_num')::int < 100000));
  coalesce 
 ----------
@@ -295,7 +295,7 @@ SELECT wait_worker_counts(1,0,0,0);
  t
 (1 row)
 
-/* Connect to the template1 database */ 
+/* Connect to the template1 database */
 \c template1
 \ir include/bgw_launcher_utils.sql
 /*

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -2,10 +2,10 @@
 
 \ir include/bgw_launcher_utils.sql
 
-/* 
- * When we've connected to single_2, we should be able to see the cluster launcher 
+/*
+ * When we've connected to single_2, we should be able to see the cluster launcher
  * and the scheduler for single in pg_stat_activity
- * but single_2 shouldn't have a scheduler because ext not created yet 
+ * but single_2 shouldn't have a scheduler because ext not created yet
  */
 SELECT wait_worker_counts(1,1,0,0);
 
@@ -21,19 +21,19 @@ DROP DATABASE single;
 SELECT wait_worker_counts(1,0,1,0);
 
 /*Now let's restart the scheduler and make sure our backend_start changed */
-SELECT backend_start as orig_backend_start 
-FROM pg_stat_activity 
-WHERE application_name = 'TimescaleDB Background Worker Scheduler' 
+SELECT backend_start as orig_backend_start
+FROM pg_stat_activity
+WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2' \gset
 /* We'll do this in a txn so that we can see that the worker locks on our txn before continuing*/
 BEGIN;
 SELECT _timescaledb_internal.restart_background_workers();
 SELECT wait_worker_counts(1,0,1,0);
 
-SELECT (backend_start > :'orig_backend_start'::timestamptz) backend_start_changed, 
+SELECT (backend_start > :'orig_backend_start'::timestamptz) backend_start_changed,
 (wait_event = 'virtualxid') wait_event_changed
-FROM pg_stat_activity 
-WHERE application_name = 'TimescaleDB Background Worker Scheduler' 
+FROM pg_stat_activity
+WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2';
 COMMIT;
 
@@ -63,9 +63,9 @@ AND datname = 'single_2' \gset
 
 /* Since we're doing idempotency tests, we're also going to exercise our queue and start 20 times*/
 SELECT _timescaledb_internal.start_background_workers() as start_background_workers, * FROM generate_series(1,20);
-/*Here we're waiting to see if something shows up in pg_stat_activity, 
- * so we have to condition our loop in the opposite way. We'll only wait 
- * half a second in total as well so that tests don't take too long. */ 
+/*Here we're waiting to see if something shows up in pg_stat_activity,
+ * so we have to condition our loop in the opposite way. We'll only wait
+ * half a second in total as well so that tests don't take too long. */
 CREATE FUNCTION wait_equals(TIMESTAMPTZ) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $BODY$
 DECLARE
@@ -134,7 +134,7 @@ WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = 'single_2' \gset
 
 SELECT coalesce(
-  (SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher'), 
+  (SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher'),
   (SELECT current_setting('server_version_num')::int < 100000));
 
 SELECT wait_worker_counts(1,0,1,0);
@@ -148,7 +148,7 @@ DROP EXTENSION timescaledb;
 COMMIT;
 SELECT wait_worker_counts(1,0,0,0);
 
-/* Connect to the template1 database */ 
+/* Connect to the template1 database */
 \c template1
 \ir include/bgw_launcher_utils.sql
 BEGIN;

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -148,6 +148,24 @@ DROP EXTENSION timescaledb;
 COMMIT;
 SELECT wait_worker_counts(1,0,0,0);
 
+/* Test that background workers are stopped with DROP OWNED */
+ALTER ROLE :ROLE_DEFAULT_PERM_USER WITH SUPERUSER;
+\c single_2  :ROLE_DEFAULT_PERM_USER
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb CASCADE;
+RESET client_min_messages;
+/* Make sure there is 1 launcher and 1 bgw in single_2 */
+SELECT wait_worker_counts(launcher_ct=>1, scheduler1_ct=> 0, scheduler2_ct=>1, template1_ct=>0);
+/* drop a non-owner of the extension results in no change to worker counts */
+DROP OWNED BY  :ROLE_DEFAULT_PERM_USER_2;
+SELECT wait_worker_counts(launcher_ct=>1, scheduler1_ct=> 0, scheduler2_ct=>1, template1_ct=>0);
+/* drop of owner of extension results in extension drop and a stop to the bgw */
+DROP OWNED BY  :ROLE_DEFAULT_PERM_USER;
+/* The worker in single_2 is dead. Note that 0s are respected */
+SELECT wait_worker_counts(launcher_ct=>1, scheduler1_ct=>0, scheduler2_ct=>0, template1_ct=>0);
+\c single_2  :ROLE_SUPERUSER
+ALTER ROLE :ROLE_DEFAULT_PERM_USER WITH NOSUPERUSER;
+
 /* Connect to the template1 database */
 \c template1
 \ir include/bgw_launcher_utils.sql


### PR DESCRIPTION
n extension can be dropped indirectly via DROP OWNED. This
PR makes sure that such cases are correctly handled by stopping
the appropriate background workers.

This PR also includes a cleanup PR.