### PR TITLE
Switch 'IO' error prefix to 'TS'

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -43,7 +43,7 @@ BEGIN
 
         IF exist_count = 0 THEN
             RAISE 'hypertable "%" does not exist', drop_chunks_impl.table_name
-            USING ERRCODE = 'IO001';
+            USING ERRCODE = 'TS001';
         END IF;
     END IF;
 

--- a/sql/updates/0.4.2--0.5.0.sql
+++ b/sql/updates/0.4.2--0.5.0.sql
@@ -76,7 +76,7 @@ BEGIN
 
         IF missing_column IS NOT NULL THEN
             RAISE EXCEPTION 'Cannot create a unique index without the column: % (used in partitioning)', missing_column
-            USING ERRCODE = 'IO103';
+            USING ERRCODE = 'TS103';
         END IF;
     END IF;
 END
@@ -159,7 +159,7 @@ BEGIN
 
         IF constraint_row.connoinherit THEN
             RAISE 'NO INHERIT option not supported on hypertables: %', constraint_row.conname
-            USING ERRCODE = 'IO101';
+            USING ERRCODE = 'TS101';
         END IF;
 
         RETURN FALSE;

--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -120,7 +120,7 @@ BEGIN
 
     IF h_id IS NULL THEN
         RAISE EXCEPTION 'hypertable "%" not found', table_name
-        USING ERRCODE = 'IO101';
+        USING ERRCODE = 'TS101';
     END IF;
 
     SELECT COUNT(*)
@@ -130,7 +130,7 @@ BEGIN
 
     IF dimension_cnt > 2 THEN
         RAISE EXCEPTION 'get_create_command only supports hypertables with up to 2 dimensions'
-        USING ERRCODE = 'IO101';
+        USING ERRCODE = 'TS101';
     END IF;
 
     FOR dimension_row IN

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -650,7 +650,7 @@ chunk_adaptive_sizing_info_validate(ChunkSizingInfo *info)
 
 	if (NULL == info->colname)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_DIMENSION_NOT_EXIST),
+				(errcode(ERRCODE_TS_DIMENSION_NOT_EXIST),
 				 errmsg("no open dimension found for adaptive chunking")));
 
 	attnum = get_attnum(info->table_relid, info->colname);
@@ -721,7 +721,7 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 
 	if (NULL == ht)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(info.table_relid))));
 
@@ -730,7 +730,7 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 
 	if (NULL == dim)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_DIMENSION_NOT_EXIST),
+				(errcode(ERRCODE_TS_DIMENSION_NOT_EXIST),
 				 errmsg("no open dimension found for adaptive chunking")));
 
 	info.colname = NameStr(dim->fd.column_name);

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -793,7 +793,7 @@ dimension_update(FunctionCallInfo fcinfo,
 
 	if (NULL == ht)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(table_relid))));
 
@@ -814,7 +814,7 @@ dimension_update(FunctionCallInfo fcinfo,
 
 	if (NULL == dim)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_DIMENSION_NOT_EXIST),
+				(errcode(ERRCODE_TS_DIMENSION_NOT_EXIST),
 				 errmsg("hypertable \"%s\" does not have a matching dimension",
 						get_rel_name(table_relid))));
 
@@ -942,7 +942,7 @@ dimension_validate_info(DimensionInfo *info)
 		{
 			if (!info->if_not_exists)
 				ereport(ERROR,
-						(errcode(ERRCODE_IO_DUPLICATE_DIMENSION),
+						(errcode(ERRCODE_TS_DUPLICATE_DIMENSION),
 						 errmsg("column \"%s\" is already a dimension",
 								NameStr(*info->colname))));
 
@@ -1046,7 +1046,7 @@ ts_dimension_add(PG_FUNCTION_ARGS)
 
 	if (NULL == info.ht)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(info.table_relid))));
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,41 +1,41 @@
 /* Defines error codes used
--- PREFIX IO
+-- PREFIX TS
 */
 
 /*
--- IO000 - GROUP: query errors
--- IO001 - hypertable does not exist
--- IO002 - column does not exist
+-- TS000 - GROUP: query errors
+-- TS001 - hypertable does not exist
+-- TS002 - column does not exist
 */
-#define ERRCODE_IO_QUERY_ERRORS MAKE_SQLSTATE('I','O','0','0','0')
-#define ERRCODE_IO_HYPERTABLE_NOT_EXIST MAKE_SQLSTATE('I','O','0','0','1')
-#define ERRCODE_IO_DIMENSION_NOT_EXIST MAKE_SQLSTATE('I','O','0','0','2')
+#define ERRCODE_TS_QUERY_ERRORS MAKE_SQLSTATE('T','S','0','0','0')
+#define ERRCODE_TS_HYPERTABLE_NOT_EXIST MAKE_SQLSTATE('T','S','0','0','1')
+#define ERRCODE_TS_DIMENSION_NOT_EXIST MAKE_SQLSTATE('T','S','0','0','2')
 
 /*
---IO100 - GROUP: DDL errors
---IO101 - operation not supported
---IO102 - bad hypertable definition
---IO103 - bad hypertable index definition
---IO110 - hypertable already exists
---I0120 - node already exists
---I0130 - user already exists
+--TS100 - GROUP: DDL errors
+--TS101 - operation not supported
+--TS102 - bad hypertable definition
+--TS103 - bad hypertable index definition
+--TS110 - hypertable already exists
+--TS120 - node already exists
+--TS130 - user already exists
 */
-#define ERRCODE_IO_DDL_ERRORS MAKE_SQLSTATE('I','O','1','0','0')
-#define ERRCODE_IO_OPERATION_NOT_SUPPORTED MAKE_SQLSTATE('I','O','1','0','1')
-#define ERRCODE_IO_BAD_HYPERTABLE_DEFINITION MAKE_SQLSTATE('I','O','1','0','2')
-#define ERRCODE_IO_BAD_HYPERTABLE_INDEX_DEFINITION MAKE_SQLSTATE('I','O','1','0','3')
-#define ERRCODE_IO_HYPERTABLE_EXISTS MAKE_SQLSTATE('I','O','1','1','0')
-#define ERRCODE_IO_NODE_EXISTS MAKE_SQLSTATE('I','O','1','2','0')
-#define ERRCODE_IO_USER_EXISTS MAKE_SQLSTATE('I','O','1','3','0')
-#define ERRCODE_IO_TABLESPACE_ALREADY_ATTACHED MAKE_SQLSTATE('I','O','1','4','0')
-#define ERRCODE_IO_TABLESPACE_NOT_ATTACHED MAKE_SQLSTATE('I','O','1','5','0')
-#define ERRCODE_IO_DUPLICATE_DIMENSION MAKE_SQLSTATE('I','O','1','6','0')
+#define ERRCODE_TS_DDL_ERRORS MAKE_SQLSTATE('T','S','1','0','0')
+#define ERRCODE_TS_OPERATION_NOT_SUPPORTED MAKE_SQLSTATE('T','S','1','0','1')
+#define ERRCODE_TS_BAD_HYPERTABLE_DEFINITION MAKE_SQLSTATE('T','S','1','0','2')
+#define ERRCODE_TS_BAD_HYPERTABLE_INDEX_DEFINITION MAKE_SQLSTATE('T','S','1','0','3')
+#define ERRCODE_TS_HYPERTABLE_EXISTS MAKE_SQLSTATE('T','S','1','1','0')
+#define ERRCODE_TS_NODE_EXISTS MAKE_SQLSTATE('T','S','1','2','0')
+#define ERRCODE_TS_USER_EXISTS MAKE_SQLSTATE('T','S','1','3','0')
+#define ERRCODE_TS_TABLESPACE_ALREADY_ATTACHED MAKE_SQLSTATE('T','S','1','4','0')
+#define ERRCODE_TS_TABLESPACE_NOT_ATTACHED MAKE_SQLSTATE('T','S','1','5','0')
+#define ERRCODE_TS_DUPLICATE_DIMENSION MAKE_SQLSTATE('T','S','1','6','0')
 
 /*
 --IO500 - GROUP: internal error
 --IO501 - unexpected state/event
 --IO502 - communication/remote error
 */
-#define ERRCODE_IO_INTERNAL_ERROR MAKE_SQLSTATE('I','O','5','0','0')
-#define ERRCODE_IO_UNEXPECTED MAKE_SQLSTATE('I','O','5','0','1')
-#define ERRCODE_IO_COMMUNICATION_ERROR MAKE_SQLSTATE('I','O','5','0','2')
+#define ERRCODE_TS_INTERNAL_ERROR MAKE_SQLSTATE('T','S','5','0','0')
+#define ERRCODE_TS_UNEXPECTED MAKE_SQLSTATE('T','S','5','0','1')
+#define ERRCODE_TS_COMMUNICATION_ERROR MAKE_SQLSTATE('T','S','5','0','2')

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -459,7 +459,7 @@ hypertable_lock_tuple(Oid table_relid)
 
 	if (num_found != 1)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(table_relid))));
 
@@ -1251,7 +1251,7 @@ ts_hypertable_create(PG_FUNCTION_ARGS)
 	if (if_not_exists && is_hypertable(table_relid))
 	{
 		ereport(NOTICE,
-				(errcode(ERRCODE_IO_HYPERTABLE_EXISTS),
+				(errcode(ERRCODE_TS_HYPERTABLE_EXISTS),
 				 errmsg("table \"%s\" is already a hypertable, skipping",
 						get_rel_name(table_relid))));
 
@@ -1282,7 +1282,7 @@ ts_hypertable_create(PG_FUNCTION_ARGS)
 		if (if_not_exists)
 		{
 			ereport(NOTICE,
-					(errcode(ERRCODE_IO_HYPERTABLE_EXISTS),
+					(errcode(ERRCODE_TS_HYPERTABLE_EXISTS),
 					 errmsg("table \"%s\" is already a hypertable, skipping",
 							get_rel_name(table_relid))));
 
@@ -1290,7 +1290,7 @@ ts_hypertable_create(PG_FUNCTION_ARGS)
 		}
 
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_EXISTS),
+				(errcode(ERRCODE_TS_HYPERTABLE_EXISTS),
 				 errmsg("table \"%s\" is already a hypertable",
 						get_rel_name(table_relid))));
 	}

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -79,7 +79,7 @@ indexing_verify_columns(Hyperspace *hs, List *indexelems)
 
 		if (!index_has_attribute(indexelems, NameStr(dim->fd.column_name)))
 			ereport(ERROR,
-					(errcode(ERRCODE_IO_BAD_HYPERTABLE_INDEX_DEFINITION),
+					(errcode(ERRCODE_TS_BAD_HYPERTABLE_INDEX_DEFINITION),
 					 errmsg("cannot create a unique index without the column \"%s\" (used in partitioning)",
 							NameStr(dim->fd.column_name))));
 	}

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -911,7 +911,7 @@ process_altertable_drop_not_null(Hypertable *ht, AlterTableCmd *cmd)
 		if (IS_OPEN_DIMENSION(dim) &&
 			strncmp(NameStr(dim->fd.column_name), cmd->name, NAMEDATALEN) == 0)
 			ereport(ERROR,
-					(errcode(ERRCODE_IO_OPERATION_NOT_SUPPORTED),
+					(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 					 errmsg("cannot drop not-null constraint from a time-partitioned column")));
 	}
 }
@@ -1378,7 +1378,7 @@ process_alter_column_type_start(Hypertable *ht, AlterTableCmd *cmd)
 		if (IS_CLOSED_DIMENSION(dim) &&
 			strncmp(NameStr(dim->fd.column_name), cmd->name, NAMEDATALEN) == 0)
 			ereport(ERROR,
-					(errcode(ERRCODE_IO_OPERATION_NOT_SUPPORTED),
+					(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 					 errmsg("cannot change the type of a hash-partitioned column")));
 	}
 }

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -516,7 +516,7 @@ tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_attach
 
 	if (NULL == ht)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(hypertable_oid))));
 
@@ -524,12 +524,12 @@ tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_attach
 	{
 		if (if_not_attached)
 			ereport(NOTICE,
-					(errcode(ERRCODE_IO_TABLESPACE_ALREADY_ATTACHED),
+					(errcode(ERRCODE_TS_TABLESPACE_ALREADY_ATTACHED),
 					 errmsg("tablespace \"%s\" is already attached to hypertable \"%s\", skipping",
 							NameStr(*tspcname), get_rel_name(hypertable_oid))));
 		else
 			ereport(ERROR,
-					(errcode(ERRCODE_IO_TABLESPACE_ALREADY_ATTACHED),
+					(errcode(ERRCODE_TS_TABLESPACE_ALREADY_ATTACHED),
 					 errmsg("tablespace \"%s\" is already attached to hypertable \"%s\"",
 							NameStr(*tspcname), get_rel_name(hypertable_oid))));
 	}
@@ -557,7 +557,7 @@ tablespace_detach_one(Oid hypertable_oid, const char *tspcname, Oid tspcoid, boo
 
 	if (NULL == ht)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(hypertable_oid))));
 
@@ -565,12 +565,12 @@ tablespace_detach_one(Oid hypertable_oid, const char *tspcname, Oid tspcoid, boo
 		ret = tablespace_delete(ht->fd.id, tspcname);
 	else if (if_attached)
 		ereport(NOTICE,
-				(errcode(ERRCODE_IO_TABLESPACE_NOT_ATTACHED),
+				(errcode(ERRCODE_TS_TABLESPACE_NOT_ATTACHED),
 				 errmsg("tablespace \"%s\" is not attached to hypertable \"%s\", skipping",
 						tspcname, get_rel_name(hypertable_oid))));
 	else
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_TABLESPACE_NOT_ATTACHED),
+				(errcode(ERRCODE_TS_TABLESPACE_NOT_ATTACHED),
 				 errmsg("tablespace \"%s\" is not attached to hypertable \"%s\"",
 						tspcname, get_rel_name(hypertable_oid))));
 
@@ -593,7 +593,7 @@ tablespace_detach_all(Oid hypertable_oid)
 
 	if (NULL == ht)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(hypertable_oid))));
 
@@ -688,7 +688,7 @@ ts_tablespace_show(PG_FUNCTION_ARGS)
 
 	if (NULL == ht)
 		ereport(ERROR,
-				(errcode(ERRCODE_IO_HYPERTABLE_NOT_EXIST),
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("table \"%s\" is not a hypertable",
 						get_rel_name(hypertable_oid))));
 


### PR DESCRIPTION
Our errorcodes have a `IO` prefix from when we were Iobeam. This commit
switches that prefix to `TS` for consistency.