### PR TITLE
Refactor scanner callback interface

### DIFF
--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -104,7 +104,7 @@ typedef struct DimensionSliceScanData
 	int			limit;
 }			DimensionSliceScanData;
 
-static bool
+static ScanTupleResult
 dimension_vec_tuple_found(TupleInfo *ti, void *data)
 {
 	DimensionVec **slices = data;
@@ -112,7 +112,7 @@ dimension_vec_tuple_found(TupleInfo *ti, void *data)
 
 	*slices = dimension_vec_add_slice(slices, slice);
 
-	return true;
+	return SCAN_CONTINUE;
 }
 
 static int
@@ -363,7 +363,7 @@ dimension_slice_scan_by_dimension_before_point(int32 dimension_id, int64 point, 
 	return dimension_vec_sort(&slices);
 }
 
-static bool
+static ScanTupleResult
 dimension_slice_tuple_delete(TupleInfo *ti, void *data)
 {
 	bool		isnull;
@@ -381,7 +381,7 @@ dimension_slice_tuple_delete(TupleInfo *ti, void *data)
 	catalog_delete(ti->scanrel, ti->tuple);
 	catalog_restore_user(&sec_ctx);
 
-	return true;
+	return SCAN_CONTINUE;
 }
 
 int
@@ -426,13 +426,13 @@ dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraints)
 											   CurrentMemoryContext);
 }
 
-static bool
+static ScanTupleResult
 dimension_slice_fill(TupleInfo *ti, void *data)
 {
 	DimensionSlice **slice = data;
 
 	memcpy(&(*slice)->fd, GETSTRUCT(ti->tuple), sizeof(FormData_dimension_slice));
-	return false;
+	return SCAN_DONE;
 }
 
 /*
@@ -458,7 +458,7 @@ dimension_slice_scan_for_existing(DimensionSlice *slice)
 	return slice;
 }
 
-static bool
+static ScanTupleResult
 dimension_slice_tuple_found(TupleInfo *ti, void *data)
 {
 	DimensionSlice **slice = data;
@@ -466,7 +466,7 @@ dimension_slice_tuple_found(TupleInfo *ti, void *data)
 
 	*slice = dimension_slice_from_tuple(ti->tuple);
 	MemoryContextSwitchTo(old);
-	return false;
+	return SCAN_DONE;
 }
 
 DimensionSlice *

--- a/src/hypertable_cache.c
+++ b/src/hypertable_cache.c
@@ -73,13 +73,13 @@ hypertable_cache_create()
 
 static Cache *hypertable_cache_current = NULL;
 
-static bool
+static ScanTupleResult
 hypertable_tuple_found(TupleInfo *ti, void *data)
 {
 	HypertableCacheEntry *entry = data;
 
 	entry->hypertable = hypertable_from_tuple(ti->tuple, ti->mctx);
-	return false;
+	return SCAN_DONE;
 }
 
 static void *

--- a/src/installation_metadata.c
+++ b/src/installation_metadata.c
@@ -73,7 +73,7 @@ typedef struct DatumValue
 	bool		isnull;
 } DatumValue;
 
-static bool
+static ScanTupleResult
 installation_metadata_tuple_get_value(TupleInfo *ti, void *data)
 {
 	DatumValue *dv = data;
@@ -83,7 +83,7 @@ installation_metadata_tuple_get_value(TupleInfo *ti, void *data)
 	if (!dv->isnull)
 		dv->value = convert_text_to_type(dv->value, dv->typeid);
 
-	return false;
+	return SCAN_DONE;
 }
 
 static Datum

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -14,6 +14,12 @@
 
 #include "scanner.h"
 
+enum ScannerType
+{
+	ScannerTypeHeap,
+	ScannerTypeIndex,
+};
+
 typedef union ScanDesc
 {
 	IndexScanDesc index_scan;
@@ -188,7 +194,7 @@ scanner_scan(ScannerCtx *ctx)
 
 	while (is_valid)
 	{
-		if (ctx->filter == NULL || ctx->filter(&ictx.tinfo, ctx->data))
+		if (ctx->filter == NULL || ctx->filter(&ictx.tinfo, ctx->data) == SCAN_INCLUDE)
 		{
 			ictx.tinfo.count++;
 
@@ -211,7 +217,8 @@ scanner_scan(ScannerCtx *ctx)
 			}
 
 			/* Abort the scan if the handler wants us to */
-			if (ctx->tuple_found != NULL && !ctx->tuple_found(&ictx.tinfo, ctx->data))
+			if (ctx->tuple_found != NULL &&
+				ctx->tuple_found(&ictx.tinfo, ctx->data) == SCAN_DONE)
 				break;
 		}
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -13,12 +13,6 @@
 #include <access/heapam.h>
 #include <nodes/lockoptions.h>
 
-typedef enum ScannerType
-{
-	ScannerTypeHeap,
-	ScannerTypeIndex,
-}			ScannerType;
-
 /* Tuple information passed on to handlers when scanning for tuples. */
 typedef struct TupleInfo
 {
@@ -43,8 +37,20 @@ typedef struct TupleInfo
 	MemoryContext mctx;
 } TupleInfo;
 
-typedef bool (*tuple_found_func) (TupleInfo *ti, void *data);
-typedef bool (*tuple_filter_func) (TupleInfo *ti, void *data);
+typedef enum ScanTupleResult
+{
+	SCAN_DONE,
+	SCAN_CONTINUE
+} ScanTupleResult;
+
+typedef enum ScanFilterResult
+{
+	SCAN_EXCLUDE,
+	SCAN_INCLUDE
+} ScanFilterResult;
+
+typedef ScanTupleResult (*tuple_found_func) (TupleInfo *ti, void *data);
+typedef ScanFilterResult (*tuple_filter_func) (TupleInfo *ti, void *data);
 
 typedef struct ScannerCtx
 {
@@ -82,16 +88,17 @@ typedef struct ScannerCtx
 	void		(*postscan) (int num_tuples, void *data);
 
 	/*
-	 * Optional handler to filter tuples. Should return true for tuples that
-	 * should be passed on to tuple_found, or false otherwise.
+	 * Optional handler to filter tuples. Should return SCAN_INCLUDE for
+	 * tuples that should be passed on to tuple_found, or SCAN_EXCLUDE
+	 * otherwise.
 	 */
-	bool		(*filter) (TupleInfo *ti, void *data);
+	ScanFilterResult (*filter) (TupleInfo *ti, void *data);
 
 	/*
-	 * Handler for found tuples. Should return true to continue the scan or
-	 * false to abort.
+	 * Handler for found tuples. Should return SCAN_CONTINUE to continue the
+	 * scan or SCAN_DONE to finish without scanning further tuples.
 	 */
-	bool		(*tuple_found) (TupleInfo *ti, void *data);
+	ScanTupleResult (*tuple_found) (TupleInfo *ti, void *data);
 } ScannerCtx;
 
 /* Performs an index scan or heap scan and returns the number of matching


### PR DESCRIPTION
This change adds proper result types for the scanner's filter and
tuple handling callbacks. Previously, these callbacks were supposed to
return bool, which was hard to interpret. For instance, for the tuple
handler callback, true meant continue processing the next tuple while
false meant finish the scan. However, this wasn't always clear. Having
proper return types also makes it easier to see from a function's
signature that it is a scanner callback handler, rather than some
other function that can be called directly.