### PR TITLE
Eliminate typedef redeclarations

### DIFF
--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -1,22 +1,26 @@
 #ifndef BGW_JOB_H
 #define BGW_JOB_H
 
-#include "catalog.h"
 #include <postmaster/bgworker.h>
 
-typedef enum JobType
+typedef enum JobType JobType;
+typedef struct BgwJob BgwJob;
+
+#include "catalog.h"
+
+enum JobType
 {
 	JOB_TYPE_VERSION_CHECK = 0,
 	JOB_TYPE_UNKNOWN,
 	_MAX_JOB_TYPE
-} JobType;
+};
 
-typedef struct BgwJob
+struct BgwJob
 {
 	FormData_bgw_job fd;
 	JobType		bgw_type;
 
-} BgwJob;
+};
 
 typedef bool job_main_func (void);
 typedef bool (*unknown_job_type_hook_type) (BgwJob *job);

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -1,19 +1,22 @@
 #ifndef BGW_JOB_STAT_H
 #define BGW_JOB_STAT_H
 
+typedef enum JobResult JobResult;
+typedef struct BgwJobStat BgwJobStat;
+
 #include "catalog.h"
 #include "job.h"
 
-typedef struct BgwJobStat
+struct BgwJobStat
 {
 	FormData_bgw_job_stat fd;
-} BgwJobStat;
+};
 
-typedef enum JobResult
+enum JobResult
 {
 	JOB_FAILURE = 0,
 	JOB_SUCCESS = 1,
-} JobResult;
+};
 
 extern BgwJobStat *bgw_job_stat_find(int job_id);
 extern void bgw_job_stat_mark_start(int32 bgw_job_id);

--- a/src/bgw/timer.h
+++ b/src/bgw/timer.h
@@ -4,14 +4,16 @@
 #include <postgres.h>
 #include <utils/timestamp.h>
 
+typedef struct Timer Timer;
+
 #include "config.h"
 
-typedef struct Timer
+struct Timer
 {
 	TimestampTz (*get_current_timestamp) ();
 	bool		(*wait) (TimestampTz until);
 
-} Timer;
+};
 
 extern bool timer_wait(TimestampTz until);
 extern TimestampTz timer_get_current_timestamp(void);

--- a/src/cache.h
+++ b/src/cache.h
@@ -5,20 +5,24 @@
 #include <utils/memutils.h>
 #include <utils/hsearch.h>
 
-typedef struct CacheQuery
+typedef struct Cache Cache;
+typedef struct CacheQuery CacheQuery;
+typedef struct CacheStats CacheStats;
+
+struct CacheQuery
 {
 	void	   *result;
 	void	   *data;
-} CacheQuery;
+};
 
-typedef struct CacheStats
+struct CacheStats
 {
 	long		numelements;
 	uint64		hits;
 	uint64		misses;
-} CacheStats;
+};
 
-typedef struct Cache
+struct Cache
 {
 	HASHCTL		hctl;
 	HTAB	   *htab;
@@ -34,7 +38,7 @@ typedef struct Cache
 	bool		release_on_commit;	/* This should be false if doing
 									 * cross-commit operations like CLUSTER or
 									 * VACUUM */
-} Cache;
+};
 
 extern void cache_init(Cache *cache);
 extern void cache_invalidate(Cache *cache);

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -6,7 +6,37 @@
 #include <utils/rel.h>
 #include <nodes/nodes.h>
 #include <access/heapam.h>
+
+typedef enum CacheType CacheType;
+typedef enum CatalogTable CatalogTable;
+typedef enum InternalFunction InternalFunction;
+typedef struct Catalog Catalog;
+typedef struct CatalogSecurityContext CatalogSecurityContext;
+typedef struct FormData_bgw_job FormData_bgw_job;
+typedef struct FormData_bgw_job_stat FormData_bgw_job_stat;
+typedef struct FormData_chunk FormData_chunk;
+typedef struct FormData_chunk_constraint FormData_chunk_constraint;
+typedef struct FormData_chunk_index FormData_chunk_index;
+typedef struct FormData_dimension FormData_dimension;
+typedef struct FormData_dimension_slice FormData_dimension_slice;
+typedef struct FormData_hypertable FormData_hypertable;
+typedef struct FormData_installation_metadata FormData_installation_metadata;
+typedef struct FormData_tablespace FormData_tablespace;
+typedef struct FormData_tablespace_hypertable_id_tablespace_name_idx FormData_tablespace_hypertable_id_tablespace_name_idx;
+typedef struct FormData_tablespace_pkey_idx FormData_tablespace_pkey_idx;
+typedef FormData_bgw_job *Form_bgw_job;
+typedef FormData_bgw_job_stat *Form_bgw_job_stat;
+typedef FormData_chunk *Form_chunk;
+typedef FormData_chunk_constraint *Form_chunk_constraint;
+typedef FormData_chunk_index *Form_chunk_index;
+typedef FormData_dimension *Form_dimension;
+typedef FormData_dimension_slice *Form_dimension_slice;
+typedef FormData_hypertable *Form_hypertable;
+typedef FormData_installation_metadata *Form_installation_metadata;
+typedef FormData_tablespace *Form_tablespace;
+
 #include "extension_constants.h"
+
 /*
  * TimescaleDB catalog.
  *
@@ -22,7 +52,7 @@
  * Generally, definitions and naming should roughly follow how things are done
  * in Postgres internally.
  */
-typedef enum CatalogTable
+enum CatalogTable
 {
 	HYPERTABLE = 0,
 	DIMENSION,
@@ -35,7 +65,7 @@ typedef enum CatalogTable
 	BGW_JOB_STAT,
 	INSTALLATION_METADATA,
 	_MAX_CATALOG_TABLES,
-} CatalogTable;
+};
 
 #define INVALID_CATALOG_TABLE _MAX_CATALOG_TABLES
 #define INVALID_INDEXID -1
@@ -52,11 +82,11 @@ typedef enum CatalogTable
 #define CatalogInternalCall4(func, datum1, datum2, datum3, datum4) \
 	OidFunctionCall4(catalog_get_internal_function_id(catalog_get(), func), datum1, datum2, datum3, datum4)
 
-typedef enum InternalFunction
+enum InternalFunction
 {
 	DDL_ADD_CHUNK_CONSTRAINT,
 	_MAX_INTERNAL_FUNCTIONS,
-} InternalFunction;
+};
 
 
 /******************************
@@ -85,7 +115,7 @@ enum Anum_hypertable
 #define Natts_hypertable \
 	(_Anum_hypertable_max - 1)
 
-typedef struct FormData_hypertable
+struct FormData_hypertable
 {
 	int32		id;
 	NameData	schema_name;
@@ -96,9 +126,8 @@ typedef struct FormData_hypertable
 	NameData	chunk_sizing_func_schema;
 	NameData	chunk_sizing_func_name;
 	int64		chunk_target_size;
-} FormData_hypertable;
+};
 
-typedef FormData_hypertable *Form_hypertable;
 
 /* Hypertable primary index attribute numbers */
 enum Anum_hypertable_pkey_idx
@@ -152,7 +181,7 @@ enum Anum_dimension
 #define Natts_dimension \
 	(_Anum_dimension_max - 1)
 
-typedef struct FormData_dimension
+struct FormData_dimension
 {
 	int32		id;
 	int32		hypertable_id;
@@ -165,9 +194,8 @@ typedef struct FormData_dimension
 	NameData	partitioning_func;
 	/* open (time) columns */
 	int64		interval_length;
-} FormData_dimension;
+};
 
-typedef FormData_dimension *Form_dimension;
 
 enum Anum_dimension_id_idx
 {
@@ -215,15 +243,13 @@ enum Anum_dimension_slice
 #define Natts_dimension_slice \
 	(_Anum_dimension_slice_max - 1)
 
-typedef struct FormData_dimension_slice
+struct FormData_dimension_slice
 {
 	int32		id;
 	int32		dimension_id;
 	int64		range_start;
 	int64		range_end;
-} FormData_dimension_slice;
-
-typedef FormData_dimension_slice *Form_dimension_slice;
+};
 
 enum Anum_dimension_slice_id_idx
 {
@@ -272,15 +298,13 @@ enum Anum_chunk
 #define Natts_chunk \
 	(_Anum_chunk_max - 1)
 
-typedef struct FormData_chunk
+struct FormData_chunk
 {
 	int32		id;
 	int32		hypertable_id;
 	NameData	schema_name;
 	NameData	table_name;
-} FormData_chunk;
-
-typedef FormData_chunk *Form_chunk;
+};
 
 enum
 {
@@ -328,15 +352,13 @@ enum Anum_chunk_constraint
 	(_Anum_chunk_constraint_max - 1)
 
 /* Do Not use GET_STRUCT with FormData_chunk_constraint. It contains NULLS */
-typedef struct FormData_chunk_constraint
+struct FormData_chunk_constraint
 {
 	int32		chunk_id;
 	int32		dimension_slice_id;
 	NameData	constraint_name;
 	NameData	hypertable_constraint_name;
-} FormData_chunk_constraint;
-
-typedef FormData_chunk_constraint *Form_chunk_constraint;
+};
 
 enum
 {
@@ -379,15 +401,13 @@ enum Anum_chunk_index
 #define Natts_chunk_index \
 	(_Anum_chunk_index_max - 1)
 
-typedef struct FormData_chunk_index
+struct FormData_chunk_index
 {
 	int32		chunk_id;
 	NameData	index_name;
 	int32		hypertable_id;
 	NameData	hypertable_index_name;
-} FormData_chunk_index;
-
-typedef FormData_chunk_index *Form_chunk_index;
+};
 
 enum
 {
@@ -429,14 +449,12 @@ enum Anum_tablespace
 #define Natts_tablespace \
 	(_Anum_tablespace_max - 1)
 
-typedef struct FormData_tablespace
+struct FormData_tablespace
 {
 	int32		id;
 	int32		hypertable_id;
 	NameData	tablespace_name;
-} FormData_tablespace;
-
-typedef FormData_tablespace *Form_tablespace;
+};
 
 enum
 {
@@ -451,10 +469,10 @@ enum Anum_tablespace_pkey_idx
 	_Anum_tablespace_pkey_idx_max,
 };
 
-typedef struct FormData_tablespace_pkey_idx
+struct FormData_tablespace_pkey_idx
 {
 	int32		tablespace_id;
-}			FormData_tablespace_pkey_idx;
+};
 
 enum Anum_tablespace_hypertable_id_tablespace_name_idx
 {
@@ -463,11 +481,11 @@ enum Anum_tablespace_hypertable_id_tablespace_name_idx
 	_Anum_tablespace_hypertable_id_tablespace_name_idx_max,
 };
 
-typedef struct FormData_tablespace_hypertable_id_tablespace_name_idx
+struct FormData_tablespace_hypertable_id_tablespace_name_idx
 {
 	int32		hypertable_id;
 	NameData	tablespace_name;
-}			FormData_tablespace_hypertable_id_tablespace_name_idx;
+};
 
 /************************************
  *
@@ -492,7 +510,7 @@ enum Anum_bgw_job
 #define Natts_bgw_job \
 	(_Anum_bgw_job_max - 1)
 
-typedef struct FormData_bgw_job
+struct FormData_bgw_job
 {
 	int32		id;
 	NameData	application_name;
@@ -501,9 +519,7 @@ typedef struct FormData_bgw_job
 	Interval	max_runtime;
 	int32		max_retries;
 	Interval	retry_period;
-} FormData_bgw_job;
-
-typedef FormData_bgw_job *Form_bgw_job;
+};
 
 enum
 {
@@ -550,7 +566,7 @@ enum Anum_bgw_job_stat
 #define Natts_bgw_job_stat \
 	(_Anum_bgw_job_stat_max - 1)
 
-typedef struct FormData_bgw_job_stat
+struct FormData_bgw_job_stat
 {
 	int32		id;
 	TimestampTz last_start;
@@ -564,9 +580,7 @@ typedef struct FormData_bgw_job_stat
 	int64		total_crashes;
 	int32		consecutive_failures;
 	int32		consecutive_crashes;
-} FormData_bgw_job_stat;
-
-typedef FormData_bgw_job_stat *Form_bgw_job_stat;
+};
 
 enum
 {
@@ -601,13 +615,11 @@ enum Anum_installation_metadata
 #define Natts_installation_metadata \
 	(_Anum_installation_metadata_max - 1)
 
-typedef struct FormData_installation_metadata
+struct FormData_installation_metadata
 {
 	NameData	key;
 	text	   *value;
-} FormData_installation_metadata;
-
-typedef FormData_installation_metadata *Form_installation_metadata;
+};
 
 /* installation_metadata primary index attribute numbers */
 enum Anum_installation_metadata_pkey_idx
@@ -631,14 +643,14 @@ enum
  */
 #define _MAX_TABLE_INDEXES 5
 
-typedef enum CacheType
+enum CacheType
 {
 	CACHE_TYPE_HYPERTABLE,
 	CACHE_TYPE_CHUNK,
 	_MAX_CACHE_TYPES
-} CacheType;
+};
 
-typedef struct Catalog
+struct Catalog
 {
 	char		database_name[NAMEDATALEN];
 	Oid			database_id;
@@ -664,14 +676,14 @@ typedef struct Catalog
 	{
 		Oid			function_id;
 	}			functions[_MAX_INTERNAL_FUNCTIONS];
-} Catalog;
+};
 
 
-typedef struct CatalogSecurityContext
+struct CatalogSecurityContext
 {
 	Oid			saved_uid;
 	int			saved_security_context;
-} CatalogSecurityContext;
+};
 
 bool		catalog_is_valid(Catalog *catalog);
 Catalog    *catalog_get(void);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -6,14 +6,15 @@
 #include <access/tupdesc.h>
 #include <utils/hsearch.h>
 
+typedef struct Chunk Chunk;
+typedef struct ChunkScanCtx ChunkScanCtx;
+typedef struct ChunkScanEntry ChunkScanEntry;
+
 #include "catalog.h"
 #include "chunk_constraint.h"
+#include "dimension.h"
+#include "hypercube.h"
 #include "hypertable.h"
-
-typedef struct Hypercube Hypercube;
-typedef struct Point Point;
-typedef struct Hyperspace Hyperspace;
-typedef struct Hypertable Hypertable;
 
 /*
  * A chunk represents a table that stores data, part of a partitioned
@@ -23,7 +24,7 @@ typedef struct Hypertable Hypertable;
  * boundaries of the cube is represented by a collection of slices from the N
  * distinct dimensions.
  */
-typedef struct Chunk
+struct Chunk
 {
 	FormData_chunk fd;
 	Oid			table_id;
@@ -36,7 +37,7 @@ typedef struct Chunk
 	 */
 	Hypercube  *cube;
 	ChunkConstraints *constraints;
-} Chunk;
+};
 
 /*
  * ChunkScanCtx is used to scan for chunks in a hypertable's N-dimensional
@@ -45,7 +46,7 @@ typedef struct Chunk
  * For every matching constraint, a corresponding chunk will be created in the
  * context's hash table, keyed on the chunk ID.
  */
-typedef struct ChunkScanCtx
+struct ChunkScanCtx
 {
 	HTAB	   *htab;
 	Hyperspace *space;
@@ -53,14 +54,14 @@ typedef struct ChunkScanCtx
 	bool		early_abort;
 	LOCKMODE	lockmode;
 	void	   *data;
-} ChunkScanCtx;
+};
 
 /* The hash table entry for the ChunkScanCtx */
-typedef struct ChunkScanEntry
+struct ChunkScanEntry
 {
 	int32		chunk_id;
 	Chunk	   *chunk;
-} ChunkScanEntry;
+};
 
 extern Chunk *chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
 extern Chunk *chunk_create_stub(int32 id, int16 num_constraints);

--- a/src/chunk_adaptive.h
+++ b/src/chunk_adaptive.h
@@ -3,7 +3,9 @@
 
 #include <postgres.h>
 
-typedef struct ChunkSizingInfo
+typedef struct ChunkSizingInfo ChunkSizingInfo;
+
+struct ChunkSizingInfo
 {
 	Oid			table_relid;
 	/* Set manually */
@@ -18,7 +20,7 @@ typedef struct ChunkSizingInfo
 	NameData	func_name;
 	NameData	func_schema;
 	int64		target_size_bytes;
-} ChunkSizingInfo;
+};
 
 void		chunk_adaptive_sizing_info_validate(ChunkSizingInfo *info);
 

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -5,22 +5,27 @@
 #include <postgres.h>
 #include <nodes/pg_list.h>
 
-#include "catalog.h"
-#include "hypertable.h"
+typedef struct ChunkConstraint ChunkConstraint;
+typedef struct ChunkConstraints ChunkConstraints;
 
-typedef struct ChunkConstraint
+#include "catalog.h"
+#include "chunk.h"
+#include "dimension.h"
+#include "hypercube.h"
+
+struct ChunkConstraint
 {
 	FormData_chunk_constraint fd;
-} ChunkConstraint;
+};
 
-typedef struct ChunkConstraints
+struct ChunkConstraints
 {
 	MemoryContext mctx;
 	int16		capacity;
 	int16		num_constraints;
 	int16		num_dimension_constraints;
 	ChunkConstraint *constraints;
-} ChunkConstraints;
+};
 
 #define chunk_constraints_get(cc, i)			\
 	&((cc)->constraints[i])
@@ -28,11 +33,6 @@ typedef struct ChunkConstraints
 #define is_dimension_constraint(cc)				\
 	((cc)->fd.dimension_slice_id > 0)
 
-
-typedef struct Chunk Chunk;
-typedef struct DimensionSlice DimensionSlice;
-typedef struct Hypercube Hypercube;
-typedef struct ChunkScanCtx ChunkScanCtx;
 
 extern ChunkConstraints *chunk_constraints_alloc(int size_hint, MemoryContext mctx);
 extern ChunkConstraints *chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint, MemoryContext mctx);

--- a/src/chunk_dispatch.h
+++ b/src/chunk_dispatch.h
@@ -5,17 +5,20 @@
 #include <nodes/parsenodes.h>
 #include <nodes/execnodes.h>
 
-#include "hypertable_cache.h"
+typedef struct ChunkDispatch ChunkDispatch;
+
 #include "cache.h"
-#include "subspace_store.h"
 #include "chunk_dispatch_state.h"
+#include "chunk_insert_state.h"
+#include "hypertable_cache.h"
+#include "subspace_store.h"
 
 /*
  * ChunkDispatch keeps cached state needed to dispatch tuples to chunks. It is
  * separate from any plan and executor nodes, since it is used both for INSERT
  * and COPY.
 */
-typedef struct ChunkDispatch
+struct ChunkDispatch
 {
 	Hypertable *hypertable;
 	SubspaceStore *cache;
@@ -34,10 +37,7 @@ typedef struct ChunkDispatch
 	List	   *on_conflict_where;
 	CmdType		cmd_type;
 
-} ChunkDispatch;
-
-typedef struct Point Point;
-typedef struct ChunkInsertState ChunkInsertState;
+};
 
 ChunkDispatch *chunk_dispatch_create(Hypertable *ht, EState *estate);
 void		chunk_dispatch_destroy(ChunkDispatch *dispatch);

--- a/src/chunk_dispatch_info.h
+++ b/src/chunk_dispatch_info.h
@@ -5,17 +5,19 @@
 #include <nodes/parsenodes.h>
 #include <nodes/extensible.h>
 
+typedef struct ChunkDispatchInfo ChunkDispatchInfo;
+
 /*
  * ChunkDispatchInfo holds plan info that needs to be passed on to the
  * execution stage. Since it is part of the plan tree, it needs to be able
  * support copyObject(), and therefore extends ExtensibleNode.
  */
-typedef struct ChunkDispatchInfo
+struct ChunkDispatchInfo
 {
 	ExtensibleNode enode;
 	/* Copied fields */
 	Oid			hypertable_relid;
-} ChunkDispatchInfo;
+};
 
 extern ChunkDispatchInfo *chunk_dispatch_info_create(Oid hypertable_relid, Query *parse);
 

--- a/src/chunk_dispatch_state.h
+++ b/src/chunk_dispatch_state.h
@@ -5,12 +5,13 @@
 #include <nodes/execnodes.h>
 #include <nodes/parsenodes.h>
 
-typedef struct ChunkDispatch ChunkDispatch;
-typedef struct ChunkDispatchInfo ChunkDispatchInfo;
-typedef struct Cache Cache;
+typedef struct ChunkDispatchState ChunkDispatchState;
+
+#include "chunk_dispatch.h"
+#include "chunk_dispatch_info.h"
 
 /* State used for every tuple in an insert statement */
-typedef struct ChunkDispatchState
+struct ChunkDispatchState
 {
 	CustomScanState cscan_state;
 	Plan	   *subplan;
@@ -29,7 +30,7 @@ typedef struct ChunkDispatchState
 	 * for each chunk.
 	 */
 	ChunkDispatch *dispatch;
-} ChunkDispatchState;
+};
 
 #define CHUNK_DISPATCH_STATE_NAME "ChunkDispatchState"
 

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -5,16 +5,18 @@
 #include <nodes/parsenodes.h>
 #include <fmgr.h>
 
-typedef struct Chunk Chunk;
-typedef struct Hypertable Hypertable;
+typedef struct ChunkIndexMapping ChunkIndexMapping;
 
-typedef struct ChunkIndexMapping
+#include "chunk.h"
+#include "hypertable.h"
+
+struct ChunkIndexMapping
 {
 	Oid			chunkoid;
 	Oid			parent_indexoid;
 	Oid			indexoid;
 	Oid			hypertableoid;
-} ChunkIndexMapping;
+};
 
 extern void chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid, int32 chunk_id, Oid chunkrelid);
 extern Oid	chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid, int32 hypertable_id, Oid hypertable_indexrelid);

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -6,12 +6,15 @@
 #include <funcapi.h>
 #include <access/tupconvert.h>
 
-#include "hypertable.h"
-#include "chunk.h"
-#include "cache.h"
-#include "chunk_dispatch_state.h"
+typedef struct ChunkInsertState ChunkInsertState;
 
-typedef struct ChunkInsertState
+#include "cache.h"
+#include "chunk.h"
+#include "chunk_dispatch.h"
+#include "chunk_dispatch_state.h"
+#include "hypertable.h"
+
+struct ChunkInsertState
 {
 	Relation	rel;
 	ResultRelInfo *result_relation_info;
@@ -21,9 +24,7 @@ typedef struct ChunkInsertState
 	MemoryContext mctx;
 
 	EState	   *estate;
-} ChunkInsertState;
-
-typedef struct ChunkDispatch ChunkDispatch;
+};
 
 extern HeapTuple chunk_insert_state_convert_tuple(ChunkInsertState *state, HeapTuple tuple, TupleTableSlot **existing_slot);
 extern ChunkInsertState *chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch);

--- a/src/constraint_aware_append.h
+++ b/src/constraint_aware_append.h
@@ -5,19 +5,23 @@
 #include <nodes/relation.h>
 #include <nodes/extensible.h>
 
-typedef struct ConstraintAwareAppendPath
+typedef struct ConstraintAwareAppendPath ConstraintAwareAppendPath;
+typedef struct ConstraintAwareAppendState ConstraintAwareAppendState;
+
+#include "hypertable.h"
+
+struct ConstraintAwareAppendPath
 {
 	CustomPath	cpath;
-} ConstraintAwareAppendPath;
+};
 
-typedef struct ConstraintAwareAppendState
+struct ConstraintAwareAppendState
 {
 	CustomScanState csstate;
 	Plan	   *subplan;
 	Size		num_append_subplans;
-} ConstraintAwareAppendState;
+};
 
-typedef struct Hypertable Hypertable;
 
 Path	   *constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath);
 

--- a/src/copy.c
+++ b/src/copy.c
@@ -23,6 +23,8 @@
 #include <utils/rel.h>
 #include <utils/rls.h>
 
+typedef struct CopyChunkState CopyChunkState;
+
 #include "hypertable.h"
 #include "copy.h"
 #include "dimension.h"
@@ -41,12 +43,10 @@
  *
  */
 
-typedef struct CopyChunkState CopyChunkState;
-
 typedef bool (*CopyFromFunc) (CopyChunkState *ccstate, ExprContext *econtext,
 							  Datum *values, bool *nulls, Oid *tuple_oid);
 
-typedef struct CopyChunkState
+struct CopyChunkState
 {
 	Relation	rel;
 	EState	   *estate;
@@ -58,7 +58,7 @@ typedef struct CopyChunkState
 		HeapScanDesc scandesc;
 		void	   *data;
 	}			fromctx;
-} CopyChunkState;
+};
 
 
 static CopyChunkState *

--- a/src/copy.h
+++ b/src/copy.h
@@ -7,7 +7,7 @@
 #include <executor/executor.h>
 #include <commands/copy.h>
 
-typedef struct Hypertable Hypertable;
+#include "hypertable.h"
 
 void		timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed, Hypertable *ht);
 void		timescaledb_move_from_table_to_chunks(Hypertable *ht, LOCKMODE lockmode);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -4,9 +4,13 @@
 #include <postgres.h>
 #include <nodes/pg_list.h>
 
+typedef struct DimensionSlice DimensionSlice;
+
 #include "catalog.h"
-#include "dimension.h"
 #include "chunk_constraint.h"
+#include "dimension.h"
+#include "dimension_vector.h"
+#include "hypercube.h"
 
 #define DIMENSION_SLICE_MAXVALUE ((int64)PG_INT64_MAX)
 #define DIMENSION_SLICE_MINVALUE ((int64)PG_INT64_MIN)
@@ -14,15 +18,12 @@
 /* partition functions return int32 */
 #define DIMENSION_SLICE_CLOSED_MAX ((int64)PG_INT32_MAX)
 
-typedef struct DimensionSlice
+struct DimensionSlice
 {
 	FormData_dimension_slice fd;
 	void		(*storage_free) (void *);
 	void	   *storage;
-} DimensionSlice;
-
-typedef struct DimensionVec DimensionVec;
-typedef struct Hypercube Hypercube;
+};
 
 extern DimensionVec *dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit);
 extern DimensionVec *dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy, int64 start_value, StrategyNumber end_strategy, int64 end_value, int limit);

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -3,19 +3,21 @@
 
 #include <postgres.h>
 
+typedef struct DimensionVec DimensionVec;
+
 #include "dimension_slice.h"
 
 /*
  *	DimensionVec is a collection of slices (ranges) along one dimension for a
  *	time range.
  */
-typedef struct DimensionVec
+struct DimensionVec
 {
 	int32		capacity;		/* The capacity of the slices array */
 	int32		num_slices;		/* The current number of slices in slices
 								 * array */
 	DimensionSlice *slices[FLEXIBLE_ARRAY_MEMBER];
-} DimensionVec;
+};
 
 #define DIMENSION_VEC_SIZE(num_slices)								\
 	(sizeof(DimensionVec) + sizeof(DimensionSlice *) * num_slices)

--- a/src/event_trigger.h
+++ b/src/event_trigger.h
@@ -4,55 +4,63 @@
 #include <postgres.h>
 #include <nodes/pg_list.h>
 
-typedef enum EventTriggerDropType
+typedef enum EventTriggerDropType EventTriggerDropType;
+typedef struct EventTriggerDropIndex EventTriggerDropIndex;
+typedef struct EventTriggerDropObject EventTriggerDropObject;
+typedef struct EventTriggerDropSchema EventTriggerDropSchema;
+typedef struct EventTriggerDropTable EventTriggerDropTable;
+typedef struct EventTriggerDropTableConstraint EventTriggerDropTableConstraint;
+typedef struct EventTriggerDropTrigger EventTriggerDropTrigger;
+
+enum EventTriggerDropType
 {
 	EVENT_TRIGGER_DROP_TABLE_CONSTRAINT,
 	EVENT_TRIGGER_DROP_INDEX,
 	EVENT_TRIGGER_DROP_TABLE,
 	EVENT_TRIGGER_DROP_SCHEMA,
 	EVENT_TRIGGER_DROP_TRIGGER
-} EventTriggerDropType;
+};
 
-typedef struct EventTriggerDropObject
+struct EventTriggerDropObject
 {
 	EventTriggerDropType type;
-} EventTriggerDropObject;
+};
 
-typedef struct EventTriggerDropTableConstraint
+struct EventTriggerDropTableConstraint
 {
 	EventTriggerDropObject obj;
 	char	   *constraint_name;
 	char	   *schema;
 	char	   *table;
-} EventTriggerDropTableConstraint;
+};
 
-typedef struct EventTriggerDropIndex
+struct EventTriggerDropIndex
 {
 	EventTriggerDropObject obj;
 	char	   *index_name;
 	char	   *schema;
-} EventTriggerDropIndex;
+};
 
-typedef struct EventTriggerDropTable
+struct EventTriggerDropTable
 {
 	EventTriggerDropObject obj;
 	char	   *table_name;
 	char	   *schema;
-} EventTriggerDropTable;
+};
 
-typedef struct EventTriggerDropSchema
+struct EventTriggerDropSchema
 {
 	EventTriggerDropObject obj;
 	char	   *schema;
-} EventTriggerDropSchema;
+};
 
-typedef struct EventTriggerDropTrigger
+struct EventTriggerDropTrigger
 {
 	EventTriggerDropObject obj;
 	char	   *trigger_name;
 	char	   *schema;
 	char	   *table;
-} EventTriggerDropTrigger;
+};
 
 extern List *event_trigger_dropped_objects(void);
 extern List *event_trigger_ddl_commands(void);

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -3,20 +3,22 @@
 
 #include <postgres.h>
 
+typedef struct Hypercube Hypercube;
+
 #include "dimension_slice.h"
 
 /*
  * Hypercube is a collection of slices from N distinct dimensions, i.e., the
  * N-dimensional analogue of a cube.
  */
-typedef struct Hypercube
+struct Hypercube
 {
 	int16		capacity;		/* capacity of slices[] */
 	int16		num_slices;		/* actual number of slices (should equal
 								 * capacity after create) */
 	/* Slices are stored in dimension order */
 	DimensionSlice *slices[FLEXIBLE_ARRAY_MEMBER];
-} Hypercube;
+};
 
 #define HYPERCUBE_SIZE(num_dimensions)									\
 	(sizeof(Hypercube) + sizeof(DimensionSlice *) * (num_dimensions))

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -4,26 +4,26 @@
 #include <postgres.h>
 #include <nodes/primnodes.h>
 
+typedef struct Hypertable Hypertable;
+
 #include "catalog.h"
+#include "chunk.h"
 #include "dimension.h"
-#include "tablespace.h"
 #include "scanner.h"
+#include "subspace_store.h"
+#include "tablespace.h"
 
 #define OLD_INSERT_BLOCKER_NAME	"insert_blocker"
 #define INSERT_BLOCKER_NAME "ts_insert_blocker"
 
-typedef struct SubspaceStore SubspaceStore;
-typedef struct Chunk Chunk;
-typedef struct HeapTupleData *HeapTuple;
-
-typedef struct Hypertable
+struct Hypertable
 {
 	FormData_hypertable fd;
 	Oid			main_table_relid;
 	Oid			chunk_sizing_func;
 	Hyperspace *space;
 	SubspaceStore *chunk_cache;
-} Hypertable;
+};
 
 extern int	number_of_hypertables(void);
 

--- a/src/hypertable_insert.h
+++ b/src/hypertable_insert.h
@@ -4,11 +4,13 @@
 #include <postgres.h>
 #include <nodes/execnodes.h>
 
-typedef struct HypertableInsertState
+typedef struct HypertableInsertState HypertableInsertState;
+
+struct HypertableInsertState
 {
 	CustomScanState cscan_state;
 	ModifyTable *mt;
-} HypertableInsertState;
+};
 
 Plan	   *hypertable_insert_plan_create(ModifyTable *mt);
 

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -178,14 +178,14 @@ dimension_restrict_info_slices(DimensionRestrictInfo *dri)
 	}
 }
 
-typedef struct HypertableRestrictInfo
+struct HypertableRestrictInfo
 {
 	int			num_base_restrictions;	/* number of base restrictions
 										 * successfully added */
 	int			num_dimensions;
 	DimensionRestrictInfo *dimension_restriction[FLEXIBLE_ARRAY_MEMBER];	/* array of dimension
 																			 * restrictions */
-} HypertableRestrictInfo;
+};
 
 
 HypertableRestrictInfo *

--- a/src/hypertable_restrict_info.h
+++ b/src/hypertable_restrict_info.h
@@ -1,12 +1,11 @@
 #ifndef TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H
 #define TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H
 
-#include "hypertable.h"
-
-
 /* HypertableRestrictInfo represents restrictions on a hypertable. It uses
  * range exclusion logic to figure out which chunks can match the description */
 typedef struct HypertableRestrictInfo HypertableRestrictInfo;
+
+#include "hypertable.h"
 
 extern HypertableRestrictInfo *hypertable_restrict_info_create(RelOptInfo *rel, Hypertable *ht);
 

--- a/src/loader/bgw_message_queue.h
+++ b/src/loader/bgw_message_queue.h
@@ -4,15 +4,17 @@
 #include <postgres.h>
 #include <storage/dsm.h>
 
+typedef enum BgwMessageType BgwMessageType;
+typedef struct BgwMessage BgwMessage;
 
-typedef enum BgwMessageType
+enum BgwMessageType
 {
 	STOP = 0,
 	START,
 	RESTART
-} BgwMessageType;
+};
 
-typedef struct BgwMessage
+struct BgwMessage
 {
 	BgwMessageType message_type;
 
@@ -21,7 +23,7 @@ typedef struct BgwMessage
 	dsm_handle	ack_dsm_handle;
 
 
-} BgwMessage;
+};
 
 extern bool bgw_message_send_and_wait(BgwMessageType message, Oid db_oid);
 

--- a/src/net/conn.h
+++ b/src/net/conn.h
@@ -3,17 +3,19 @@
 
 #include <pg_config.h>
 
+typedef enum ConnectionType ConnectionType;
 typedef struct ConnOps ConnOps;
+typedef struct Connection Connection;
 
-typedef enum ConnectionType
+enum ConnectionType
 {
 	CONNECTION_PLAIN,
 	CONNECTION_SSL,
 	CONNECTION_MOCK,
 	_CONNECTION_MAX,
-} ConnectionType;
+};
 
-typedef struct Connection
+struct Connection
 {
 	ConnectionType type;
 #ifdef WIN32
@@ -23,7 +25,7 @@ typedef struct Connection
 #endif
 	ConnOps    *ops;
 	int			err;
-} Connection;
+};
 
 extern Connection *connection_create(ConnectionType type);
 extern int	connection_connect(Connection *conn, const char *host, const char *servname, int port);

--- a/src/net/conn_internal.h
+++ b/src/net/conn_internal.h
@@ -3,7 +3,7 @@
 
 #include "conn.h"
 
-typedef struct ConnOps
+struct ConnOps
 {
 	size_t		size;			/* Size of the connection object */
 	int			(*init) (Connection *conn);
@@ -13,7 +13,7 @@ typedef struct ConnOps
 	ssize_t		(*read) (Connection *conn, char *buf, size_t readlen);
 	int			(*set_timeout) (Connection *conn, unsigned long millis);
 	const char *(*errmsg) (Connection *conn);
-} ConnOps;
+};
 
 extern int	connection_register(ConnectionType type, ConnOps *ops);
 

--- a/src/net/conn_plain.h
+++ b/src/net/conn_plain.h
@@ -1,7 +1,7 @@
 #ifndef TIMESCALEDB_CONN_PLAIN_H
 #define TIMESCALEDB_CONN_PLAIN_H
 
-typedef struct Connection Connection;
+#include "conn.h"
 
 #ifdef WIN32
 #define IS_SOCKET_ERROR(err) (err == SOCKET_ERROR)

--- a/src/net/http.h
+++ b/src/net/http.h
@@ -9,31 +9,38 @@
 #define MAX_RAW_BUFFER_SIZE	4096
 #define MAX_REQUEST_DATA_SIZE	2048
 
-typedef struct HttpHeader
+typedef enum HttpError HttpError;
+typedef enum HttpRequestMethod HttpRequestMethod;
+typedef enum HttpVersion HttpVersion;
+typedef struct HttpHeader HttpHeader;
+
+#include "conn.h"
+
+struct HttpHeader
 {
 	char	   *name;
 	int			name_len;
 	char	   *value;
 	int			value_len;
 	struct HttpHeader *next;
-} HttpHeader;
+};
 
 /******* http_request.c *******/
 /*  We can add more methods later, but for now we do not need others */
-typedef enum HttpRequestMethod
+enum HttpRequestMethod
 {
 	HTTP_GET,
 	HTTP_POST,
-} HttpRequestMethod;
+};
 
-typedef enum HttpVersion
+enum HttpVersion
 {
 	HTTP_VERSION_10,
 	HTTP_VERSION_11,
 	HTTP_VERSION_INVALID,
-} HttpVersion;
+};
 
-typedef enum HttpError
+enum HttpError
 {
 	HTTP_ERROR_NONE = 0,
 	HTTP_ERROR_WRITE,			/* Connection write error, check errno */
@@ -44,12 +51,11 @@ typedef enum HttpError
 	HTTP_ERROR_RESPONSE_INCOMPLETE,
 	HTTP_ERROR_INVALID_BUFFER_STATE,
 	HTTP_ERROR_UNKNOWN,			/* Should always be last */
-} HttpError;
+};
 
 /*  NOTE: HttpRequest* structs are all responsible */
 /*  for allocating and deallocating the char* */
 typedef struct HttpRequest HttpRequest;
-typedef struct Connection Connection;
 
 HttpVersion http_version_from_string(const char *version);
 const char *http_version_string(HttpVersion version);

--- a/src/net/http_request.c
+++ b/src/net/http_request.c
@@ -42,7 +42,7 @@ http_header_create(const char *name,
 
 /*  NOTE: The setter functions for HttpRequest should all */
 /*  ensure that every char * in this struct is null-terminated */
-typedef struct HttpRequest
+struct HttpRequest
 {
 	HttpRequestMethod method;
 	char	   *uri;
@@ -52,7 +52,7 @@ typedef struct HttpRequest
 	char	   *body;
 	size_t		body_len;
 	MemoryContext context;
-} HttpRequest;
+};
 
 static const char *http_method_strings[] = {
 	[HTTP_GET] = "GET",

--- a/src/net/http_response.c
+++ b/src/net/http_response.c
@@ -23,7 +23,7 @@ typedef enum HttpParseState
 	HTTP_STATE_DONE,
 } HttpParseState;
 
-typedef struct HttpResponseState
+struct HttpResponseState
 {
 	MemoryContext context;
 	char		version[HTTP_VERSION_BUFFER_SIZE];
@@ -40,7 +40,7 @@ typedef struct HttpResponseState
 	size_t		content_length;
 	char	   *body_start;
 	HttpParseState state;
-} HttpResponseState;
+};
 
 void
 http_response_state_init(HttpResponseState *state)

--- a/src/partitioning.h
+++ b/src/partitioning.h
@@ -9,6 +9,9 @@
 #include <utils/typcache.h>
 #include <fmgr.h>
 
+typedef struct PartitioningFunc PartitioningFunc;
+typedef struct PartitioningInfo PartitioningInfo;
+
 #include "catalog.h"
 
 #define OPEN_START_TIME -1
@@ -17,7 +20,7 @@
 #define DEFAULT_PARTITIONING_FUNC_SCHEMA INTERNAL_SCHEMA_NAME
 #define DEFAULT_PARTITIONING_FUNC_NAME "get_partition_hash"
 
-typedef struct PartitioningFunc
+struct PartitioningFunc
 {
 	char		schema[NAMEDATALEN];
 	char		name[NAMEDATALEN];
@@ -27,15 +30,15 @@ typedef struct PartitioningFunc
 	 * partitioning column's text representation.
 	 */
 	FmgrInfo	func_fmgr;
-} PartitioningFunc;
+};
 
 
-typedef struct PartitioningInfo
+struct PartitioningInfo
 {
 	char		column[NAMEDATALEN];
 	AttrNumber	column_attnum;
 	PartitioningFunc partfunc;
-} PartitioningInfo;
+};
 
 
 extern Oid	partitioning_func_get_default(void);

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -7,14 +7,20 @@
 #include <access/heapam.h>
 #include <nodes/lockoptions.h>
 
-typedef enum ScannerType
+typedef enum ScannerType ScannerType;
+typedef struct ScannerCtx ScannerCtx;
+typedef struct TupleInfo TupleInfo;
+typedef bool (*tuple_filter_func) (TupleInfo *ti, void *data);
+typedef bool (*tuple_found_func) (TupleInfo *ti, void *data);
+
+enum ScannerType
 {
 	ScannerTypeHeap,
 	ScannerTypeIndex,
-}			ScannerType;
+};
 
 /* Tuple information passed on to handlers when scanning for tuples. */
-typedef struct TupleInfo
+struct TupleInfo
 {
 	Relation	scanrel;
 	HeapTuple	tuple;
@@ -35,12 +41,9 @@ typedef struct TupleInfo
 	 * can be used to allocate data on in the tuple handle function.
 	 */
 	MemoryContext mctx;
-} TupleInfo;
+};
 
-typedef bool (*tuple_found_func) (TupleInfo *ti, void *data);
-typedef bool (*tuple_filter_func) (TupleInfo *ti, void *data);
-
-typedef struct ScannerCtx
+struct ScannerCtx
 {
 	Oid			table;
 	Oid			index;
@@ -86,7 +89,7 @@ typedef struct ScannerCtx
 	 * false to abort.
 	 */
 	bool		(*tuple_found) (TupleInfo *ti, void *data);
-} ScannerCtx;
+};
 
 /* Performs an index scan or heap scan and returns the number of matching
  * tuples. */

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -23,14 +23,14 @@ typedef struct SubspaceStoreInternalNode
 	bool		last_internal_node;
 } SubspaceStoreInternalNode;
 
-typedef struct SubspaceStore
+struct SubspaceStore
 {
 	MemoryContext mcxt;
 	int16		num_dimensions;
 /* limit growth of store by  limiting number of slices in first dimension,	0 for no limit */
 	int16		max_items;
 	SubspaceStoreInternalNode *origin;	/* origin of the tree */
-} SubspaceStore;
+};
 
 static inline SubspaceStoreInternalNode *
 subspace_store_internal_node_create(bool last_internal_node)

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -10,9 +10,9 @@
  * Thus, a subspace is a "rectangular" cutout in a multidimensional space.
  */
 
-typedef struct Hypercube Hypercube;
-typedef struct Point Point;
 typedef struct SubspaceStore SubspaceStore;
+
+#include "hypercube.h"
 
 extern SubspaceStore *subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items);
 

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -4,20 +4,23 @@
 #include <postgres.h>
 #include <nodes/parsenodes.h>
 
+typedef struct Tablespace Tablespace;
+typedef struct Tablespaces Tablespaces;
+
 #include "catalog.h"
 
-typedef struct Tablespace
+struct Tablespace
 {
 	FormData_tablespace fd;
 	Oid			tablespace_oid;
-} Tablespace;
+};
 
-typedef struct Tablespaces
+struct Tablespaces
 {
 	int			capacity;
 	int			num_tablespaces;
 	Tablespace *tablespaces;
-} Tablespaces;
+};
 
 extern Tablespace *tablespaces_add(Tablespaces *tablespaces, FormData_tablespace *form, Oid tspc_oid);
 extern bool tablespaces_delete(Tablespaces *tspcs, Oid tspc_oid);

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -5,6 +5,8 @@
 #include <pg_config.h> // To get USE_OPENSSL from postgres build
 #include <utils/builtins.h>
 
+typedef struct VersionResult VersionResult;
+
 #include "compat.h"
 #include "version.h"
 #include "net/conn.h"
@@ -15,13 +17,13 @@
 #define TELEMETRY_HOST "telemetry.timescale.com"
 #define TELEMETRY_PATH "/v1/metrics"
 
-typedef struct VersionResult
+struct VersionResult
 {
 	VersionInfo vinfo;
 	const char *versionstr;
 	bool		is_up_to_date;
 	const char *errhint;
-} VersionResult;
+};
 
 HttpRequest *build_version_request(const char *host, const char *path);
 Connection *telemetry_connect(const char *host, const char *service);

--- a/src/version.h
+++ b/src/version.h
@@ -6,19 +6,22 @@
 #define VERSION_INFO_LEN 128
 #define VERSION_PARTS 3
 
-typedef struct VersionInfo
+typedef struct VersionInfo VersionInfo;
+typedef struct VersionOSInfo VersionOSInfo;
+
+struct VersionInfo
 {
 	long		version[VERSION_PARTS];
 	char		version_mod[VERSION_INFO_LEN];
 	bool		has_version_mod;
-} VersionInfo;
+};
 
-typedef struct VersionOSInfo
+struct VersionOSInfo
 {
 	char		sysname[VERSION_INFO_LEN];
 	char		version[VERSION_INFO_LEN];
 	char		release[VERSION_INFO_LEN];
-} VersionOSInfo;
+};
 
 extern void version_get_info(VersionInfo *vinfo);
 extern int	version_cmp(VersionInfo *v1, VersionInfo *v2);


### PR DESCRIPTION
Place typedefs before local includes in order for the alias types to be
declared even in the case of with mutual dependencies between header
files.

Fixes #37 for GCC 4.3.

This is a trivial change.