### PR TITLE
Turn off telemetry in Docker images used in CI

### DIFF
--- a/scripts/docker-run-memory-test.sh
+++ b/scripts/docker-run-memory-test.sh
@@ -42,7 +42,7 @@ docker_exec() {
 }
 
 docker_run() {
-    docker run -d --name $1 $2
+    docker run --env TIMESCALEDB_TELEMETRY=off -d --name $1 $2
     wait_for_pg $1
 }
 

--- a/scripts/test_update_from_tag.sh
+++ b/scripts/test_update_from_tag.sh
@@ -79,12 +79,12 @@ docker_pgdiff() {
 }
 
 docker_run() {
-    docker run -d --name $1 -v ${BASE_DIR}:/src $2 -c timezone="US/Eastern"
+    docker run --env TIMESCALEDB_TELEMETRY=off -d --name $1 -v ${BASE_DIR}:/src $2 -c timezone="US/Eastern"
     wait_for_pg $1
 }
 
 docker_run_vol() {
-    docker run -d --name $1 -v ${BASE_DIR}:/src -v $2 $3 -c timezone="US/Eastern"
+    docker run --env TIMESCALEDB_TELEMETRY=off -d --name $1 -v ${BASE_DIR}:/src -v $2 $3 -c timezone="US/Eastern"
     wait_for_pg $1
 }
 


### PR DESCRIPTION
Using the new flag available in Docker images, turn off telemetry in Docker images used by Travis