### PR TITLE
 Run update tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,16 +76,24 @@ jobs:
       stage: test
       env: PG_VERSION=9.6.6 PG_GIT_TAG=REL9_6_6
       name: "Update tests (versions w/o constraints support) 9.6"
+      before_install:
+      install:
+      after_failure:
+      after_script:
       script:
-        - PGTEST_TMPDIR=/tmp/ bash -x ./scripts/test_updates_no_constraints.sh
+        - bash -x ./scripts/test_updates_no_constraints.sh
 
     # This tests the ability to upgrade to the latest version from versions with constraint support
     - if: (type = pull_request) OR (type = cron)
       stage: test
       env: PG_VERSION=9.6.6 PG_GIT_TAG=REL9_6_6
       name: "Update tests (versions w/ constraints support) 9.6"
+      before_install:
+      install:
+      after_failure:
+      after_script:
       script:
-        - PGTEST_TMPDIR=/tmp/ bash -x ./scripts/test_updates_with_constraints.sh
+        - bash -x ./scripts/test_updates_with_constraints.sh
 
     # This tests the formatting of a PR.
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -5,7 +5,7 @@
 #
 SCRIPT_DIR=$(dirname $0)
 BASE_DIR=${PWD}/${SCRIPT_DIR}/..
-PG_VERSION=${PG_VERSION:-10.4}
+PG_VERSION=${PG_VERSION:-9.6.5}
 PG_IMAGE_TAG=${PG_IMAGE_TAG:-${PG_VERSION}-alpine}
 BUILD_CONTAINER_NAME=${BUILD_CONTAINER_NAME:-pgbuild}
 BUILD_IMAGE_NAME=${BUILD_IMAGE_NAME:-$USER/pgbuild}
@@ -15,7 +15,7 @@ GIT_TAG=$(git -C ${BASE_DIR} rev-parse --short --verify HEAD)
 GIT_ID=$(git -C ${BASE_DIR} describe --dirty | sed -e "s|/|_|g")
 TAG_NAME=${TAG_NAME:-$GIT_ID}
 BUILD_TYPE=${BUILD_TYPE:-Debug}
-USE_OPENSSL=${USE_OPENSSL:-True}
+USE_OPENSSL=${USE_OPENSSL:-true}
 PUSH_PG_IMAGE=${PUSH_PG_IMAGE:-false}
 
 # Full image identifiers
@@ -96,10 +96,10 @@ fi
 
 if ! postgres_build_image_exists; then
     if ! fetch_postgres_build_image; then
-        create_postgres_build_image || exit -1
+        create_postgres_build_image || exit 1
     fi
 fi
 
-build_timescaledb || exit -1
+build_timescaledb || exit 1
 
 message_and_exit

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -5,39 +5,101 @@
 #
 SCRIPT_DIR=$(dirname $0)
 BASE_DIR=${PWD}/${SCRIPT_DIR}/..
-PG_VERSION=${PG_VERSION:-10.0}
+PG_VERSION=${PG_VERSION:-10.4}
 PG_IMAGE_TAG=${PG_IMAGE_TAG:-${PG_VERSION}-alpine}
 BUILD_CONTAINER_NAME=${BUILD_CONTAINER_NAME:-pgbuild}
 BUILD_IMAGE_NAME=${BUILD_IMAGE_NAME:-$USER/pgbuild}
 IMAGE_NAME=${IMAGE_NAME:-$USER/timescaledb}
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD ${BASE_DIR} | awk '{print $1; exit}' | sed -e "s|/|_|g")
-TAG_NAME=${TAG_NAME:-$GIT_BRANCH}
+GIT_TAG=$(git -C ${BASE_DIR} rev-parse --short --verify HEAD)
+GIT_ID=$(git -C ${BASE_DIR} describe --dirty | sed -e "s|/|_|g")
+TAG_NAME=${TAG_NAME:-$GIT_ID}
+BUILD_TYPE=${BUILD_TYPE:-Debug}
+USE_OPENSSL=${USE_OPENSSL:-True}
+PUSH_PG_IMAGE=${PUSH_PG_IMAGE:-false}
 
-# Clean previous containers
-docker rm -f $(docker ps -a -q -f name=${BUILD_CONTAINER_NAME} 2>/dev/null) 2>/dev/null
+# Full image identifiers
+PG_IMAGE=${BUILD_IMAGE_NAME}:${PG_IMAGE_TAG}
+TS_IMAGE=${IMAGE_NAME}:${TAG_NAME}
 
-if docker image ls -f "reference=${BUILD_IMAGE_NAME}:${PG_IMAGE_TAG}" | grep "$BUILD_IMAGE_NAME" 2>/dev/null; then
-    echo "Using existing build image ${BUILD_IMAGE_NAME}:${PG_IMAGE_TAG}"
-    docker run -d --name ${BUILD_CONTAINER_NAME} -v ${BASE_DIR}:/src ${BUILD_IMAGE_NAME}:${PG_IMAGE_TAG}
-else
-    echo "Creating new build image ${BUILD_IMAGE_NAME}:${PG_IMAGE_TAG}"
+trap remove_build_container EXIT
+
+image_exists() {
+    [[ $(docker image ls -f "reference=$1" -q) ]]
+}
+
+postgres_build_image_exists() {
+    image_exists ${PG_IMAGE}
+}
+
+timescaledb_image_exists() {
+    image_exists ${TS_IMAGE}
+}
+
+remove_build_container() {
+    local container=${1:-${BUILD_CONTAINER_NAME}}
+    docker rm -vf $(docker ps -a -q -f name=${container} 2>/dev/null) 2>/dev/null
+}
+
+fetch_postgres_build_image() {
+    local image=${1:-${PG_IMAGE}}
+    docker pull ${image}
+}
+
+create_postgres_build_image() {
+    local image=${1:-${PG_IMAGE}}
+
+    echo "Creating new PostgreSQL build image ${image}"
     # Run a Postgres container
     docker run -d --name ${BUILD_CONTAINER_NAME} -v ${BASE_DIR}:/src postgres:${PG_IMAGE_TAG}
 
     # Install build dependencies
     docker exec -u root -it ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps gdb git coreutils dpkg-dev gcc libc-dev make cmake util-linux-dev diffutils openssl-dev && mkdir -p /build/debug"
+    docker commit -a $USER -m "TimescaleDB build base image version $PG_IMAGE_TAG" ${BUILD_CONTAINER_NAME} ${image}
+    remove_build_container ${BUILD_CONTAINER_NAME}
 
-    docker commit -a $USER -m "TimescaleDB build base image version $PG_IMAGE_TAG" ${BUILD_CONTAINER_NAME} ${BUILD_IMAGE_NAME}:${PG_IMAGE_TAG}
+    if ${PUSH_PG_IMAGE}; then
+        docker push ${image}
+    fi
+}
+
+run_postgres_build_image() {
+    local image=${1:-${PG_IMAGE}}
+    echo "Starting image ${image}"
+    docker run -d --name ${BUILD_CONTAINER_NAME} -v ${BASE_DIR}:/src ${image}
+}
+
+build_timescaledb()
+{
+    echo "Building TimescaleDB image \"${TS_IMAGE}\" with USE_OPENSSL=${USE_OPENSSL} BUILD_TYPE=${BUILD_TYPE}"
+
+    run_postgres_build_image ${PG_IMAGE}
+
+    # Build and install the extension with debug symbols and assertions
+    docker exec -u root -it ${BUILD_CONTAINER_NAME} /bin/bash -c "cp -a /src/{src,sql,test,scripts,version.config,CMakeLists.txt,timescaledb.control.in} /build/ && cd build/debug && cmake -DUSE_OPENSSL=${USE_OPENSSL} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} .. && make && make install && echo \"shared_preload_libraries = 'timescaledb'\" >> /usr/local/share/postgresql/postgresql.conf.sample && echo \"timescaledb.telemetry_level=off\" >> /usr/local/share/postgresql/postgresql.conf.sample && cd / && rm -rf /build"
+    docker commit -a $USER -m "TimescaleDB development image" ${BUILD_CONTAINER_NAME} ${TS_IMAGE}
+}
+
+message_and_exit() {
+    echo
+    echo "Run 'docker run -d --name some-timescaledb -p 5432:5432 ${TS_IMAGE}' to launch"
+    exit
+}
+
+remove_build_container
+
+if timescaledb_image_exists; then
+    echo "Image \"${TS_IMAGE}\" already exists."
+    message_and_exit
 fi
 
-# Build and install the extension with debug symbols and assertions
-docker exec -u root -it ${BUILD_CONTAINER_NAME} /bin/bash -c "cp -a /src/{src,sql,test,scripts,version.config,CMakeLists.txt,timescaledb.control.in} /build/ && cd build/debug && cmake -DCMAKE_BUILD_TYPE=Debug .. && make && make install && echo \"shared_preload_libraries = 'timescaledb'\" >> /usr/local/share/postgresql/postgresql.conf.sample && echo \"timescaledb.telemetry_level=off\" >> /usr/local/share/postgresql/postgresql.conf.sample && cd / && rm -rf /build"
 
-docker commit -a $USER -m "TimescaleDB development image" ${BUILD_CONTAINER_NAME} ${IMAGE_NAME}:${TAG_NAME}
+if ! postgres_build_image_exists; then
+    if ! fetch_postgres_build_image; then
+        create_postgres_build_image || exit -1
+    fi
+fi
 
-# Clean build containers
-docker rm -f ${BUILD_CONTAINER_NAME}
+build_timescaledb || exit -1
 
-echo
-echo "Built image ${IMAGE_NAME}:${TAG_NAME}"
-echo "Run 'docker run -d --name some-timescaledb -p 5432:5432 ${IMAGE_NAME}:${TAG_NAME}' to launch"
+message_and_exit

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -o pipefail
+
+SCRIPT_DIR=$(dirname $0)
+TEST_TMPDIR=${TEST_TMPDIR:-$(mktemp -d 2>/dev/null || mktemp -d -t 'timescaledb_update_test' || mkdir -p /tmp/$RANDOM )}
+BASE_DIR=${PWD}/${SCRIPT_DIR}/..
+TAGS=${TAGS:-}
+TEST_VERSION=${TEST_VERSION:-}
+GIT_ID=$(git -C ${BASE_DIR} describe --dirty | sed -e "s|/|_|g")
+UPDATE_TO_IMAGE=${UPDATE_TO_IMAGE:-update_test}
+UPDATE_TO_TAG=${UPDATE_TO_TAG:-${GIT_ID}}
+PG_VERSION=${PG_VERSION:-9.6.5} # Need 9.6.x version since we are
+                                # upgrading the extension from
+                                # versions that didn't support PG10.
+
+FAILED_TEST=
+
+# Declare a hash table to keep test names keyed by pid
+declare -A tests
+
+while getopts "c" opt;
+do
+    case $opt in
+        c)
+            echo "Forcing cleanup of build image"
+            docker rmi -f ${UPDATE_TO_IMAGE}:${UPDATE_TO_TAG}
+            ;;
+    esac
+done
+
+cleanup() {
+    local exit_code="$?"
+    set +e # do not exit immediately on failure
+    echo "Waiting for remaining tests to finish..."
+    wait
+    if [ -f ${TEST_TMPDIR}/${FAILED_TEST}.log ]; then
+        echo "###### Failed test log below #####"
+        cat ${TEST_TMPDIR}/${FAILED_TEST}.log
+    fi
+    rm -rf ${TEST_TMPDIR}
+    echo "exit code is $exit_code"
+    return $exit_code
+}
+
+kill_all_tests() {
+    local exit_code="$?"
+    set +e # do not exit immediately on failure
+    echo "Killing all tests"
+    kill ${!tests[@]} 2>/dev/null
+    return $exit_code
+}
+
+trap kill_all_tests INT HUP
+trap cleanup EXIT
+
+if [ -z "${TEST_VERSION}" ]; then
+    echo "No TEST_VERSION specified"
+    exit 1
+fi
+
+if [ -z "${TAGS}" ]; then
+    echo "No TAGS specified"
+    exit 1
+fi
+
+# Build the docker image with current source here so that the parallel
+# tests don't all compete in trying to build it first
+IMAGE_NAME=${UPDATE_TO_IMAGE} TAG_NAME=${UPDATE_TO_TAG} PG_VERSION=${PG_VERSION} bash ${SCRIPT_DIR}/docker-build.sh
+
+# Run update tests in parallel
+for tag in ${TAGS};
+do
+    UPDATE_FROM_TAG=${tag} TEST_VERSION=${TEST_VERSION} $(dirname $0)/test_update_from_tag.sh > ${TEST_TMPDIR}/${tag}.log 2>&1 &
+
+    tests[$!]=${tag}
+    echo "Launched test ${tag} with pid $!"
+done
+
+# Need to wait on each pid in a loop to return the exit status of each
+echo "Waiting for tests to finish..."
+
+# Since we are iterating a hash table, the tests are not going to be
+# in order started. But it doesn't matter.
+for pid in ${!tests[@]};
+do
+    wait $pid;
+    exit_code=$?
+    echo "Test ${tests[$pid]} (pid $pid) exited with code $exit_code"
+
+    if [ $exit_code -ne 0 ]; then
+        FAILED_TEST=${tests[$pid]}
+        kill_all_tests
+        exit $exit_code
+    fi
+    $(exit $exit_code)
+done

--- a/scripts/test_updates_no_constraints.sh
+++ b/scripts/test_updates_no_constraints.sh
@@ -7,9 +7,8 @@
 set -e
 set -o pipefail
 
+SCRIPT_DIR=$(dirname $0)
 TAGS="0.1.0 0.2.0 0.3.0 0.4.0 0.4.1 0.4.2"
+TEST_VERSION="v1"
 
-for tag in ${TAGS};
-do
-    UPDATE_FROM_TAG=${tag} TEST_VERSION="v1" $(dirname $0)/test_update_from_tag.sh
-done
+. ${SCRIPT_DIR}/test_updates.sh

--- a/scripts/test_updates_with_constraints.sh
+++ b/scripts/test_updates_with_constraints.sh
@@ -10,9 +10,9 @@
 set -e
 set -o pipefail
 
-TAGS="0.5.0 0.6.0 0.6.1 0.7.0-pg9.6 0.7.1-pg9.6 0.8.0-pg9.6 0.9.0-pg9.6 0.9.1-pg9.6 0.9.2-pg9.6 0.10.0-pg9.6 0.10.1-pg9.6 0.11.0-pg9.6 0.12.0-pg9.6 1.0.0-rc1-pg9.6 1.0.0-rc2-pg9.6 1.0.0-rc3-pg9.6"
+SCRIPT_DIR=$(dirname $0)
 
-for tag in ${TAGS};
-do
-    UPDATE_FROM_TAG=${tag} TEST_VERSION="v2" $(dirname $0)/test_update_from_tag.sh
-done
+TAGS="0.5.0 0.6.0 0.6.1 0.7.0-pg9.6 0.7.1-pg9.6 0.8.0-pg9.6 0.9.0-pg9.6 0.9.1-pg9.6 0.9.2-pg9.6 0.10.0-pg9.6 0.10.1-pg9.6 0.11.0-pg9.6 0.12.0-pg9.6 1.0.0-rc1-pg9.6 1.0.0-rc2-pg9.6 1.0.0-rc3-pg9.6"
+TEST_VERSION="v2"
+
+. ${SCRIPT_DIR}/test_updates.sh


### PR DESCRIPTION
This change makes the update tests from each prior version of TimescaleDB to run in parallel instead of in serial order.
    
This speeds up the testing significantly.
