### PR TITLE
Ensure TSDB schedulers created for CREATE DATABASE

### DIFF
--- a/src/loader/bgw_message_queue.h
+++ b/src/loader/bgw_message_queue.h
@@ -9,7 +9,8 @@ typedef enum BgwMessageType
 {
 	STOP = 0,
 	START,
-	RESTART
+	RESTART,
+	REGISTER_CREATEDB,
 } BgwMessageType;
 
 typedef struct BgwMessage
@@ -19,8 +20,6 @@ typedef struct BgwMessage
 	pid_t		sender_pid;
 	Oid			db_oid;
 	dsm_handle	ack_dsm_handle;
-
-
 } BgwMessage;
 
 extern bool bgw_message_send_and_wait(BgwMessageType message, Oid db_oid);

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -2,6 +2,8 @@
 #include <pg_config.h>
 #include <access/xact.h>
 #include "../compat-msvc-enter.h"
+#include "catalog/objectaccess.h"
+#include "catalog/pg_database.h"
 #include <commands/extension.h>
 #include <commands/user.h>
 #include <miscadmin.h>
@@ -12,9 +14,6 @@
 #include <utils/inval.h>
 #include <nodes/print.h>
 #include <commands/dbcommands.h>
-
-
-
 
 /* for setting our wait event during waitlatch*/
 #include <pgstat.h>
@@ -73,12 +72,11 @@ static shmem_startup_hook_type prev_shmem_startup_hook;
 /* This is timescaleDB's versioned-extension's post_parse_analyze_hook */
 static post_parse_analyze_hook_type extension_post_parse_analyze_hook = NULL;
 
+static object_access_hook_type prev_object_access_hook = NULL;
+
 static void inline extension_check(void);
 static void call_extension_post_parse_analyze_hook(ParseState *pstate,
 									   Query *query);
-
-
-
 
 extern char *
 loader_extension_version(void)
@@ -353,6 +351,35 @@ post_analyze_hook(ParseState *pstate, Query *query)
 	}
 }
 
+/* For now, this hook is only used by the launcher to intercept CREATE DATABASE calls */
+static void
+timescale_object_access_hook(ObjectAccessType access,
+							 Oid classId,
+							 Oid objectId,
+							 int subId,
+							 void *arg)
+{
+	/* First make sure it's a CREATE call */
+	switch (access)
+	{
+		case OAT_POST_CREATE:
+			/* Now make sure that it's a CREATE DATABASE call */
+			if (classId != DatabaseRelationId)
+				break;
+
+			/* Tell the launcher about the new database */
+			if (!bgw_message_send_and_wait(REGISTER_CREATEDB, objectId))
+				ereport(LOG, (errmsg("Could not notify the launcher in timescale_object_access_hook")));
+			break;
+		default:
+			/* Do nothing for all other calls. */
+			break;
+	}
+
+	if (prev_object_access_hook != NULL)
+		prev_object_access_hook(access, classId, objectId, subId, arg);
+}
+
 static void
 timescale_shmem_startup_hook(void)
 {
@@ -414,6 +441,9 @@ _PG_init(void)
 
 	post_parse_analyze_hook = post_analyze_hook;
 	shmem_startup_hook = timescale_shmem_startup_hook;
+
+	prev_object_access_hook = object_access_hook;
+	object_access_hook = timescale_object_access_hook;
 }
 
 void
@@ -421,6 +451,7 @@ _PG_fini(void)
 {
 	post_parse_analyze_hook = prev_post_parse_analyze_hook;
 	shmem_startup_hook = prev_shmem_startup_hook;
+	object_access_hook = prev_object_access_hook;
 	/* No way to unregister relcache callback */
 }
 

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -381,8 +381,35 @@ SELECT wait_worker_counts(1,0,0,0);
  t
 (1 row)
 
+\c single_2
+/* Now try creating a DB from a template with the extension already installed.
+ * Make sure we see a scheduler start. */
+CREATE DATABASE single;
+SELECT wait_worker_counts(1,1,0,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+DROP DATABASE single;
+/* Now make sure that there's no race between create database and create extension.
+ * Although to be honest, this race probably wouldn't manifest in this test. */
+\c template1
+DROP EXTENSION timescaledb;
+\c single_2
+CREATE DATABASE single;
+\c single
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+SELECT wait_worker_counts(1,1,0,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+\c template1
 /* Clean up after ourselves */
 \ir include/bgw_launcher_utils_cleanup.sql
 DROP FUNCTION wait_worker_counts(integer, integer, integer, integer);
 DROP VIEW worker_counts;
-DROP EXTENSION timescaledb;

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -180,6 +180,29 @@ COMMIT;
 /* End our transaction and it should immediately exit because it's a template database.*/
 SELECT wait_worker_counts(1,0,0,0);
 
+\c single_2
+/* Now try creating a DB from a template with the extension already installed.
+ * Make sure we see a scheduler start. */
+CREATE DATABASE single;
+
+SELECT wait_worker_counts(1,1,0,0);
+DROP DATABASE single;
+
+/* Now make sure that there's no race between create database and create extension.
+ * Although to be honest, this race probably wouldn't manifest in this test. */
+\c template1
+DROP EXTENSION timescaledb;
+
+\c single_2
+CREATE DATABASE single;
+
+\c single
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+
+SELECT wait_worker_counts(1,1,0,0);
+
+\c template1
 /* Clean up after ourselves */
 \ir include/bgw_launcher_utils_cleanup.sql
-DROP EXTENSION timescaledb;


### PR DESCRIPTION
Previously, the only way to start a DB scheduler for a database is via an explicit call to start_background_workers in the extension script. This meant that in the case that template1 (or whatever template that a new database is being created from) already has the TS extension installed, then a call to CREATE DATABASE would NOT cause a background DB scheduler to be started for the new database. This is bad, because a database with the TS extension would not have a corresponding scheduler (until the database was restarted, in which case launcher start-up would catch the database and start a scheduler)

Hence, we now intercept all CREATE DATABASE calls via the object_access_hook. This hook is called in the middle of the CREATE DATABASE transaction, so we actually cannot connect to the database until the CREATE DATABASE transaction has finished. We create a new type of scheduler, a staging scheduler, in the launcher module to wait on the transaction. When the transaction finishes, the staging scheduler will launch a proper scheduler for the new database. As before, the new scheduler will check to see if the TS extension exists, and if not, it will exit.