### PR TITLE
Only install the mock functions for debug builds

### DIFF
--- a/test/sql/loader/CMakeLists.txt
+++ b/test/sql/loader/CMakeLists.txt
@@ -1,3 +1,4 @@
+if (CMAKE_BUILD_TYPE MATCHES Debug)
 install(
   FILES timescaledb--mock-1.sql
         timescaledb--mock-2.sql
@@ -12,3 +13,4 @@ install(
         timescaledb--mock-5--mock-6.sql
         timescaledb--mock-broken--mock-5.sql
   DESTINATION "${PG_SHAREDIR}/extension")
+endif (CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
This way they don't end up in a release installation