### PR TITLE
Add state machine and polling to launcher

### DIFF
--- a/src/loader/README.md
+++ b/src/loader/README.md
@@ -1,0 +1,76 @@
+# Loader
+
+The loader has two main purposes:
+
+1) Load the correct versioned library for each database.
+Multiple databases in the same Postgres instance may contain
+different versions of TimescaleDB installed. The loader is
+responsible for loading the shared library corresponding
+to the correct TimescaleDB version for the database as soon
+as possible. For example, a database containing TimescaleDB
+version 0.8.0 will have timescaledb-0.8.0.so loaded.
+
+2) Starting background worker schedulers for each database.
+   Background worker schedulers launch background worker tasks
+   for TimescaleDB. The launcher is responsible for launching
+   schedulers for any database that has TimescaleDB installed.
+   This is done by a background task called the launcher.
+
+
+# Launcher per-DB state machine
+
+The following is the state machine that the launcher maintains
+for each database. The CAPITAL labels are the possible states,
+and the `lowercase` names for messages that trigger the accompanying
+transitions. Transitions without labels are taken automatically
+whenever available resources exist.
+```
+
+                   stop
+      ENABLED+--------------+
+         +   ^--------------|
+         |         start   ||
+         |                 ||
+         |                 ||
+         v                 +v
+      ALLOCATED+------> DISABLED
+        ^+       stop       ^
+        ||                  |
+restart ||                  |
+        ||                  |
+        +v                  |
+      STARTED+--------------+
+                stop / scheduler quit
+
+```
+
+## The following is a detailed description of the transitions
+
+Note that `set vxid` sets a vxid variable on the scheduler. This variable
+is passed down to the scheduler and the scheduler waits on that vxid when
+it first starts.
+
+Transitions that happen automatically (at least once per poll period).
+* `ENABLED->ALLOCATED`: Reserved slot for worker
+* `ALLOCATED->STARTED`: Scheduler started
+* `STARTED->DISABLED`: Iff scheduler has stopped. Slot released.
+
+Transition that happen upon getting a STOP MESSAGE:
+* `ENABLED->DISABLED`: No action
+* `ALLOCATED->DISABLED`: Slot released
+* `STARTED->DISABLED`: Scheduler terminated & slot released
+* `DISABLED->DISABLED`: No Action
+
+Transition that happen upon getting a START MESSAGE
+* Database not yet registed: Register, set to ENABLED and take ENABLED action below.
+* `ENABLED->ENABLED`: Set vxid; then try the automatic transitions
+* `ALLOCATED->ALLOCATED`: Set vxid; then try the automatic transitions
+* `STARTED->STARTED`: No action
+* `DISABLED->ENABLED`: Set vxid
+
+Transition that happen upon getting a RESTART MESSAGE
+* Database not yet registed: Failure - no action taken
+* `ENABLED->ENABLED`: Set vxid
+* `ALLOCATED->ALLOCATED`: Set vxid
+* `STARTED->ALLOCATED`: Scheduler terminated, slot /not/ released, set vxid
+* `DISABLED->DISABLED`: Failure - no action taken

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -381,8 +381,35 @@ SELECT wait_worker_counts(1,0,0,0);
  t
 (1 row)
 
-/* Clean up after ourselves */
+/* Clean up the template database, removing our test utilities etc */
 \ir include/bgw_launcher_utils_cleanup.sql
 DROP FUNCTION wait_worker_counts(integer, integer, integer, integer);
 DROP VIEW worker_counts;
+\c single_2
+/* Now try creating a DB from a template with the extension already installed.
+ * Make sure we see a scheduler start. */
+CREATE DATABASE single;
+ SELECT wait_worker_counts(1,1,0,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+DROP DATABASE single;
+ /* Now make sure that there's no race between create database and create extension.
+ * Although to be honest, this race probably wouldn't manifest in this test. */
+\c template1
 DROP EXTENSION timescaledb;
+ \c single_2
+CREATE DATABASE single;
+ \c single
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+\c single_2
+SELECT wait_worker_counts(1,1,0,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -179,7 +179,24 @@ SELECT wait_worker_counts(1,0,0,1);
 COMMIT;
 /* End our transaction and it should immediately exit because it's a template database.*/
 SELECT wait_worker_counts(1,0,0,0);
-
-/* Clean up after ourselves */
+/* Clean up the template database, removing our test utilities etc */
 \ir include/bgw_launcher_utils_cleanup.sql
+
+\c single_2
+/* Now try creating a DB from a template with the extension already installed.
+ * Make sure we see a scheduler start. */
+CREATE DATABASE single;
+ SELECT wait_worker_counts(1,1,0,0);
+DROP DATABASE single;
+ /* Now make sure that there's no race between create database and create extension.
+ * Although to be honest, this race probably wouldn't manifest in this test. */
+\c template1
 DROP EXTENSION timescaledb;
+ \c single_2
+CREATE DATABASE single;
+ \c single
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+\c single_2
+SELECT wait_worker_counts(1,1,0,0);


### PR DESCRIPTION
This PR changes the launcher to use a state machine to keep track
of the state of each database scheduler. Further, it add polling
to go through the list of databases and check their states. This
solves several issues

1) A CREATE DATABASE call using a template that already has TimescaleDB
installed previously did not start a scheduler until the next database
restart. A test for this case has been added.
2) A lack of available slots or background workers when a new database was added
meant that the scheduler would not be stared until the next database
restart. Now this will be retried on every polling event.

This PR also simplifies logic since database entries are never removed
from the hash table and thus never added more than once. State
transitions are now easier to read and reason about.

Documentations for the state transitions has been added.