### PR TITLE
Launcher START_OR_RESTART

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -7,6 +7,7 @@ set(INSTALL_FILE ${PROJECT_NAME}--${PROJECT_VERSION_MOD}.sql)
 set(PRE_INSTALL_SOURCE_FILES
   pre_install/schemas.sql # Must be first
   pre_install/tables.sql
+  pre_install/bgw_startup.sql
 )
 
 # Things like aggregate functions cannot be REPLACEd and really

--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -13,7 +13,10 @@ RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_start'
 LANGUAGE C VOLATILE;
 
-SELECT _timescaledb_internal.start_background_workers();
+CREATE OR REPLACE FUNCTION _timescaledb_internal.start_or_restart_background_workers()
+RETURNS BOOL
+AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_start_or_restart'
+LANGUAGE C VOLATILE;
 
 INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
 (1, 'Telemetry Reporter', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h')

--- a/sql/pre_install/bgw_startup.sql
+++ b/sql/pre_install/bgw_startup.sql
@@ -1,0 +1,7 @@
+-- Create and run the start_or_restart function here, see loader readme for more details. 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.start_or_restart_background_workers()
+RETURNS BOOL
+AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_start_or_restart'
+LANGUAGE C VOLATILE;
+
+SELECT _timescaledb_internal.start_or_restart_background_workers();

--- a/sql/updates/0.11.0--0.12.0.sql
+++ b/sql/updates/0.11.0--0.12.0.sql
@@ -66,3 +66,11 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.installation_metadata (
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.installation_metadata', $$WHERE key='exported_uuid'$$);
 
 INSERT INTO _timescaledb_catalog.installation_metadata SELECT 'install_timestamp', to_timestamp(0);
+
+--Create and run the start_or_restart function here, in the first version that has a scheduler, see loader readme for more details.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.start_or_restart_background_workers()
+RETURNS BOOL
+AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_start_or_restart'
+LANGUAGE C VOLATILE;
+
+SELECT _timescaledb_internal.start_or_restart_background_workers();

--- a/src/bgw/launcher_interface.c
+++ b/src/bgw/launcher_interface.c
@@ -6,7 +6,7 @@
 #include "launcher_interface.h"
 #include "compat.h"
 
-#define MIN_LOADER_API_VERSION 1
+#define MIN_LOADER_API_VERSION 2
 
 extern bool
 bgw_worker_reserve(void)

--- a/src/loader/README.md
+++ b/src/loader/README.md
@@ -2,28 +2,86 @@
 
 The loader has two main purposes:
 
-1) Load the correct versioned library for each database.
-Multiple databases in the same Postgres instance may contain
-different versions of TimescaleDB installed. The loader is
-responsible for loading the shared library corresponding
-to the correct TimescaleDB version for the database as soon
-as possible. For example, a database containing TimescaleDB
-version 0.8.0 will have timescaledb-0.8.0.so loaded.
+1) Load the correct versioned library for each database. Multiple databases in
+   the same Postgres instance may have different versions of TimescaleDB
+   installed. The loader is responsible for loading the shared library
+   corresponding to the correct TimescaleDB version for the database as soon as
+   possible. For example, a database containing TimescaleDB version 0.8.0 will
+   have timescaledb-0.8.0.so loaded.
 
-2) Starting background worker schedulers for each database.
-   Background worker schedulers launch background worker tasks
-   for TimescaleDB. The launcher is responsible for launching
-   schedulers for any database that has TimescaleDB installed.
-   This is done by a background task called the launcher.
+2) Starting background worker schedulers for each database. Background worker
+   schedulers launch background worker tasks for TimescaleDB. The launcher is
+   responsible for launching schedulers for any database that has TimescaleDB
+   installed. This is done by a background task called the launcher.
+
+# Messages the launcher may receive
+The launcher implements a simple message queue to be notified when it should
+take certain actions, like starting or restarting a scheduler for a given
+database. 
+
+##Message types sent to the launcher:
+
+`start`: Used to start the scheduler by the user. It is meant to be an idempotent
+start, as in, if it is run multiple times, and startup is successful, it is the
+same as if it were run once. It is used mainly to reactivate a scheduler that
+the user had stopped.
+
+`stop`: Used to stop the scheduler immediately. It does not wait on a vxid and
+it is idempotent. 
+
+`restart`: Used to stop and restart the scheduler if it is running. The
+scheduler is immediately restarted, but waits on the vxid of the txn that sent
+the message. It is not idempotent, and will restart newly started schedulers,
+even while they are waiting.  
+
+`start_or_restart`: Used to either stop and restart the scheduler if it is
+running or start it if it is not. It waits on a vxid and, much like restart, is
+not idempotent. 
+
+## When/which messages are sent:
+
+Server startup: no message sent. The launcher will attempt to start a scheduler
+for each database. It cannot figure out whether a scheduler should exist for a
+given database because it can only connect to shared catalogs. The scheduler is
+responsible for shutting down if it should not exist (because either TimescaleDB
+is not installed in the database or the version of TimescaleDB installed does
+not have a scheduler function to call). 
+
+`CREATE DATABASE`: essentially the same as server startup. The launcher checks
+for new databases each time it wakes up and will start schedulers for any that
+it has not seen before.
+
+`CREATE EXTENSION`: the create script sends a `start_or_restart` message. It
+does not use the `start` message because there is a race condition where a
+scheduler starts (say at server start), and is not waiting on the vxid of the
+process that is running `CREATE EXTENSION`, but has not yet shut down (therefore
+the start action does nothing), so we need to restart and wait on the correct
+vxid in that case. (A normal restart action will not work as much of the time
+there is no existing scheduler and then the restart action will have no effect).
+
+`ALTER EXTENSION UPDATE`: the pre-update script sends a `restart` message. For
+updates that move either between versions that do not have a scheduler or that
+do have a scheduler, this respects any schedulers that have been shut down using
+the `stop` message by the user. However, the update script from `0.11-0.12`, the
+first version to use the scheduler, sends a `start_or_restart` message, as it is
+similar to the `CREATE EXTENSION` case.
+
+`DROP EXTENSION`: sends a `restart` message, which is necessary because a
+rollback of the drop extension command can still happen. The scheduler therefore
+waits on the vxid of the txn running `DROP EXTENSION` and then will take the
+correct action depending on whether the extension exists when the txn finishes.
+
+`DROP DATABASE`: sends a `stop` message, causing immediate shutdown of the
+scheduler. This is necessary as the database cannot be dropped if there are any
+open connections to it (the scheduler maintains a connection to the db).
 
 
 # Launcher per-DB state machine
 
-The following is the state machine that the launcher maintains
-for each database. The CAPITAL labels are the possible states,
-and the `lowercase` names for messages that trigger the accompanying
-transitions. Transitions without labels are taken automatically
-whenever available resources exist.
+The following is the state machine that the launcher maintains for each
+database. The CAPITAL labels are the possible states, and the `lowercase` names
+for messages that trigger the accompanying transitions. Transitions without
+labels are taken automatically whenever available resources exist.
 ```
 
                    stop
@@ -46,31 +104,38 @@ restart ||                  |
 
 ## The following is a detailed description of the transitions
 
-Note that `set vxid` sets a vxid variable on the scheduler. This variable
-is passed down to the scheduler and the scheduler waits on that vxid when
-it first starts.
+Note that `set vxid` sets a vxid variable on the scheduler. This variable is
+passed down to the scheduler and the scheduler waits on that vxid when it first
+starts. 
 
 Transitions that happen automatically (at least once per poll period).
 * `ENABLED->ALLOCATED`: Reserved slot for worker
 * `ALLOCATED->STARTED`: Scheduler started
-* `STARTED->DISABLED`: Iff scheduler has stopped. Slot released.
+* `STARTED->DISABLED`: Iff scheduler has stopped. Release slot.
 
-Transition that happen upon getting a STOP MESSAGE:
+Transitions that happen upon getting a STOP MESSAGE:
 * `ENABLED->DISABLED`: No action
-* `ALLOCATED->DISABLED`: Slot released
-* `STARTED->DISABLED`: Scheduler terminated & slot released
+* `ALLOCATED->DISABLED`: Release slot.
+* `STARTED->DISABLED`: Terminate scheduler & release slot
 * `DISABLED->DISABLED`: No Action
 
-Transition that happen upon getting a START MESSAGE
+Transitions that happen upon getting a START MESSAGE
 * Database not yet registed: Register, set to ENABLED and take ENABLED action below.
-* `ENABLED->ENABLED`: Set vxid; then try the automatic transitions
-* `ALLOCATED->ALLOCATED`: Set vxid; then try the automatic transitions
+* `ENABLED->ENABLED`: Set vxid, try automatic transitions
+* `ALLOCATED->ALLOCATED`: Set vxid, try automatic transitions
 * `STARTED->STARTED`: No action
-* `DISABLED->ENABLED`: Set vxid
+* `DISABLED->ENABLED`: Set vxid, try automatic transitions
 
-Transition that happen upon getting a RESTART MESSAGE
+Transitions that happen upon getting a RESTART MESSAGE
 * Database not yet registed: Failure - no action taken
-* `ENABLED->ENABLED`: Set vxid
-* `ALLOCATED->ALLOCATED`: Set vxid
-* `STARTED->ALLOCATED`: Scheduler terminated, slot /not/ released, set vxid
+* `ENABLED->ENABLED`: Set vxid, try automatic transitions
+* `ALLOCATED->ALLOCATED`: Set vxid, try automatic transitions
+* `STARTED->ALLOCATED`: Terminate scheduler,do /not/ release slot, set vxid, then try automatic transitions
 * `DISABLED->DISABLED`: Failure - no action taken
+
+Transitions that happen upon getting a START_OR_RESTART MESSAGE
+* Database not yet registed: Register it set to ENABLED, take ENABLED actions
+* `ENABLED->ENABLED`: Set vxid, try automatic transitions
+* `ALLOCATED->ALLOCATED`: Set vxid, try automatic transitions
+* `STARTED->ALLOCATED`: Terminate scheduler, do /not/ release slot, set vxid, then try automatic transitions
+* `DISABLED->ENABLED`: Set vxid, try automatic transitions 

--- a/src/loader/bgw_interface.c
+++ b/src/loader/bgw_interface.c
@@ -12,7 +12,7 @@
 
 /* This is where versioned-extension facing functions live. They shouldn't live anywhere else. */
 
-const int32 ts_bgw_loader_api_version = 1;
+const int32 ts_bgw_loader_api_version = 2;
 
 TS_FUNCTION_INFO_V1(ts_bgw_worker_reserve);
 TS_FUNCTION_INFO_V1(ts_bgw_worker_release);
@@ -22,6 +22,8 @@ TS_FUNCTION_INFO_V1(ts_bgw_db_workers_start);
 TS_FUNCTION_INFO_V1(ts_bgw_db_workers_stop);
 
 TS_FUNCTION_INFO_V1(ts_bgw_db_workers_restart);
+
+TS_FUNCTION_INFO_V1(ts_bgw_db_workers_start_or_restart);
 
 void
 bgw_interface_register_api_version()
@@ -71,4 +73,10 @@ Datum
 ts_bgw_db_workers_restart(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_BOOL(bgw_message_send_and_wait(RESTART, MyDatabaseId));
+}
+
+Datum
+ts_bgw_db_workers_start_or_restart(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(bgw_message_send_and_wait(START_OR_RESTART, MyDatabaseId));
 }

--- a/src/loader/bgw_message_queue.h
+++ b/src/loader/bgw_message_queue.h
@@ -9,7 +9,8 @@ typedef enum BgwMessageType
 {
 	STOP = 0,
 	START,
-	RESTART
+	RESTART,
+	START_OR_RESTART
 } BgwMessageType;
 
 typedef struct BgwMessage

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -260,6 +260,49 @@ SELECT wait_greater(:'orig_backend_start');
  t
 (1 row)
 
+--make sure start_or_restart has same behavior as restart when worker already exists
+SELECT backend_start as orig_backend_start
+FROM pg_stat_activity
+WHERE application_name = 'TimescaleDB Background Worker Scheduler'
+AND datname = 'single_2' \gset
+SELECT _timescaledb_internal.start_or_restart_background_workers();
+ start_or_restart_background_workers 
+-------------------------------------
+ t
+(1 row)
+
+SELECT wait_greater(:'orig_backend_start');
+ wait_greater 
+--------------
+ t
+(1 row)
+
+--make sure start_or_restart has same behavior as start from stopped case
+--we won't test that restart, doesn't start background workers as it's hard to prove a negative.
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+SELECT wait_worker_counts(1,0,0,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+SELECT _timescaledb_internal.start_or_restart_background_workers();
+ start_or_restart_background_workers 
+-------------------------------------
+ t
+(1 row)
+
+SELECT wait_worker_counts(1,0,1,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
 /* Make sure canceling the launcher backend causes a restart of schedulers */
 SELECT backend_start as orig_backend_start
 FROM pg_stat_activity


### PR DESCRIPTION
Fixes a potential race condition where a scheduler could be started for a given
database, but before it has shut down a create database command is run,
the start action then would not change the state of the worker but it would be waiting
on the wrong vxid, so not see that the extension exists. There is a similar case for
alter extension. In addition, we correct behavior and cause workers not to start
on every alter extension but rather only when there is, in fact a worker, and when
we are upgrading to a version with a scheduler from a version without a scheduler.
