### PR TITLE
Search for pg_isolation_regress in pg_config bin directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ message(STATUS "Using pg_regress ${PG_REGRESS}")
 
 find_program(PG_ISOLATION_REGRESS pg_isolation_regress
   HINTS
+  ${BINDIR}/
   ${PG_PKGLIBDIR}/pgxs/src/test/isolation/
   ${PG_SOURCE_DIR}/src/test/isolation
   REQUIRED)


### PR DESCRIPTION
Hi,

If there's multiple postgresql try to find the right pg_isolation_regress, likely in pg_config bin directory.


Regards
Didier

