### PR TITLE
Add bool created to create_hypertable and add_dimension return value

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -29,7 +29,7 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     migrate_data            BOOLEAN = FALSE,
     chunk_target_size       TEXT = NULL,
     chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc
-) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME) AS '@MODULE_PATHNAME@', 'ts_hypertable_create' LANGUAGE C VOLATILE;
+) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create' LANGUAGE C VOLATILE;
 
 -- Set adaptive chunking. To disable, set chunk_target_size => 'off'.
 CREATE OR REPLACE FUNCTION  set_adaptive_chunking(
@@ -138,7 +138,7 @@ CREATE OR REPLACE FUNCTION  add_dimension(
     chunk_time_interval     ANYELEMENT = NULL::BIGINT,
     partitioning_func       REGPROC = NULL,
     if_not_exists           BOOLEAN = FALSE
-) RETURNS TABLE(dimension_id INT, schema_name NAME, table_name NAME, column_name NAME)
+) RETURNS TABLE(dimension_id INT, schema_name NAME, table_name NAME, column_name NAME, created BOOL)
 AS '@MODULE_PATHNAME@', 'ts_dimension_add' LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE FUNCTION attach_tablespace(

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -115,6 +115,7 @@ enum Anum_add_dimension
 	Anum_add_dimension_schema_name,
 	Anum_add_dimension_table_name,
 	Anum_add_dimension_column_name,
+	Anum_add_dimension_created,
 	_Anum_add_dimension_max,
 };
 

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -31,6 +31,7 @@ enum Anum_create_hypertable
 	Anum_create_hypertable_id = 1,
 	Anum_create_hypertable_schema_name,
 	Anum_create_hypertable_table_name,
+	Anum_create_hypertable_created,
 	_Anum_create_hypertable_max,
 };
 

--- a/test/expected/agg_bookends.out
+++ b/test/expected/agg_bookends.out
@@ -1,9 +1,9 @@
 CREATE TABLE "btest"(time timestamp, time_alt timestamp, gp INTEGER, temp float, strid TEXT DEFAULT 'testing');
 SELECT create_hypertable('"btest"', 'time');
 NOTICE:  adding not-null constraint to column "time"
- create_hypertable 
--------------------
- (1,public,btest)
+ create_hypertable  
+--------------------
+ (1,public,btest,t)
 (1 row)
 
 INSERT INTO "btest" VALUES('2017-01-20T09:00:01', '2017-01-20T10:00:00', 1, 22.5);
@@ -133,9 +133,9 @@ CREATE TABLE btest_numeric
 );
 SELECT create_hypertable('btest_numeric', 'time');
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable     
---------------------------
- (2,public,btest_numeric)
+     create_hypertable      
+----------------------------
+ (2,public,btest_numeric,t)
 (1 row)
 
 -- Insert rows, with rows that contain NULL values

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -8,9 +8,9 @@ ALTER TABLE alter_before ALTER COLUMN temp SET STATISTICS 100;
 ALTER TABLE alter_before ALTER COLUMN notes SET STORAGE EXTERNAL;
 SELECT create_hypertable('alter_before', 'time', chunk_time_interval => 2628000000000);
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable    
--------------------------
- (1,public,alter_before)
+     create_hypertable     
+---------------------------
+ (1,public,alter_before,t)
 (1 row)
 
 INSERT INTO alter_before VALUES ('2017-03-22T09:18:22', 23.5, 1);
@@ -46,9 +46,9 @@ ORDER BY c.relname, a.attnum;
 CREATE TABLE alter_after(id serial, time timestamp, temp float, colorid integer, notes text, notes_2 text);
 SELECT create_hypertable('alter_after', 'time', chunk_time_interval => 2628000000000);
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (2,public,alter_after)
+    create_hypertable     
+--------------------------
+ (2,public,alter_after,t)
 (1 row)
 
 -- Create first chunk
@@ -222,9 +222,9 @@ WHERE tablename = 'hyper_in_space' OR tablename LIKE '\_hyper\__\__\_chunk' ORDE
 CREATE TABLE hyper_in_space(time bigint, temp float, device int);
 SELECT create_hypertable('hyper_in_space', 'time', 'device', 4, chunk_time_interval=>1);
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable     
----------------------------
- (3,public,hyper_in_space)
+      create_hypertable      
+-----------------------------
+ (3,public,hyper_in_space,t)
 (1 row)
 
 INSERT INTO hyper_in_space(time, temp, device) VALUES (1, 20, 1);
@@ -307,9 +307,9 @@ DROP TABLE hyper_in_space;
 CREATE TABLE hyper_in_space(time bigint, temp float, device int) TABLESPACE tablespace1;
 SELECT create_hypertable('hyper_in_space', 'time', 'device', 4, chunk_time_interval=>1);
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable     
----------------------------
- (4,public,hyper_in_space)
+      create_hypertable      
+-----------------------------
+ (4,public,hyper_in_space,t)
 (1 row)
 
 INSERT INTO hyper_in_space(time, temp, device) VALUES (1, 20, 1);
@@ -419,9 +419,9 @@ CREATE TABLE original_name.my_table (
   quantity double precision
 );
 SELECT create_hypertable('original_name.my_table','date');
-     create_hypertable      
-----------------------------
- (5,original_name,my_table)
+      create_hypertable       
+------------------------------
+ (5,original_name,my_table,t)
 (1 row)
 
 INSERT INTO original_name.my_table (date, quantity) VALUES ('2018-07-04T21:00:00+00:00', 8);
@@ -443,21 +443,21 @@ CREATE TABLE regular_table (
   quantity double precision
 );
 SELECT create_hypertable('original_name.my_table','date');
-     create_hypertable      
-----------------------------
- (6,original_name,my_table)
+      create_hypertable       
+------------------------------
+ (6,original_name,my_table,t)
 (1 row)
 
 SELECT create_hypertable('original_name.my_table2','date');
-      create_hypertable      
------------------------------
- (7,original_name,my_table2)
+       create_hypertable       
+-------------------------------
+ (7,original_name,my_table2,t)
 (1 row)
 
 SELECT create_hypertable('regular_table','date');
-    create_hypertable     
---------------------------
- (8,public,regular_table)
+     create_hypertable      
+----------------------------
+ (8,public,regular_table,t)
 (1 row)
 
 INSERT INTO original_name.my_table (date, quantity) VALUES ('2018-07-04T21:00:00+00:00', 8);
@@ -479,15 +479,15 @@ CREATE TABLE original_name.my_table2 (
   quantity double precision
 );
 SELECT create_hypertable('original_name.my_table','date');
-     create_hypertable      
-----------------------------
- (9,original_name,my_table)
+      create_hypertable       
+------------------------------
+ (9,original_name,my_table,t)
 (1 row)
 
 SELECT create_hypertable('original_name.my_table2','date');
-      create_hypertable       
-------------------------------
- (10,original_name,my_table2)
+       create_hypertable        
+--------------------------------
+ (10,original_name,my_table2,t)
 (1 row)
 
 INSERT INTO original_name.my_table (date, quantity) VALUES ('2018-07-04T21:00:00+00:00', 8);
@@ -518,9 +518,9 @@ CREATE TABLE my_table (
   quantity double precision
 );
 SELECT create_hypertable('my_table','date', associated_schema_name => 'my_associated_schema');
-  create_hypertable   
-----------------------
- (11,public,my_table)
+   create_hypertable    
+------------------------
+ (11,public,my_table,t)
 (1 row)
 
 INSERT INTO my_table (date, quantity) VALUES ('2018-07-04T21:00:00+00:00', 8);

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -16,9 +16,9 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_boo
 CREATE SCHEMA "one_Partition" AUTHORIZATION :ROLE_DEFAULT_PERM_USER;
 \c single :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |  table_name   
----------------+-------------+---------------
-             1 | public      | one_Partition
+ hypertable_id | schema_name |  table_name   | created 
+---------------+-------------+---------------+---------
+             1 | public      | one_Partition | t
 (1 row)
 
 --output command tags
@@ -69,7 +69,7 @@ SELECT create_hypertable('"1dim"', 'time');
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
- (2,public,1dim)
+ (2,public,1dim,t)
 (1 row)
 
 INSERT INTO "1dim" VALUES('2017-01-20T09:00:01', 22.5);
@@ -107,15 +107,15 @@ CREATE TABLE "customSchema"."Hypertable_1" (
 );
 CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-             3 | public      | Hypertable_1
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             3 | public      | Hypertable_1 | t
 (1 row)
 
 SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name  |  table_name  
----------------+--------------+--------------
-             4 | customSchema | Hypertable_1
+ hypertable_id | schema_name  |  table_name  | created 
+---------------+--------------+--------------+---------
+             4 | customSchema | Hypertable_1 | t
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
@@ -189,9 +189,9 @@ DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 CREATE TABLE my_ht (time BIGINT, val integer);
 SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 psql:include/ddl_ops_1.sql:62: NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             5 | public      | my_ht
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             5 | public      | my_ht      | t
 (1 row)
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
@@ -263,9 +263,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             6 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             6 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -285,9 +285,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Device_id", "Time" DESC);
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             7 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             7 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -307,9 +307,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             8 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             8 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -328,9 +328,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             9 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             9 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -348,9 +348,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-            10 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+            10 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -424,9 +424,9 @@ CREATE TABLE plain_table_su (time timestamp, temp float);
 CREATE TABLE hypertable_su (time timestamp, temp float);
 SELECT create_hypertable('hypertable_su', 'time');
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable     
----------------------------
- (11,public,hypertable_su)
+      create_hypertable      
+-----------------------------
+ (11,public,hypertable_su,t)
 (1 row)
 
 CREATE INDEX "ind_1" ON hypertable_su (time);

--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -29,9 +29,9 @@ $BODY$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
 psql:include/append.sql:31: NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (1,public,append_test)
+    create_hypertable     
+--------------------------
+ (1,public,append_test,t)
 (1 row)
 
 -- create three chunks
@@ -416,9 +416,9 @@ psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
 psql:include/append.sql:172: NOTICE:  adding not-null constraint to column "time"
-  create_hypertable   
-----------------------
- (2,public,join_test)
+   create_hypertable    
+------------------------
+ (2,public,join_test,t)
 (1 row)
 
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),

--- a/test/expected/append_unoptimized.out
+++ b/test/expected/append_unoptimized.out
@@ -29,9 +29,9 @@ $BODY$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
 psql:include/append.sql:31: NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (1,public,append_test)
+    create_hypertable     
+--------------------------
+ (1,public,append_test,t)
 (1 row)
 
 -- create three chunks
@@ -446,9 +446,9 @@ psql:include/append.sql:166: NOTICE:  Stable function now_s() called!
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
 psql:include/append.sql:172: NOTICE:  adding not-null constraint to column "time"
-  create_hypertable   
-----------------------
- (2,public,join_test)
+   create_hypertable    
+------------------------
+ (2,public,join_test,t)
 (1 row)
 
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -44,9 +44,9 @@ SELECT create_hypertable('test_adaptive', 'time',
                          chunk_sizing_func => 'calculate_chunk_interval');
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable     
---------------------------
- (1,public,test_adaptive)
+     create_hypertable      
+----------------------------
+ (1,public,test_adaptive,t)
 (1 row)
 
 DROP TABLE test_adaptive;
@@ -57,9 +57,9 @@ SELECT create_hypertable('test_adaptive', 'time',
                          create_default_indexes => true);
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable     
---------------------------
- (2,public,test_adaptive)
+     create_hypertable      
+----------------------------
+ (2,public,test_adaptive,t)
 (1 row)
 
 SELECT table_name, chunk_sizing_func_schema, chunk_sizing_func_name, chunk_target_size
@@ -262,9 +262,9 @@ SELECT create_hypertable('test_adaptive_no_index', 'time',
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 WARNING:  no index on "time" found for adaptive chunking on hypertable "test_adaptive_no_index"
 NOTICE:  adding not-null constraint to column "time"
-         create_hypertable         
------------------------------------
- (3,public,test_adaptive_no_index)
+          create_hypertable          
+-------------------------------------
+ (3,public,test_adaptive_no_index,t)
 (1 row)
 
 SELECT id, hypertable_id, interval_length FROM _timescaledb_catalog.dimension;
@@ -361,9 +361,9 @@ SELECT create_hypertable('test_adaptive_correct_index', 'time',
                          create_default_indexes => false);
 WARNING:  no index on "time" found for adaptive chunking on hypertable "test_adaptive_correct_index"
 NOTICE:  adding not-null constraint to column "time"
-           create_hypertable            
-----------------------------------------
- (4,public,test_adaptive_correct_index)
+            create_hypertable             
+------------------------------------------
+ (4,public,test_adaptive_correct_index,t)
 (1 row)
 
 CREATE INDEX ON test_adaptive_correct_index(location);
@@ -457,9 +457,9 @@ SELECT create_hypertable('test_adaptive_space', 'time', 'location', 2,
                          create_default_indexes => true);
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adding not-null constraint to column "time"
-       create_hypertable        
---------------------------------
- (5,public,test_adaptive_space)
+        create_hypertable         
+----------------------------------
+ (5,public,test_adaptive_space,t)
 (1 row)
 
 SELECT id, hypertable_id, interval_length FROM _timescaledb_catalog.dimension;
@@ -537,9 +537,9 @@ SELECT create_hypertable('test_adaptive_after_multiple_dims', 'time',
                          chunk_target_size => '100MB',
                          create_default_indexes => true);
 NOTICE:  adding not-null constraint to column "time"
-              create_hypertable               
-----------------------------------------------
- (6,public,test_adaptive_after_multiple_dims)
+               create_hypertable                
+------------------------------------------------
+ (6,public,test_adaptive_after_multiple_dims,t)
 (1 row)
 
 INSERT INTO test_adaptive_after_multiple_dims VALUES('2018-01-01T00:00:00+00'::timestamptz, 0.0, 5);
@@ -565,9 +565,9 @@ SELECT create_hypertable('test_adaptive', 'time',
                          chunk_sizing_func => 'my_chunk_func_schema.calculate_chunk_interval');
 WARNING:  target chunk size for adaptive chunking is less than 10 MB
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable     
---------------------------
- (7,public,test_adaptive)
+     create_hypertable      
+----------------------------
+ (7,public,test_adaptive,t)
 (1 row)
 
 ALTER SCHEMA my_chunk_func_schema RENAME TO new_chunk_func_schema;

--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -1,9 +1,9 @@
 CREATE TABLE cluster_test(time timestamptz, temp float, location int);
 SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => interval '1 day');
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable    
--------------------------
- (1,public,cluster_test)
+     create_hypertable     
+---------------------------
+ (1,public,cluster_test,t)
 (1 row)
 
 -- Show default indexes

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -4,9 +4,9 @@ CREATE TABLE hyper (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             1 | public      | hyper
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | hyper      | t
 (1 row)
 
 --check and not-null constraints are inherited through regular inheritance.
@@ -48,9 +48,9 @@ CREATE TABLE hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name |                           table_name                            
----------------+-------------+-----------------------------------------------------------------
-             2 | public      | hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name
+ hypertable_id | schema_name |                           table_name                            | created 
+---------------+-------------+-----------------------------------------------------------------+---------
+             2 | public      | hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name | t
 (1 row)
 
 INSERT INTO hyper_unique_with_looooooooooooooooooooooooooooooooooooong_name(time, device_id,sensor_1) VALUES
@@ -306,9 +306,9 @@ CREATE TABLE hyper_pk (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_pk', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             3 | public      | hyper_pk
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | hyper_pk   | t
 (1 row)
 
 INSERT INTO hyper_pk(time, device_id,sensor_1) VALUES
@@ -393,9 +393,9 @@ CREATE TABLE hyper_fk (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_fk', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             4 | public      | hyper_fk
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             4 | public      | hyper_fk   | t
 (1 row)
 
 --fail fk constraint
@@ -536,9 +536,9 @@ CREATE TABLE hyper_for_ref (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_for_ref', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name |  table_name   
----------------+-------------+---------------
-             5 | public      | hyper_for_ref
+ hypertable_id | schema_name |  table_name   | created 
+---------------+-------------+---------------+---------
+             5 | public      | hyper_for_ref | t
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -567,9 +567,9 @@ CREATE TABLE hyper_ex (
 );
 SELECT * FROM create_hypertable('hyper_ex', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             6 | public      | hyper_ex
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             6 | public      | hyper_ex   | t
 (1 row)
 
 INSERT INTO hyper_ex(time, device_id,sensor_1) VALUES
@@ -648,9 +648,9 @@ CREATE TABLE hyper_noinherit_alter (
 );
 SELECT * FROM create_hypertable('hyper_noinherit_alter', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name |      table_name       
----------------+-------------+-----------------------
-             8 | public      | hyper_noinherit_alter
+ hypertable_id | schema_name |      table_name       | created 
+---------------+-------------+-----------------------+---------
+             8 | public      | hyper_noinherit_alter | t
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -664,9 +664,9 @@ CREATE TABLE hyper_unique_deferred (
 );
 SELECT * FROM create_hypertable('hyper_unique_deferred', 'time', chunk_time_interval => 10);
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name |      table_name       
----------------+-------------+-----------------------
-             9 | public      | hyper_unique_deferred
+ hypertable_id | schema_name |      table_name       | created 
+---------------+-------------+-----------------------+---------
+             9 | public      | hyper_unique_deferred | t
 (1 row)
 
 INSERT INTO hyper_unique_deferred(time, device_id,sensor_1) VALUES (1257987700000000000, 'dev2', 11);
@@ -690,9 +690,9 @@ CREATE TABLE hyper_pk_deferred (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_pk_deferred', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name |    table_name     
----------------+-------------+-------------------
-            10 | public      | hyper_pk_deferred
+ hypertable_id | schema_name |    table_name     | created 
+---------------+-------------+-------------------+---------
+            10 | public      | hyper_pk_deferred | t
 (1 row)
 
 INSERT INTO hyper_pk_deferred(time, device_id,sensor_1) VALUES (1257987700000000000, 'dev2', 11);
@@ -716,9 +716,9 @@ CREATE TABLE hyper_fk_deferred (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_fk_deferred', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name |    table_name     
----------------+-------------+-------------------
-            11 | public      | hyper_fk_deferred
+ hypertable_id | schema_name |    table_name     | created 
+---------------+-------------+-------------------+---------
+            11 | public      | hyper_fk_deferred | t
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -745,9 +745,9 @@ CREATE TABLE hyper_ex_deferred (
 );
 SELECT * FROM create_hypertable('hyper_ex_deferred', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name |    table_name     
----------------+-------------+-------------------
-            12 | public      | hyper_ex_deferred
+ hypertable_id | schema_name |    table_name     | created 
+---------------+-------------+-------------------+---------
+            12 | public      | hyper_ex_deferred | t
 (1 row)
 
 INSERT INTO hyper_ex_deferred(time, device_id,sensor_1) VALUES (1257987700000000000, 'dev2', 12);
@@ -772,9 +772,9 @@ CREATE TABLE hyper_unique (
   sensor_1 NUMERIC NULL DEFAULT 1 CHECK (sensor_1 > 10)
 );
 SELECT * FROM create_hypertable('hyper_unique', 'time', chunk_time_interval => 10, associated_schema_name => 'my_associated_schema');
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-            13 | public      | hyper_unique
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            13 | public      | hyper_unique | t
 (1 row)
 
 INSERT INTO hyper_unique(time, device_id,sensor_1) VALUES (1257987700000000000, 'dev2', 11);

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -60,9 +60,9 @@ CREATE TABLE "hyper" (
     "value" double precision NOT NULL
 );
 SELECT create_hypertable('hyper', 'time', chunk_time_interval => 100);
- create_hypertable 
--------------------
- (2,public,hyper)
+ create_hypertable  
+--------------------
+ (2,public,hyper,t)
 (1 row)
 
 INSERT INTO "meta" ("id") values (1);

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -25,9 +25,9 @@
 CREATE TABLE chunk_test(time integer, temp float8, tag integer, color integer);
 SELECT create_hypertable('chunk_test', 'time', 'tag', 2, chunk_time_interval => 3);
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable   
------------------------
- (1,public,chunk_test)
+    create_hypertable    
+-------------------------
+ (1,public,chunk_test,t)
 (1 row)
 
 INSERT INTO chunk_test VALUES (4, 24.3, 1, 1);
@@ -120,9 +120,9 @@ ORDER BY c.id, d.id;
 CREATE TABLE chunk_test_ends(time bigint, temp float8, tag integer, color integer);
 SELECT create_hypertable('chunk_test_ends', 'time', chunk_time_interval => 5);
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable      
-----------------------------
- (2,public,chunk_test_ends)
+      create_hypertable       
+------------------------------
+ (2,public,chunk_test_ends,t)
 (1 row)
 
 INSERT INTO chunk_test_ends VALUES ((-9223372036854775808)::bigint, 23.1, 11233, 1);
@@ -150,9 +150,9 @@ CREATE TABLE chunk_test2(time TIMESTAMPTZ, temp float8, tag integer, color integ
 SELECT create_hypertable('chunk_test2', 'time', 'tag', 2, chunk_time_interval => 3);
 WARNING:  unexpected interval: smaller than one second
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (3,public,chunk_test2)
+    create_hypertable     
+--------------------------
+ (3,public,chunk_test2,t)
 (1 row)
 
 SELECT interval_length

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -34,9 +34,9 @@ GRANT :ROLE_DEFAULT_PERM_USER TO :ROLE_DEFAULT_PERM_USER_2;
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 select * from create_hypertable('test_schema.test_table_no_not_null', 'time', 'device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name |       table_name       
----------------+-------------+------------------------
-             1 | test_schema | test_table_no_not_null
+ hypertable_id | schema_name |       table_name       | created 
+---------------+-------------+------------------------+---------
+             1 | test_schema | test_table_no_not_null | t
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -57,9 +57,9 @@ GRANT CREATE ON SCHEMA chunk_schema TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 select * from create_hypertable('test_schema.test_table', 'time', 'device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'), associated_schema_name => 'chunk_schema');
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             2 | test_schema | test_table
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             2 | test_schema | test_table | t
 (1 row)
 
 -- Check that the insert block trigger exists
@@ -77,9 +77,9 @@ SELECT * FROM _timescaledb_internal.get_create_command('test_table');
 
 --test adding one more closed dimension
 select add_dimension('test_schema.test_table', 'location', 4);
-            add_dimension            
--------------------------------------
- (5,test_schema,test_table,location)
+             add_dimension             
+---------------------------------------
+ (5,test_schema,test_table,location,t)
 (1 row)
 
 select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
@@ -140,9 +140,9 @@ ERROR:  get_create_command only supports hypertables with up to 2 dimensions
 --test adding one more open dimension
 select add_dimension('test_schema.test_table', 'id', chunk_time_interval => 1000);
 NOTICE:  adding not-null constraint to column "id"
-         add_dimension         
--------------------------------
- (6,test_schema,test_table,id)
+          add_dimension          
+---------------------------------
+ (6,test_schema,test_table,id,t)
 (1 row)
 
 select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
@@ -166,16 +166,16 @@ select * from _timescaledb_catalog.dimension;
 CREATE TABLE dim_test_time(time TIMESTAMPTZ, time2 TIMESTAMPTZ, time3 BIGINT, temp float8, device int, location int);
 SELECT create_hypertable('dim_test_time', 'time');
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable     
---------------------------
- (3,public,dim_test_time)
+     create_hypertable      
+----------------------------
+ (3,public,dim_test_time,t)
 (1 row)
 
 SELECT add_dimension('dim_test_time', 'time2', chunk_time_interval => INTERVAL '1 day');
 NOTICE:  adding not-null constraint to column "time2"
-         add_dimension          
---------------------------------
- (8,public,dim_test_time,time2)
+          add_dimension           
+----------------------------------
+ (8,public,dim_test_time,time2,t)
 (1 row)
 
 -- Test add_dimension: only integral should work on BIGINT columns
@@ -188,34 +188,34 @@ ERROR:  invalid interval: must be an interval or integer type
 \set ON_ERROR_STOP 1
 SELECT add_dimension('dim_test_time', 'time3', chunk_time_interval => 500);
 NOTICE:  adding not-null constraint to column "time3"
-         add_dimension          
---------------------------------
- (9,public,dim_test_time,time3)
+          add_dimension           
+----------------------------------
+ (9,public,dim_test_time,time3,t)
 (1 row)
 
 -- Test add_dimension: integrals should work on TIMESTAMPTZ columns
 CREATE TABLE dim_test_time2(time TIMESTAMPTZ, time2 TIMESTAMPTZ, temp float8, device int, location int);
 SELECT create_hypertable('dim_test_time2', 'time');
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable     
----------------------------
- (4,public,dim_test_time2)
+      create_hypertable      
+-----------------------------
+ (4,public,dim_test_time2,t)
 (1 row)
 
 SELECT add_dimension('dim_test_time2', 'time2', chunk_time_interval => 500);
 WARNING:  unexpected interval: smaller than one second
 NOTICE:  adding not-null constraint to column "time2"
-          add_dimension           
-----------------------------------
- (11,public,dim_test_time2,time2)
+           add_dimension            
+------------------------------------
+ (11,public,dim_test_time2,time2,t)
 (1 row)
 
 --adding a dimension twice should not fail with 'if_not_exists'
 SELECT add_dimension('dim_test_time2', 'time2', chunk_time_interval => 500, if_not_exists => true);
 NOTICE:  column "time2" is already a dimension, skipping
- add_dimension 
----------------
- 
+           add_dimension            
+------------------------------------
+ (11,public,dim_test_time2,time2,f)
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -243,9 +243,9 @@ ERROR:  hypertable "test_table" is not empty
 -- should not fail on non-empty table with 'if_not_exists' in case the dimension exists
 select add_dimension('test_schema.test_table', 'location', 2, if_not_exists => true);
 NOTICE:  column "location" is already a dimension, skipping
- add_dimension 
----------------
- 
+             add_dimension             
+---------------------------------------
+ (5,test_schema,test_table,location,f)
 (1 row)
 
 --show chunks in the associated schema
@@ -260,9 +260,9 @@ NOTICE:  column "location" is already a dimension, skipping
 create table test_schema.test_1dim(time timestamp, temp float);
 select create_hypertable('test_schema.test_1dim', 'time');
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable     
----------------------------
- (5,test_schema,test_1dim)
+      create_hypertable      
+-----------------------------
+ (5,test_schema,test_1dim,t)
 (1 row)
 
 SELECT * FROM _timescaledb_internal.get_create_command('test_1dim');
@@ -282,9 +282,9 @@ SELECT * FROM _timescaledb_internal.get_create_command('test_1dim');
 
 select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true);
 NOTICE:  table "test_1dim" is already a hypertable, skipping
- create_hypertable 
--------------------
- 
+      create_hypertable      
+-----------------------------
+ (5,test_schema,test_1dim,f)
 (1 row)
 
 -- Should error when creating again without if_not_exists set to true
@@ -296,9 +296,9 @@ ERROR:  table "test_1dim" is already a hypertable
 insert into test_schema.test_1dim VALUES ('2004-10-19 10:23:54+02', 1.0);
 select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true);
 NOTICE:  table "test_1dim" is already a hypertable, skipping
- create_hypertable 
--------------------
- 
+      create_hypertable      
+-----------------------------
+ (5,test_schema,test_1dim,f)
 (1 row)
 
 -- Should error when creating again without if_not_exists set to true
@@ -324,9 +324,9 @@ ERROR:  table "test_migrate" is not empty
 select create_hypertable('test_schema.test_migrate', 'time', migrate_data => true);
 NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
-      create_hypertable       
-------------------------------
- (6,test_schema,test_migrate)
+       create_hypertable        
+--------------------------------
+ (6,test_schema,test_migrate,t)
 (1 row)
 
 --there should be two new chunks
@@ -374,18 +374,18 @@ select * from only _timescaledb_internal._hyper_6_5_chunk;
 create table test_schema.test_migrate_empty(time timestamp, temp float);
 select create_hypertable('test_schema.test_migrate_empty', 'time', migrate_data => true);
 NOTICE:  adding not-null constraint to column "time"
-         create_hypertable          
-------------------------------------
- (7,test_schema,test_migrate_empty)
+          create_hypertable           
+--------------------------------------
+ (7,test_schema,test_migrate_empty,t)
 (1 row)
 
 CREATE TYPE test_type AS (time timestamp, temp float);
 CREATE TABLE test_table_of_type OF test_type;
 SELECT create_hypertable('test_table_of_type', 'time');
 NOTICE:  adding not-null constraint to column "time"
-       create_hypertable       
--------------------------------
- (8,public,test_table_of_type)
+        create_hypertable        
+---------------------------------
+ (8,public,test_table_of_type,t)
 (1 row)
 
 INSERT INTO test_table_of_type VALUES ('2004-10-19 10:23:54+02', 1.0), ('2004-12-19 10:23:54+02', 2.0);
@@ -398,9 +398,9 @@ NOTICE:  drop cascades to 3 other objects
 CREATE TABLE test_table_of_type (time timestamp, temp float);
 SELECT create_hypertable('test_table_of_type', 'time');
 NOTICE:  adding not-null constraint to column "time"
-       create_hypertable       
--------------------------------
- (9,public,test_table_of_type)
+        create_hypertable        
+---------------------------------
+ (9,public,test_table_of_type,t)
 (1 row)
 
 INSERT INTO test_table_of_type VALUES ('2004-10-19 10:23:54+02', 1.0), ('2004-12-19 10:23:54+02', 2.0);
@@ -470,9 +470,9 @@ ERROR:  invalid partitioning function
 -- Test that add_dimension fails due to invalid partitioning function
 select create_hypertable('test_schema.test_partfunc', 'time');
 NOTICE:  adding not-null constraint to column "time"
-       create_hypertable        
---------------------------------
- (10,test_schema,test_partfunc)
+        create_hypertable         
+----------------------------------
+ (10,test_schema,test_partfunc,t)
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -487,8 +487,8 @@ ERROR:  invalid partitioning function
 \set ON_ERROR_STOP 1
 -- A valid function should work:
 select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_valid');
-             add_dimension             
----------------------------------------
- (18,test_schema,test_partfunc,device)
+              add_dimension              
+-----------------------------------------
+ (18,test_schema,test_partfunc,device,t)
 (1 row)
 

--- a/test/expected/create_table.out
+++ b/test/expected/create_table.out
@@ -3,9 +3,9 @@ CREATE TABLE test_hyper_pk(time TIMESTAMPTZ PRIMARY KEY, temp FLOAT, device INT)
 CREATE TABLE test_pk(device INT PRIMARY KEY);
 CREATE TABLE test_like(LIKE test_pk);
 SELECT create_hypertable('test_hyper_pk', 'time');
-    create_hypertable     
---------------------------
- (1,public,test_hyper_pk)
+     create_hypertable      
+----------------------------
+ (1,public,test_hyper_pk,t)
 (1 row)
 
 \set ON_ERROR_STOP 0

--- a/test/expected/custom_type.out
+++ b/test/expected/custom_type.out
@@ -61,9 +61,9 @@ CREATE OPERATOR >= (
 CREATE TABLE customtype_test(time_custom customtype, val int);
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time_custom"
-     create_hypertable      
-----------------------------
- (1,public,customtype_test)
+      create_hypertable       
+------------------------------
+ (1,public,customtype_test,t)
 (1 row)
 
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -25,15 +25,15 @@ CREATE TABLE "customSchema"."Hypertable_1" (
 );
 CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-             1 | public      | Hypertable_1
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             1 | public      | Hypertable_1 | t
 (1 row)
 
 SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name  |  table_name  
----------------+--------------+--------------
-             2 | customSchema | Hypertable_1
+ hypertable_id | schema_name  |  table_name  | created 
+---------------+--------------+--------------+---------
+             2 | customSchema | Hypertable_1 | t
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
@@ -86,9 +86,9 @@ DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 CREATE TABLE my_ht (time BIGINT, val integer);
 SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 psql:include/ddl_ops_1.sql:62: NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             3 | public      | my_ht
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | my_ht      | t
 (1 row)
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
@@ -160,9 +160,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             4 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             4 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -182,9 +182,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Device_id", "Time" DESC);
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             5 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             5 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -204,9 +204,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             6 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             6 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -225,9 +225,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             7 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             7 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -245,9 +245,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             8 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             8 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');

--- a/test/expected/ddl_alter_column.out
+++ b/test/expected/ddl_alter_column.out
@@ -2,9 +2,9 @@ CREATE TABLE alter_test(time timestamptz, temp float, color varchar(10));
 -- create hypertable with two chunks
 SELECT create_hypertable('alter_test', 'time', 'color', 2, chunk_time_interval => 2628000000000);
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable   
------------------------
- (1,public,alter_test)
+    create_hypertable    
+-------------------------
+ (1,public,alter_test,t)
 (1 row)
 
 INSERT INTO alter_test VALUES ('2017-01-20T09:00:01', 17.5, 'blue'),
@@ -135,9 +135,9 @@ ERROR:  ONLY option not supported on hypertable operations
 CREATE TABLE alter_test_bigint(time bigint, temp float);
 SELECT create_hypertable('alter_test_bigint', 'time', chunk_time_interval => 2628000000000);
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable       
-------------------------------
- (2,public,alter_test_bigint)
+       create_hypertable        
+--------------------------------
+ (2,public,alter_test_bigint,t)
 (1 row)
 
 \set ON_ERROR_STOP 0

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -19,9 +19,9 @@ ERROR:  table "Hypertable_1" is not empty
 DELETE FROM  PUBLIC."Hypertable_1" ;
 \set ON_ERROR_STOP 1
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-             1 | public      | Hypertable_1
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             1 | public      | Hypertable_1 | t
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -64,9 +64,9 @@ ERROR:  table "Hypertable_unlogged" has to be logged
 \set ON_ERROR_STOP 1
 ALTER TABLE PUBLIC."Hypertable_unlogged" SET LOGGED;
 SELECT * FROM create_hypertable('"public"."Hypertable_unlogged"', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |     table_name      
----------------+-------------+---------------------
-             2 | public      | Hypertable_unlogged
+ hypertable_id | schema_name |     table_name      | created 
+---------------+-------------+---------------------+---------
+             2 | public      | Hypertable_unlogged | t
 (1 row)
 
 CREATE TEMP TABLE "Hypertable_temp" (
@@ -110,9 +110,9 @@ ERROR:  hypertables do not support rules
 \set ON_ERROR_STOP 1
 DROP RULE notify_me ON "Hypertable_1_rule";
 SELECT * FROM create_hypertable('"public"."Hypertable_1_rule"', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |    table_name     
----------------+-------------+-------------------
-             3 | public      | Hypertable_1_rule
+ hypertable_id | schema_name |    table_name     | created 
+---------------+-------------+-------------------+---------
+             3 | public      | Hypertable_1_rule | t
 (1 row)
 
 \set ON_ERROR_STOP 0

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -25,15 +25,15 @@ CREATE TABLE "customSchema"."Hypertable_1" (
 );
 CREATE INDEX ON "customSchema"."Hypertable_1" (time, "Device_id");
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-             1 | public      | Hypertable_1
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             1 | public      | Hypertable_1 | t
 (1 row)
 
 SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name  |  table_name  
----------------+--------------+--------------
-             2 | customSchema | Hypertable_1
+ hypertable_id | schema_name  |  table_name  | created 
+---------------+--------------+--------------+---------
+             2 | customSchema | Hypertable_1 | t
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
@@ -86,9 +86,9 @@ DELETE FROM ONLY PUBLIC."Hypertable_1" WHERE "Device_id" = 'dev1';
 CREATE TABLE my_ht (time BIGINT, val integer);
 SELECT * FROM create_hypertable('my_ht', 'time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 psql:include/ddl_ops_1.sql:62: NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             3 | public      | my_ht
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | my_ht      | t
 (1 row)
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
@@ -160,9 +160,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             4 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             4 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -182,9 +182,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Device_id", "Time" DESC);
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             5 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             5 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -204,9 +204,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1_with_default_index_enabled" ("Time" DESC);
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             6 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             6 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -225,9 +225,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             7 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             7 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');
@@ -245,9 +245,9 @@ CREATE TABLE PUBLIC."Hypertable_1_with_default_index_enabled" (
   sensor_1 NUMERIC NULL DEFAULT 1
 );
 SELECT * FROM create_hypertable('"public"."Hypertable_1_with_default_index_enabled"', 'Time', 'Device_id', 1, create_default_indexes=>FALSE, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |               table_name                
----------------+-------------+-----------------------------------------
-             8 | public      | Hypertable_1_with_default_index_enabled
+ hypertable_id | schema_name |               table_name                | created 
+---------------+-------------+-----------------------------------------+---------
+             8 | public      | Hypertable_1_with_default_index_enabled | t
 (1 row)
 
 SELECT * FROM test.show_indexes('"Hypertable_1_with_default_index_enabled"');

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -4,42 +4,42 @@ CREATE TABLE PUBLIC.drop_chunk_test3(time bigint, temp float8, device_id text);
 CREATE INDEX ON drop_chunk_test1(time DESC);
 SELECT create_hypertable('public.drop_chunk_test1', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (1,public,drop_chunk_test1)
+       create_hypertable       
+-------------------------------
+ (1,public,drop_chunk_test1,t)
 (1 row)
 
 SELECT create_hypertable('public.drop_chunk_test2', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (2,public,drop_chunk_test2)
+       create_hypertable       
+-------------------------------
+ (2,public,drop_chunk_test2,t)
 (1 row)
 
 SELECT create_hypertable('public.drop_chunk_test3', 'time', chunk_time_interval => 1, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (3,public,drop_chunk_test3)
+       create_hypertable       
+-------------------------------
+ (3,public,drop_chunk_test3,t)
 (1 row)
 
 -- Add space dimensions to ensure chunks share dimension slices
 SELECT add_dimension('public.drop_chunk_test1', 'device_id', 2);
-             add_dimension             
----------------------------------------
- (4,public,drop_chunk_test1,device_id)
+              add_dimension              
+-----------------------------------------
+ (4,public,drop_chunk_test1,device_id,t)
 (1 row)
 
 SELECT add_dimension('public.drop_chunk_test2', 'device_id', 2);
-             add_dimension             
----------------------------------------
- (5,public,drop_chunk_test2,device_id)
+              add_dimension              
+-----------------------------------------
+ (5,public,drop_chunk_test2,device_id,t)
 (1 row)
 
 SELECT add_dimension('public.drop_chunk_test3', 'device_id', 2);
-             add_dimension             
----------------------------------------
- (6,public,drop_chunk_test3,device_id)
+              add_dimension              
+-----------------------------------------
+ (6,public,drop_chunk_test3,device_id,t)
 (1 row)
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
@@ -537,17 +537,17 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
 CREATE TABLE PUBLIC.drop_chunk_test_ts(time timestamp, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_ts', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"
-       create_hypertable       
--------------------------------
- (4,public,drop_chunk_test_ts)
+        create_hypertable        
+---------------------------------
+ (4,public,drop_chunk_test_ts,t)
 (1 row)
 
 CREATE TABLE PUBLIC.drop_chunk_test_tstz(time timestamptz, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_tstz', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"
-        create_hypertable        
----------------------------------
- (5,public,drop_chunk_test_tstz)
+         create_hypertable         
+-----------------------------------
+ (5,public,drop_chunk_test_tstz,t)
 (1 row)
 
 SET timezone = '+1';
@@ -626,9 +626,9 @@ ERROR:  cannot call drop_chunks with a timestamp without time zone on hypertable
 CREATE TABLE PUBLIC.drop_chunk_test_date(time date, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_date', 'time', chunk_time_interval => interval '1 day', create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"
-        create_hypertable        
----------------------------------
- (6,public,drop_chunk_test_date)
+         create_hypertable         
+-----------------------------------
+ (6,public,drop_chunk_test_date,t)
 (1 row)
 
 SET timezone = '+100';

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -1,9 +1,9 @@
 CREATE TABLE drop_test(time timestamp, temp float8, device text);
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
-  create_hypertable   
-----------------------
- (1,public,drop_test)
+   create_hypertable    
+------------------------
+ (1,public,drop_test,t)
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
@@ -46,9 +46,9 @@ CREATE EXTENSION IF NOT EXISTS timescaledb;
 NOTICE:  extension "timescaledb" already exists, skipping
 -- Make the table a hypertable again
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
-  create_hypertable   
-----------------------
- (1,public,drop_test)
+   create_hypertable    
+------------------------
+ (1,public,drop_test,t)
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -11,17 +11,17 @@ SELECT * from _timescaledb_catalog.dimension;
 CREATE TABLE should_drop (time timestamp, temp float8);
 SELECT create_hypertable('should_drop', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (1,public,should_drop)
+    create_hypertable     
+--------------------------
+ (1,public,should_drop,t)
 (1 row)
 
 CREATE TABLE hyper_with_dependencies (time timestamp, temp float8);
 SELECT create_hypertable('hyper_with_dependencies', 'time');
 NOTICE:  adding not-null constraint to column "time"
-         create_hypertable          
-------------------------------------
- (2,public,hyper_with_dependencies)
+          create_hypertable           
+--------------------------------------
+ (2,public,hyper_with_dependencies,t)
 (1 row)
 
 CREATE VIEW dependent_view AS SELECT * FROM hyper_with_dependencies;
@@ -41,9 +41,9 @@ NOTICE:  drop cascades to view dependent_view
 CREATE TABLE chunk_with_dependencies (time timestamp, temp float8);
 SELECT create_hypertable('chunk_with_dependencies', 'time');
 NOTICE:  adding not-null constraint to column "time"
-         create_hypertable          
-------------------------------------
- (3,public,chunk_with_dependencies)
+          create_hypertable           
+--------------------------------------
+ (3,public,chunk_with_dependencies,t)
 (1 row)
 
 INSERT INTO chunk_with_dependencies VALUES (now(), 1.0);
@@ -64,9 +64,9 @@ NOTICE:  drop cascades to view dependent_view_chunk
 -- although no new hypertable is created. Make sure we can handle this.
 SELECT create_hypertable('should_drop', 'time', if_not_exists => true);
 NOTICE:  table "should_drop" is already a hypertable, skipping
- create_hypertable 
--------------------
- 
+    create_hypertable     
+--------------------------
+ (1,public,should_drop,f)
 (1 row)
 
 SELECT * from _timescaledb_catalog.hypertable;
@@ -85,9 +85,9 @@ DROP TABLE should_drop;
 CREATE TABLE should_drop (time timestamp, temp float8);
 SELECT create_hypertable('should_drop', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (4,public,should_drop)
+    create_hypertable     
+--------------------------
+ (4,public,should_drop,t)
 (1 row)
 
 INSERT INTO should_drop VALUES (now(), 1.0);

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -5,9 +5,9 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE hypertable_schema.default_perm_user (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.default_perm_user', 'time', 'location', 2);
 NOTICE:  adding not-null constraint to column "time"
-            create_hypertable            
------------------------------------------
- (1,hypertable_schema,default_perm_user)
+             create_hypertable             
+-------------------------------------------
+ (1,hypertable_schema,default_perm_user,t)
 (1 row)
 
 INSERT INTO hypertable_schema.default_perm_user VALUES ('2001-01-01 01:01:01', 23.3, 1);
@@ -15,9 +15,9 @@ RESET ROLE;
 CREATE TABLE hypertable_schema.superuser (time timestamptz, temp float, location int);
 SELECT create_hypertable('hypertable_schema.superuser', 'time', 'location', 2);
 NOTICE:  adding not-null constraint to column "time"
-        create_hypertable        
----------------------------------
- (2,hypertable_schema,superuser)
+         create_hypertable         
+-----------------------------------
+ (2,hypertable_schema,superuser,t)
 (1 row)
 
 INSERT INTO hypertable_schema.superuser VALUES ('2001-01-01 01:01:01', 23.3, 1);

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -12,16 +12,16 @@ CREATE TABLE hypertable_schema.test2 (time timestamptz, temp float, location int
 --create two identical tables with their own chunk schemas
 SELECT create_hypertable('hypertable_schema.test1', 'time', 'location', 2, associated_schema_name => 'chunk_schema1');
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (1,hypertable_schema,test1)
+       create_hypertable       
+-------------------------------
+ (1,hypertable_schema,test1,t)
 (1 row)
 
 SELECT create_hypertable('hypertable_schema.test2', 'time', 'location', 2, associated_schema_name => 'chunk_schema2');
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (2,hypertable_schema,test2)
+       create_hypertable       
+-------------------------------
+ (2,hypertable_schema,test2,t)
 (1 row)
 
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);

--- a/test/expected/dump_meta.out
+++ b/test/expected/dump_meta.out
@@ -15,9 +15,9 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |   table_name   
----------------+-------------+----------------
-             1 | public      | two_Partitions
+ hypertable_id | schema_name |   table_name   | created 
+---------------+-------------+----------------+---------
+             1 | public      | two_Partitions | t
 (1 row)
 
 \set QUIET off

--- a/test/expected/generated_as_identity.out
+++ b/test/expected/generated_as_identity.out
@@ -3,9 +3,9 @@ CREATE table test_gen (
     payload text
 );
  SELECT create_hypertable('test_gen', 'id', chunk_time_interval=>10);
-  create_hypertable  
----------------------
- (1,public,test_gen)
+   create_hypertable   
+-----------------------
+ (1,public,test_gen,t)
 (1 row)
 
 insert into test_gen (payload) select generate_series(1,15) returning *;

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -1,9 +1,9 @@
 CREATE TABLE index_test(time timestamptz, temp float);
 SELECT create_hypertable('index_test', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable   
------------------------
- (1,public,index_test)
+    create_hypertable    
+-------------------------
+ (1,public,index_test,t)
 (1 row)
 
 -- Default indexes created
@@ -27,9 +27,9 @@ ERROR:  cannot create a unique index without the column "device" (used in partit
 -- Partitioning on only time should work
 SELECT create_hypertable('index_test', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable   
------------------------
- (3,public,index_test)
+    create_hypertable    
+-------------------------
+ (3,public,index_test,t)
 (1 row)
 
 INSERT INTO index_test VALUES ('2017-01-20T09:00:01', 1, 17.5);
@@ -108,9 +108,9 @@ SELECT * FROM test.show_columns('index_test');
 -- No pre-existing UNIQUE index, so partitioning on two columns should work
 SELECT create_hypertable('index_test', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable   
------------------------
- (4,public,index_test)
+    create_hypertable    
+-------------------------
+ (4,public,index_test,t)
 (1 row)
 
 INSERT INTO index_test VALUES ('2017-01-20T09:00:01', 1, 17.5);
@@ -370,9 +370,9 @@ CREATE TABLE index_test(time timestamptz, temp float, device int) TABLESPACE tab
 -- Default indexes should be in the table's tablespace
 SELECT create_hypertable('index_test', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable   
------------------------
- (5,public,index_test)
+    create_hypertable    
+-------------------------
+ (5,public,index_test,t)
 (1 row)
 
 -- Explicitly defining an index tablespace should work and propagate

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -15,9 +15,9 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |   table_name   
----------------+-------------+----------------
-             1 | public      | two_Partitions
+ hypertable_id | schema_name |   table_name   | created 
+---------------+-------------+----------------+---------
+             1 | public      | two_Partitions | t
 (1 row)
 
 \set QUIET off
@@ -185,9 +185,9 @@ SELECT * FROM ONLY "two_Partitions";
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable   
------------------------
- (2,public,error_test)
+    create_hypertable    
+-------------------------
+ (2,public,error_test,t)
 (1 row)
 
 \set QUIET off
@@ -216,9 +216,9 @@ CREATE TABLE tick_character (
     time        TIMESTAMPTZ       NOT NULL
 );
 SELECT create_hypertable ('tick_character', 'time', 'symbol', 2);
-     create_hypertable     
----------------------------
- (3,public,tick_character)
+      create_hypertable      
+-----------------------------
+ (3,public,tick_character,t)
 (1 row)
 
 INSERT INTO tick_character ( symbol, mid, spread, time ) VALUES ( 'GBPJPY', 142.639000, 5.80, 'Mon Mar 20 09:18:22.3 2017') RETURNING time, symbol, mid;
@@ -236,9 +236,9 @@ SELECT * FROM tick_character;
 CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
 NOTICE:  adding not-null constraint to column "time"
-        create_hypertable        
----------------------------------
- (4,public,many_partitions_test)
+         create_hypertable         
+-----------------------------------
+ (4,public,many_partitions_test,t)
 (1 row)
 
 --NOTE: how much slower the first two queries are -- they are creating chunks
@@ -264,9 +264,9 @@ SELECT count(*) FROM  many_partitions_test;
 CREATE TABLE  date_col_test(time date, temp float8, device text NOT NULL);
 SELECT create_hypertable('date_col_test', 'time', 'device', 1000, chunk_time_interval => INTERVAL '1 Day');
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable     
---------------------------
- (5,public,date_col_test)
+     create_hypertable      
+----------------------------
+ (5,public,date_col_test,t)
 (1 row)
 
 INSERT INTO date_col_test
@@ -282,9 +282,9 @@ SELECT * FROM date_col_test WHERE time > '2001-01-01';
 CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
 NOTICE:  adding not-null constraint to column "time"
-         create_hypertable          
-------------------------------------
- (6,public,many_partitions_test_1m)
+          create_hypertable           
+--------------------------------------
+ (6,public,many_partitions_test_1m,t)
 (1 row)
 
 EXPLAIN (verbose on, costs off)
@@ -675,9 +675,9 @@ set timescaledb.max_open_chunks_per_insert=1;
 CREATE TABLE chunk_assert_fail(i bigint, j bigint);
 SELECT create_hypertable('chunk_assert_fail', 'i', 'j', 1000, chunk_time_interval=>1);
 NOTICE:  adding not-null constraint to column "i"
-      create_hypertable       
-------------------------------
- (7,public,chunk_assert_fail)
+       create_hypertable        
+--------------------------------
+ (7,public,chunk_assert_fail,t)
 (1 row)
 
 insert into chunk_assert_fail values (1, 1), (1, 2), (2,1);
@@ -708,9 +708,9 @@ SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable     
----------------------------
- (8,public,one_space_test)
+      create_hypertable      
+-----------------------------
+ (8,public,one_space_test,t)
 (1 row)
 
 INSERT INTO one_space_test VALUES

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -16,9 +16,9 @@ CREATE INDEX ON PUBLIC."one_Partition" ("timeCustom" DESC NULLS LAST, series_boo
 CREATE SCHEMA "one_Partition" AUTHORIZATION :ROLE_DEFAULT_PERM_USER;
 \c single :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM create_hypertable('"public"."one_Partition"', 'timeCustom', associated_schema_name=>'one_Partition', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |  table_name   
----------------+-------------+---------------
-             1 | public      | one_Partition
+ hypertable_id | schema_name |  table_name   | created 
+---------------+-------------+---------------+---------
+             1 | public      | one_Partition | t
 (1 row)
 
 --output command tags
@@ -117,7 +117,7 @@ CREATE TABLE "1dim"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim"', 'time');
  create_hypertable 
 -------------------
- (2,public,1dim)
+ (2,public,1dim,t)
 (1 row)
 
 INSERT INTO "1dim" VALUES('2017-01-20T09:00:01', 22.5) RETURNING *;
@@ -170,9 +170,9 @@ SELECT "1dim" FROM "1dim";
 --test that we can insert pre-1970 dates
 CREATE TABLE "1dim_pre1970"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim_pre1970"', 'time', chunk_time_interval=> INTERVAL '1 Month');
-    create_hypertable    
--------------------------
- (3,public,1dim_pre1970)
+     create_hypertable     
+---------------------------
+ (3,public,1dim_pre1970,t)
 (1 row)
 
 INSERT INTO "1dim_pre1970" VALUES('1969-12-01T19:00:00', 21.2);
@@ -184,27 +184,27 @@ BEGIN;
 CREATE TABLE "1dim_usec_interval"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim_usec_interval"', 'time', chunk_time_interval=> 10);
 WARNING:  unexpected interval: smaller than one second
-       create_hypertable       
--------------------------------
- (4,public,1dim_usec_interval)
+        create_hypertable        
+---------------------------------
+ (4,public,1dim_usec_interval,t)
 (1 row)
 
 INSERT INTO "1dim_usec_interval" VALUES('1969-12-01T19:00:00', 21.2);
 ROLLBACK;
 CREATE TABLE "1dim_usec_interval"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim_usec_interval"', 'time', chunk_time_interval=> 1000000);
-       create_hypertable       
--------------------------------
- (5,public,1dim_usec_interval)
+        create_hypertable        
+---------------------------------
+ (5,public,1dim_usec_interval,t)
 (1 row)
 
 INSERT INTO "1dim_usec_interval" VALUES('1969-12-01T19:00:00', 21.2);
 CREATE TABLE "1dim_neg"(time INTEGER, temp float);
 SELECT create_hypertable('"1dim_neg"', 'time', chunk_time_interval=>10);
 NOTICE:  adding not-null constraint to column "time"
-  create_hypertable  
----------------------
- (6,public,1dim_neg)
+   create_hypertable   
+-----------------------
+ (6,public,1dim_neg,t)
 (1 row)
 
 INSERT INTO "1dim_neg" VALUES (-20, 21.2);
@@ -279,13 +279,13 @@ SELECT create_hypertable('"3dim"', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
- (7,public,3dim)
+ (7,public,3dim,t)
 (1 row)
 
 SELECT add_dimension('"3dim"', 'location', 2);
-      add_dimension       
---------------------------
- (9,public,3dim,location)
+       add_dimension        
+----------------------------
+ (9,public,3dim,location,t)
 (1 row)
 
 INSERT INTO "3dim" VALUES('2017-01-20T09:00:01', 22.5, 'blue', 'nyc');
@@ -385,9 +385,9 @@ SELECT create_hypertable('"inttime_err"', 'time');
 ERROR:  integer dimensions require an explicit interval
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('"inttime_err"', 'time', chunk_time_interval=>2147483647);
-   create_hypertable    
-------------------------
- (8,public,inttime_err)
+    create_hypertable     
+--------------------------
+ (8,public,inttime_err,t)
 (1 row)
 
 -- Test that large intervals and no interval fail for SMALLINT
@@ -399,18 +399,18 @@ SELECT create_hypertable('"smallinttime_err"', 'time');
 ERROR:  integer dimensions require an explicit interval
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('"smallinttime_err"', 'time', chunk_time_interval=>32767);
-      create_hypertable      
------------------------------
- (9,public,smallinttime_err)
+       create_hypertable       
+-------------------------------
+ (9,public,smallinttime_err,t)
 (1 row)
 
 --make sure date inserts work even when the timezone changes the
 CREATE TABLE hyper_date(time date, temp float);
 SELECT create_hypertable('"hyper_date"', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (10,public,hyper_date)
+    create_hypertable     
+--------------------------
+ (10,public,hyper_date,t)
 (1 row)
 
 SET timezone=+1;
@@ -420,9 +420,9 @@ RESET timezone;
 SET timezone = 'UTC';
 CREATE TABLE "test_tz"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"test_tz"', 'time', chunk_time_interval=> INTERVAL '1 day');
-  create_hypertable  
----------------------
- (11,public,test_tz)
+   create_hypertable   
+-----------------------
+ (11,public,test_tz,t)
 (1 row)
 
 INSERT INTO "test_tz" VALUES('2017-09-22 10:00:00', 21.2);
@@ -448,9 +448,9 @@ SET timescaledb.max_open_chunks_per_insert = 10;
 SET timescaledb.max_cached_chunks_per_hypertable = 10;
 CREATE TABLE "nondefault_mem_settings"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"nondefault_mem_settings"', 'time', chunk_time_interval=> INTERVAL '1 Month');
-          create_hypertable          
--------------------------------------
- (12,public,nondefault_mem_settings)
+           create_hypertable           
+---------------------------------------
+ (12,public,nondefault_mem_settings,t)
 (1 row)
 
 INSERT INTO "nondefault_mem_settings" VALUES('2000-12-01T19:00:00', 21.2);
@@ -495,9 +495,9 @@ BEGIN;
 CREATE TABLE "data_records" ("time" bigint NOT NULL, "value" integer CHECK (VALUE >= 0));
 CREATE TABLE
 SELECT create_hypertable('data_records', 'time', chunk_time_interval => 2592000000);
-    create_hypertable     
---------------------------
- (13,public,data_records)
+     create_hypertable      
+----------------------------
+ (13,public,data_records,t)
 (1 row)
 
 INSERT INTO "data_records" ("time", "value") VALUES (0, 1);

--- a/test/expected/lateral.out
+++ b/test/expected/lateral.out
@@ -3,7 +3,7 @@ CREATE TABLE ht(time timestamptz NOT NULL, location text);
 SELECT create_hypertable('ht', 'time');
  create_hypertable 
 -------------------
- (1,public,ht)
+ (1,public,ht,t)
 (1 row)
 
 INSERT INTO ht(time) select timestamp 'epoch' + (i * interval '1 second') from generate_series(1, 100) as T(i);
@@ -24,9 +24,9 @@ DROP TABLE regular_table;
 DROP TABLE ht;
 CREATE TABLE orders(id int, user_id int, time TIMESTAMPTZ NOT NULL);
 SELECT create_hypertable('orders', 'time');
- create_hypertable 
--------------------
- (2,public,orders)
+  create_hypertable  
+---------------------
+ (2,public,orders,t)
 (1 row)
 
 INSERT INTO orders values(1,1,timestamp 'epoch' + '1 second');

--- a/test/expected/partitioning-10.out
+++ b/test/expected/partitioning-10.out
@@ -10,9 +10,9 @@ CREATE TABLE partitioned_attachment_vanilla(time timestamptz, temp float, device
 CREATE TABLE attachment_hypertable(time timestamptz, temp float, device int);
 SELECT create_hypertable('attachment_hypertable', 'time');
 NOTICE:  adding not-null constraint to column "time"
-        create_hypertable         
-----------------------------------
- (1,public,attachment_hypertable)
+         create_hypertable          
+------------------------------------
+ (1,public,attachment_hypertable,t)
 (1 row)
 
 ALTER TABLE partitioned_attachment_vanilla ATTACH PARTITION attachment_hypertable FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');

--- a/test/expected/partitioning-9.6.out
+++ b/test/expected/partitioning-9.6.out
@@ -12,9 +12,9 @@ ERROR:  syntax error at or near "PARTITION" at character 87
 CREATE TABLE attachment_hypertable(time timestamptz, temp float, device int);
 SELECT create_hypertable('attachment_hypertable', 'time');
 NOTICE:  adding not-null constraint to column "time"
-        create_hypertable         
-----------------------------------
- (1,public,attachment_hypertable)
+         create_hypertable          
+------------------------------------
+ (1,public,attachment_hypertable,t)
 (1 row)
 
 ALTER TABLE partitioned_attachment_vanilla ATTACH PARTITION attachment_hypertable FOR VALUES FROM ('2016-07-01') TO ('2016-08-01');

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -1,9 +1,9 @@
 CREATE TABLE part_legacy(time timestamptz, temp float, device int);
 SELECT create_hypertable('part_legacy', 'time', 'device', 2, partitioning_func => '_timescaledb_internal.get_partition_for_key');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (1,public,part_legacy)
+    create_hypertable     
+--------------------------
+ (1,public,part_legacy,t)
 (1 row)
 
 -- Show legacy partitioning function is used
@@ -44,9 +44,9 @@ SELECT * FROM part_legacy WHERE device = 1;
 CREATE TABLE part_new(time timestamptz, temp float, device int);
 SELECT create_hypertable('part_new', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
-  create_hypertable  
----------------------
- (2,public,part_new)
+   create_hypertable   
+-----------------------
+ (2,public,part_new,t)
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -88,9 +88,9 @@ SELECT * FROM part_new WHERE device = 1;
 CREATE TABLE part_new_convert1(time timestamptz, temp float8, device int);
 SELECT create_hypertable('part_new_convert1', 'time', 'temp', 2);
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable       
-------------------------------
- (3,public,part_new_convert1)
+       create_hypertable        
+--------------------------------
+ (3,public,part_new_convert1,t)
 (1 row)
 
 INSERT INTO part_new_convert1 VALUES ('2017-03-22T09:18:23', 1.0, 2);
@@ -112,9 +112,9 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_3_%_chunk');
 CREATE TABLE part_add_dim(time timestamptz, temp float8, device int, location int);
 SELECT create_hypertable('part_add_dim', 'time', 'temp', 2);
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable    
--------------------------
- (4,public,part_add_dim)
+     create_hypertable     
+---------------------------
+ (4,public,part_add_dim,t)
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -122,9 +122,9 @@ SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => 'bad_fu
 ERROR:  function "bad_func" does not exist at character 74
 \set ON_ERROR_STOP 1
 SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => '_timescaledb_internal.get_partition_for_key');
-          add_dimension           
-----------------------------------
- (9,public,part_add_dim,location)
+           add_dimension            
+------------------------------------
+ (9,public,part_add_dim,location,t)
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -158,9 +158,9 @@ $BODY$;
 CREATE TABLE part_custom_func(time timestamptz, temp float8, device text);
 SELECT create_hypertable('part_custom_func', 'time', 'device', 2, partitioning_func => 'custom_partfunc');
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (5,public,part_custom_func)
+       create_hypertable       
+-------------------------------
+ (5,public,part_custom_func,t)
 (1 row)
 
 SELECT _timescaledb_internal.get_partition_hash(substring('dev1' FROM '[A-za-z0-9 ]+'));
@@ -208,9 +208,9 @@ SELECT create_hypertable(
     chunk_time_interval => interval '1 day',
     partitioning_func=>'simpl_type_hash');
 NOTICE:  adding not-null constraint to column "timestamp"
-     create_hypertable      
-----------------------------
- (6,public,simpl_partition)
+      create_hypertable       
+------------------------------
+ (6,public,simpl_partition,t)
 (1 row)
 
 INSERT INTO simpl_partition VALUES ('2017-03-22T09:18:23', ROW(1)::simpl);
@@ -266,9 +266,9 @@ ERROR:  cannot create a unique index without the column "device" (used in partit
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('hyper_with_index', 'time');
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable       
-------------------------------
- (11,public,hyper_with_index)
+       create_hypertable        
+--------------------------------
+ (11,public,hyper_with_index,t)
 (1 row)
 
 -- make sure user created index is used.
@@ -287,9 +287,9 @@ ERROR:  cannot create a unique index without the column "device" (used in partit
 DROP INDEX time_index;
 CREATE UNIQUE INDEX time_space_index ON hyper_with_index(time, device);
 SELECT add_dimension('hyper_with_index', 'device', 4);
-            add_dimension            
--------------------------------------
- (23,public,hyper_with_index,device)
+             add_dimension             
+---------------------------------------
+ (23,public,hyper_with_index,device,t)
 (1 row)
 
 CREATE TABLE hyper_with_primary(time TIMESTAMPTZ PRIMARY KEY, temp float, device int);
@@ -298,9 +298,9 @@ SELECT create_hypertable('hyper_with_primary', 'time', 'device', 4);
 ERROR:  cannot create a unique index without the column "device" (used in partitioning)
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('hyper_with_primary', 'time');
-       create_hypertable        
---------------------------------
- (13,public,hyper_with_primary)
+        create_hypertable         
+----------------------------------
+ (13,public,hyper_with_primary,t)
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -329,9 +329,9 @@ ERROR:  could not find hash function for type tuple
 \set ON_ERROR_STOP 1
 SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4, partitioning_func=>'tuple_hash');
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (15,public,part_custom_dim)
+       create_hypertable       
+-------------------------------
+ (15,public,part_custom_dim,t)
 (1 row)
 
 INSERT INTO part_custom_dim(time, combo) VALUES (now(), (1,2));
@@ -352,9 +352,9 @@ $BODY$;
 CREATE TABLE part_custom_dim (time TIMESTAMPTZ, combo TUPLE, device TEXT);
 SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4, partitioning_func=>'my_partitioning_schema.tuple_hash');
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (16,public,part_custom_dim)
+       create_hypertable       
+-------------------------------
+ (16,public,part_custom_dim,t)
 (1 row)
 
 INSERT INTO part_custom_dim(time, combo) VALUES (now(), (1,2));

--- a/test/expected/plan_expand_hypertable_optimized.out
+++ b/test/expected/plan_expand_hypertable_optimized.out
@@ -8,9 +8,9 @@ DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper', 'time',  chunk_time_interval => 10);
 psql:include/plan_expand_hypertable_load.sql:8: NOTICE:  adding not-null constraint to column "time"
- create_hypertable 
--------------------
- (1,public,hyper)
+ create_hypertable  
+--------------------
+ (1,public,hyper,t)
 (1 row)
 
 INSERT INTO hyper SELECT g, g FROM generate_series(0,1000) g;
@@ -23,9 +23,9 @@ DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper_w_space', 'time', 'device_id', 2, chunk_time_interval => 10);
 psql:include/plan_expand_hypertable_load.sql:24: NOTICE:  adding not-null constraint to column "time"
-    create_hypertable     
---------------------------
- (2,public,hyper_w_space)
+     create_hypertable      
+----------------------------
+ (2,public,hyper_w_space,t)
 (1 row)
 
 INSERT INTO hyper_w_space (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
@@ -38,9 +38,9 @@ DROP COLUMN time_broken,
 ADD COLUMN time TIMESTAMPTZ;
 SELECT create_hypertable('hyper_ts', 'time', 'device_id', 2, chunk_time_interval => '10 seconds'::interval);
 psql:include/plan_expand_hypertable_load.sql:39: NOTICE:  adding not-null constraint to column "time"
-  create_hypertable  
----------------------
- (3,public,hyper_ts)
+   create_hypertable   
+-----------------------
+ (3,public,hyper_ts,t)
 (1 row)
 
 INSERT INTO tag(name) SELECT 'tag'||g FROM generate_series(0,10) g;

--- a/test/expected/plan_hashagg_optimized-10.out
+++ b/test/expected/plan_hashagg_optimized-10.out
@@ -6,9 +6,9 @@ CREATE TABLE hyper(time TIMESTAMP, time_int BIGINT, time_broken DATE, metricid i
 CREATE TABLE regular(time TIMESTAMP, time_int BIGINT, time_date DATE, metricid int REFERENCES metric(id), VALUE double precision);
 SELECT create_hypertable('hyper', 'time', chunk_time_interval => interval '20 day', create_default_indexes=>FALSE);
 psql:include/plan_hashagg_load.sql:5: NOTICE:  adding not-null constraint to column "time"
- create_hypertable 
--------------------
- (1,public,hyper)
+ create_hypertable  
+--------------------
+ (1,public,hyper,t)
 (1 row)
 
 ALTER TABLE hyper

--- a/test/expected/plan_hashagg_optimized-9.6.out
+++ b/test/expected/plan_hashagg_optimized-9.6.out
@@ -6,9 +6,9 @@ CREATE TABLE hyper(time TIMESTAMP, time_int BIGINT, time_broken DATE, metricid i
 CREATE TABLE regular(time TIMESTAMP, time_int BIGINT, time_date DATE, metricid int REFERENCES metric(id), VALUE double precision);
 SELECT create_hypertable('hyper', 'time', chunk_time_interval => interval '20 day', create_default_indexes=>FALSE);
 psql:include/plan_hashagg_load.sql:5: NOTICE:  adding not-null constraint to column "time"
- create_hypertable 
--------------------
- (1,public,hyper)
+ create_hypertable  
+--------------------
+ (1,public,hyper,t)
 (1 row)
 
 ALTER TABLE hyper

--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -2,9 +2,9 @@ CREATE TABLE reindex_test(time timestamp, temp float, PRIMARY KEY(time, temp));
 CREATE UNIQUE INDEX reindex_test_time_unique_idx ON reindex_test(time);
 -- create hypertable with three chunks
 SELECT create_hypertable('reindex_test', 'time', chunk_time_interval => 2628000000000);
-    create_hypertable    
--------------------------
- (1,public,reindex_test)
+     create_hypertable     
+---------------------------
+ (1,public,reindex_test,t)
 (1 row)
 
 INSERT INTO reindex_test VALUES ('2017-01-20T09:00:01', 17.5),

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -12,23 +12,23 @@ CREATE TABLE test_tz(time timestamptz, temp float8, device text);
 CREATE TABLE test_dt(time date, temp float8, device text);
 SELECT "testSchema0".create_hypertable('test_ts', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
- create_hypertable  
---------------------
- (1,public,test_ts)
+  create_hypertable   
+----------------------
+ (1,public,test_ts,t)
 (1 row)
 
 SELECT "testSchema0".create_hypertable('test_tz', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
- create_hypertable  
---------------------
- (2,public,test_tz)
+  create_hypertable   
+----------------------
+ (2,public,test_tz,t)
 (1 row)
 
 SELECT "testSchema0".create_hypertable('test_dt', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
- create_hypertable  
---------------------
- (3,public,test_dt)
+  create_hypertable   
+----------------------
+ (3,public,test_dt,t)
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;

--- a/test/expected/reloptions.out
+++ b/test/expected/reloptions.out
@@ -2,9 +2,9 @@ CREATE TABLE reloptions_test(time integer, temp float8, color integer)
 WITH (fillfactor=75, oids=true, autovacuum_vacuum_threshold=100);
 SELECT create_hypertable('reloptions_test', 'time', chunk_time_interval => 3);
 NOTICE:  adding not-null constraint to column "time"
-     create_hypertable      
-----------------------------
- (1,public,reloptions_test)
+      create_hypertable       
+------------------------------
+ (1,public,reloptions_test,t)
 (1 row)
 
 INSERT INTO reloptions_test VALUES (4, 24.3, 1), (9, 13.3, 2);

--- a/test/expected/rowsecurity-10.out
+++ b/test/expected/rowsecurity-10.out
@@ -65,9 +65,9 @@ CREATE TABLE document (
 );
 GRANT ALL ON document TO public;
 SELECT public.create_hypertable('document', 'did', chunk_time_interval=>2);
-        create_hypertable        
----------------------------------
- (1,regress_rls_schema,document)
+         create_hypertable         
+-----------------------------------
+ (1,regress_rls_schema,document,t)
 (1 row)
 
 INSERT INTO document VALUES
@@ -993,9 +993,9 @@ GRANT ALL ON hyper_document TO public;
 SELECT public.create_hypertable('hyper_document', 'did', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "did"
 DETAIL:  Time dimensions cannot have NULL values
-           create_hypertable           
----------------------------------------
- (2,regress_rls_schema,hyper_document)
+            create_hypertable            
+-----------------------------------------
+ (2,regress_rls_schema,hyper_document,t)
 (1 row)
 
 INSERT INTO hyper_document VALUES
@@ -1486,18 +1486,18 @@ CREATE TABLE dependee (x integer, y integer);
 SELECT public.create_hypertable('dependee', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable        
----------------------------------
- (3,regress_rls_schema,dependee)
+         create_hypertable         
+-----------------------------------
+ (3,regress_rls_schema,dependee,t)
 (1 row)
 
 CREATE TABLE dependent (x integer, y integer);
 SELECT public.create_hypertable('dependent', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable         
-----------------------------------
- (4,regress_rls_schema,dependent)
+         create_hypertable          
+------------------------------------
+ (4,regress_rls_schema,dependent,t)
 (1 row)
 
 CREATE POLICY d1 ON dependent FOR ALL
@@ -1525,9 +1525,9 @@ CREATE TABLE rec1 (x integer, y integer);
 SELECT public.create_hypertable('rec1', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable      
------------------------------
- (5,regress_rls_schema,rec1)
+       create_hypertable       
+-------------------------------
+ (5,regress_rls_schema,rec1,t)
 (1 row)
 
 CREATE POLICY r1 ON rec1 USING (x = (SELECT r.x FROM rec1 r WHERE y = r.y));
@@ -1584,9 +1584,9 @@ CREATE TABLE s1 (a int, b text);
 SELECT public.create_hypertable('s1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (6,regress_rls_schema,s1)
+      create_hypertable      
+-----------------------------
+ (6,regress_rls_schema,s1,t)
 (1 row)
 
 INSERT INTO s1 (SELECT x, md5(x::text) FROM generate_series(-10,10) x);
@@ -1594,9 +1594,9 @@ CREATE TABLE s2 (x int, y text);
 SELECT public.create_hypertable('s2', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (7,regress_rls_schema,s2)
+      create_hypertable      
+-----------------------------
+ (7,regress_rls_schema,s2,t)
 (1 row)
 
 INSERT INTO s2 (SELECT x, md5(x::text) FROM generate_series(-6,6) x);
@@ -2220,9 +2220,9 @@ CREATE TABLE b1 (a int, b text);
 SELECT public.create_hypertable('b1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (8,regress_rls_schema,b1)
+      create_hypertable      
+-----------------------------
+ (8,regress_rls_schema,b1,t)
 (1 row)
 
 INSERT INTO b1 (SELECT x, md5(x::text) FROM generate_series(-10,10) x);
@@ -2495,18 +2495,18 @@ CREATE TABLE z1 (a int, b text);
 SELECT public.create_hypertable('z1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (9,regress_rls_schema,z1)
+      create_hypertable      
+-----------------------------
+ (9,regress_rls_schema,z1,t)
 (1 row)
 
 CREATE TABLE z2 (a int, b text);
 SELECT public.create_hypertable('z2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (10,regress_rls_schema,z2)
+      create_hypertable       
+------------------------------
+ (10,regress_rls_schema,z2,t)
 (1 row)
 
 GRANT SELECT ON z1,z2 TO regress_rls_group1, regress_rls_group2,
@@ -3019,9 +3019,9 @@ CREATE TABLE x1 (a int, b text, c text);
 SELECT public.create_hypertable('x1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (11,regress_rls_schema,x1)
+      create_hypertable       
+------------------------------
+ (11,regress_rls_schema,x1,t)
 (1 row)
 
 GRANT ALL ON x1 TO PUBLIC;
@@ -3135,9 +3135,9 @@ CREATE TABLE y1 (a int, b text);
 SELECT public.create_hypertable('y1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (12,regress_rls_schema,y1)
+      create_hypertable       
+------------------------------
+ (12,regress_rls_schema,y1,t)
 (1 row)
 
 INSERT INTO y1 VALUES(1,2);
@@ -3145,9 +3145,9 @@ CREATE TABLE y2 (a int, b text);
 SELECT public.create_hypertable('y2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (13,regress_rls_schema,y2)
+      create_hypertable       
+------------------------------
+ (13,regress_rls_schema,y2,t)
 (1 row)
 
 GRANT ALL ON y1, y2 TO regress_rls_bob;
@@ -3458,9 +3458,9 @@ CREATE TABLE t1 (a integer);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (14,regress_rls_schema,t1)
+      create_hypertable       
+------------------------------
+ (14,regress_rls_schema,t1,t)
 (1 row)
 
 GRANT SELECT ON t1 TO regress_rls_bob, regress_rls_carol;
@@ -3510,9 +3510,9 @@ CREATE TABLE t1 (a integer, b text);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (15,regress_rls_schema,t1)
+      create_hypertable       
+------------------------------
+ (15,regress_rls_schema,t1,t)
 (1 row)
 
 CREATE POLICY p1 ON t1 USING (a % 2 = 0);
@@ -3639,9 +3639,9 @@ CREATE TABLE t2 (a integer, b text);
 SELECT public.create_hypertable('t2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (16,regress_rls_schema,t2)
+      create_hypertable       
+------------------------------
+ (16,regress_rls_schema,t2,t)
 (1 row)
 
 INSERT INTO t2 (SELECT * FROM t1);
@@ -3759,18 +3759,18 @@ CREATE TABLE blog (id integer, author text, post text);
 SELECT public.create_hypertable('blog', 'id', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "id"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable       
-------------------------------
- (17,regress_rls_schema,blog)
+       create_hypertable        
+--------------------------------
+ (17,regress_rls_schema,blog,t)
 (1 row)
 
 CREATE TABLE comment (blog_id integer, message text);
 SELECT public.create_hypertable('comment', 'blog_id', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "blog_id"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable        
----------------------------------
- (18,regress_rls_schema,comment)
+         create_hypertable         
+-----------------------------------
+ (18,regress_rls_schema,comment,t)
 (1 row)
 
 GRANT ALL ON blog, comment TO regress_rls_bob;
@@ -3964,9 +3964,9 @@ CREATE TABLE copy_t (a integer, b text);
 SELECT public.create_hypertable('copy_t', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-       create_hypertable        
---------------------------------
- (19,regress_rls_schema,copy_t)
+        create_hypertable         
+----------------------------------
+ (19,regress_rls_schema,copy_t,t)
 (1 row)
 
 CREATE POLICY p1 ON copy_t USING (a % 2 = 0);
@@ -4057,9 +4057,9 @@ CREATE TABLE copy_rel_to (a integer, b text);
 SELECT public.create_hypertable('copy_rel_to', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-          create_hypertable          
--------------------------------------
- (20,regress_rls_schema,copy_rel_to)
+           create_hypertable           
+---------------------------------------
+ (20,regress_rls_schema,copy_rel_to,t)
 (1 row)
 
 CREATE POLICY p1 ON copy_rel_to USING (a % 2 = 0);
@@ -4133,9 +4133,9 @@ CREATE TABLE current_check (currentid int, payload text, rlsuser text);
 SELECT public.create_hypertable('current_check', 'currentid', chunk_time_interval=>10);
 NOTICE:  adding not-null constraint to column "currentid"
 DETAIL:  Time dimensions cannot have NULL values
-           create_hypertable           
----------------------------------------
- (21,regress_rls_schema,current_check)
+            create_hypertable            
+-----------------------------------------
+ (21,regress_rls_schema,current_check,t)
 (1 row)
 
 GRANT ALL ON current_check TO PUBLIC;
@@ -4368,9 +4368,9 @@ CREATE TABLE t (c int);
 SELECT public.create_hypertable('t', 'c', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (22,regress_rls_schema,t)
+      create_hypertable      
+-----------------------------
+ (22,regress_rls_schema,t,t)
 (1 row)
 
 CREATE POLICY p ON t USING (c % 2 = 1);
@@ -4407,18 +4407,18 @@ CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (23,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (23,regress_rls_schema,r1,t)
 (1 row)
 
 CREATE TABLE r2 (a int);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (24,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (24,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4501,9 +4501,9 @@ CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (25,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (25,regress_rls_schema,r1,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4556,9 +4556,9 @@ CREATE TABLE r2 (a int REFERENCES r1);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (26,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (26,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4600,9 +4600,9 @@ CREATE TABLE r2 (a int REFERENCES r1 ON DELETE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (27,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (27,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4633,9 +4633,9 @@ CREATE TABLE r2 (a int REFERENCES r1 ON UPDATE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (28,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (28,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4674,9 +4674,9 @@ CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (29,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (29,regress_rls_schema,r1,t)
 (1 row)
 
 CREATE POLICY p1 ON r1 FOR SELECT USING (false);
@@ -4709,9 +4709,9 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int PRIMARY KEY);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>100);
-     create_hypertable      
-----------------------------
- (30,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (30,regress_rls_schema,r1,t)
 (1 row)
 
 CREATE POLICY p1 ON r1 FOR SELECT USING (a < 20);
@@ -4765,18 +4765,18 @@ CREATE TABLE dep1 (c1 int);
 SELECT public.create_hypertable('dep1', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable       
-------------------------------
- (31,regress_rls_schema,dep1)
+       create_hypertable        
+--------------------------------
+ (31,regress_rls_schema,dep1,t)
 (1 row)
 
 CREATE TABLE dep2 (c1 int);
 SELECT public.create_hypertable('dep2', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable       
-------------------------------
- (32,regress_rls_schema,dep2)
+       create_hypertable        
+--------------------------------
+ (32,regress_rls_schema,dep2,t)
 (1 row)
 
 CREATE POLICY dep_p1 ON dep1 TO regress_rls_bob USING (c1 > (select max(dep2.c1) from dep2));
@@ -4826,9 +4826,9 @@ CREATE TABLE dob_t1 (c1 int);
 SELECT public.create_hypertable('dob_t1', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-       create_hypertable        
---------------------------------
- (33,regress_rls_schema,dob_t1)
+        create_hypertable         
+----------------------------------
+ (33,regress_rls_schema,dob_t1,t)
 (1 row)
 
 CREATE TABLE dob_t2 (c1 int) PARTITION BY RANGE (c1);
@@ -4866,9 +4866,9 @@ CREATE TABLE rls_tbl (c1 int);
 SELECT public.create_hypertable('rls_tbl', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable        
----------------------------------
- (34,regress_rls_schema,rls_tbl)
+         create_hypertable         
+-----------------------------------
+ (34,regress_rls_schema,rls_tbl,t)
 (1 row)
 
 ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
@@ -4880,9 +4880,9 @@ CREATE TABLE rls_tbl_force (c1 int);
 SELECT public.create_hypertable('rls_tbl_force', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-           create_hypertable           
----------------------------------------
- (35,regress_rls_schema,rls_tbl_force)
+            create_hypertable            
+-----------------------------------------
+ (35,regress_rls_schema,rls_tbl_force,t)
 (1 row)
 
 ALTER TABLE rls_tbl_force ENABLE ROW LEVEL SECURITY;

--- a/test/expected/rowsecurity-9.6.out
+++ b/test/expected/rowsecurity-9.6.out
@@ -63,9 +63,9 @@ CREATE TABLE document (
 );
 GRANT ALL ON document TO public;
 SELECT public.create_hypertable('document', 'did', chunk_time_interval=>2);
-        create_hypertable        
----------------------------------
- (1,regress_rls_schema,document)
+         create_hypertable         
+-----------------------------------
+ (1,regress_rls_schema,document,t)
 (1 row)
 
 INSERT INTO document VALUES
@@ -833,9 +833,9 @@ GRANT ALL ON hyper_document TO public;
 SELECT public.create_hypertable('hyper_document', 'did', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "did"
 DETAIL:  Time dimensions cannot have NULL values
-           create_hypertable           
----------------------------------------
- (2,regress_rls_schema,hyper_document)
+            create_hypertable            
+-----------------------------------------
+ (2,regress_rls_schema,hyper_document,t)
 (1 row)
 
 INSERT INTO hyper_document VALUES
@@ -1253,18 +1253,18 @@ CREATE TABLE dependee (x integer, y integer);
 SELECT public.create_hypertable('dependee', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable        
----------------------------------
- (3,regress_rls_schema,dependee)
+         create_hypertable         
+-----------------------------------
+ (3,regress_rls_schema,dependee,t)
 (1 row)
 
 CREATE TABLE dependent (x integer, y integer);
 SELECT public.create_hypertable('dependent', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable         
-----------------------------------
- (4,regress_rls_schema,dependent)
+         create_hypertable          
+------------------------------------
+ (4,regress_rls_schema,dependent,t)
 (1 row)
 
 CREATE POLICY d1 ON dependent FOR ALL
@@ -1292,9 +1292,9 @@ CREATE TABLE rec1 (x integer, y integer);
 SELECT public.create_hypertable('rec1', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable      
------------------------------
- (5,regress_rls_schema,rec1)
+       create_hypertable       
+-------------------------------
+ (5,regress_rls_schema,rec1,t)
 (1 row)
 
 CREATE POLICY r1 ON rec1 USING (x = (SELECT r.x FROM rec1 r WHERE y = r.y));
@@ -1351,9 +1351,9 @@ CREATE TABLE s1 (a int, b text);
 SELECT public.create_hypertable('s1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (6,regress_rls_schema,s1)
+      create_hypertable      
+-----------------------------
+ (6,regress_rls_schema,s1,t)
 (1 row)
 
 INSERT INTO s1 (SELECT x, md5(x::text) FROM generate_series(-10,10) x);
@@ -1361,9 +1361,9 @@ CREATE TABLE s2 (x int, y text);
 SELECT public.create_hypertable('s2', 'x', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "x"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (7,regress_rls_schema,s2)
+      create_hypertable      
+-----------------------------
+ (7,regress_rls_schema,s2,t)
 (1 row)
 
 INSERT INTO s2 (SELECT x, md5(x::text) FROM generate_series(-6,6) x);
@@ -2050,9 +2050,9 @@ CREATE TABLE b1 (a int, b text);
 SELECT public.create_hypertable('b1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (8,regress_rls_schema,b1)
+      create_hypertable      
+-----------------------------
+ (8,regress_rls_schema,b1,t)
 (1 row)
 
 INSERT INTO b1 (SELECT x, md5(x::text) FROM generate_series(-10,10) x);
@@ -2560,18 +2560,18 @@ CREATE TABLE z1 (a int, b text);
 SELECT public.create_hypertable('z1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (9,regress_rls_schema,z1)
+      create_hypertable      
+-----------------------------
+ (9,regress_rls_schema,z1,t)
 (1 row)
 
 CREATE TABLE z2 (a int, b text);
 SELECT public.create_hypertable('z2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (10,regress_rls_schema,z2)
+      create_hypertable       
+------------------------------
+ (10,regress_rls_schema,z2,t)
 (1 row)
 
 GRANT SELECT ON z1,z2 TO regress_rls_group1, regress_rls_group2,
@@ -3103,9 +3103,9 @@ CREATE TABLE x1 (a int, b text, c text);
 SELECT public.create_hypertable('x1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (11,regress_rls_schema,x1)
+      create_hypertable       
+------------------------------
+ (11,regress_rls_schema,x1,t)
 (1 row)
 
 GRANT ALL ON x1 TO PUBLIC;
@@ -3219,9 +3219,9 @@ CREATE TABLE y1 (a int, b text);
 SELECT public.create_hypertable('y1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (12,regress_rls_schema,y1)
+      create_hypertable       
+------------------------------
+ (12,regress_rls_schema,y1,t)
 (1 row)
 
 INSERT INTO y1 VALUES(1,2);
@@ -3229,9 +3229,9 @@ CREATE TABLE y2 (a int, b text);
 SELECT public.create_hypertable('y2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (13,regress_rls_schema,y2)
+      create_hypertable       
+------------------------------
+ (13,regress_rls_schema,y2,t)
 (1 row)
 
 GRANT ALL ON y1, y2 TO regress_rls_bob;
@@ -3545,9 +3545,9 @@ CREATE TABLE t1 (a integer);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (14,regress_rls_schema,t1)
+      create_hypertable       
+------------------------------
+ (14,regress_rls_schema,t1,t)
 (1 row)
 
 GRANT SELECT ON t1 TO regress_rls_bob, regress_rls_carol;
@@ -3597,9 +3597,9 @@ CREATE TABLE t1 (a integer, b text);
 SELECT public.create_hypertable('t1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (15,regress_rls_schema,t1)
+      create_hypertable       
+------------------------------
+ (15,regress_rls_schema,t1,t)
 (1 row)
 
 CREATE POLICY p1 ON t1 USING (a % 2 = 0);
@@ -3727,9 +3727,9 @@ CREATE TABLE t2 (a integer, b text);
 SELECT public.create_hypertable('t2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (16,regress_rls_schema,t2)
+      create_hypertable       
+------------------------------
+ (16,regress_rls_schema,t2,t)
 (1 row)
 
 INSERT INTO t2 (SELECT * FROM t1);
@@ -3847,18 +3847,18 @@ CREATE TABLE blog (id integer, author text, post text);
 SELECT public.create_hypertable('blog', 'id', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "id"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable       
-------------------------------
- (17,regress_rls_schema,blog)
+       create_hypertable        
+--------------------------------
+ (17,regress_rls_schema,blog,t)
 (1 row)
 
 CREATE TABLE comment (blog_id integer, message text);
 SELECT public.create_hypertable('comment', 'blog_id', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "blog_id"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable        
----------------------------------
- (18,regress_rls_schema,comment)
+         create_hypertable         
+-----------------------------------
+ (18,regress_rls_schema,comment,t)
 (1 row)
 
 GRANT ALL ON blog, comment TO regress_rls_bob;
@@ -4052,9 +4052,9 @@ CREATE TABLE copy_t (a integer, b text);
 SELECT public.create_hypertable('copy_t', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-       create_hypertable        
---------------------------------
- (19,regress_rls_schema,copy_t)
+        create_hypertable         
+----------------------------------
+ (19,regress_rls_schema,copy_t,t)
 (1 row)
 
 CREATE POLICY p1 ON copy_t USING (a % 2 = 0);
@@ -4145,9 +4145,9 @@ CREATE TABLE copy_rel_to (a integer, b text);
 SELECT public.create_hypertable('copy_rel_to', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-          create_hypertable          
--------------------------------------
- (20,regress_rls_schema,copy_rel_to)
+           create_hypertable           
+---------------------------------------
+ (20,regress_rls_schema,copy_rel_to,t)
 (1 row)
 
 CREATE POLICY p1 ON copy_rel_to USING (a % 2 = 0);
@@ -4221,9 +4221,9 @@ CREATE TABLE current_check (currentid int, payload text, rlsuser text);
 SELECT public.create_hypertable('current_check', 'currentid', chunk_time_interval=>10);
 NOTICE:  adding not-null constraint to column "currentid"
 DETAIL:  Time dimensions cannot have NULL values
-           create_hypertable           
----------------------------------------
- (21,regress_rls_schema,current_check)
+            create_hypertable            
+-----------------------------------------
+ (21,regress_rls_schema,current_check,t)
 (1 row)
 
 GRANT ALL ON current_check TO PUBLIC;
@@ -4464,9 +4464,9 @@ CREATE TABLE t (c int);
 SELECT public.create_hypertable('t', 'c', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable     
----------------------------
- (22,regress_rls_schema,t)
+      create_hypertable      
+-----------------------------
+ (22,regress_rls_schema,t,t)
 (1 row)
 
 CREATE POLICY p ON t USING (c % 2 = 1);
@@ -4503,18 +4503,18 @@ CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (23,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (23,regress_rls_schema,r1,t)
 (1 row)
 
 CREATE TABLE r2 (a int);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (24,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (24,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4599,9 +4599,9 @@ CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (25,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (25,regress_rls_schema,r1,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4654,9 +4654,9 @@ CREATE TABLE r2 (a int REFERENCES r1);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (26,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (26,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4698,9 +4698,9 @@ CREATE TABLE r2 (a int REFERENCES r1 ON DELETE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (27,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (27,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4731,9 +4731,9 @@ CREATE TABLE r2 (a int REFERENCES r1 ON UPDATE CASCADE);
 SELECT public.create_hypertable('r2', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (28,regress_rls_schema,r2)
+      create_hypertable       
+------------------------------
+ (28,regress_rls_schema,r2,t)
 (1 row)
 
 INSERT INTO r1 VALUES (10), (20);
@@ -4772,9 +4772,9 @@ CREATE TABLE r1 (a int);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "a"
 DETAIL:  Time dimensions cannot have NULL values
-     create_hypertable      
-----------------------------
- (29,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (29,regress_rls_schema,r1,t)
 (1 row)
 
 CREATE POLICY p1 ON r1 FOR SELECT USING (false);
@@ -4807,9 +4807,9 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 SET row_security = on;
 CREATE TABLE r1 (a int PRIMARY KEY);
 SELECT public.create_hypertable('r1', 'a', chunk_time_interval=>100);
-     create_hypertable      
-----------------------------
- (30,regress_rls_schema,r1)
+      create_hypertable       
+------------------------------
+ (30,regress_rls_schema,r1,t)
 (1 row)
 
 CREATE POLICY p1 ON r1 FOR SELECT USING (a < 20);
@@ -4848,18 +4848,18 @@ CREATE TABLE dep1 (c1 int);
 SELECT public.create_hypertable('dep1', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable       
-------------------------------
- (31,regress_rls_schema,dep1)
+       create_hypertable        
+--------------------------------
+ (31,regress_rls_schema,dep1,t)
 (1 row)
 
 CREATE TABLE dep2 (c1 int);
 SELECT public.create_hypertable('dep2', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-      create_hypertable       
-------------------------------
- (32,regress_rls_schema,dep2)
+       create_hypertable        
+--------------------------------
+ (32,regress_rls_schema,dep2,t)
 (1 row)
 
 CREATE POLICY dep_p1 ON dep1 TO regress_rls_bob USING (c1 > (select max(dep2.c1) from dep2));
@@ -4909,9 +4909,9 @@ CREATE TABLE dob_t1 (c1 int);
 SELECT public.create_hypertable('dob_t1', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-       create_hypertable        
---------------------------------
- (33,regress_rls_schema,dob_t1)
+        create_hypertable         
+----------------------------------
+ (33,regress_rls_schema,dob_t1,t)
 (1 row)
 
 CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1 USING (true);
@@ -4944,9 +4944,9 @@ CREATE TABLE rls_tbl (c1 int);
 SELECT public.create_hypertable('rls_tbl', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-        create_hypertable        
----------------------------------
- (34,regress_rls_schema,rls_tbl)
+         create_hypertable         
+-----------------------------------
+ (34,regress_rls_schema,rls_tbl,t)
 (1 row)
 
 ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
@@ -4958,9 +4958,9 @@ CREATE TABLE rls_tbl_force (c1 int);
 SELECT public.create_hypertable('rls_tbl_force', 'c1', chunk_time_interval=>2);
 NOTICE:  adding not-null constraint to column "c1"
 DETAIL:  Time dimensions cannot have NULL values
-           create_hypertable           
----------------------------------------
- (35,regress_rls_schema,rls_tbl_force)
+            create_hypertable            
+-----------------------------------------
+ (35,regress_rls_schema,rls_tbl_force,t)
 (1 row)
 
 ALTER TABLE rls_tbl_force ENABLE ROW LEVEL SECURITY;

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -15,9 +15,9 @@ CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_2)
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, series_bool) WHERE series_bool IS NOT NULL;
 CREATE INDEX ON PUBLIC."two_Partitions" ("timeCustom" DESC NULLS LAST, device_id);
 SELECT * FROM create_hypertable('"public"."two_Partitions"'::regclass, 'timeCustom'::name, 'device_id'::name, associated_schema_name=>'_timescaledb_internal'::text, number_partitions => 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
- hypertable_id | schema_name |   table_name   
----------------+-------------+----------------
-             1 | public      | two_Partitions
+ hypertable_id | schema_name |   table_name   | created 
+---------------+-------------+----------------+---------
+             1 | public      | two_Partitions | t
 (1 row)
 
 \set QUIET off
@@ -94,9 +94,9 @@ SELECT * FROM indexes_relation_size_pretty('"public"."two_Partitions"');
 CREATE TABLE timestamp_partitioned(time TIMESTAMP, value TEXT);
 SELECT * FROM create_hypertable('timestamp_partitioned', 'time', 'value', 2);
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name |      table_name       
----------------+-------------+-----------------------
-             2 | public      | timestamp_partitioned
+ hypertable_id | schema_name |      table_name       | created 
+---------------+-------------+-----------------------+---------
+             2 | public      | timestamp_partitioned | t
 (1 row)
 
 INSERT INTO timestamp_partitioned VALUES('2004-10-19 10:23:54', '10');
@@ -118,9 +118,9 @@ SELECT * FROM chunk_relation_size_pretty('timestamp_partitioned');
 CREATE TABLE timestamp_partitioned_2(time TIMESTAMP, value CHAR(9));
 SELECT * FROM create_hypertable('timestamp_partitioned_2', 'time', 'value', 2);
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name |       table_name        
----------------+-------------+-------------------------
-             3 | public      | timestamp_partitioned_2
+ hypertable_id | schema_name |       table_name        | created 
+---------------+-------------+-------------------------+---------
+             3 | public      | timestamp_partitioned_2 | t
 (1 row)
 
 INSERT INTO timestamp_partitioned_2 VALUES('2004-10-19 10:23:54', '10');
@@ -145,9 +145,9 @@ CREATE TABLE toast_test(time TIMESTAMP, value TEXT);
 ALTER TABLE toast_test ALTER COLUMN value SET STORAGE EXTERNAL;
 SELECT * FROM create_hypertable('toast_test', 'time');
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             4 | public      | toast_test
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             4 | public      | toast_test | t
 (1 row)
 
 INSERT INTO toast_test VALUES('2004-10-19 10:23:54', $$
@@ -168,9 +168,9 @@ SELECT * FROM chunk_relation_size_pretty('toast_test');
 CREATE TABLE approx_count(time TIMESTAMP, value int);
 SELECT * FROM create_hypertable('approx_count', 'time');
 NOTICE:  adding not-null constraint to column "time"
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-             5 | public      | approx_count
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             5 | public      | approx_count | t
 (1 row)
 
 INSERT INTO approx_count VALUES('2004-01-01 10:00:01', 1);

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -110,9 +110,9 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE 'dev
 CREATE TABLE "int_part"(time timestamp, object_id int, temp float);
 SELECT create_hypertable('"int_part"', 'time', 'object_id', 2);
 NOTICE:  adding not-null constraint to column "time"
-  create_hypertable  
----------------------
- (2,public,int_part)
+   create_hypertable   
+-----------------------
+ (2,public,int_part,t)
 (1 row)
 
 INSERT INTO "int_part" VALUES('2017-01-20T09:00:01', 1, 22.5);

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -8,9 +8,9 @@ CREATE TABLE PUBLIC.hyper_1 (
 );
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             1 | public      | hyper_1
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | hyper_1    | t
 (1 row)
 
 INSERT INTO hyper_1 SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
@@ -23,9 +23,9 @@ CREATE TABLE PUBLIC.hyper_1_tz (
 );
 CREATE INDEX "time_plain_tz" ON PUBLIC.hyper_1_tz (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             2 | public      | hyper_1_tz
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             2 | public      | hyper_1_tz | t
 (1 row)
 
 INSERT INTO hyper_1_tz SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
@@ -38,9 +38,9 @@ CREATE TABLE PUBLIC.hyper_1_int (
 );
 CREATE INDEX "time_plain_int" ON PUBLIC.hyper_1_int (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000, create_default_indexes=>FALSE);
- hypertable_id | schema_name | table_name  
----------------+-------------+-------------
-             3 | public      | hyper_1_int
+ hypertable_id | schema_name | table_name  | created 
+---------------+-------------+-------------+---------
+             3 | public      | hyper_1_int | t
 (1 row)
 
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
@@ -53,9 +53,9 @@ CREATE TABLE PUBLIC.hyper_1_date (
 );
 CREATE INDEX "time_plain_date" ON PUBLIC.hyper_1_date (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1_date"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>86400000000, create_default_indexes=>FALSE);
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-             4 | public      | hyper_1_date
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             4 | public      | hyper_1_date | t
 (1 row)
 
 INSERT INTO hyper_1_date SELECT to_timestamp(ser)::date, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -8,9 +8,9 @@ CREATE TABLE PUBLIC.hyper_1 (
 );
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             1 | public      | hyper_1
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | hyper_1    | t
 (1 row)
 
 INSERT INTO hyper_1 SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
@@ -23,9 +23,9 @@ CREATE TABLE PUBLIC.hyper_1_tz (
 );
 CREATE INDEX "time_plain_tz" ON PUBLIC.hyper_1_tz (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1_tz"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             2 | public      | hyper_1_tz
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             2 | public      | hyper_1_tz | t
 (1 row)
 
 INSERT INTO hyper_1_tz SELECT to_timestamp(ser), ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
@@ -38,9 +38,9 @@ CREATE TABLE PUBLIC.hyper_1_int (
 );
 CREATE INDEX "time_plain_int" ON PUBLIC.hyper_1_int (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1_int"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>10000, create_default_indexes=>FALSE);
- hypertable_id | schema_name | table_name  
----------------+-------------+-------------
-             3 | public      | hyper_1_int
+ hypertable_id | schema_name | table_name  | created 
+---------------+-------------+-------------+---------
+             3 | public      | hyper_1_int | t
 (1 row)
 
 INSERT INTO hyper_1_int SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
@@ -53,9 +53,9 @@ CREATE TABLE PUBLIC.hyper_1_date (
 );
 CREATE INDEX "time_plain_date" ON PUBLIC.hyper_1_date (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1_date"'::regclass, 'time'::name, number_partitions => 1, chunk_time_interval=>86400000000, create_default_indexes=>FALSE);
- hypertable_id | schema_name |  table_name  
----------------+-------------+--------------
-             4 | public      | hyper_1_date
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+             4 | public      | hyper_1_date | t
 (1 row)
 
 INSERT INTO hyper_1_date SELECT to_timestamp(ser)::date, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -11,9 +11,9 @@ CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 CREATE TABLE tspace_2dim(time timestamp, temp float, device text) TABLESPACE tablespace1;
 SELECT create_hypertable('tspace_2dim', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (1,public,tspace_2dim)
+    create_hypertable     
+--------------------------
+ (1,public,tspace_2dim,t)
 (1 row)
 
 INSERT INTO tspace_2dim VALUES ('2017-01-20T09:00:01', 24.3, 'blue');
@@ -107,9 +107,9 @@ SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
 SELECT create_hypertable('tspace_1dim', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (2,public,tspace_1dim)
+    create_hypertable     
+--------------------------
+ (2,public,tspace_1dim,t)
 (1 row)
 
 --user doesn't have permission on tablespace1 --> error
@@ -331,9 +331,9 @@ SELECT * FROM _timescaledb_catalog.tablespace;
 CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
 SELECT create_hypertable('tspace_1dim', 'time');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (3,public,tspace_1dim)
+    create_hypertable     
+--------------------------
+ (3,public,tspace_1dim,t)
 (1 row)
 
 SELECT attach_tablespace('tablespace1', 'tspace_1dim');

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -22,9 +22,9 @@ CREATE INDEX ON PUBLIC."testNs" (device_id, "timeCustom" DESC NULLS LAST) WHERE 
 CREATE SCHEMA "testNs" AUTHORIZATION :ROLE_DEFAULT_PERM_USER;
 \c single :ROLE_DEFAULT_PERM_USER
 SELECT * FROM create_hypertable('"public"."testNs"', 'timeCustom', 'device_id', 2, associated_schema_name=>'testNs' );
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             1 | public      | testNs
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | testNs     | t
 (1 row)
 
 \c single

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -71,9 +71,9 @@ CREATE TRIGGER _0_test_trigger_delete_s_after
     AFTER DELETE ON hyper
     FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
 SELECT * FROM create_hypertable('hyper', 'time', chunk_time_interval => 10);
- hypertable_id | schema_name | table_name 
----------------+-------------+------------
-             1 | public      | hyper
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | hyper      | t
 (1 row)
 
 --test triggers before create_hypertable
@@ -307,16 +307,16 @@ CREATE TRIGGER create_color_trigger
     BEFORE INSERT OR UPDATE ON location
     FOR EACH ROW EXECUTE PROCEDURE create_color_trigger_fn();
 SELECT create_hypertable('location', 'time');
-  create_hypertable  
----------------------
- (2,public,location)
+   create_hypertable   
+-----------------------
+ (2,public,location,t)
 (1 row)
 
 --make color also a hypertable
 SELECT create_hypertable('color', 'color_id', chunk_time_interval=>10);
- create_hypertable 
--------------------
- (3,public,color)
+ create_hypertable  
+--------------------
+ (3,public,color,t)
 (1 row)
 
 -- Test that we can create and use triggers with another user

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -1,8 +1,8 @@
 CREATE TABLE upsert_test(time timestamp PRIMARY KEY, temp float, color text);
 SELECT create_hypertable('upsert_test', 'time');
-   create_hypertable    
-------------------------
- (1,public,upsert_test)
+    create_hypertable     
+--------------------------
+ (1,public,upsert_test,t)
 (1 row)
 
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 22.5, 'yellow') RETURNING *;
@@ -44,9 +44,9 @@ ERROR:  duplicate key value violates unique constraint "1_1_upsert_test_pkey"
 CREATE TABLE upsert_test_unique(time timestamp, temp float, color text);
 SELECT create_hypertable('upsert_test_unique', 'time');
 NOTICE:  adding not-null constraint to column "time"
-       create_hypertable       
--------------------------------
- (2,public,upsert_test_unique)
+        create_hypertable        
+---------------------------------
+ (2,public,upsert_test_unique,t)
 (1 row)
 
 CREATE UNIQUE INDEX time_color_idx ON upsert_test_unique (time, color);
@@ -78,9 +78,9 @@ SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
 CREATE TABLE upsert_test_multi_unique(time timestamp, temp float, color text);
 SELECT create_hypertable('upsert_test_multi_unique', 'time');
 NOTICE:  adding not-null constraint to column "time"
-          create_hypertable          
--------------------------------------
- (3,public,upsert_test_multi_unique)
+           create_hypertable           
+---------------------------------------
+ (3,public,upsert_test_multi_unique,t)
 (1 row)
 
 CREATE UNIQUE INDEX multi_time_temp_idx ON upsert_test_multi_unique (time, temp);
@@ -131,9 +131,9 @@ ALTER TABLE upsert_test_space DROP device_id_1, ADD device_id char(20);
 CREATE UNIQUE INDEX time_space_idx ON upsert_test_space (time, device_id);
 SELECT create_hypertable('upsert_test_space', 'time', 'device_id', 2, partitioning_func=>'_timescaledb_internal.get_partition_for_key'::regproc);
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable       
-------------------------------
- (4,public,upsert_test_space)
+       create_hypertable        
+--------------------------------
+ (4,public,upsert_test_space,t)
 (1 row)
 
 INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 25.9, 'yellow') RETURNING *;

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -2,9 +2,9 @@ CREATE TABLE vacuum_test(time timestamp, temp float);
 -- create hypertable with three chunks
 SELECT create_hypertable('vacuum_test', 'time', chunk_time_interval => 2628000000000);
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (1,public,vacuum_test)
+    create_hypertable     
+--------------------------
+ (1,public,vacuum_test,t)
 (1 row)
 
 INSERT INTO vacuum_test VALUES ('2017-01-20T16:00:01', 17.5),
@@ -82,9 +82,9 @@ DROP TABLE vacuum_test;
 CREATE TABLE analyze_test(time timestamp, temp float);
 SELECT create_hypertable('analyze_test', 'time', chunk_time_interval => 2628000000000);
 NOTICE:  adding not-null constraint to column "time"
-    create_hypertable    
--------------------------
- (2,public,analyze_test)
+     create_hypertable     
+---------------------------
+ (2,public,analyze_test,t)
 (1 row)
 
 INSERT INTO analyze_test VALUES ('2017-01-20T16:00:01', 17.5),

--- a/test/isolation/expected/isolation_nop.out
+++ b/test/isolation/expected/isolation_nop.out
@@ -3,7 +3,7 @@ Parsed test spec with 1 sessions
 starting permutation: s1a
 create_hypertable
 
-(1,public,ts_cluster_test)
+(1,public,ts_cluster_test,t)
 step s1a: SELECT pg_sleep(0);
 pg_sleep       
 

--- a/test/isolation/expected/read_committed_insert.out
+++ b/test/isolation/expected/read_committed_insert.out
@@ -3,7 +3,7 @@ Parsed test spec with 2 sessions
 starting permutation: s1a s1c s2a s2b
 create_hypertable
 
-(2,public,ts_cluster_test)
+(2,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s1c: COMMIT;
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
@@ -12,7 +12,7 @@ step s2b: COMMIT;
 starting permutation: s1a s2a s1c s2b
 create_hypertable
 
-(3,public,ts_cluster_test)
+(3,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
 step s1c: COMMIT;
@@ -22,7 +22,7 @@ step s2b: COMMIT;
 starting permutation: s1a s2a s2b s1c
 create_hypertable
 
-(4,public,ts_cluster_test)
+(4,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
 step s2a: <... completed>
@@ -33,7 +33,7 @@ step s1c: COMMIT;
 starting permutation: s2a s1a s1c s2b
 create_hypertable
 
-(5,public,ts_cluster_test)
+(5,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
 step s1a: <... completed>
@@ -44,7 +44,7 @@ step s2b: COMMIT;
 starting permutation: s2a s1a s2b s1c
 create_hypertable
 
-(6,public,ts_cluster_test)
+(6,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
 step s2b: COMMIT;
@@ -54,7 +54,7 @@ step s1c: COMMIT;
 starting permutation: s2a s2b s1a s1c
 create_hypertable
 
-(7,public,ts_cluster_test)
+(7,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s2b: COMMIT;
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);

--- a/test/isolation/expected/read_uncommitted_insert.out
+++ b/test/isolation/expected/read_uncommitted_insert.out
@@ -3,7 +3,7 @@ Parsed test spec with 2 sessions
 starting permutation: s1a s1c s2a s2b
 create_hypertable
 
-(8,public,ts_cluster_test)
+(8,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s1c: COMMIT;
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
@@ -12,7 +12,7 @@ step s2b: COMMIT;
 starting permutation: s1a s2a s1c s2b
 create_hypertable
 
-(9,public,ts_cluster_test)
+(9,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
 step s1c: COMMIT;
@@ -22,7 +22,7 @@ step s2b: COMMIT;
 starting permutation: s1a s2a s2b s1c
 create_hypertable
 
-(10,public,ts_cluster_test)
+(10,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
 step s2a: <... completed>
@@ -33,7 +33,7 @@ step s1c: COMMIT;
 starting permutation: s2a s1a s1c s2b
 create_hypertable
 
-(11,public,ts_cluster_test)
+(11,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
 step s1a: <... completed>
@@ -44,7 +44,7 @@ step s2b: COMMIT;
 starting permutation: s2a s1a s2b s1c
 create_hypertable
 
-(12,public,ts_cluster_test)
+(12,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
 step s2b: COMMIT;
@@ -54,7 +54,7 @@ step s1c: COMMIT;
 starting permutation: s2a s2b s1a s1c
 create_hypertable
 
-(13,public,ts_cluster_test)
+(13,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s2b: COMMIT;
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);

--- a/test/isolation/expected/repeatable_read_insert.out
+++ b/test/isolation/expected/repeatable_read_insert.out
@@ -3,7 +3,7 @@ Parsed test spec with 2 sessions
 starting permutation: s1a s1c s2a s2b
 create_hypertable
 
-(14,public,ts_cluster_test)
+(14,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s1c: COMMIT;
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
@@ -12,7 +12,7 @@ step s2b: COMMIT;
 starting permutation: s1a s2a s1c s2b
 create_hypertable
 
-(15,public,ts_cluster_test)
+(15,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
 step s1c: COMMIT;
@@ -22,7 +22,7 @@ step s2b: COMMIT;
 starting permutation: s1a s2a s2b s1c
 create_hypertable
 
-(16,public,ts_cluster_test)
+(16,public,ts_cluster_test,t)
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1); <waiting ...>
 step s2a: <... completed>
@@ -33,7 +33,7 @@ step s1c: COMMIT;
 starting permutation: s2a s1a s1c s2b
 create_hypertable
 
-(17,public,ts_cluster_test)
+(17,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
 step s1a: <... completed>
@@ -44,7 +44,7 @@ step s2b: COMMIT;
 starting permutation: s2a s1a s2b s1c
 create_hypertable
 
-(18,public,ts_cluster_test)
+(18,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1); <waiting ...>
 step s2b: COMMIT;
@@ -54,7 +54,7 @@ step s1c: COMMIT;
 starting permutation: s2a s2b s1a s1c
 create_hypertable
 
-(19,public,ts_cluster_test)
+(19,public,ts_cluster_test,t)
 step s2a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090002', 0.72, 1);
 step s2b: COMMIT;
 step s1a: INSERT INTO ts_cluster_test VALUES ('2017-01-20T090001', 23.4, 1);


### PR DESCRIPTION
Add bool created to return value of create_hypertable and add_dimension. When if_not_exists is true and creation is skipped because the object already exists created will be false, otherwise it will be true. This modifies the functions to return meta data even if no object was created and if_not_exists was set to true.