### PR TITLE
Test get_git_commit, get_os_info and get_version returned types

### DIFF
--- a/test/expected/version.out
+++ b/test/expected/version.out
@@ -1,8 +1,21 @@
--- Just test that the function does not error out as the output
--- will change.
-select count(*) from _timescaledb_internal.get_git_commit();
- count 
--------
-     1
+-- Test that get_git_commit returns text
+select pg_typeof(git) from _timescaledb_internal.get_git_commit() AS git;
+ pg_typeof 
+-----------
+ text
+(1 row)
+
+-- Test that get_os_info returns 3 x text
+select pg_typeof(sysname) AS sysname_type,pg_typeof(version) AS version_type,pg_typeof(release) AS release_type from _timescaledb_internal.get_os_info();
+ sysname_type | version_type | release_type 
+--------------+--------------+--------------
+ text         | text         | text
+(1 row)
+
+-- Test that get_version major, minor and patch are int
+select pg_typeof(major) AS major_type,pg_typeof(minor) AS minor_type,pg_typeof(patch) AS patch_type from _timescaledb_internal.get_version();
+ major_type | minor_type | patch_type 
+------------+------------+------------
+ integer    | integer    | integer
 (1 row)
 

--- a/test/sql/version.sql
+++ b/test/sql/version.sql
@@ -1,4 +1,9 @@
--- Just test that the function does not error out as the output
--- will change.
-select count(*) from _timescaledb_internal.get_git_commit();
+-- Test that get_git_commit returns text
+select pg_typeof(git) from _timescaledb_internal.get_git_commit() AS git;
+
+-- Test that get_os_info returns 3 x text
+select pg_typeof(sysname) AS sysname_type,pg_typeof(version) AS version_type,pg_typeof(release) AS release_type from _timescaledb_internal.get_os_info();
+
+-- Test that get_version major, minor and patch are int
+select pg_typeof(major) AS major_type,pg_typeof(minor) AS minor_type,pg_typeof(patch) AS patch_type from _timescaledb_internal.get_version();
 


### PR DESCRIPTION
Currently only get_git_commit is tested in our regression tests, I think it's a good idea to call them all at least once to check they are not broken. Since the returned values are highly variable I only check returned types.