### PR TITLE
Enable scheduler to update its jobs list

### DIFF
--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -21,3 +21,13 @@ LANGUAGE C VOLATILE;
 INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
 (1, 'Telemetry Reporter', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h')
 ON CONFLICT (id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION insert_job(application_name NAME, job_type NAME, schedule_interval INTERVAL, max_runtime INTERVAL, max_retries INTEGER, retry_period INTERVAL)
+RETURNS VOID
+AS '@MODULE_PATHNAME@', 'ts_bgw_job_insert_relation'
+LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION delete_job(job_id INTEGER)
+RETURNS VOID
+AS '@MODULE_PATHNAME@', 'ts_bgw_job_delete_by_id'
+LANGUAGE C VOLATILE;

--- a/sql/cache.sql
+++ b/sql/cache.sql
@@ -8,6 +8,9 @@
 -- description of how this works.
 CREATE TABLE IF NOT EXISTS  _timescaledb_cache.cache_inval_hypertable();
 
+-- For notifying the scheduler of changes to the bgw_job table.
+CREATE TABLE IF NOT EXISTS  _timescaledb_cache.cache_inval_bgw_job();
+
 -- This is pretty subtle. We create this dummy cache_inval_extension table
 -- solely for the purpose of getting a relcache invalidation event when it is
 -- deleted on DROP extension. It has no related triggers. When the table is
@@ -19,6 +22,7 @@ CREATE TABLE IF NOT EXISTS  _timescaledb_cache.cache_inval_extension();
 -- not actually strictly needed but good for sanity as all tables should be dumped.
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_hypertable', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_extension', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_cache.cache_inval_bgw_job', '');
 
 GRANT SELECT ON ALL TABLES IN SCHEMA _timescaledb_cache TO PUBLIC;
 

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -89,6 +89,19 @@ bgw_job_stat_find(int32 bgw_job_id)
 	return job_stat;
 }
 
+static bool
+bgw_job_stat_tuple_delete(TupleInfo *ti, void *const data)
+{
+	catalog_delete(ti->scanrel, ti->tuple);
+	return true;
+}
+
+void
+bgw_job_stat_delete(int32 bgw_job_id)
+{
+	bgw_job_stat_scan_job_id(bgw_job_id, bgw_job_stat_tuple_delete, NULL, NULL, RowExclusiveLock);
+}
+
 /* Mark the start of a job. This should be done in a separate transaction by the scheduler
 *  before the bgw for a job is launched. This ensures that the job is counted as started
 * before /any/ job specific code is executed. A job that has been started but never ended

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -22,6 +22,7 @@ typedef enum JobResult
 } JobResult;
 
 extern BgwJobStat *bgw_job_stat_find(int job_id);
+extern void bgw_job_stat_delete(int job_id);
 extern void bgw_job_stat_mark_start(int32 bgw_job_id);
 extern void bgw_job_stat_mark_end(BgwJob *job, JobResult result);
 extern bool bgw_job_stat_end_was_marked(BgwJobStat *jobstat);

--- a/src/bgw/scheduler.h
+++ b/src/bgw/scheduler.h
@@ -13,12 +13,22 @@
 
 #include "timer.h"
 
+typedef struct ScheduledBgwJob ScheduledBgwJob;
+
 /* callback used in testing */
 typedef void (*register_background_worker_callback_type) (BackgroundWorkerHandle *);
+
+/* Exposed for testing */
+List	   *update_scheduled_jobs_list(List *cur_jobs_list, MemoryContext mctx);
+#ifdef TS_DEBUG
+void		populate_scheduled_job_tuple(ScheduledBgwJob *sjob, Datum *values);
+#endif
 
 void		bgw_scheduler_process(int32 run_for_interval_ms, register_background_worker_callback_type bgw_register);
 
 /* exposed for access by mock */
 void		bgw_scheduler_setup_callbacks(void);
+
+void		bgw_job_cache_invalidate_callback(void);
 
 #endif							/* BGW_SCHEDULER_H */

--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -17,6 +17,8 @@
 #include "extension.h"
 #include "hypertable_cache.h"
 
+#include "bgw/scheduler.h"
+
 /*
  * Notes on the way cache invalidation works.
  *
@@ -76,6 +78,9 @@ cache_invalidate_callback(Datum arg, Oid relid)
 
 	if (relid == catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE))
 		hypertable_cache_invalidate_callback();
+
+	if (relid == catalog_get_cache_proxy_id(catalog, CACHE_TYPE_BGW_JOB))
+		bgw_job_cache_invalidate_callback();
 }
 
 TS_FUNCTION_INFO_V1(ts_timescaledb_invalidate_cache);

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -186,7 +186,7 @@ const static InternalFunctionDef internal_function_definitions[_MAX_INTERNAL_FUN
  * sql/cache.sql */
 static const char *cache_proxy_table_names[_MAX_CACHE_TYPES] = {
 	[CACHE_TYPE_HYPERTABLE] = "cache_inval_hypertable",
-	[CACHE_TYPE_CHUNK] = "cache_inval_chunk",
+	[CACHE_TYPE_BGW_JOB] = "cache_inval_bgw_job",
 };
 
 /* Catalog information for the current database. */
@@ -564,6 +564,10 @@ catalog_invalidate_cache(Oid catalog_relid, CmdType operation)
 		case HYPERTABLE:
 		case DIMENSION:
 			relid = catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE);
+			CacheInvalidateRelcacheByRelid(relid);
+			break;
+		case BGW_JOB:
+			relid = catalog_get_cache_proxy_id(catalog, CACHE_TYPE_BGW_JOB);
 			CacheInvalidateRelcacheByRelid(relid);
 			break;
 		case CHUNK_INDEX:

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -640,7 +640,7 @@ enum
 typedef enum CacheType
 {
 	CACHE_TYPE_HYPERTABLE,
-	CACHE_TYPE_CHUNK,
+	CACHE_TYPE_BGW_JOB,
 	_MAX_CACHE_TYPES
 } CacheType;
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -8,6 +8,7 @@
 #define TIMESCALEDB_COMPAT_H
 
 #include <postgres.h>
+#include <pgstat.h>
 
 #include "export.h"
 

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -16,9 +16,12 @@ CREATE OR REPLACE FUNCTION ts_bgw_params_create() RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 CREATE OR REPLACE FUNCTION ts_bgw_params_destroy() RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
-CREATE OR REPLACE FUNCTION ts_bgw_params_reset_time() RETURNS VOID
+CREATE OR REPLACE FUNCTION ts_bgw_params_reset_time(set_time BIGINT = 0, wait BOOLEAN = false) RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
-CREATE OR REPLACE FUNCTION ts_bgw_params_mock_wait_returns_immediately(new_val BOOLEAN) RETURNS VOID
+\set WAIT_ON_JOB 0
+\set IMMEDIATELY_SET_UNTIL 1
+\set WAIT_FOR_OTHER_TO_ADVANCE 2
+CREATE OR REPLACE FUNCTION ts_bgw_params_mock_wait_returns_immediately(new_val INTEGER) RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 --allow us to inject test jobs
 ALTER TABLE _timescaledb_config.bgw_job DROP CONSTRAINT valid_job_type;
@@ -404,7 +407,7 @@ DELETE FROM _timescaledb_config.bgw_job;
 INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
 ('test_job_3_long', 'bgw_test_job_3_long', INTERVAL '5000ms', INTERVAL '20ms', 3, INTERVAL '50ms');
 \c single :ROLE_DEFAULT_PERM_USER
-SELECT ts_bgw_params_mock_wait_returns_immediately(true);
+SELECT ts_bgw_params_mock_wait_returns_immediately(:IMMEDIATELY_SET_UNTIL);
  ts_bgw_params_mock_wait_returns_immediately 
 ---------------------------------------------
  
@@ -470,7 +473,7 @@ SELECT * FROM bgw_log;
       1 |    550000 | test_job_3_long  | After sleep job 3
 (4 rows)
 
-SELECT ts_bgw_params_mock_wait_returns_immediately(false);
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_ON_JOB);
  ts_bgw_params_mock_wait_returns_immediately 
 ---------------------------------------------
  
@@ -803,4 +806,347 @@ SELECT * FROM bgw_log;
       2 |    200000 | DB Scheduler     | [TESTING] Wait until 225000, started at 200000
       0 |    200000 | test_job_4       | Execute job 4
 (7 rows)
+
+-- Test updating jobs list
+TRUNCATE bgw_log;
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+\c single :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_job_refresh() RETURNS TABLE(
+id INTEGER,
+application_name NAME,
+job_type NAME,
+schedule_interval INTERVAL,
+max_runtime INTERVAL,
+max_retries INT,
+retry_period INTERVAL,
+next_start TIMESTAMPTZ,
+timeout_at TIMESTAMPTZ,
+reserved_worker BOOLEAN,
+may_next_mark_end BOOLEAN
+)
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE FUNCTION verify_refresh_correct() RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+    num_jobs INTEGER;
+    num_jobs_in_list INTEGER;
+BEGIN
+    SELECT COUNT(*) from _timescaledb_config.bgw_job INTO num_jobs;
+	select COUNT(*) from ts_test_job_refresh() JOIN _timescaledb_config.bgw_job USING (id,application_name,job_type,schedule_interval,max_runtime,max_retries,retry_period) INTO num_jobs_in_list;
+	IF (num_jobs = num_jobs_in_list) THEN
+		RETURN true;
+	END IF;
+	RETURN false;
+END
+$BODY$;
+CREATE FUNCTION wait_for_job_1_to_run(runs INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+	num_runs INTEGER;
+BEGIN
+	FOR i in 1..10
+	LOOP
+	SELECT COUNT(*) from bgw_log where msg='Execute job 1' INTO num_runs;
+	if (num_runs = runs) THEN
+		RETURN true;
+	ELSE
+		PERFORM pg_sleep(0.1);
+	END IF;
+	END LOOP;
+	RETURN false;
+END
+$BODY$;
+CREATE FUNCTION wait_for_timer_to_run(started_at INTEGER) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+	num_runs INTEGER;
+	message TEXT;
+BEGIN
+	select format('[TESTING] Wait until %%, started at %s', started_at) into message;
+	FOR i in 1..10
+	LOOP
+	SELECT COUNT(*) from bgw_log where msg LIKE message INTO num_runs;
+	if (num_runs > 0) THEN
+		RETURN true;
+	ELSE
+		PERFORM pg_sleep(0.1);
+	END IF;
+	END LOOP;
+	RETURN false;
+END
+$BODY$;
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+-- Should return the same table
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job;
+-- Make sure jobs list is empty
+select count(*) from ts_test_job_refresh();
+ count 
+-------
+     0
+(1 row)
+
+INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+('test_1', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s'),
+('test_2', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s'),
+('test_3', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+DELETE from _timescaledb_config.bgw_job where application_name='test_2';
+INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+('test_4', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job;
+INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+('test_10', 'test_10', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s');
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+-- Should be idempotent
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job;
+INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+('another', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s'),
+('another1', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s'),
+('another2', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s'),
+('another3', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s'),
+('another4', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s');
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job where application_name='another' OR application_name='another3';
+INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+('blah', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s');
+select * from verify_refresh_correct();
+ verify_refresh_correct 
+------------------------
+ t
+(1 row)
+
+-- Now test a real scheduler-mock running in a loop and updating the list of jobs
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+SELECT ts_bgw_params_reset_time();
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job;
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_FOR_OTHER_TO_ADVANCE);
+ ts_bgw_params_mock_wait_returns_immediately 
+---------------------------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run(500);
+ ts_bgw_db_scheduler_test_run 
+------------------------------
+ 
+(1 row)
+
+-- Wait for scheduler to start up
+SELECT wait_for_timer_to_run(0);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+SELECT insert_job('another', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s');
+ insert_job 
+------------
+ 
+(1 row)
+
+SELECT ts_bgw_params_reset_time(50000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_timer_to_run(50000);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+SELECT wait_for_job_1_to_run(1);
+ wait_for_job_1_to_run 
+-----------------------
+ t
+(1 row)
+
+SELECT ts_bgw_params_reset_time(150000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_timer_to_run(150000);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+SELECT wait_for_job_1_to_run(2);
+ wait_for_job_1_to_run 
+-----------------------
+ t
+(1 row)
+
+select * from _timescaledb_internal.bgw_job_stat;
+ job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1025 | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.25 1999 PST | t                |          2 | @ 0            |               2 |              0 |             0 |                    0 |                   0
+(1 row)
+
+SELECT delete_job(x.id) FROM (select * from _timescaledb_config.bgw_job) x;
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT ts_bgw_params_reset_time(200000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_timer_to_run(200000);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+-- In the next time interval, nothing should be run because scheduler should have an empty list
+SELECT ts_bgw_params_reset_time(300000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_timer_to_run(300000);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+-- Same for this time interval
+SELECT ts_bgw_params_reset_time(400000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_timer_to_run(400000);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+-- Now add a new job and make sure it gets run before the scheduler dies
+SELECT insert_job('new_job', 'bgw_test_job_1', INTERVAL '10ms', INTERVAL '100s', 5, INTERVAL '1s');
+ insert_job 
+------------
+ 
+(1 row)
+
+SELECT ts_bgw_params_reset_time(450000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+-- New job should be run once, for a total of 3 runs of this job in the log
+SELECT wait_for_job_1_to_run(3);
+ wait_for_job_1_to_run 
+-----------------------
+ t
+(1 row)
+
+-- New job should be run again
+SELECT ts_bgw_params_reset_time(480000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_job_1_to_run(4);
+ wait_for_job_1_to_run 
+-----------------------
+ t
+(1 row)
+
+SELECT ts_bgw_params_reset_time(500000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+ ts_bgw_db_scheduler_test_wait_for_scheduler_finish 
+----------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM bgw_log;
+ msg_no | mock_time | application_name |                      msg                       
+--------+-----------+------------------+------------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Wait until 500000, started at 0
+      1 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |     50000 | DB Scheduler     | [TESTING] Wait until 500000, started at 50000
+      0 |     50000 | another          | Execute job 1
+      3 |    150000 | DB Scheduler     | [TESTING] Registered new background worker
+      4 |    150000 | DB Scheduler     | [TESTING] Wait until 500000, started at 150000
+      0 |    150000 | another          | Execute job 1
+      5 |    200000 | DB Scheduler     | [TESTING] Wait until 500000, started at 200000
+      6 |    300000 | DB Scheduler     | [TESTING] Wait until 500000, started at 300000
+      7 |    400000 | DB Scheduler     | [TESTING] Wait until 500000, started at 400000
+      8 |    450000 | DB Scheduler     | [TESTING] Registered new background worker
+      9 |    450000 | DB Scheduler     | [TESTING] Wait until 500000, started at 450000
+      0 |    450000 | new_job          | Execute job 1
+     10 |    480000 | DB Scheduler     | [TESTING] Registered new background worker
+     11 |    480000 | DB Scheduler     | [TESTING] Wait until 500000, started at 480000
+      0 |    480000 | new_job          | Execute job 1
+(16 rows)
+
+select * from _timescaledb_internal.bgw_job_stat;
+ job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1026 | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.49 1999 PST | t                |          2 | @ 0            |               2 |              0 |             0 |                    0 |                   0
+(1 row)
 

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -20,6 +20,7 @@ ORDER BY proname;
  chunk_relation_size
  chunk_relation_size_pretty
  create_hypertable
+ delete_job
  detach_tablespace
  detach_tablespaces
  drop_chunks
@@ -31,11 +32,12 @@ ORDER BY proname;
  hypertable_relation_size_pretty
  indexes_relation_size
  indexes_relation_size_pretty
+ insert_job
  last
  set_adaptive_chunking
  set_chunk_time_interval
  set_number_partitions
  show_tablespaces
  time_bucket
-(22 rows)
+(24 rows)
 

--- a/test/src/bgw/CMakeLists.txt
+++ b/test/src/bgw/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/log.c
   ${CMAKE_CURRENT_SOURCE_DIR}/timer_mock.c
   ${CMAKE_CURRENT_SOURCE_DIR}/scheduler_mock.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/params.c)
+  ${CMAKE_CURRENT_SOURCE_DIR}/params.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_job_refresh.c)
 
 target_sources(${TESTS_LIB_NAME} PRIVATE ${SOURCES})

--- a/test/src/bgw/params.h
+++ b/test/src/bgw/params.h
@@ -7,13 +7,26 @@
 #ifndef TEST_BGW_PARAMS_H
 #define TEST_BGW_PARAMS_H
 #include <postgres.h>
+#include <storage/latch.h>
+
+typedef enum MockWaitType
+{
+	WAIT_ON_JOB = 0,
+	IMMEDIATELY_SET_UNTIL,
+	WAIT_FOR_OTHER_TO_ADVANCE,
+	_MAX_MOCK_WAIT_TYPE
+} MockWaitType;
+
 typedef struct TestParams
 {
+	Latch		timer_latch;
 	int64		current_time;
-	bool		mock_wait_returns_immediately;
+	MockWaitType mock_wait_type;
 } TestParams;
 
 extern TestParams *params_get(void);
-extern void params_set_time(int64 new_val);
+extern void params_set_time(int64 new_val, bool set_latch);
+void		initialize_timer_latch(void);
+void		reset_and_wait_timer_latch(void);
 
 #endif							/* TEST_BGW_PARAMS_H */

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -110,7 +110,9 @@ ts_bgw_db_scheduler_test_main(PG_FUNCTION_ARGS)
 
 	StartTransactionCommand();
 	params_get();
+	initialize_timer_latch();
 	CommitTransactionCommand();
+
 	bgw_log_set_application_name("DB Scheduler");
 	register_emit_log_hook();
 

--- a/test/src/bgw/test_job_refresh.c
+++ b/test/src/bgw/test_job_refresh.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2018  Timescale, Inc. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License,
+ * see LICENSE-APACHE at the top level directory.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <postgres.h>
+#include <fmgr.h>
+#include <funcapi.h>
+#include <access/htup_details.h>
+#include <utils/memutils.h>
+
+#include "export.h"
+#include "bgw/scheduler.h"
+
+TS_FUNCTION_INFO_V1(ts_test_job_refresh);
+
+static List *cur_scheduled_jobs = NIL;
+
+/* Test update_scheduled_jobs_list will correctly update with jobs in bgw_job table.
+ * Call this function after loading up bgw_job table
+ */
+Datum
+ts_test_job_refresh(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *funcctx;
+	ListCell   *lc;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		MemoryContext oldcontext;
+		TupleDesc	tupdesc;
+
+		/* Use top-level memory context to preserve the global static list */
+		cur_scheduled_jobs = update_scheduled_jobs_list(cur_scheduled_jobs, TopMemoryContext);
+
+		funcctx = SRF_FIRSTCALL_INIT();
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		funcctx->user_fctx = list_head(cur_scheduled_jobs);
+
+		if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("function returning record called in context "
+							"that cannot accept type record")));
+		}
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	lc = (ListCell *) funcctx->user_fctx;
+
+	if (lc == NULL)
+		SRF_RETURN_DONE(funcctx);
+	else
+	{
+		/* Return the current list_cell and advance ptr */
+		Datum		values[funcctx->tuple_desc->natts];
+		bool		nulls[funcctx->tuple_desc->natts];
+		HeapTuple	tuple;
+
+		populate_scheduled_job_tuple(lfirst(lc), values);
+		memset(nulls, 0, sizeof(nulls));
+		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+
+		funcctx->user_fctx = lnext(lc);
+		SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+	}
+
+	PG_RETURN_NULL();
+}


### PR DESCRIPTION
Previously, the scheduler only populated its jobs list once at start time. This commit enables the scheduler to receive notifications for updates (insert, update, delete) to the bgw_job table. Notifications are sent via the cache invalidation framework. Whenever the scheduler receives a notification, it re-reads the bgw_job table. For each job currently in the bgw_job table, it either instantiates new scheduler state for the job or copies over any existing scheduler state, for persisting jobs. For jobs that have disappeared from the bgw_job table, the scheduler deletes any local state it has.

Note that any updates to the bgw_job table must now go through the C, so that the cache invalidation framework in catalog.c can run. In particular, this commit includes a rudimentary API for interacting with the bgw_job table, for testing purposes. This API will be rewritten in the future.