### PR TITLE
[Documentation Only Change] Document timescales loading procedure

### DIFF
--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -37,6 +37,24 @@
 #include "bgw_interface.h"
 
 /*
+ * Loading process:
+ *
+ *   1. _PG_init starts up cluster-wide background worker stuff, and sets the
+ *      post_parse_analyze_hook (a postgres-defined hook which is called after
+ *      every statement is parsed) to our function post_analyze_hook
+ *   2. When a command is run with timescale not loaded, post_analyze_hook:
+ *        a. Gets the extension version.
+ *        b. Loads the versioned extension.
+ *        c. Grabs the post_parse_analyze_hook from the versioned extension
+ *           (src/init.c:post_analyze_hook) and stores it in
+ *           extension_post_parse_analyze_hook.
+ *        d. Sets the post_parse_analyze_hook back to what it was before we
+ *           loaded the versioned extention (this hook eventually called our
+ *           post_analyze_hook, but may not be our function, for instance, if
+ *           another extension is loaded).
+ *        e. Calls extension_post_parse_analyze_hook.
+ *        f. Calls the prev_post_parse_analyze_hook.
+ *
  * Some notes on design:
  *
  * We do not check for the installation of the extension upon loading the extension and instead rely on a hook for two reasons:
@@ -471,6 +489,12 @@ do_load()
 	old_hook = post_parse_analyze_hook;
 	post_parse_analyze_hook = NULL;
 
+	/*
+	 * We want to call the post_parse_analyze_hook from the versioned
+	 * extension after we've loaded the versioned so. When the file is loaded
+	 * it sets post_parse_analyze_hook, which we capture and store in
+	 * extension_post_parse_analyze_hook to call at the end _PG_init
+	 */
 	PG_TRY();
 	{
 		load_file(soname, false);


### PR DESCRIPTION
We use a custom loader to enable different databases within a single cluster to have different timescaledb versions. This code can be confusing to the uninitiated, so this PR adds documentation about how the loading happens.