### PR TITLE
Check extension exists for DropOwnedStatement in post_analyze_hook

### DIFF
--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -127,6 +127,9 @@ inval_cache_callback(Datum arg, Oid relid)
 static bool
 drop_statement_drops_extension(DropStmt *stmt)
 {
+	if (!extension_exists())
+		return false;
+
 	if (stmt->removeType == OBJECT_EXTENSION)
 	{
 		if (list_length(stmt->objects) == 1)
@@ -196,6 +199,9 @@ drop_owned_statement_drops_extension(DropOwnedStmt *stmt)
 	Oid			extension_owner_oid;
 	List	   *role_ids;
 	ListCell   *lc;
+
+	if (!extension_exists())
+		return false;
 
 	Assert(IsTransactionState());
 	extension_owner_oid = extension_owner();
@@ -312,6 +318,11 @@ load_utility_cmd(Node *utility_stmt)
 static void
 stop_workers_on_db_drop(DropdbStmt *drop_db_statement)
 {
+	/*
+	 * Don't check if extension exists here because even though the current
+	 * database might not have TimescaleDB installed the database we are
+	 * dropping might.
+	 */
 	Oid			dropped_db_oid = get_database_oid(drop_db_statement->dbname, drop_db_statement->missing_ok);
 
 	if (dropped_db_oid != InvalidOid)

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -84,3 +84,10 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 ----------+--------------------+-----------------+----------------------------
 (0 rows)
 
+-- test drop owned in database without extension installed
+\c single :ROLE_SUPERUSER
+CREATE database test_drop_owned;
+\c test_drop_owned
+DROP OWNED BY :ROLE_SUPERUSER;
+\c single :ROLE_SUPERUSER
+DROP DATABASE test_drop_owned;

--- a/test/sql/drop_owned.sql
+++ b/test/sql/drop_owned.sql
@@ -35,3 +35,12 @@ SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT * FROM _timescaledb_catalog.chunk_index;
 SELECT * FROM _timescaledb_catalog.chunk_constraint;
+
+-- test drop owned in database without extension installed
+\c single :ROLE_SUPERUSER
+CREATE database test_drop_owned;
+\c test_drop_owned
+DROP OWNED BY :ROLE_SUPERUSER;
+\c single :ROLE_SUPERUSER
+DROP DATABASE test_drop_owned;
+


### PR DESCRIPTION
Currently `DROP OWNED BY user` throws an error in a database without timescaledb installed but with timesaledb preloaded. This patch fixes the behaviour and also adds a test for that case.