### PR TITLE
Provide helper function creating struct from tuple

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -19,6 +19,7 @@
 #include "extension.h"
 #include "compat.h"
 #include "job_stat.h"
+#include "utils.h"
 #include "telemetry/telemetry.h"
 
 #define TELEMETRY_INITIAL_NUM_RUNS	12
@@ -81,10 +82,12 @@ bgw_job_from_tuple(HeapTuple tuple, size_t alloc_size, MemoryContext mctx)
 {
 	BgwJob	   *job;
 
-	/* allow for embedding */
+	/*
+	 * allow for embedding with arbitrary alloc_size, which means we can't use
+	 * the STRUCT_FROM_TUPLE macro
+	 */
 	Assert(alloc_size >= sizeof(BgwJob));
-	job = MemoryContextAllocZero(mctx, alloc_size);
-	memcpy(&job->fd, GETSTRUCT(tuple), sizeof(FormData_bgw_job));
+	job = (BgwJob *) create_struct_from_tuple(tuple, mctx, alloc_size, sizeof(FormData_bgw_job));
 	job->bgw_type = get_job_type_from_name(&job->fd.job_type);
 
 	return job;

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -11,23 +11,13 @@
 #include "scanner.h"
 #include "compat.h"
 #include "timer.h"
+#include "utils.h"
 
 #if PG10
 #include <utils/fmgrprotos.h>
 #endif
 #define MAX_INTERVALS_BACKOFF 5
 #define MIN_WAIT_AFTER_CRASH_MS (5 * 60 * 1000)
-
-static BgwJobStat *
-bgw_job_stat_from_tuple(HeapTuple tuple, MemoryContext mctx)
-{
-	BgwJobStat *job_stat;
-
-	job_stat = MemoryContextAllocZero(mctx, sizeof(BgwJobStat));
-	memcpy(&job_stat->fd, GETSTRUCT(tuple), sizeof(FormData_bgw_job_stat));
-
-	return job_stat;
-}
 
 static bool
 bgw_job_stat_next_start_was_set(FormData_bgw_job_stat *fd)
@@ -41,7 +31,7 @@ bgw_job_stat_tuple_found(TupleInfo *ti, void *const data)
 {
 	BgwJobStat **job_stat_pp = data;
 
-	*job_stat_pp = bgw_job_stat_from_tuple(ti->tuple, ti->mctx);
+	*job_stat_pp = STRUCT_FROM_TUPLE(ti->tuple, ti->mctx, BgwJobStat, FormData_bgw_job_stat);
 
 	/*
 	 * Return SCAN_CONTINUE because we check for multiple tuples as an error

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -50,6 +50,7 @@
 #include "copy.h"
 #include "utils.h"
 #include "funcapi.h"
+#include "utils.h"
 
 Oid
 rel_get_owner(Oid relid)
@@ -94,11 +95,9 @@ hypertable_permissions_check(Oid hypertable_oid, Oid userid)
 Hypertable *
 hypertable_from_tuple(HeapTuple tuple, MemoryContext mctx)
 {
-	Hypertable *h;
 	Oid			namespace_oid;
+	Hypertable *h = STRUCT_FROM_TUPLE(tuple, mctx, Hypertable, FormData_hypertable);
 
-	h = MemoryContextAllocZero(mctx, sizeof(Hypertable));
-	memcpy(&h->fd, GETSTRUCT(tuple), sizeof(FormData_hypertable));
 	namespace_oid = get_namespace_oid(NameStr(h->fd.schema_name), false);
 	h->main_table_relid = get_relname_relid(NameStr(h->fd.table_name), namespace_oid);
 	h->space = dimension_scan(h->fd.id, h->main_table_relid, h->fd.num_dimensions, mctx);

--- a/src/utils.c
+++ b/src/utils.c
@@ -357,3 +357,18 @@ type_is_int8_binary_compatible(Oid sourcetype)
 	ReleaseSysCache(tuple);
 	return result;
 }
+
+/*
+ * Create a fresh struct pointer that will contain copied contents of the tuple.
+ * Note that this function uses GETSTRUCT, which will not work correctly for tuple types
+ * that might have variable lengths.
+ */
+void *
+create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size)
+{
+	void	   *struct_ptr = MemoryContextAllocZero(mctx, alloc_size);
+
+	memcpy(struct_ptr, GETSTRUCT(tuple), copy_size);
+
+	return struct_ptr;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,7 +12,7 @@
 #include <nodes/primnodes.h>
 #include <catalog/pg_proc.h>
 #include <utils/datetime.h>
-
+#include <access/htup_details.h>
 
 extern bool type_is_int8_binary_compatible(Oid sourcetype);
 
@@ -37,6 +37,11 @@ extern FmgrInfo *create_fmgr(char *schema, char *function_name, int num_args);
 extern RangeVar *makeRangeVarFromRelid(Oid relid);
 extern int	int_cmp(const void *a, const void *b);
 extern Oid	inheritance_parent_relid(Oid relid);
+
+void	   *create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size);
+
+#define STRUCT_FROM_TUPLE(tuple, mctx, to_type, form_type) \
+      (to_type *) create_struct_from_tuple(tuple, mctx, sizeof(to_type), sizeof(form_type));
 
 /* note PG10 has_superclass but PG96 does not so use this */
 #define is_inheritance_child(relid) \


### PR DESCRIPTION
Refactored the boilerplate that allocates and copies over data from a tuple to a struct. This is typically used in the scanner context in order to read rows from a SQL table in C.