### PR TITLE
Ensure deterministic results in cluster test

### DIFF
--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -33,12 +33,12 @@ INSERT INTO cluster_test VALUES ('2017-01-22T09:00:01', 19.5, 3);
 -- Show clustered indexes
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
-WHERE indisclustered = true;
+WHERE indisclustered = true ORDER BY 1;
                           indexrelid                          | indisclustered 
 --------------------------------------------------------------+----------------
- _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx | t
- _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx | t
  cluster_test_time_idx                                        | t
+ _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx | t
 (3 rows)
 
 -- Recluster just our table
@@ -54,12 +54,12 @@ INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 -- Show clustered indexes, including new chunk
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
-WHERE indisclustered = true;
+WHERE indisclustered = true ORDER BY 1;
                           indexrelid                          | indisclustered 
 --------------------------------------------------------------+----------------
- _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx | t
- _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx | t
  cluster_test_time_idx                                        | t
+ _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx | t
  _timescaledb_internal._hyper_1_3_chunk_cluster_test_time_idx | t
 (4 rows)
 
@@ -87,13 +87,13 @@ INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 -- Show updated clustered indexes
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
-WHERE indisclustered = true;
+WHERE indisclustered = true ORDER BY 1;
                         indexrelid                        | indisclustered 
 ----------------------------------------------------------+----------------
- _timescaledb_internal._hyper_1_3_chunk_time_location_idx | t
- _timescaledb_internal._hyper_1_2_chunk_time_location_idx | t
- _timescaledb_internal._hyper_1_1_chunk_time_location_idx | t
  cluster_test_time_location_idx                           | t
+ _timescaledb_internal._hyper_1_1_chunk_time_location_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_time_location_idx | t
+ _timescaledb_internal._hyper_1_3_chunk_time_location_idx | t
 (4 rows)
 
 --check the setting of cluster indexes on hypertables and chunks

--- a/test/sql/cluster.sql
+++ b/test/sql/cluster.sql
@@ -23,7 +23,7 @@ INSERT INTO cluster_test VALUES ('2017-01-22T09:00:01', 19.5, 3);
 -- Show clustered indexes
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
-WHERE indisclustered = true;
+WHERE indisclustered = true ORDER BY 1;
 
 -- Recluster just our table
 CLUSTER VERBOSE cluster_test;
@@ -31,7 +31,7 @@ CLUSTER VERBOSE cluster_test;
 -- Show clustered indexes, including new chunk
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
-WHERE indisclustered = true;
+WHERE indisclustered = true ORDER BY 1;
 
 -- Recluster all tables (although will only be our test table)
 CLUSTER VERBOSE;
@@ -44,7 +44,7 @@ CLUSTER VERBOSE cluster_test using cluster_test_time_location_idx;
 -- Show updated clustered indexes
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
-WHERE indisclustered = true;
+WHERE indisclustered = true ORDER BY 1;
 
 --check the setting of cluster indexes on hypertables and chunks
 ALTER TABLE cluster_test CLUSTER ON cluster_test_time_idx;


### PR DESCRIPTION
Adding ORDER BY to some select statements in cluster.sql test to ensure determinism.