### PR TITLE
set client_min_messages to 'error' not 'fatal'

### DIFF
--- a/test/expected/plan_hashagg_results_x_diff.out
+++ b/test/expected/plan_hashagg_results_x_diff.out
@@ -3,6 +3,8 @@
 -- This file is licensed under the Apache License,
 -- see LICENSE-APACHE at the top level directory.
 \set ECHO errors
+psql:include/plan_hashagg_query.sql:61: ERROR:  timestamp units "invalid" not recognized
+psql:include/plan_hashagg_query.sql:61: ERROR:  timestamp units "invalid" not recognized
  ?column? 
 ----------
  Done

--- a/test/sql/plan_expand_hypertable_results_diff.sql
+++ b/test/sql/plan_expand_hypertable_results_diff.sql
@@ -21,7 +21,7 @@ RESET client_min_messages;
 \o
 
 --generate the results into two different files
-SET client_min_messages = 'fatal';
+SET client_min_messages = 'error';
 \set ECHO none
 --make output contain query results
 \set PREFIX ''

--- a/test/sql/plan_hashagg_results_x_diff.sql
+++ b/test/sql/plan_hashagg_results_x_diff.sql
@@ -11,7 +11,7 @@ RESET client_min_messages;
 \o
 
 --generate the results into two different files
-SET client_min_messages = 'fatal';
+SET client_min_messages = 'error';
 \set ECHO none
 --make output contain query results
 \set PREFIX ''


### PR DESCRIPTION
after postgres commit c09daa9104099422ea998e0398934ca82eb37898 'fatal' is either not valid
or replaced by 'error'.