### PR TITLE
Clean up catalog code

### DIFF
--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -38,6 +38,7 @@ extern BgwJob *bgw_job_find(int job_id, MemoryContext mctx);
 extern bool bgw_job_has_timeout(BgwJob *job);
 extern TimestampTz bgw_job_timeout_at(BgwJob *job, TimestampTz start_time);
 
+bool		bgw_job_delete_by_id(int32 job_id);
 
 bool		bgw_job_execute(BgwJob *job);
 

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -46,8 +46,8 @@ bgw_job_stat_scan_one(int indexid, ScanKeyData scankey[], int nkeys,
 {
 	Catalog    *catalog = catalog_get();
 	ScannerCtx	scanctx = {
-		.table = catalog->tables[BGW_JOB_STAT].id,
-		.index = CATALOG_INDEX(catalog, BGW_JOB_STAT, indexid),
+		.table = catalog_get_table_id(catalog, BGW_JOB_STAT),
+		.index = catalog_get_index(catalog, BGW_JOB_STAT, indexid),
 		.nkeys = nkeys,
 		.scankey = scankey,
 		.tuple_found = tuple_found,
@@ -282,7 +282,7 @@ bgw_job_stat_insert_mark_start_relation(Relation rel,
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_total_crashes)] = Int64GetDatum(1);
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_consecutive_crashes)] = Int32GetDatum(1);
 
-	catalog_become_owner(catalog_get(), &sec_ctx);
+	catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 	catalog_insert_values(rel, desc, values, nulls);
 	catalog_restore_user(&sec_ctx);
 
@@ -296,7 +296,7 @@ bgw_job_stat_insert_mark_start(int32 bgw_job_id)
 	Relation	rel;
 	bool		result;
 
-	rel = heap_open(catalog->tables[BGW_JOB_STAT].id, RowExclusiveLock);
+	rel = heap_open(catalog_get_table_id(catalog, BGW_JOB_STAT), RowExclusiveLock);
 	result = bgw_job_stat_insert_mark_start_relation(rel, bgw_job_id);
 	heap_close(rel, RowExclusiveLock);
 

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -794,7 +794,7 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 
 	/* Update the hypertable entry */
 	ht->fd.chunk_target_size = info.target_size_bytes;
-	catalog_become_owner(catalog_get(), &sec_ctx);
+	catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 	hypertable_update(ht);
 	catalog_restore_user(&sec_ctx);
 

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -98,7 +98,7 @@ chunk_constraint_choose_name(Name dst,
 
 		Assert(hypertable_constraint_name != NULL);
 
-		catalog_become_owner(catalog_get(), &sec_ctx);
+		catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 		snprintf(constrname,
 				 100,
 				 "%d_" INT64_FORMAT "_%s",
@@ -188,9 +188,9 @@ chunk_constraints_insert(ChunkConstraints *ccs)
 	Relation	rel;
 	int			i;
 
-	rel = heap_open(catalog->tables[CHUNK_CONSTRAINT].id, RowExclusiveLock);
+	rel = heap_open(catalog_get_table_id(catalog, CHUNK_CONSTRAINT), RowExclusiveLock);
 
-	catalog_become_owner(catalog_get(), &sec_ctx);
+	catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 
 	for (i = 0; i < ccs->num_constraints; i++)
 		chunk_constraint_insert_relation(rel, &ccs->constraints[i]);
@@ -209,9 +209,9 @@ chunk_constraint_insert(ChunkConstraint *constraint)
 	CatalogSecurityContext sec_ctx;
 	Relation	rel;
 
-	rel = heap_open(catalog->tables[CHUNK_CONSTRAINT].id, RowExclusiveLock);
+	rel = heap_open(catalog_get_table_id(catalog, CHUNK_CONSTRAINT), RowExclusiveLock);
 
-	catalog_become_owner(catalog_get(), &sec_ctx);
+	catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 	chunk_constraint_insert_relation(rel, constraint);
 	catalog_restore_user(&sec_ctx);
 	heap_close(rel, RowExclusiveLock);
@@ -263,11 +263,11 @@ chunk_constraint_create_on_table(ChunkConstraint *cc, Oid chunk_oid)
 
 	chunk_constraint_fill_tuple_values(cc, values, nulls);
 
-	rel = RelationIdGetRelation(catalog_table_get_id(catalog_get(), CHUNK_CONSTRAINT));
+	rel = RelationIdGetRelation(catalog_get_table_id(catalog_get(), CHUNK_CONSTRAINT));
 	tuple = heap_form_tuple(RelationGetDescr(rel), values, nulls);
 	RelationClose(rel);
 
-	catalog_become_owner(catalog_get(), &sec_ctx);
+	catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 	CatalogInternalCall1(DDL_ADD_CHUNK_CONSTRAINT, HeapTupleGetDatum(tuple));
 	catalog_restore_user(&sec_ctx);
 
@@ -382,8 +382,8 @@ chunk_constraint_scan_internal(int indexid,
 {
 	Catalog    *catalog = catalog_get();
 	ScannerCtx	scanctx = {
-		.table = catalog->tables[CHUNK_CONSTRAINT].id,
-		.index = CATALOG_INDEX(catalog, CHUNK_CONSTRAINT, indexid),
+		.table = catalog_get_table_id(catalog, CHUNK_CONSTRAINT),
+		.index = catalog_get_index(catalog, CHUNK_CONSTRAINT, indexid),
 		.nkeys = nkeys,
 		.scankey = scankey,
 		.data = data,

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -331,7 +331,7 @@ chunk_index_insert_relation(Relation rel,
 	values[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_index_name)] =
 		DirectFunctionCall1(namein, CStringGetDatum(parent_index));
 
-	catalog_become_owner(catalog_get(), &sec_ctx);
+	catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 	catalog_insert_values(rel, desc, values, nulls);
 	catalog_restore_user(&sec_ctx);
 
@@ -351,7 +351,7 @@ chunk_index_insert(int32 chunk_id,
 	Relation	rel;
 	bool		result;
 
-	rel = heap_open(catalog->tables[CHUNK_INDEX].id, RowExclusiveLock);
+	rel = heap_open(catalog_get_table_id(catalog, CHUNK_INDEX), RowExclusiveLock);
 	result = chunk_index_insert_relation(rel, chunk_id, chunk_index, hypertable_id, hypertable_index);
 	heap_close(rel, RowExclusiveLock);
 
@@ -517,8 +517,8 @@ chunk_index_scan(int indexid, ScanKeyData scankey[], int nkeys,
 {
 	Catalog    *catalog = catalog_get();
 	ScannerCtx	scanCtx = {
-		.table = catalog->tables[CHUNK_INDEX].id,
-		.index = CATALOG_INDEX(catalog, CHUNK_INDEX, indexid),
+		.table = catalog_get_table_id(catalog, CHUNK_INDEX),
+		.index = catalog_get_index(catalog, CHUNK_INDEX, indexid),
 		.nkeys = nkeys,
 		.scankey = scankey,
 		.tuple_found = tuple_found,

--- a/src/installation_metadata.c
+++ b/src/installation_metadata.c
@@ -100,8 +100,8 @@ installation_metadata_get_value_internal(Datum metadata_key,
 	};
 	Catalog    *catalog = catalog_get();
 	ScannerCtx	scanctx = {
-		.table = catalog->tables[INSTALLATION_METADATA].id,
-		.index = CATALOG_INDEX(catalog, INSTALLATION_METADATA, INSTALLATION_METADATA_PKEY_IDX),
+		.table = catalog_get_table_id(catalog, INSTALLATION_METADATA),
+		.index = catalog_get_index(catalog, INSTALLATION_METADATA, INSTALLATION_METADATA_PKEY_IDX),
 		.nkeys = 1,
 		.scankey = scankey,
 		.tuple_found = installation_metadata_tuple_get_value,
@@ -152,7 +152,7 @@ installation_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_va
 	Catalog    *catalog = catalog_get();
 	Relation	rel;
 
-	rel = heap_open(catalog->tables[INSTALLATION_METADATA].id, ShareRowExclusiveLock);
+	rel = heap_open(catalog_get_table_id(catalog, INSTALLATION_METADATA), ShareRowExclusiveLock);
 
 	/* Check for row existence while we have the lock */
 	existing_value = installation_metadata_get_value_internal(metadata_key,

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1178,7 +1178,7 @@ process_index_end(Node *parsetree, CollectedCommand *cmd)
 		 * Change user since chunk's are typically located in an internal
 		 * schema and chunk indexes require metadata changes
 		 */
-		catalog_become_owner(catalog_get(), &sec_ctx);
+		catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 
 		/* Recurse to each chunk and create a corresponding index */
 		foreach_chunk(ht, process_index_chunk, &info);
@@ -2081,7 +2081,7 @@ process_drop_table_constraint(EventTriggerDropObject *obj)
 	{
 		CatalogSecurityContext sec_ctx;
 
-		catalog_become_owner(catalog_get(), &sec_ctx);
+		catalog_database_info_become_owner(catalog_database_info_get(), &sec_ctx);
 
 		/* Recurse to each chunk and drop the corresponding constraint */
 		foreach_chunk(ht, process_drop_constraint_on_chunk, constraint->constraint_name);


### PR DESCRIPTION
Organize catalog.c so that functions that access the Catalog struct are physically separate from the functions that modify the actual catalog tables on disk. Also added macros and made static some functions that aren't used outside the catalog files. Also refactored out the CatalogDatabaseInfo struct, which is independent of the Catalog struct and will be reused in the future.