### PR TITLE
Add convenience function to show all hypertables

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCE_FILES
   cache.sql
   bgw_scheduler.sql
   installation_metadata.sql
+  views.sql
 )
 
 # These files should be pre-pended to update scripts so that they are

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -1,0 +1,26 @@
+-- Copyright (c) 2016-2018  Timescale, Inc. All Rights Reserved.
+--
+-- This file is licensed under the Apache License, see LICENSE-APACHE
+-- at the top level directory of the TimescaleDB distribution.
+
+
+-- Convenience view to list all hypertables and their space usage
+CREATE OR REPLACE VIEW information_schema._timescaledb_hypertables AS
+  SELECT ht.schema_name,
+    ht.table_name,
+    ht.num_dimensions,
+    (SELECT count(1)
+     FROM _timescaledb_catalog.chunk ch
+     WHERE ch.hypertable_id=ht.id
+    ) AS num_chunks,
+    size.table_size,
+    size.index_size,
+    size.toast_size,
+    size.total_size
+  FROM _timescaledb_catalog.hypertable ht,
+    @extschema@.hypertable_relation_size_pretty(
+      format('%I.%I',ht.schema_name,ht.table_name)
+    ) size
+  WHERE
+    has_schema_privilege(ht.schema_name, 'USAGE');
+

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -488,9 +488,10 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         deptype = 'e' AND
         classid='pg_catalog.pg_class'::pg_catalog.regclass
         AND objid NOT IN (select unnest(extconfig) from pg_extension where extname='timescaledb');
-                 objid                  
-----------------------------------------
+                    objid                    
+---------------------------------------------
+ information_schema._timescaledb_hypertables
  _timescaledb_internal.bgw_job_stat
  _timescaledb_catalog.tablespace_id_seq
-(2 rows)
+(3 rows)
 


### PR DESCRIPTION
```
foo=# select * from show_hypertables();
 schema_name | table_name | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size
-------------+------------+----------------+------------+------------+------------+------------+------------
 public      | devices    |              1 |          5 | 4855 MB    | 6894 MB    |            | 11 GB
(1 row)
```