### PR TITLE
Fix NULL handling in multiple functions and add calls with NULL arguments to tests

### DIFF
--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -25,9 +25,9 @@ ON CONFLICT (id) DO NOTHING;
 CREATE OR REPLACE FUNCTION insert_job(application_name NAME, job_type NAME, schedule_interval INTERVAL, max_runtime INTERVAL, max_retries INTEGER, retry_period INTERVAL)
 RETURNS VOID
 AS '@MODULE_PATHNAME@', 'ts_bgw_job_insert_relation'
-LANGUAGE C VOLATILE;
+LANGUAGE C VOLATILE STRICT;
 
 CREATE OR REPLACE FUNCTION delete_job(job_id INTEGER)
 RETURNS VOID
 AS '@MODULE_PATHNAME@', 'ts_bgw_job_delete_by_id'
-LANGUAGE C VOLATILE;
+LANGUAGE C VOLATILE STRICT;

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -25,7 +25,7 @@ RETURNS TABLE (table_bytes BIGINT,
                index_bytes BIGINT,
                toast_bytes BIGINT,
                total_bytes BIGINT
-               ) LANGUAGE PLPGSQL STABLE
+               ) LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
 DECLARE
@@ -102,7 +102,7 @@ $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.partitioning_column_to_pretty(
     d   _timescaledb_catalog.dimension
 )
-    RETURNS TEXT LANGUAGE PLPGSQL STABLE AS
+    RETURNS TEXT LANGUAGE PLPGSQL STABLE STRICT AS
 $BODY$
 DECLARE
 BEGIN
@@ -133,7 +133,7 @@ CREATE OR REPLACE FUNCTION hypertable_relation_size_pretty(
 RETURNS TABLE (table_size  TEXT,
                index_size  TEXT,
                toast_size  TEXT,
-               total_size  TEXT) LANGUAGE PLPGSQL STABLE
+               total_size  TEXT) LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
 DECLARE
@@ -182,7 +182,7 @@ RETURNS TABLE (chunk_id INT,
                index_bytes BIGINT,
                toast_bytes BIGINT,
                total_bytes BIGINT)
-               LANGUAGE PLPGSQL STABLE
+               LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
 DECLARE
@@ -281,7 +281,7 @@ RETURNS TABLE (chunk_id INT,
                toast_size  TEXT,
                total_size  TEXT
                )
-               LANGUAGE PLPGSQL STABLE
+               LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
 DECLARE
@@ -363,7 +363,7 @@ CREATE OR REPLACE FUNCTION indexes_relation_size(
 )
 RETURNS TABLE (index_name TEXT,
                total_bytes BIGINT)
-               LANGUAGE PLPGSQL STABLE
+               LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
 <<main>>
@@ -410,7 +410,7 @@ CREATE OR REPLACE FUNCTION indexes_relation_size_pretty(
     main_table              REGCLASS
 )
 RETURNS TABLE (index_name TEXT,
-               total_size TEXT) LANGUAGE PLPGSQL STABLE
+               total_size TEXT) LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
 BEGIN

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -739,6 +739,11 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 	Datum		values[2];
 	bool		nulls[2] = {false, false};
 
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid hypertable: cannot be NULL")));
+
 	if (!OidIsValid(info.table_relid))
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_TABLE),

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -858,6 +858,11 @@ ts_dimension_set_num_slices(PG_FUNCTION_ARGS)
 	Name		colname = PG_ARGISNULL(2) ? NULL : PG_GETARG_NAME(2);
 	int16		num_slices;
 
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid main_table: cannot be NULL")));
+
 	hypertable_permissions_check(table_relid, GetUserId());
 
 	if (PG_ARGISNULL(1) || !IS_VALID_NUM_SLICES(num_slices_arg))
@@ -880,12 +885,28 @@ ts_dimension_set_num_slices(PG_FUNCTION_ARGS)
 
 TS_FUNCTION_INFO_V1(ts_dimension_set_interval);
 
+/*
+ * Update chunk_time_interval for a hypertable.
+ *
+ * main_table - The OID of the table corresponding to a hypertable whose time
+ *     interval should be updated
+ * chunk_time_interval - The new time interval. For hypertables with integral
+ *     time columns, this must be an integral type. For hypertables with a
+ *     TIMESTAMP/TIMESTAMPTZ/DATE type, it can be integral which is treated as
+ *     microseconds, or an INTERVAL type.
+ * dimension_name - The name of the dimension
+ */
 Datum
 ts_dimension_set_interval(PG_FUNCTION_ARGS)
 {
 	Oid			table_relid = PG_GETARG_OID(0);
 	Datum		interval = PG_GETARG_DATUM(1);
 	Name		colname = PG_ARGISNULL(2) ? NULL : PG_GETARG_NAME(2);
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid main_table: cannot be NULL")));
 
 	hypertable_permissions_check(table_relid, GetUserId());
 
@@ -1065,6 +1086,11 @@ ts_dimension_add(PG_FUNCTION_ARGS)
 		.if_not_exists = PG_ARGISNULL(5) ? false : PG_GETARG_BOOL(5),
 	};
 	Datum		retval = 0;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid main_table: cannot be NULL")));
 
 	hypertable_permissions_check(info.table_relid, GetUserId());
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1280,6 +1280,16 @@ ts_hypertable_create(PG_FUNCTION_ARGS)
 	Relation	rel;
 	Datum		retval;
 
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid main_table: cannot be NULL")));
+
+	if (PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid time_column_name: cannot be NULL")));
+
 	/* quick exit in the easy if-not-exists case to avoid all locking */
 	if (if_not_exists && is_hypertable(table_relid))
 	{

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -1040,6 +1040,13 @@ SELECT delete_job(x.id) FROM (select * from _timescaledb_config.bgw_job) x;
  
 (1 row)
 
+-- test null handling in delete_job
+SELECT delete_job(NULL);
+ delete_job 
+------------
+ 
+(1 row)
+
 SELECT ts_bgw_params_reset_time(200000, true);
  ts_bgw_params_reset_time 
 --------------------------
@@ -1148,5 +1155,11 @@ select * from _timescaledb_internal.bgw_job_stat;
  job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
 --------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
    1026 | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.49 1999 PST | t                |          2 | @ 0            |               2 |              0 |             0 |                    0 |                   0
+(1 row)
+
+SELECT * FROM insert_job(NULL,NULL,NULL,NULL,NULL,NULL);
+ insert_job 
+------------
+ 
 (1 row)
 

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -34,6 +34,11 @@ SELECT * FROM test.set_memory_cache_size('2GB');
             2147483648
 (1 row)
 
+-- test NULL handling
+\set ON_ERROR_STOP 0
+SELECT * FROM set_adaptive_chunking(NULL,NULL);
+ERROR:  invalid hypertable: cannot be NULL
+\set ON_ERROR_STOP 1
 CREATE TABLE test_adaptive(time timestamptz, temp float, location int);
 \set ON_ERROR_STOP 0
 -- Bad signature of sizing func should fail

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -207,6 +207,8 @@ ORDER BY d.id;
 (2 rows)
 
 \set ON_ERROR_STOP 0
+select set_chunk_time_interval(NULL,NULL::interval);
+ERROR:  invalid main_table: cannot be NULL
 -- should fail since time column is an int
 SELECT set_chunk_time_interval('chunk_test', INTERVAL '1 minute');
 ERROR:  invalid interval: must be an integer type for integer dimensions

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -9,6 +9,10 @@ CREATE TABLE PUBLIC."Hypertable_1" (
 );
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
 \set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable(NULL, NULL);
+ERROR:  invalid main_table: cannot be NULL
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', NULL);
+ERROR:  invalid time_column_name: cannot be NULL
 SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  relation "public.Hypertable_1_mispelled" does not exist at character 33
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
@@ -122,4 +126,16 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_rule"', 'time', chunk_ti
 \set ON_ERROR_STOP 0
 CREATE RULE notify_me AS ON UPDATE TO "Hypertable_1_rule" DO ALSO NOTIFY "Hypertable_1_rule";
 ERROR:  hypertables do not support rules
+\set ON_ERROR_STOP 1
 \set ON_ERROR_STOP 0
+SELECT add_dimension(NULL,NULL);
+ERROR:  invalid main_table: cannot be NULL
+\set ON_ERROR_STOP 1
+\set ON_ERROR_STOP 0
+SELECT attach_tablespace(NULL,NULL);
+ERROR:  invalid tablespace name
+\set ON_ERROR_STOP 1
+\set ON_ERROR_STOP 0
+select set_number_partitions(NULL,NULL);
+ERROR:  invalid main_table: cannot be NULL
+\set ON_ERROR_STOP 1

--- a/test/expected/drop_chunks.out
+++ b/test/expected/drop_chunks.out
@@ -144,6 +144,10 @@ CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chu
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(2);
 ERROR:  cannot drop table _timescaledb_internal._hyper_1_1_chunk because other objects depend on it
+SELECT drop_chunks(NULL::interval);
+ERROR:  can only use drop_chunks with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
+SELECT drop_chunks(NULL::int);
+ERROR:  the timestamp provided to drop_chunks cannot be NULL
 \set ON_ERROR_STOP 1
 -- show created constraints and dimension slices for each chunk
 SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -209,3 +209,43 @@ SELECT * FROM hypertable_approximate_row_count();
  public      | two_Partitions          |            0
 (5 rows)
 
+SELECT * FROM hypertable_approximate_row_count(NULL);
+ schema_name |       table_name        | row_estimate 
+-------------+-------------------------+--------------
+ public      | approx_count            |           10
+ public      | timestamp_partitioned   |            0
+ public      | timestamp_partitioned_2 |            0
+ public      | toast_test              |            0
+ public      | two_Partitions          |            0
+(5 rows)
+
+SELECT * FROM chunk_relation_size(NULL);
+ chunk_id | chunk_table | partitioning_columns | partitioning_column_types | partitioning_hash_functions | ranges | table_bytes | index_bytes | toast_bytes | total_bytes 
+----------+-------------+----------------------+---------------------------+-----------------------------+--------+-------------+-------------+-------------+-------------
+(0 rows)
+
+SELECT * FROM chunk_relation_size_pretty(NULL);
+ chunk_id | chunk_table | partitioning_columns | partitioning_column_types | partitioning_hash_functions | ranges | table_size | index_size | toast_size | total_size 
+----------+-------------+----------------------+---------------------------+-----------------------------+--------+------------+------------+------------+------------
+(0 rows)
+
+SELECT * FROM hypertable_relation_size(NULL);
+ table_bytes | index_bytes | toast_bytes | total_bytes 
+-------------+-------------+-------------+-------------
+(0 rows)
+
+SELECT * FROM hypertable_relation_size_pretty(NULL);
+ table_size | index_size | toast_size | total_size 
+------------+------------+------------+------------
+(0 rows)
+
+SELECT * FROM indexes_relation_size(NULL);
+ index_name | total_bytes 
+------------+-------------
+(0 rows)
+
+SELECT * FROM indexes_relation_size_pretty(NULL);
+ index_name | total_size 
+------------+------------
+(0 rows)
+

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -31,6 +31,8 @@ INNER JOIN _timescaledb_catalog.chunk ch ON (ch.table_name = c.relname);
 (1 row)
 
 --check some error conditions
+SELECT attach_tablespace(NULL,NULL);
+ERROR:  invalid tablespace name
 SELECT attach_tablespace('tablespace2', NULL);
 ERROR:  invalid hypertable
 SELECT attach_tablespace(NULL, 'tspace_2dim');
@@ -39,6 +41,15 @@ SELECT attach_tablespace('none_existing_tablespace', 'tspace_2dim');
 ERROR:  tablespace "none_existing_tablespace" does not exist
 SELECT attach_tablespace('tablespace2', 'none_existing_table');
 ERROR:  relation "none_existing_table" does not exist at character 41
+SELECT detach_tablespace(NULL);
+ERROR:  invalid tablespace name
+SELECT detach_tablespaces(NULL);
+ERROR:  invalid argument
+SELECT show_tablespaces(NULL);
+ show_tablespaces 
+------------------
+(0 rows)
+
 --attach another tablespace without first creating it --> should generate error
 SELECT attach_tablespace('tablespace2', 'tspace_2dim');
 ERROR:  tablespace "tablespace2" does not exist

--- a/test/sql/bgw_db_scheduler.sql
+++ b/test/sql/bgw_db_scheduler.sql
@@ -470,6 +470,9 @@ SELECT wait_for_job_1_to_run(2);
 select * from _timescaledb_internal.bgw_job_stat;
 SELECT delete_job(x.id) FROM (select * from _timescaledb_config.bgw_job) x;
 
+-- test null handling in delete_job
+SELECT delete_job(NULL);
+
 SELECT ts_bgw_params_reset_time(200000, true);
 SELECT wait_for_timer_to_run(200000);
 
@@ -495,3 +498,5 @@ SELECT ts_bgw_params_reset_time(500000, true);
 SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
 SELECT * FROM bgw_log;
 select * from _timescaledb_internal.bgw_job_stat;
+
+SELECT * FROM insert_job(NULL,NULL,NULL,NULL,NULL,NULL);

--- a/test/sql/chunk_adaptive.sql
+++ b/test/sql/chunk_adaptive.sql
@@ -33,6 +33,11 @@ $BODY$;
 -- (independent of available machine memory)
 SELECT * FROM test.set_memory_cache_size('2GB');
 
+-- test NULL handling
+\set ON_ERROR_STOP 0
+SELECT * FROM set_adaptive_chunking(NULL,NULL);
+\set ON_ERROR_STOP 1
+
 CREATE TABLE test_adaptive(time timestamptz, temp float, location int);
 
 \set ON_ERROR_STOP 0

--- a/test/sql/create_chunks.sql
+++ b/test/sql/create_chunks.sql
@@ -113,6 +113,7 @@ WHERE h.schema_name = 'public' AND h.table_name = 'chunk_test2'
 ORDER BY d.id;
 
 \set ON_ERROR_STOP 0
+select set_chunk_time_interval(NULL,NULL::interval);
 -- should fail since time column is an int
 SELECT set_chunk_time_interval('chunk_test', INTERVAL '1 minute');
 -- should fail since its not a valid way to represent time

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -282,3 +282,4 @@ select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func
 
 -- A valid function should work:
 select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_valid');
+

--- a/test/sql/ddl_errors.sql
+++ b/test/sql/ddl_errors.sql
@@ -11,6 +11,8 @@ CREATE TABLE PUBLIC."Hypertable_1" (
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
 
 \set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable(NULL, NULL);
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', NULL);
 SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'Device_id', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
@@ -115,4 +117,16 @@ SELECT * FROM create_hypertable('"public"."Hypertable_1_rule"', 'time', chunk_ti
 
 \set ON_ERROR_STOP 0
 CREATE RULE notify_me AS ON UPDATE TO "Hypertable_1_rule" DO ALSO NOTIFY "Hypertable_1_rule";
+\set ON_ERROR_STOP 1
+
 \set ON_ERROR_STOP 0
+SELECT add_dimension(NULL,NULL);
+\set ON_ERROR_STOP 1
+
+\set ON_ERROR_STOP 0
+SELECT attach_tablespace(NULL,NULL);
+\set ON_ERROR_STOP 1
+
+\set ON_ERROR_STOP 0
+select set_number_partitions(NULL,NULL);
+\set ON_ERROR_STOP 1

--- a/test/sql/drop_chunks.sql
+++ b/test/sql/drop_chunks.sql
@@ -63,6 +63,8 @@ CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chu
 
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(2);
+SELECT drop_chunks(NULL::interval);
+SELECT drop_chunks(NULL::int);
 \set ON_ERROR_STOP 1
 
 -- show created constraints and dimension slices for each chunk

--- a/test/sql/size_utils.sql
+++ b/test/sql/size_utils.sql
@@ -59,3 +59,12 @@ SELECT * FROM hypertable_approximate_row_count('approx_count');
 
 -- all hypertables
 SELECT * FROM hypertable_approximate_row_count();
+SELECT * FROM hypertable_approximate_row_count(NULL);
+
+SELECT * FROM chunk_relation_size(NULL);
+SELECT * FROM chunk_relation_size_pretty(NULL);
+SELECT * FROM hypertable_relation_size(NULL);
+SELECT * FROM hypertable_relation_size_pretty(NULL);
+SELECT * FROM indexes_relation_size(NULL);
+SELECT * FROM indexes_relation_size_pretty(NULL);
+

--- a/test/sql/tablespace.sql
+++ b/test/sql/tablespace.sql
@@ -27,10 +27,14 @@ INNER JOIN pg_tablespace t ON (c.reltablespace = t.oid)
 INNER JOIN _timescaledb_catalog.chunk ch ON (ch.table_name = c.relname);
 
 --check some error conditions
+SELECT attach_tablespace(NULL,NULL);
 SELECT attach_tablespace('tablespace2', NULL);
 SELECT attach_tablespace(NULL, 'tspace_2dim');
 SELECT attach_tablespace('none_existing_tablespace', 'tspace_2dim');
 SELECT attach_tablespace('tablespace2', 'none_existing_table');
+SELECT detach_tablespace(NULL);
+SELECT detach_tablespaces(NULL);
+SELECT show_tablespaces(NULL);
 
 --attach another tablespace without first creating it --> should generate error
 SELECT attach_tablespace('tablespace2', 'tspace_2dim');


### PR DESCRIPTION
Change hypertable_relation_size, hypertable_relation_size_pretty, chunk_relation_size, chunk_relation_size_pretty, indexes_relation_size, indexes_relation_size_pretty, partitioning_column_to_pretty ,insert_job and delete_job to STRICT

Add checks for NULL arguments to ts_chunk_adaptive_set,
ts_dimension_set_num_slices, ts_dimension_set_interval,
ts_dimension_add and ts_hypertable_create