### PR TITLE
Add view to show hypertable information

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCE_FILES
   cache.sql
   bgw_scheduler.sql
   installation_metadata.sql
+  views.sql
 )
 
 # These files should be pre-pended to update scripts so that they are

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -1,0 +1,30 @@
+-- Copyright (c) 2016-2018  Timescale, Inc. All Rights Reserved.
+--
+-- This file is licensed under the Apache License, see LICENSE-APACHE
+-- at the top level directory of the TimescaleDB distribution.
+
+CREATE SCHEMA IF NOT EXISTS timescaledb_information;
+
+-- Convenience view to list all hypertables and their space usage
+CREATE OR REPLACE VIEW timescaledb_information.hypertable AS
+  SELECT ht.schema_name AS table_schema,
+    ht.table_name,
+    t.tableowner AS table_owner,
+    ht.num_dimensions,
+    (SELECT count(1)
+     FROM _timescaledb_catalog.chunk ch
+     WHERE ch.hypertable_id=ht.id
+    ) AS num_chunks,
+    size.table_size,
+    size.index_size,
+    size.toast_size,
+    size.total_size
+  FROM _timescaledb_catalog.hypertable ht
+    LEFT OUTER JOIN pg_tables t ON ht.table_name=t.tablename AND ht.schema_name=t.schemaname
+    LEFT OUTER JOIN LATERAL @extschema@.hypertable_relation_size_pretty(
+      CASE WHEN has_schema_privilege(ht.schema_name,'USAGE') THEN format('%I.%I',ht.schema_name,ht.table_name) ELSE NULL END
+    ) size ON true;
+
+GRANT USAGE ON SCHEMA timescaledb_information TO PUBLIC;
+GRANT SELECT ON ALL TABLES IN SCHEMA timescaledb_information TO PUBLIC;
+

--- a/test/expected/loader.out
+++ b/test/expected/loader.out
@@ -18,6 +18,7 @@ SELECT 1;
         1
 (1 row)
 
+\c single :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 WARNING:  mock init "mock-1"
 SELECT 1;

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -490,7 +490,8 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         AND objid NOT IN (select unnest(extconfig) from pg_extension where extname='timescaledb');
                  objid                  
 ----------------------------------------
+ timescaledb_information.hypertable
  _timescaledb_internal.bgw_job_stat
  _timescaledb_catalog.tablespace_id_seq
-(2 rows)
+(3 rows)
 

--- a/test/expected/views.out
+++ b/test/expected/views.out
@@ -1,0 +1,99 @@
+-- Copyright (c) 2016-2018  Timescale, Inc. All Rights Reserved.
+--
+-- This file is licensed under the Apache License,
+-- see LICENSE-APACHE at the top level directory.
+SELECT * FROM timescaledb_information.hypertable;
+ table_schema | table_name | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
+--------------+------------+-------------+----------------+------------+------------+------------+------------+------------
+(0 rows)
+
+-- create simple hypertable with 1 chunk
+CREATE TABLE ht1(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('ht1','time');
+ create_hypertable 
+-------------------
+ (1,public,ht1,t)
+(1 row)
+
+INSERT INTO ht1 SELECT '2000-01-01'::TIMESTAMPTZ;
+-- create simple hypertable with 1 chunk and toasted data
+CREATE TABLE ht2(time TIMESTAMPTZ NOT NULL, data TEXT);
+SELECT create_hypertable('ht2','time');
+ create_hypertable 
+-------------------
+ (2,public,ht2,t)
+(1 row)
+
+INSERT INTO ht2 SELECT '2000-01-01'::TIMESTAMPTZ, repeat('8k',4096);
+SELECT * FROM timescaledb_information.hypertable;
+ table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
+--------------+------------+-------------------+----------------+------------+------------+------------+------------+------------
+ public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB
+ public       | ht2        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      | 8192 bytes | 32 kB
+(2 rows)
+
+\c single :ROLE_SUPERUSER
+-- create schema open and hypertable with 3 chunks
+CREATE SCHEMA open;
+GRANT USAGE ON SCHEMA open TO :ROLE_DEFAULT_PERM_USER;
+CREATE TABLE open.open_ht(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('open.open_ht','time');
+ create_hypertable  
+--------------------
+ (3,open,open_ht,t)
+(1 row)
+
+INSERT INTO open.open_ht SELECT '2000-01-01'::TIMESTAMPTZ;
+INSERT INTO open.open_ht SELECT '2001-01-01'::TIMESTAMPTZ;
+INSERT INTO open.open_ht SELECT '2002-01-01'::TIMESTAMPTZ;
+-- create schema closed and hypertable
+CREATE SCHEMA closed;
+CREATE TABLE closed.closed_ht(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('closed.closed_ht','time');
+   create_hypertable    
+------------------------
+ (4,closed,closed_ht,t)
+(1 row)
+
+INSERT INTO closed.closed_ht SELECT '2000-01-01'::TIMESTAMPTZ;
+SELECT * FROM timescaledb_information.hypertable;
+ table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
+--------------+------------+-------------------+----------------+------------+------------+------------+------------+------------
+ public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB
+ public       | ht2        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      | 8192 bytes | 32 kB
+ open         | open_ht    | super_user        |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB
+ closed       | closed_ht  | super_user        |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB
+(4 rows)
+
+\c single :ROLE_DEFAULT_PERM_USER
+SELECT * FROM timescaledb_information.hypertable;
+ table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
+--------------+------------+-------------------+----------------+------------+------------+------------+------------+------------
+ public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB
+ public       | ht2        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      | 8192 bytes | 32 kB
+ open         | open_ht    | super_user        |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB
+ closed       | closed_ht  | super_user        |              1 |          1 |            |            |            | 
+(4 rows)
+
+-- filter by schema
+SELECT * FROM timescaledb_information.hypertable WHERE table_schema = 'closed';
+ table_schema | table_name | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
+--------------+------------+-------------+----------------+------------+------------+------------+------------+------------
+ closed       | closed_ht  | super_user  |              1 |          1 |            |            |            | 
+(1 row)
+
+-- filter by table name
+SELECT * FROM timescaledb_information.hypertable WHERE table_name = 'ht1';
+ table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
+--------------+------------+-------------------+----------------+------------+------------+------------+------------+------------
+ public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB
+(1 row)
+
+-- filter by owner
+SELECT * FROM timescaledb_information.hypertable WHERE table_owner = 'super_user';
+ table_schema | table_name | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
+--------------+------------+-------------+----------------+------------+------------+------------+------------+------------
+ open         | open_ht    | super_user  |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB
+ closed       | closed_ht  | super_user  |              1 |          1 |            |            |            | 
+(2 rows)
+

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -21,6 +21,7 @@ file(READ
 
 # Tests to ignore
 set(PG_IGNORE_TESTS
+  rules
   tablespace
   opr_sanity
   sanity_check)

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -56,7 +56,9 @@ set(TEST_FILES
   upsert.sql
   util.sql
   vacuum.sql
-  version.sql)
+  version.sql
+  views.sql
+)
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES

--- a/test/sql/loader.sql
+++ b/test/sql/loader.sql
@@ -10,6 +10,7 @@ DROP EXTENSION timescaledb;
 \dx
 SELECT 1;
 
+\c single :ROLE_SUPERUSER
 CREATE EXTENSION timescaledb VERSION 'mock-1';
 SELECT 1;
 \dx

--- a/test/sql/views.sql
+++ b/test/sql/views.sql
@@ -1,0 +1,50 @@
+-- Copyright (c) 2016-2018  Timescale, Inc. All Rights Reserved.
+--
+-- This file is licensed under the Apache License,
+-- see LICENSE-APACHE at the top level directory.
+
+SELECT * FROM timescaledb_information.hypertable;
+
+-- create simple hypertable with 1 chunk
+CREATE TABLE ht1(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('ht1','time');
+INSERT INTO ht1 SELECT '2000-01-01'::TIMESTAMPTZ;
+
+-- create simple hypertable with 1 chunk and toasted data
+CREATE TABLE ht2(time TIMESTAMPTZ NOT NULL, data TEXT);
+SELECT create_hypertable('ht2','time');
+INSERT INTO ht2 SELECT '2000-01-01'::TIMESTAMPTZ, repeat('8k',4096);
+
+SELECT * FROM timescaledb_information.hypertable;
+
+\c single :ROLE_SUPERUSER
+
+-- create schema open and hypertable with 3 chunks
+CREATE SCHEMA open;
+GRANT USAGE ON SCHEMA open TO :ROLE_DEFAULT_PERM_USER;
+CREATE TABLE open.open_ht(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('open.open_ht','time');
+INSERT INTO open.open_ht SELECT '2000-01-01'::TIMESTAMPTZ;
+INSERT INTO open.open_ht SELECT '2001-01-01'::TIMESTAMPTZ;
+INSERT INTO open.open_ht SELECT '2002-01-01'::TIMESTAMPTZ;
+
+-- create schema closed and hypertable
+CREATE SCHEMA closed;
+CREATE TABLE closed.closed_ht(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('closed.closed_ht','time');
+INSERT INTO closed.closed_ht SELECT '2000-01-01'::TIMESTAMPTZ;
+
+SELECT * FROM timescaledb_information.hypertable;
+
+\c single :ROLE_DEFAULT_PERM_USER
+SELECT * FROM timescaledb_information.hypertable;
+
+-- filter by schema
+SELECT * FROM timescaledb_information.hypertable WHERE table_schema = 'closed';
+
+-- filter by table name
+SELECT * FROM timescaledb_information.hypertable WHERE table_name = 'ht1';
+
+-- filter by owner
+SELECT * FROM timescaledb_information.hypertable WHERE table_owner = 'super_user';
+


### PR DESCRIPTION
Add information_schema._timescaledb_hypertables view that lists
hypertables, their owner, number of chunks and storage size

```
SELECT * FROM timescaledb_information.hypertable;
 table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size 
--------------+------------+-------------------+----------------+------------+------------+------------+------------+------------
 public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB
 public       | ht2        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      | 8192 bytes | 32 kB
 open         | open_ht    | super_user        |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB
 closed       | closed_ht  | super_user        |              1 |          1 |            |            |            | 
(4 rows)
```