### PR TITLE
Set ORS to empty string instead of NUL in license check script

### DIFF
--- a/scripts/check_file_license_apache.sh
+++ b/scripts/check_file_license_apache.sh
@@ -11,16 +11,16 @@ FIRST_COMMENT=
 
 if [[ "${FLAG}" == '-c' ]]; then
     LICENSE_FILE=${SCRIPTPATH}/c_license_header.h
-    LICENSE_STRING=`awk 'BEGIN {ORS="\0"}{if($1 == "*/") {print; exit;}} {print}' ${LICENSE_FILE}`
-    FIRST_COMMENT=`awk 'BEGIN {ORS="\0"}{if($1 == "*/") {print; exit;}} {print}' ${FILE}`
+    LICENSE_STRING=`awk 'BEGIN {ORS=""}{if($1 == "*/") {print; exit;}} {print}' ${LICENSE_FILE}`
+    FIRST_COMMENT=`awk 'BEGIN {ORS=""}{if($1 == "*/") {print; exit;}} {print}' ${FILE}`
 elif [[ "${FLAG}" == '-s' ]]; then
     LICENSE_FILE=${SCRIPTPATH}/sql_license.sql
-    LICENSE_STRING=`awk 'BEGIN {ORS="\0"}{if($1 == "") {print; exit;}} {print}' ${SCRIPTPATH}/sql_license.sql`
-    FIRST_COMMENT=`awk 'BEGIN {ORS="\0"}{if($1 == "") {print; exit;}} {print}' ${FILE}`
+    LICENSE_STRING=`awk 'BEGIN {ORS=""}{if($1 == "") {print; exit;}} {print}' ${SCRIPTPATH}/sql_license.sql`
+    FIRST_COMMENT=`awk 'BEGIN {ORS=""}{if($1 == "") {print; exit;}} {print}' ${FILE}`
 elif [[ "${FLAG}" == '-t' ]]; then
     LICENSE_FILE=${SCRIPTPATH}/test_license.sql
-    LICENSE_STRING=`awk 'BEGIN {ORS="\0"}{if($1 == "") {print; exit;}} {print}' ${SCRIPTPATH}/test_license.sql`
-    FIRST_COMMENT=`awk 'BEGIN {ORS="\0"}{if($1 == "") {print; exit;}} {print}' ${FILE}`
+    LICENSE_STRING=`awk 'BEGIN {ORS=""}{if($1 == "") {print; exit;}} {print}' ${SCRIPTPATH}/test_license.sql`
+    FIRST_COMMENT=`awk 'BEGIN {ORS=""}{if($1 == "") {print; exit;}} {print}' ${FILE}`
 else
     echo "Unkown flag" ${1}
     exit 1;


### PR DESCRIPTION
This fixes multiple warnings in bash 4.4
scripts/check_file_license_apache.sh: line 22: warning: command substitution: ignored null byte in input
and is also more correct since we dont want to inject 0-Bytes into the string
