### PR TITLE
Remove unused functions from utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -284,48 +284,6 @@ interval_from_now_to_internal(Datum interval, Oid type_oid)
 	}
 }
 
-/* Make a RangeVar from a regclass Oid */
-RangeVar *
-makeRangeVarFromRelid(Oid relid)
-{
-	Oid			namespace = get_rel_namespace(relid);
-	char	   *tableName = get_rel_name(relid);
-	char	   *schemaName = get_namespace_name(namespace);
-
-	return makeRangeVar(schemaName, tableName, -1);
-}
-
-int
-int_cmp(const void *a, const void *b)
-{
-	const int  *ia = (const int *) a;
-	const int  *ib = (const int *) b;
-
-	return *ia - *ib;
-}
-
-FmgrInfo *
-create_fmgr(char *schema, char *function_name, int num_args)
-{
-	FmgrInfo   *finfo = palloc(sizeof(FmgrInfo));
-	FuncCandidateList func_list = FuncnameGetCandidates(list_make2(makeString(schema),
-																   makeString(function_name)),
-														num_args, NULL, false, false, false);
-
-	if (func_list == NULL)
-	{
-		elog(ERROR, "could not find the function \"%s.%s\"", schema, function_name);
-	}
-	if (func_list->next != NULL)
-	{
-		elog(ERROR, "multiple functions found");
-	}
-
-	fmgr_info(func_list->oid, finfo);
-
-	return finfo;
-}
-
 /* Returns approximate period in microseconds */
 int64
 get_interval_period_approx(Interval *interval)

--- a/src/utils.h
+++ b/src/utils.h
@@ -38,9 +38,6 @@ extern int64 date_trunc_interval_period_approx(text *units);
  */
 extern int64 get_interval_period_approx(Interval *interval);
 
-extern FmgrInfo *create_fmgr(char *schema, char *function_name, int num_args);
-extern RangeVar *makeRangeVarFromRelid(Oid relid);
-extern int	int_cmp(const void *a, const void *b);
 extern Oid	inheritance_parent_relid(Oid relid);
 
 void	   *create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size);


### PR DESCRIPTION
Remove int_cmp, create_fmgr and makeRangeVarFromRelid from utils.c
since they were not used and had no test coverage.