### PR TITLE
Remove EXEC_BACKEND tests from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,13 @@ before_install:
   # We need the PostgreSQL source for running the standard PostgreSQL
   # regression tests
   - git clone --branch ${PG_GIT_TAG} --depth 1 https://github.com/postgres/postgres.git /tmp/postgres
-  - if [[ -z "$EXEC_BACKEND" ]]; then docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres postgres:${PG_VERSION}-alpine; fi
-  - if [[ -n "$EXEC_BACKEND" ]]; then docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres timescaledev/postgresdev:exec_backend-${PG_VERSION}-alpine; fi
+  - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres postgres:${PG_VERSION}-alpine
 install:
   - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake bison flex curl git openssl-dev && mkdir -p /build/debug /build/debug-nossl"
   - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted lcov"
   # We set /usr/local as prefix so the regression tools will be able to find
   # initdb, psql, and postgres
-  - docker exec -it pgbuild /bin/sh -c "cd /postgres && ./configure CPPFLAGS=\"$EXEC_BACKEND\" --prefix=/usr/local --enable-coverage --enable-debug --enable-cassert --without-readline --without-zlib"
+  - docker exec -it pgbuild /bin/sh -c "cd /postgres && ./configure --prefix=/usr/local --enable-coverage --enable-debug --enable-cassert --without-readline --without-zlib"
   # We only need to build the regress and isolation stuff
   - docker exec -it pgbuild /bin/sh -c "make -C /postgres/src/test/regress"
   - docker exec -it pgbuild /bin/sh -c "make -C /postgres/src/test/isolation"
@@ -38,10 +37,7 @@ script:
   # Now run all tests
   - docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug installcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 
-  # some of the postgres tests don't pass with EXEC_BACKEND,
-  # since this is merely a windows canary, not a real platform,
-  # we simply disable postgres tests there.
-  - if [[ -z "$EXEC_BACKEND" ]]; then docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug pginstallcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"; fi
+  - docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug pginstallcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
   - ci_env=`bash <(curl -s https://codecov.io/env)`
   - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) || echo \"Codecov did not collect coverage reports\" "
 after_failure:
@@ -80,16 +76,6 @@ jobs:
       stage: test
       name: "Regression 10"
       env: PG_VERSION=10.2 PG_GIT_TAG=REL_10_2
-
-    - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
-      stage: test
-      name: "Regression 9.6 w/ EXEC_BACKEND"
-      env: EXEC_BACKEND="-DEXEC_BACKEND=1" PG_VERSION=9.6 PG_GIT_TAG=REL9_6_6
-
-    - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
-      stage: test
-      name: "Regression 10 w/ EXEC_BACKEND"
-      env: EXEC_BACKEND="-DEXEC_BACKEND=1" PG_VERSION=10 PG_GIT_TAG=REL_10_2
 
     # This tests the ability to upgrade to the latest version from versions without constraint support
     - if: (type = pull_request) OR (type = cron)


### PR DESCRIPTION
Since we have proper windows ci now we dont need this anymore