### PR TITLE
Remove unused function from hypertable.c

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -385,27 +385,6 @@ hypertable_tuple_delete(TupleInfo *ti, void *data)
 }
 
 int
-hypertable_delete_by_id(int32 hypertable_id)
-{
-	ScanKeyData scankey[1];
-
-	ScanKeyInit(&scankey[0], Anum_hypertable_pkey_idx_id,
-				BTEqualStrategyNumber, F_INT4EQ,
-				Int32GetDatum(hypertable_id));
-
-	return hypertable_scan_limit_internal(scankey,
-										  1,
-										  HYPERTABLE_ID_INDEX,
-										  hypertable_tuple_delete,
-										  NULL,
-										  1,
-										  RowExclusiveLock,
-										  false,
-										  CurrentMemoryContext);
-}
-
-
-int
 hypertable_delete_by_name(const char *schema_name, const char *table_name)
 {
 	ScanKeyData scankey[2];

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -60,7 +60,6 @@ extern int	hypertable_update(Hypertable *ht);
 extern int	hypertable_set_name(Hypertable *ht, const char *newname);
 extern int	hypertable_set_schema(Hypertable *ht, const char *newname);
 extern int	hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
-extern int	hypertable_delete_by_id(int32 hypertable_id);
 extern int	hypertable_delete_by_name(const char *schema_name, const char *table_name);
 extern int	hypertable_reset_associated_schema_name(const char *associated_schema);
 extern Oid	hypertable_id_to_relid(int32 hypertable_id);


### PR DESCRIPTION
hypertable_delete_by_id has long since been replaced by hypertable_delete_name and isn't used anywhere in the codebase.