### PR TITLE
Add ts_ prefix to everything in headers

### DIFF
--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -27,24 +27,24 @@ typedef struct BgwJob
 typedef bool job_main_func (void);
 typedef bool (*unknown_job_type_hook_type) (BgwJob *job);
 
-BackgroundWorkerHandle *bgw_start_worker(const char *function, const char *name, const char *extra);
+extern BackgroundWorkerHandle *ts_bgw_start_worker(const char *function, const char *name, const char *extra);
 
-BackgroundWorkerHandle *bgw_job_start(BgwJob *job);
+extern BackgroundWorkerHandle *ts_bgw_job_start(BgwJob *job);
 
-extern List *bgw_job_get_all(size_t alloc_size, MemoryContext mctx);
+extern List *ts_bgw_job_get_all(size_t alloc_size, MemoryContext mctx);
 
-extern BgwJob *bgw_job_find(int job_id, MemoryContext mctx);
+extern BgwJob *ts_bgw_job_find(int job_id, MemoryContext mctx);
 
-extern bool bgw_job_has_timeout(BgwJob *job);
-extern TimestampTz bgw_job_timeout_at(BgwJob *job, TimestampTz start_time);
+extern bool ts_bgw_job_has_timeout(BgwJob *job);
+extern TimestampTz ts_bgw_job_timeout_at(BgwJob *job, TimestampTz start_time);
 
-bool		bgw_job_delete_by_id(int32 job_id);
+extern bool ts_bgw_job_delete_by_id_internal(int32 job_id);
 
-bool		bgw_job_execute(BgwJob *job);
+extern bool ts_bgw_job_execute(BgwJob *job);
 
 PGDLLEXPORT extern Datum ts_bgw_job_entrypoint(PG_FUNCTION_ARGS);
-extern void bgw_job_set_unknown_job_type_hook(unknown_job_type_hook_type hook);
-extern void bgw_job_set_job_entrypoint_function_name(char *func_name);
-extern bool bgw_job_run_and_set_next_start(BgwJob *job, job_main_func func, int64 initial_runs, Interval *next_interval);
+extern void ts_bgw_job_set_unknown_job_type_hook(unknown_job_type_hook_type hook);
+extern void ts_bgw_job_set_job_entrypoint_function_name(char *func_name);
+extern bool ts_bgw_job_run_and_set_next_start(BgwJob *job, job_main_func func, int64 initial_runs, Interval *next_interval);
 
 #endif							/* BGW_JOB_H */

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -21,16 +21,16 @@ typedef enum JobResult
 	JOB_SUCCESS = 1,
 } JobResult;
 
-extern BgwJobStat *bgw_job_stat_find(int job_id);
-extern void bgw_job_stat_delete(int job_id);
-extern void bgw_job_stat_mark_start(int32 bgw_job_id);
-extern void bgw_job_stat_mark_end(BgwJob *job, JobResult result);
-extern bool bgw_job_stat_end_was_marked(BgwJobStat *jobstat);
+extern BgwJobStat *ts_bgw_job_stat_find(int job_id);
+extern void ts_bgw_job_stat_delete(int job_id);
+extern void ts_bgw_job_stat_mark_start(int32 bgw_job_id);
+extern void ts_bgw_job_stat_mark_end(BgwJob *job, JobResult result);
+extern bool ts_bgw_job_stat_end_was_marked(BgwJobStat *jobstat);
 
-extern void bgw_job_stat_set_next_start(BgwJob *job, TimestampTz next_start);
+extern void ts_bgw_job_stat_set_next_start(BgwJob *job, TimestampTz next_start);
 
-extern bool bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
+extern bool ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
 
-extern TimestampTz bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job);
+extern TimestampTz ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job);
 
 #endif							/* BGW_JOB_STAT_H */

--- a/src/bgw/launcher_interface.c
+++ b/src/bgw/launcher_interface.c
@@ -15,7 +15,7 @@
 #define MIN_LOADER_API_VERSION 1
 
 extern bool
-bgw_worker_reserve(void)
+ts_bgw_worker_reserve(void)
 {
 	PGFunction	reserve = load_external_function(EXTENSION_NAME, "ts_bgw_worker_reserve", true, NULL);
 
@@ -23,7 +23,7 @@ bgw_worker_reserve(void)
 }
 
 extern void
-bgw_worker_release(void)
+ts_bgw_worker_release(void)
 {
 	PGFunction	release = load_external_function(EXTENSION_NAME, "ts_bgw_worker_release", true, NULL);
 
@@ -31,7 +31,7 @@ bgw_worker_release(void)
 }
 
 extern int
-bgw_num_unreserved(void)
+ts_bgw_num_unreserved(void)
 {
 	PGFunction	unreserved = load_external_function(EXTENSION_NAME, "ts_bgw_num_unreserved", true, NULL);
 
@@ -39,7 +39,7 @@ bgw_num_unreserved(void)
 }
 
 extern int
-bgw_loader_api_version(void)
+ts_bgw_loader_api_version(void)
 {
 	void	  **versionptr = find_rendezvous_variable(RENDEZVOUS_BGW_LOADER_API_VERSION);
 
@@ -49,9 +49,9 @@ bgw_loader_api_version(void)
 }
 
 extern void
-bgw_check_loader_api_version()
+ts_bgw_check_loader_api_version()
 {
-	int			version = bgw_loader_api_version();
+	int			version = ts_bgw_loader_api_version();
 
 	if (version < MIN_LOADER_API_VERSION)
 		ereport(ERROR,

--- a/src/bgw/launcher_interface.h
+++ b/src/bgw/launcher_interface.h
@@ -9,9 +9,9 @@
 
 #include <postgres.h>
 
-extern bool bgw_worker_reserve(void);
-extern void bgw_worker_release(void);
-extern int	bgw_num_unreserved(void);
-extern int	bgw_loader_api_version(void);
-extern void bgw_check_loader_api_version(void);
+extern bool ts_bgw_worker_reserve(void);
+extern void ts_bgw_worker_release(void);
+extern int	ts_bgw_num_unreserved(void);
+extern int	ts_bgw_loader_api_version(void);
+extern void ts_bgw_check_loader_api_version(void);
 #endif							/* TIMESCALEDB_BGW_LAUNCHER_INTERFACE_H */

--- a/src/bgw/scheduler.h
+++ b/src/bgw/scheduler.h
@@ -19,16 +19,16 @@ typedef struct ScheduledBgwJob ScheduledBgwJob;
 typedef void (*register_background_worker_callback_type) (BackgroundWorkerHandle *);
 
 /* Exposed for testing */
-List	   *update_scheduled_jobs_list(List *cur_jobs_list, MemoryContext mctx);
+extern List *ts_update_scheduled_jobs_list(List *cur_jobs_list, MemoryContext mctx);
 #ifdef TS_DEBUG
-void		populate_scheduled_job_tuple(ScheduledBgwJob *sjob, Datum *values);
+extern void ts_populate_scheduled_job_tuple(ScheduledBgwJob *sjob, Datum *values);
 #endif
 
-void		bgw_scheduler_process(int32 run_for_interval_ms, register_background_worker_callback_type bgw_register);
+extern void ts_bgw_scheduler_process(int32 run_for_interval_ms, register_background_worker_callback_type bgw_register);
 
 /* exposed for access by mock */
-void		bgw_scheduler_setup_callbacks(void);
+extern void ts_bgw_scheduler_setup_callbacks(void);
 
-void		bgw_job_cache_invalidate_callback(void);
+extern void ts_bgw_job_cache_invalidate_callback(void);
 
 #endif							/* BGW_SCHEDULER_H */

--- a/src/bgw/timer.c
+++ b/src/bgw/timer.c
@@ -97,20 +97,20 @@ timer_get()
 }
 
 bool
-timer_wait(TimestampTz until)
+ts_timer_wait(TimestampTz until)
 {
 	return timer_get()->wait(until);
 }
 
 TimestampTz
-timer_get_current_timestamp()
+ts_timer_get_current_timestamp()
 {
 	return timer_get()->get_current_timestamp();
 }
 
 #ifdef TS_DEBUG
 void
-timer_set(const Timer *timer)
+ts_timer_set(const Timer *timer)
 {
 	current_timer_implementation = timer;
 }

--- a/src/bgw/timer.h
+++ b/src/bgw/timer.h
@@ -19,11 +19,11 @@ typedef struct Timer
 
 } Timer;
 
-extern bool timer_wait(TimestampTz until);
-extern TimestampTz timer_get_current_timestamp(void);
+extern bool ts_timer_wait(TimestampTz until);
+extern TimestampTz ts_timer_get_current_timestamp(void);
 
 #ifdef TS_DEBUG
-extern void timer_set(const Timer *timer);
+extern void ts_timer_set(const Timer *timer);
 #endif
 
 #endif							/* BGW_TIMER_H */

--- a/src/cache.h
+++ b/src/cache.h
@@ -42,16 +42,17 @@ typedef struct Cache
 									 * VACUUM */
 } Cache;
 
-extern void cache_init(Cache *cache);
-extern void cache_invalidate(Cache *cache);
-extern void *cache_fetch(Cache *cache, CacheQuery *query);
-extern bool cache_remove(Cache *cache, void *key);
+extern void ts_cache_init(Cache *cache);
+extern void ts_cache_invalidate(Cache *cache);
+extern void *ts_cache_fetch(Cache *cache, CacheQuery *query);
+extern bool ts_cache_remove(Cache *cache, void *key);
 
-extern MemoryContext cache_memory_ctx(Cache *cache);
-extern MemoryContext cache_switch_to_memory_context(Cache *cache);
+extern MemoryContext ts_cache_memory_ctx(Cache *cache);
+extern MemoryContext ts_cache_switch_to_memory_context(Cache *cache);
 
-extern Cache *cache_pin(Cache *cache);
-extern int	cache_release(Cache *cache);
+extern Cache *ts_cache_pin(Cache *cache);
+extern int	ts_cache_release(Cache *cache);
+
 extern void _cache_init(void);
 extern void _cache_fini(void);
 

--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -53,7 +53,7 @@ void		_cache_invalidate_fini(void);
 static void
 cache_invalidate_all(void)
 {
-	hypertable_cache_invalidate_callback();
+	ts_hypertable_cache_invalidate_callback();
 }
 
 /*
@@ -65,22 +65,22 @@ cache_invalidate_callback(Datum arg, Oid relid)
 {
 	Catalog    *catalog;
 
-	if (extension_invalidate(relid))
+	if (ts_extension_invalidate(relid))
 	{
 		cache_invalidate_all();
 		return;
 	}
 
-	if (!extension_is_loaded())
+	if (!ts_extension_is_loaded())
 		return;
 
-	catalog = catalog_get();
+	catalog = ts_catalog_get();
 
-	if (relid == catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE))
-		hypertable_cache_invalidate_callback();
+	if (relid == ts_catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE))
+		ts_hypertable_cache_invalidate_callback();
 
-	if (relid == catalog_get_cache_proxy_id(catalog, CACHE_TYPE_BGW_JOB))
-		bgw_job_cache_invalidate_callback();
+	if (relid == ts_catalog_get_cache_proxy_id(catalog, CACHE_TYPE_BGW_JOB))
+		ts_bgw_job_cache_invalidate_callback();
 }
 
 TS_FUNCTION_INFO_V1(ts_timescaledb_invalidate_cache);
@@ -97,7 +97,7 @@ TS_FUNCTION_INFO_V1(ts_timescaledb_invalidate_cache);
 Datum
 ts_timescaledb_invalidate_cache(PG_FUNCTION_ARGS)
 {
-	catalog_invalidate_cache(PG_GETARG_OID(0), CMD_UPDATE);
+	ts_catalog_invalidate_cache(PG_GETARG_OID(0), CMD_UPDATE);
 	PG_RETURN_VOID();
 }
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -63,13 +63,13 @@ typedef struct TableIndexDef
 	(catalog->functions[func].function_id)
 
 #define CatalogInternalCall1(func, datum1) \
-	OidFunctionCall1(CATALOG_INTERNAL_FUNC(catalog_get(), func), datum1)
+	OidFunctionCall1(CATALOG_INTERNAL_FUNC(ts_catalog_get(), func), datum1)
 #define CatalogInternalCall2(func, datum1, datum2) \
-	OidFunctionCall2(CATALOG_INTERNAL_FUNC(catalog_get(), func), datum1, datum2)
+	OidFunctionCall2(CATALOG_INTERNAL_FUNC(ts_catalog_get(), func), datum1, datum2)
 #define CatalogInternalCall3(func, datum1, datum2, datum3) \
-	OidFunctionCall3(CATALOG_INTERNAL_FUNC(catalog_get(), func), datum1, datum2, datum3)
+	OidFunctionCall3(CATALOG_INTERNAL_FUNC(ts_catalog_get(), func), datum1, datum2, datum3)
 #define CatalogInternalCall4(func, datum1, datum2, datum3, datum4) \
-	OidFunctionCall4(CATALOG_INTERNAL_FUNC(catalog_get(), func), datum1, datum2, datum3, datum4)
+	OidFunctionCall4(CATALOG_INTERNAL_FUNC(ts_catalog_get(), func), datum1, datum2, datum3, datum4)
 
 typedef enum InternalFunction
 {
@@ -699,11 +699,11 @@ typedef struct CatalogSecurityContext
 	int			saved_security_context;
 } CatalogSecurityContext;
 
-void		catalog_table_info_init(CatalogTableInfo *tables, int max_table, const TableInfoDef *table_ary, const TableIndexDef *index_ary, const char **serial_id_ary);
+extern void ts_catalog_table_info_init(CatalogTableInfo *tables, int max_table, const TableInfoDef *table_ary, const TableIndexDef *index_ary, const char **serial_id_ary);
 
-CatalogDatabaseInfo *catalog_database_info_get(void);
-Catalog    *catalog_get(void);
-void		catalog_reset(void);
+extern CatalogDatabaseInfo *ts_catalog_database_info_get(void);
+extern Catalog *ts_catalog_get(void);
+extern void ts_catalog_reset(void);
 
 /* Functions should operate on a passed-in Catalog struct */
 static inline Oid
@@ -718,20 +718,20 @@ catalog_get_index(Catalog *catalog, CatalogTable tableid, int indexid)
 	return (indexid == INVALID_INDEXID) ? InvalidOid : catalog->tables[tableid].index_ids[indexid];
 }
 
-int64		catalog_table_next_seq_id(Catalog *catalog, CatalogTable table);
-Oid			catalog_get_cache_proxy_id(Catalog *catalog, CacheType type);
+extern int64 ts_catalog_table_next_seq_id(Catalog *catalog, CatalogTable table);
+extern Oid	ts_catalog_get_cache_proxy_id(Catalog *catalog, CacheType type);
 
 /* Functions that modify the actual catalog table on disk */
-bool		catalog_database_info_become_owner(CatalogDatabaseInfo *database_info, CatalogSecurityContext *sec_ctx);
-void		catalog_restore_user(CatalogSecurityContext *sec_ctx);
-void		catalog_insert_values(Relation rel, TupleDesc tupdesc, Datum *values, bool *nulls);
-void		catalog_update_tid(Relation rel, ItemPointer tid, HeapTuple tuple);
-void		catalog_update(Relation rel, HeapTuple tuple);
-void		catalog_delete_tid(Relation rel, ItemPointer tid);
-void		catalog_delete(Relation rel, HeapTuple tuple);
-void		catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
+extern bool ts_catalog_database_info_become_owner(CatalogDatabaseInfo *database_info, CatalogSecurityContext *sec_ctx);
+extern void ts_catalog_restore_user(CatalogSecurityContext *sec_ctx);
+extern void ts_catalog_insert_values(Relation rel, TupleDesc tupdesc, Datum *values, bool *nulls);
+extern void ts_catalog_update_tid(Relation rel, ItemPointer tid, HeapTuple tuple);
+extern void ts_catalog_update(Relation rel, HeapTuple tuple);
+extern void ts_catalog_delete_tid(Relation rel, ItemPointer tid);
+extern void ts_catalog_delete(Relation rel, HeapTuple tuple);
+extern void ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
 
 /* Delete only: do not increment command counter or invalidate caches */
-void		catalog_delete_only(Relation rel, HeapTuple tuple);
+extern void ts_catalog_delete_only(Relation rel, HeapTuple tuple);
 
 #endif							/* TIMESCALEDB_CATALOG_H */

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -68,28 +68,28 @@ typedef struct ChunkScanEntry
 	Chunk	   *chunk;
 } ChunkScanEntry;
 
-extern Chunk *chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
-extern Chunk *chunk_create_stub(int32 id, int16 num_constraints);
-extern void chunk_free(Chunk *chunk);
-extern Chunk *chunk_find(Hyperspace *hs, Point *p);
-extern List *chunk_find_all_oids(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode);
-extern Chunk *chunk_copy(Chunk *chunk);
-extern Chunk *chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name, int16 num_constraints, MemoryContext mctx, bool fail_if_not_found);
-extern Chunk *chunk_get_by_relid(Oid relid, int16 num_constraints, bool fail_if_not_found);
-extern Chunk *chunk_get_by_id(int32 id, int16 num_constraints, bool fail_if_not_found);
-extern bool chunk_exists(const char *schema_name, const char *table_name);
-extern bool chunk_exists_relid(Oid relid);
-extern void chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
-extern int	chunk_delete_by_relid(Oid chunk_oid);
-extern int	chunk_delete_by_hypertable_id(int32 hypertable_id);
-extern int	chunk_delete_by_name(const char *schema, const char *table);
-extern bool chunk_set_name(Chunk *chunk, const char *newname);
-extern bool chunk_set_schema(Chunk *chunk, const char *newschema);
-extern List *chunk_get_window(int32 dimension_id, int64 point, int count, MemoryContext mctx);
-extern void chunks_rename_schema_name(char *old_schema, char *new_schema);
+extern Chunk *ts_chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
+extern Chunk *ts_chunk_create_stub(int32 id, int16 num_constraints);
+extern void ts_chunk_free(Chunk *chunk);
+extern Chunk *ts_chunk_find(Hyperspace *hs, Point *p);
+extern List *ts_chunk_find_all_oids(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode);
+extern Chunk *ts_chunk_copy(Chunk *chunk);
+extern Chunk *ts_chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name, int16 num_constraints, MemoryContext mctx, bool fail_if_not_found);
+extern Chunk *ts_chunk_get_by_relid(Oid relid, int16 num_constraints, bool fail_if_not_found);
+extern Chunk *ts_chunk_get_by_id(int32 id, int16 num_constraints, bool fail_if_not_found);
+extern bool ts_chunk_exists(const char *schema_name, const char *table_name);
+extern bool ts_chunk_exists_relid(Oid relid);
+extern void ts_chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
+extern int	ts_chunk_delete_by_relid(Oid chunk_oid);
+extern int	ts_chunk_delete_by_hypertable_id(int32 hypertable_id);
+extern int	ts_chunk_delete_by_name(const char *schema, const char *table);
+extern bool ts_chunk_set_name(Chunk *chunk, const char *newname);
+extern bool ts_chunk_set_schema(Chunk *chunk, const char *newschema);
+extern List *ts_chunk_get_window(int32 dimension_id, int64 point, int count, MemoryContext mctx);
+extern void ts_chunks_rename_schema_name(char *old_schema, char *new_schema);
 
 #define chunk_get_by_name(schema_name, table_name, num_constraints, fail_if_not_found) \
-	chunk_get_by_name_with_memory_context(schema_name, table_name, num_constraints, \
+	ts_chunk_get_by_name_with_memory_context(schema_name, table_name, num_constraints, \
 										  CurrentMemoryContext, fail_if_not_found)
 
 #endif							/* TIMESCALEDB_CHUNK_H */

--- a/src/chunk_adaptive.h
+++ b/src/chunk_adaptive.h
@@ -23,6 +23,6 @@ typedef struct ChunkSizingInfo
 	int64		target_size_bytes;
 } ChunkSizingInfo;
 
-void		chunk_adaptive_sizing_info_validate(ChunkSizingInfo *info);
+extern void ts_chunk_adaptive_sizing_info_validate(ChunkSizingInfo *info);
 
 #endif							/* TIMESCALEDB_CHUNK_ADAPTIVE_H */

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -40,22 +40,22 @@ typedef struct DimensionSlice DimensionSlice;
 typedef struct Hypercube Hypercube;
 typedef struct ChunkScanCtx ChunkScanCtx;
 
-extern ChunkConstraints *chunk_constraints_alloc(int size_hint, MemoryContext mctx);
-extern ChunkConstraints *chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint, MemoryContext mctx);
-extern ChunkConstraints *chunk_constraints_copy(ChunkConstraints *constraints);
-extern int	chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx *ctx, MemoryContext mctx);
-extern int	chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkConstraints *ccs, MemoryContext mctx);
-extern int	chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, int32 chunk_id, Hypercube *cube);
-extern int	chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs, int32 chunk_id, Oid hypertable_oid);
-extern void chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid, int32 chunk_id, Oid hypertable_oid, int32 hypertable_id);
-extern void chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
-extern int	chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, char *hypertable_constraint_name, bool delete_metadata, bool drop_constraint);
-extern int	chunk_constraint_delete_by_chunk_id(int32 chunk_id, ChunkConstraints *ccs);
-extern int	chunk_constraint_delete_by_dimension_slice_id(int32 dimension_slice_id);
-extern int	chunk_constraint_delete_by_constraint_name(int32 chunk_id, const char *constraint_name, bool delete_metadata, bool drop_constraint);
-extern void chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
-extern int	chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);
+extern ChunkConstraints *ts_chunk_constraints_alloc(int size_hint, MemoryContext mctx);
+extern ChunkConstraints *ts_chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint, MemoryContext mctx);
+extern ChunkConstraints *ts_chunk_constraints_copy(ChunkConstraints *constraints);
+extern int	ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx *ctx, MemoryContext mctx);
+extern int	ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id, ChunkConstraints *ccs, MemoryContext mctx);
+extern int	ts_chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, int32 chunk_id, Hypercube *cube);
+extern int	ts_chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs, int32 chunk_id, Oid hypertable_oid);
+extern void ts_chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid, int32 chunk_id, Oid hypertable_oid, int32 hypertable_id);
+extern void ts_chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
+extern int	ts_chunk_constraint_delete_by_hypertable_constraint_name(int32 chunk_id, char *hypertable_constraint_name, bool delete_metadata, bool drop_constraint);
+extern int	ts_chunk_constraint_delete_by_chunk_id(int32 chunk_id, ChunkConstraints *ccs);
+extern int	ts_chunk_constraint_delete_by_dimension_slice_id(int32 dimension_slice_id);
+extern int	ts_chunk_constraint_delete_by_constraint_name(int32 chunk_id, const char *constraint_name, bool delete_metadata, bool drop_constraint);
+extern void ts_chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
+extern int	ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname, const char *newname);
 
-extern char *chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid, const char *hypertable_constraint_name);
+extern char *ts_chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid, const char *hypertable_constraint_name);
 
 #endif							/* TIMESCALEDB_CHUNK_CONSTRAINT_H */

--- a/src/chunk_dispatch.h
+++ b/src/chunk_dispatch.h
@@ -45,8 +45,8 @@ typedef struct ChunkDispatch
 typedef struct Point Point;
 typedef struct ChunkInsertState ChunkInsertState;
 
-ChunkDispatch *chunk_dispatch_create(Hypertable *ht, EState *estate);
-void		chunk_dispatch_destroy(ChunkDispatch *dispatch);
-ChunkInsertState *chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *p);
+extern ChunkDispatch *ts_chunk_dispatch_create(Hypertable *ht, EState *estate);
+void		ts_chunk_dispatch_destroy(ChunkDispatch *dispatch);
+extern ChunkInsertState *ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *p);
 
 #endif							/* TIMESCALEDB_CHUNK_DISPATCH_H */

--- a/src/chunk_dispatch_plan.c
+++ b/src/chunk_dispatch_plan.c
@@ -24,8 +24,8 @@
 static Node *
 create_chunk_dispatch_state(CustomScan *cscan)
 {
-	return (Node *) chunk_dispatch_state_create(linitial_oid(cscan->custom_private),
-												linitial(cscan->custom_plans));
+	return (Node *) ts_chunk_dispatch_state_create(linitial_oid(cscan->custom_private),
+												   linitial(cscan->custom_plans));
 }
 
 static CustomScanMethods chunk_dispatch_plan_methods = {
@@ -126,7 +126,7 @@ build_customscan_targetlist(Relation rel, List *targetlist)
  * node.
  */
 CustomScan *
-chunk_dispatch_plan_create(Plan *subplan, Index hypertable_rti, Oid hypertable_relid, Query *parse)
+ts_chunk_dispatch_plan_create(Plan *subplan, Index hypertable_rti, Oid hypertable_relid, Query *parse)
 {
 	CustomScan *cscan = makeNode(CustomScan);
 	Relation	rel;

--- a/src/chunk_dispatch_plan.h
+++ b/src/chunk_dispatch_plan.h
@@ -12,6 +12,6 @@
 #include <nodes/parsenodes.h>
 #include <nodes/extensible.h>
 
-extern CustomScan *chunk_dispatch_plan_create(Plan *subplan, Index hypertable_rti, Oid hypertable_relid, Query *parse);
+extern CustomScan *ts_chunk_dispatch_plan_create(Plan *subplan, Index hypertable_rti, Oid hypertable_relid, Query *parse);
 
 #endif							/* TIMESCALEDB_CHUNK_DISPATCH_PLAN_H */

--- a/src/chunk_dispatch_state.h
+++ b/src/chunk_dispatch_state.h
@@ -38,9 +38,9 @@ typedef struct ChunkDispatchState
 
 #define CHUNK_DISPATCH_STATE_NAME "ChunkDispatchState"
 
-ChunkDispatchState *chunk_dispatch_state_create(Oid, Plan *);
+extern ChunkDispatchState *ts_chunk_dispatch_state_create(Oid, Plan *);
 void
-			chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *parent);
+			ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *parent);
 
 
 #endif							/* TIMESCALEDB_CHUNK_DISPATCH_STATE_H */

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -22,20 +22,20 @@ typedef struct ChunkIndexMapping
 	Oid			hypertableoid;
 } ChunkIndexMapping;
 
-extern void chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid, int32 chunk_id, Oid chunkrelid);
-extern Oid	chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid, int32 hypertable_id, Oid hypertable_indexrelid);
-extern int	chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool should_drop);
-extern int	chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index);
-extern int	chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
-extern int	chunk_index_delete_by_hypertable_id(int32 hypertable_id, bool drop_index);
-extern void chunk_index_delete_by_name(const char *schema, const char *index_name, bool drop_index);
-extern int	chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname);
-extern int	chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *newname);
-extern int	chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, const char *tablespace);
-extern void chunk_index_create_from_constraint(int32 hypertable_id, Oid hypertable_constaint, int32 chunk_id, Oid chunk_constraint);
-extern List *chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid);
-extern ChunkIndexMapping *chunk_index_get_by_hypertable_indexrelid(Chunk *chunk, Oid hypertable_indexrelid);
-extern void chunk_index_mark_clustered(Oid chunkrelid, Oid indexrelid);
+extern void ts_chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid, int32 chunk_id, Oid chunkrelid);
+extern Oid	ts_chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid, int32 hypertable_id, Oid hypertable_indexrelid);
+extern int	ts_chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool should_drop);
+extern int	ts_chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index);
+extern int	ts_chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
+extern int	ts_chunk_index_delete_by_hypertable_id(int32 hypertable_id, bool drop_index);
+extern void ts_chunk_index_delete_by_name(const char *schema, const char *index_name, bool drop_index);
+extern int	ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname);
+extern int	ts_chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *newname);
+extern int	ts_chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid, const char *tablespace);
+extern void ts_chunk_index_create_from_constraint(int32 hypertable_id, Oid hypertable_constaint, int32 chunk_id, Oid chunk_constraint);
+extern List *ts_chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid);
+extern ChunkIndexMapping *ts_chunk_index_get_by_hypertable_indexrelid(Chunk *chunk, Oid hypertable_indexrelid);
+extern void ts_chunk_index_mark_clustered(Oid chunkrelid, Oid indexrelid);
 
 /* chunk_index_recreate  is a process akin to reindex
  * except that indexes are created in 2 steps

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -99,9 +99,9 @@ create_chunk_range_table_entry(ChunkDispatch *dispatch, Relation rel)
  * chunks can have different attnums for columns.
  */
 HeapTuple
-chunk_insert_state_convert_tuple(ChunkInsertState *state,
-								 HeapTuple tuple,
-								 TupleTableSlot **existing_slot)
+ts_chunk_insert_state_convert_tuple(ChunkInsertState *state,
+									HeapTuple tuple,
+									TupleTableSlot **existing_slot)
 {
 	Relation	chunkrel = state->result_relation_info->ri_RelationDesc;
 
@@ -435,8 +435,8 @@ chunk_insert_state_set_arbiter_indexes(ChunkInsertState *state, ChunkDispatch *d
 	foreach(lc, dispatch->arbiter_indexes)
 	{
 		Oid			hypertable_index = lfirst_oid(lc);
-		Chunk	   *chunk = chunk_get_by_relid(RelationGetRelid(chunk_rel), 0, true);
-		ChunkIndexMapping *cim = chunk_index_get_by_hypertable_indexrelid(chunk, hypertable_index);
+		Chunk	   *chunk = ts_chunk_get_by_relid(RelationGetRelid(chunk_rel), 0, true);
+		ChunkIndexMapping *cim = ts_chunk_index_get_by_hypertable_indexrelid(chunk, hypertable_index);
 
 		state->arbiter_indexes = lappend_oid(state->arbiter_indexes, cim->indexoid);
 	}
@@ -449,7 +449,7 @@ chunk_insert_state_set_arbiter_indexes(ChunkInsertState *state, ChunkDispatch *d
  * ResultRelInfo should be similar to ExecInitModifyTable().
  */
 extern ChunkInsertState *
-chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
+ts_chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 {
 	ChunkInsertState *state;
 	Relation	rel,
@@ -529,7 +529,7 @@ chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 }
 
 extern void
-chunk_insert_state_destroy(ChunkInsertState *state)
+ts_chunk_insert_state_destroy(ChunkInsertState *state)
 {
 	if (state == NULL)
 		return;

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -31,8 +31,8 @@ typedef struct ChunkInsertState
 
 typedef struct ChunkDispatch ChunkDispatch;
 
-extern HeapTuple chunk_insert_state_convert_tuple(ChunkInsertState *state, HeapTuple tuple, TupleTableSlot **existing_slot);
-extern ChunkInsertState *chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch);
-extern void chunk_insert_state_destroy(ChunkInsertState *state);
+extern HeapTuple ts_chunk_insert_state_convert_tuple(ChunkInsertState *state, HeapTuple tuple, TupleTableSlot **existing_slot);
+extern ChunkInsertState *ts_chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch);
+extern void ts_chunk_insert_state_destroy(ChunkInsertState *state);
 
 #endif							/* TIMESCALEDB_CHUNK_INSERT_STATE_H */

--- a/src/constraint_aware_append.c
+++ b/src/constraint_aware_append.c
@@ -401,7 +401,7 @@ remove_parent_subpath(PlannerInfo *root, List *subpaths, Oid parent_relid)
 }
 
 Path *
-constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath)
+ts_constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath)
 {
 	ConstraintAwareAppendPath *path;
 	AppendRelInfo *appinfo;

--- a/src/constraint_aware_append.h
+++ b/src/constraint_aware_append.h
@@ -25,7 +25,7 @@ typedef struct ConstraintAwareAppendState
 
 typedef struct Hypertable Hypertable;
 
-Path	   *constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath);
+Path	   *ts_constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath);
 
 
 #endif							/* TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H */

--- a/src/copy.h
+++ b/src/copy.h
@@ -15,7 +15,7 @@
 
 typedef struct Hypertable Hypertable;
 
-void		timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed, Hypertable *ht);
-void		timescaledb_move_from_table_to_chunks(Hypertable *ht, LOCKMODE lockmode);
+extern void timescaledb_DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed, Hypertable *ht);
+extern void timescaledb_move_from_table_to_chunks(Hypertable *ht, LOCKMODE lockmode);
 
 #endif							/* TIMESCALEDB_COPY_H */

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -48,7 +48,7 @@ typedef struct Dimension
 	(type == TIMESTAMPOID || type == TIMESTAMPTZOID || type == DATEOID)
 
 #define IS_VALID_OPEN_DIM_TYPE(type)					\
-	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type) || type_is_int8_binary_compatible(type))
+	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type) || ts_type_is_int8_binary_compatible(type))
 
 /*
  * A hyperspace defines how to partition in a N-dimensional space.
@@ -128,26 +128,26 @@ enum Anum_add_dimension
 #define Natts_add_dimension \
 	(_Anum_add_dimension_max - 1)
 
-extern Hyperspace *dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension, MemoryContext mctx);
-extern DimensionSlice *dimension_calculate_default_slice(Dimension *dim, int64 value);
-extern Point *hyperspace_calculate_point(Hyperspace *h, HeapTuple tuple, TupleDesc tupdesc);
-extern Dimension *hyperspace_get_dimension_by_id(Hyperspace *hs, int32 id);
-extern Dimension *hyperspace_get_dimension(Hyperspace *hs, DimensionType type, Index n);
-extern Dimension *hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionType type, const char *name);
-extern DimensionVec *dimension_get_slices(Dimension *dim);
-extern int32 dimension_get_hypertable_id(int32 dimension_id);
-extern int	dimension_set_type(Dimension *dim, Oid newtype);
-extern int	dimension_set_name(Dimension *dim, const char *newname);
-extern int	dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
-extern int	dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete_slices);
-extern void dimension_validate_info(DimensionInfo *info);
-extern void dimension_open_typecheck(Oid arg_type, Oid time_column_type, char *caller_name);
-extern void dimension_add_from_info(DimensionInfo *info);
-extern void dimensions_rename_schema_name(char *oldname, char *newname);
+extern Hyperspace *ts_dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension, MemoryContext mctx);
+extern DimensionSlice *ts_dimension_calculate_default_slice(Dimension *dim, int64 value);
+extern Point *ts_hyperspace_calculate_point(Hyperspace *h, HeapTuple tuple, TupleDesc tupdesc);
+extern Dimension *ts_hyperspace_get_dimension_by_id(Hyperspace *hs, int32 id);
+extern Dimension *ts_hyperspace_get_dimension(Hyperspace *hs, DimensionType type, Index n);
+extern Dimension *ts_hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionType type, const char *name);
+extern DimensionVec *ts_dimension_get_slices(Dimension *dim);
+extern int32 ts_dimension_get_hypertable_id(int32 dimension_id);
+extern int	ts_dimension_set_type(Dimension *dim, Oid newtype);
+extern int	ts_dimension_set_name(Dimension *dim, const char *newname);
+extern int	ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
+extern int	ts_dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete_slices);
+extern void ts_dimension_validate_info(DimensionInfo *info);
+extern void ts_dimension_open_typecheck(Oid arg_type, Oid time_column_type, char *caller_name);
+extern void ts_dimension_add_from_info(DimensionInfo *info);
+extern void ts_dimensions_rename_schema_name(char *oldname, char *newname);
 
 #define hyperspace_get_open_dimension(space, i)				\
-	hyperspace_get_dimension(space, DIMENSION_TYPE_OPEN, i)
+	ts_hyperspace_get_dimension(space, DIMENSION_TYPE_OPEN, i)
 #define hyperspace_get_closed_dimension(space, i)				\
-	hyperspace_get_dimension(space, DIMENSION_TYPE_CLOSED, i)
+	ts_hyperspace_get_dimension(space, DIMENSION_TYPE_CLOSED, i)
 
 #endif							/* TIMESCALEDB_DIMENSION_H */

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -30,33 +30,33 @@ typedef struct DimensionSlice
 typedef struct DimensionVec DimensionVec;
 typedef struct Hypercube Hypercube;
 
-extern DimensionVec *dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit);
-extern DimensionVec *dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy, int64 start_value, StrategyNumber end_strategy, int64 end_value, int limit);
-extern DimensionVec *dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, int64 range_end, int limit);
-extern DimensionSlice *dimension_slice_scan_for_existing(DimensionSlice *slice);
-extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
-extern DimensionVec *dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
-extern DimensionVec *dimension_slice_scan_by_dimension_before_point(int32 dimension_id, int64 point, int limit, ScanDirection scandir, MemoryContext mctx);
-extern int	dimension_slice_delete_by_dimension_id(int32 dimension_id, bool delete_constraints);
-extern int	dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraints);
-extern DimensionSlice *dimension_slice_create(int dimension_id, int64 range_start, int64 range_end);
-extern DimensionSlice *dimension_slice_copy(const DimensionSlice *original);
-extern bool dimension_slices_collide(DimensionSlice *slice1, DimensionSlice *slice2);
-extern bool dimension_slices_equal(DimensionSlice *slice1, DimensionSlice *slice2);
-extern bool dimension_slice_cut(DimensionSlice *to_cut, DimensionSlice *other, int64 coord);
-extern void dimension_slice_free(DimensionSlice *slice);
-extern void dimension_slice_insert_multi(DimensionSlice **slice, Size num_slices);
-extern int	dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right);
-extern int	dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
+extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit);
+extern DimensionVec *ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy, int64 start_value, StrategyNumber end_strategy, int64 end_value, int limit);
+extern DimensionVec *ts_dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, int64 range_end, int limit);
+extern DimensionSlice *ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
+extern DimensionSlice *ts_dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
+extern DimensionVec *ts_dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
+extern DimensionVec *ts_dimension_slice_scan_by_dimension_before_point(int32 dimension_id, int64 point, int limit, ScanDirection scandir, MemoryContext mctx);
+extern int	ts_dimension_slice_delete_by_dimension_id(int32 dimension_id, bool delete_constraints);
+extern int	ts_dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraints);
+extern DimensionSlice *ts_dimension_slice_create(int dimension_id, int64 range_start, int64 range_end);
+extern DimensionSlice *ts_dimension_slice_copy(const DimensionSlice *original);
+extern bool ts_dimension_slices_collide(DimensionSlice *slice1, DimensionSlice *slice2);
+extern bool ts_dimension_slices_equal(DimensionSlice *slice1, DimensionSlice *slice2);
+extern bool ts_dimension_slice_cut(DimensionSlice *to_cut, DimensionSlice *other, int64 coord);
+extern void ts_dimension_slice_free(DimensionSlice *slice);
+extern void ts_dimension_slice_insert_multi(DimensionSlice **slice, Size num_slices);
+extern int	ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right);
+extern int	ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
 
 #define dimension_slice_insert(slice) \
-	dimension_slice_insert_multi(&(slice), 1)
+	ts_dimension_slice_insert_multi(&(slice), 1)
 
 #define dimension_slice_scan(dimension_id, coordinate)	\
-	dimension_slice_scan_limit(dimension_id, coordinate, 0)
+	ts_dimension_slice_scan_limit(dimension_id, coordinate, 0)
 
 #define dimension_slice_collision_scan(dimension_id, range_start, range_end)		\
-	dimension_slice_collision_scan_limit(dimension_id, range_start, range_end, 0)
+	ts_dimension_slice_collision_scan_limit(dimension_id, range_start, range_end, 0)
 
 
 #endif							/* TIMESCALEDB_DIMENSION_SLICE_H */

--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -12,7 +12,7 @@ cmp_slices(const void *left, const void *right)
 	const DimensionSlice *left_slice = *((DimensionSlice **) left);
 	const DimensionSlice *right_slice = *((DimensionSlice **) right);
 
-	return dimension_slice_cmp(left_slice, right_slice);
+	return ts_dimension_slice_cmp(left_slice, right_slice);
 }
 
 static int
@@ -21,7 +21,7 @@ cmp_coordinate_and_slice(const void *left, const void *right)
 	int64		coord = *((int64 *) left);
 	const DimensionSlice *slice = *((DimensionSlice **) right);
 
-	return dimension_slice_cmp_coordinate(slice, coord);
+	return ts_dimension_slice_cmp_coordinate(slice, coord);
 }
 
 static DimensionVec *
@@ -41,7 +41,7 @@ dimension_vec_expand(DimensionVec *vec, int32 new_capacity)
 }
 
 DimensionVec *
-dimension_vec_create(int32 initial_num_slices)
+ts_dimension_vec_create(int32 initial_num_slices)
 {
 	DimensionVec *vec = dimension_vec_expand(NULL, initial_num_slices);
 
@@ -52,7 +52,7 @@ dimension_vec_create(int32 initial_num_slices)
 }
 
 DimensionVec *
-dimension_vec_sort(DimensionVec **vecptr)
+ts_dimension_vec_sort(DimensionVec **vecptr)
 {
 	DimensionVec *vec = *vecptr;
 
@@ -62,7 +62,7 @@ dimension_vec_sort(DimensionVec **vecptr)
 }
 
 DimensionVec *
-dimension_vec_add_slice(DimensionVec **vecptr, DimensionSlice *slice)
+ts_dimension_vec_add_slice(DimensionVec **vecptr, DimensionSlice *slice)
 {
 	DimensionVec *vec = *vecptr;
 
@@ -78,34 +78,34 @@ dimension_vec_add_slice(DimensionVec **vecptr, DimensionSlice *slice)
 }
 
 DimensionVec *
-dimension_vec_add_unique_slice(DimensionVec **vecptr, DimensionSlice *slice)
+ts_dimension_vec_add_unique_slice(DimensionVec **vecptr, DimensionSlice *slice)
 {
 	DimensionVec *vec = *vecptr;
 
-	int32		existing_slice_index = dimension_vec_find_slice_index(vec, slice->fd.id);
+	int32		existing_slice_index = ts_dimension_vec_find_slice_index(vec, slice->fd.id);
 
 	if (existing_slice_index == -1)
 	{
-		return dimension_vec_add_slice(vecptr, slice);
+		return ts_dimension_vec_add_slice(vecptr, slice);
 	}
 	return vec;
 }
 
 DimensionVec *
-dimension_vec_add_slice_sort(DimensionVec **vecptr, DimensionSlice *slice)
+ts_dimension_vec_add_slice_sort(DimensionVec **vecptr, DimensionSlice *slice)
 {
 	DimensionVec *vec;
 
-	*vecptr = vec = dimension_vec_add_slice(vecptr, slice);
-	return dimension_vec_sort(vecptr);
+	*vecptr = vec = ts_dimension_vec_add_slice(vecptr, slice);
+	return ts_dimension_vec_sort(vecptr);
 }
 
 void
-dimension_vec_remove_slice(DimensionVec **vecptr, int32 index)
+ts_dimension_vec_remove_slice(DimensionVec **vecptr, int32 index)
 {
 	DimensionVec *vec = *vecptr;
 
-	dimension_slice_free(vec->slices[index]);
+	ts_dimension_slice_free(vec->slices[index]);
 	memmove(vec->slices + index, vec->slices + (index + 1), sizeof(DimensionSlice *) * (vec->num_slices - index - 1));
 	vec->num_slices--;
 }
@@ -128,7 +128,7 @@ dimension_vec_is_sorted(DimensionVec *vec)
 #endif
 
 DimensionSlice *
-dimension_vec_find_slice(DimensionVec *vec, int64 coordinate)
+ts_dimension_vec_find_slice(DimensionVec *vec, int64 coordinate)
 {
 	DimensionSlice **res;
 
@@ -147,7 +147,7 @@ dimension_vec_find_slice(DimensionVec *vec, int64 coordinate)
 }
 
 int
-dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id)
+ts_dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id)
 {
 	int			i;
 
@@ -159,7 +159,7 @@ dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id)
 }
 
 DimensionSlice *
-dimension_vec_get(DimensionVec *vec, int32 index)
+ts_dimension_vec_get(DimensionVec *vec, int32 index)
 {
 	if (index >= vec->num_slices)
 		return NULL;
@@ -168,11 +168,11 @@ dimension_vec_get(DimensionVec *vec, int32 index)
 }
 
 void
-dimension_vec_free(DimensionVec *vec)
+ts_dimension_vec_free(DimensionVec *vec)
 {
 	int			i;
 
 	for (i = 0; i < vec->num_slices; i++)
-		dimension_slice_free(vec->slices[i]);
+		ts_dimension_slice_free(vec->slices[i]);
 	pfree(vec);
 }

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -28,15 +28,15 @@ typedef struct DimensionVec
 
 #define DIMENSION_VEC_DEFAULT_SIZE 10
 
-extern DimensionVec *dimension_vec_create(int32 initial_num_slices);
-extern DimensionVec *dimension_vec_sort(DimensionVec **vec);
-extern DimensionVec *dimension_vec_add_slice_sort(DimensionVec **vec, DimensionSlice *slice);
-extern DimensionVec *dimension_vec_add_slice(DimensionVec **vecptr, DimensionSlice *slice);
-extern DimensionVec *dimension_vec_add_unique_slice(DimensionVec **vecptr, DimensionSlice *slice);
-extern void dimension_vec_remove_slice(DimensionVec **vecptr, int32 index);
-extern DimensionSlice *dimension_vec_find_slice(DimensionVec *vec, int64 coordinate);
-extern int	dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id);
-extern DimensionSlice *dimension_vec_get(DimensionVec *vec, int32 index);
-extern void dimension_vec_free(DimensionVec *vec);
+extern DimensionVec *ts_dimension_vec_create(int32 initial_num_slices);
+extern DimensionVec *ts_dimension_vec_sort(DimensionVec **vec);
+extern DimensionVec *ts_dimension_vec_add_slice_sort(DimensionVec **vec, DimensionSlice *slice);
+extern DimensionVec *ts_dimension_vec_add_slice(DimensionVec **vecptr, DimensionSlice *slice);
+extern DimensionVec *ts_dimension_vec_add_unique_slice(DimensionVec **vecptr, DimensionSlice *slice);
+extern void ts_dimension_vec_remove_slice(DimensionVec **vecptr, int32 index);
+extern DimensionSlice *ts_dimension_vec_find_slice(DimensionVec *vec, int64 coordinate);
+extern int	ts_dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id);
+extern DimensionSlice *ts_dimension_vec_get(DimensionVec *vec, int32 index);
+extern void ts_dimension_vec_free(DimensionVec *vec);
 
 #endif							/* TIMESCALEDB_DIMENSION_VECTOR_H */

--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -29,13 +29,13 @@ static FmgrInfo dropped_objects_fmgrinfo;
 /*
  * Get a list of executed DDL commands in an event trigger.
  *
- * This function calls the function pg_event_trigger_ddl_commands(), which is
+ * This function calls the function pg_ts_event_trigger_ddl_commands(), which is
  * part of the event trigger API, and retrieves the DDL commands executed in
  * relation to the event trigger. It is only valid to call this function from
  * within an event trigger.
  */
 List *
-event_trigger_ddl_commands(void)
+ts_event_trigger_ddl_commands(void)
 {
 	ReturnSetInfo rsinfo;
 	FunctionCallInfoData fcinfo;
@@ -194,7 +194,7 @@ make_event_trigger_drop_trigger(char *trigger_name, char *schema, char *table)
 
 
 List *
-event_trigger_dropped_objects(void)
+ts_event_trigger_dropped_objects(void)
 {
 	ReturnSetInfo rsinfo;
 	FunctionCallInfoData fcinfo;

--- a/src/event_trigger.h
+++ b/src/event_trigger.h
@@ -60,8 +60,8 @@ typedef struct EventTriggerDropTrigger
 	char	   *table;
 } EventTriggerDropTrigger;
 
-extern List *event_trigger_dropped_objects(void);
-extern List *event_trigger_ddl_commands(void);
+extern List *ts_event_trigger_dropped_objects(void);
+extern List *ts_event_trigger_ddl_commands(void);
 extern void _event_trigger_init(void);
 extern void _event_trigger_fini(void);
 

--- a/src/extension.c
+++ b/src/extension.c
@@ -60,7 +60,7 @@ extension_loader_present()
 }
 
 void
-extension_check_version(const char *so_version)
+ts_extension_check_version(const char *so_version)
 {
 	char	   *sql_version;
 
@@ -84,7 +84,7 @@ extension_check_version(const char *so_version)
 }
 
 void
-extension_check_server_version()
+ts_extension_check_server_version()
 {
 	/*
 	 * This is a load-time check for the correct server version since the
@@ -117,13 +117,13 @@ extension_set_state(enum ExtensionState newstate)
 		case EXTENSION_STATE_UNKNOWN:
 			break;
 		case EXTENSION_STATE_CREATED:
-			extension_check_version(TIMESCALEDB_VERSION_MOD);
+			ts_extension_check_version(TIMESCALEDB_VERSION_MOD);
 			extension_proxy_oid = get_relname_relid(EXTENSION_PROXY_TABLE, get_namespace_oid(CACHE_SCHEMA_NAME, false));
-			catalog_reset();
+			ts_catalog_reset();
 			break;
 		case EXTENSION_STATE_NOT_INSTALLED:
 			extension_proxy_oid = InvalidOid;
-			catalog_reset();
+			ts_catalog_reset();
 			break;
 	}
 	extstate = newstate;
@@ -138,7 +138,7 @@ extension_update_state()
 }
 
 Oid
-extension_schema_oid(void)
+ts_extension_schema_oid(void)
 {
 	Datum		result;
 	Relation	rel;
@@ -183,7 +183,7 @@ extension_schema_oid(void)
  *	Returns whether or not to invalidate the entire extension.
  */
 bool
-extension_invalidate(Oid relid)
+ts_extension_invalidate(Oid relid)
 {
 	switch (extstate)
 	{
@@ -222,10 +222,10 @@ extension_invalidate(Oid relid)
 }
 
 bool
-extension_is_loaded(void)
+ts_extension_is_loaded(void)
 {
 	/* when restoring deactivate extension */
-	if (guc_restoring)
+	if (ts_guc_restoring)
 		return false;
 
 	if (EXTENSION_STATE_UNKNOWN == extstate || EXTENSION_STATE_TRANSITIONING == extstate)
@@ -255,7 +255,7 @@ extension_is_loaded(void)
 }
 
 char *
-extension_get_so_name()
+ts_extension_get_so_name()
 {
 	/* TODO: after merge check whether this is the right place */
 	return EXTENSION_NAME "-" TIMESCALEDB_VERSION_MOD;

--- a/src/extension.h
+++ b/src/extension.h
@@ -9,12 +9,12 @@
 #include <postgres.h>
 #include "extension_constants.h"
 
-bool		extension_invalidate(Oid relid);
-bool		extension_is_loaded(void);
-void		extension_check_version(const char *so_version);
-void		extension_check_server_version(void);
-Oid			extension_schema_oid(void);
+extern bool ts_extension_invalidate(Oid relid);
+extern bool ts_extension_is_loaded(void);
+extern void ts_extension_check_version(const char *so_version);
+extern void ts_extension_check_server_version(void);
+extern Oid	ts_extension_schema_oid(void);
 
-char	   *extension_get_so_name(void);
+extern char *ts_extension_get_so_name(void);
 
 #endif							/* TIMESCALEDB_EXTENSION_H */

--- a/src/guc.c
+++ b/src/guc.c
@@ -24,9 +24,9 @@ typedef enum TelemetryLevel
 static const TelemetryLevel on_level = TELEMETRY_BASIC;
 
 bool
-telemetry_on()
+ts_telemetry_on()
 {
-	return guc_telemetry_level == on_level;
+	return ts_guc_telemetry_level == on_level;
 }
 
 static const struct config_enum_entry telemetry_level_options[] =
@@ -36,19 +36,19 @@ static const struct config_enum_entry telemetry_level_options[] =
 	{NULL, 0, false}
 };
 
-bool		guc_disable_optimizations = false;
-bool		guc_optimize_non_hypertables = false;
-bool		guc_restoring = false;
-bool		guc_constraint_aware_append = true;
-int			guc_max_open_chunks_per_insert = 10;
-int			guc_max_cached_chunks_per_hypertable = 10;
-int			guc_telemetry_level = TELEMETRY_BASIC;
+bool		ts_guc_disable_optimizations = false;
+bool		ts_guc_optimize_non_hypertables = false;
+bool		ts_guc_restoring = false;
+bool		ts_guc_constraint_aware_append = true;
+int			ts_guc_max_open_chunks_per_insert = 10;
+int			ts_guc_max_cached_chunks_per_hypertable = 10;
+int			ts_guc_telemetry_level = TELEMETRY_BASIC;
 
 static void
 assign_max_cached_chunks_per_hypertable_hook(int newval, void *extra)
 {
 	/* invalidate the hypertable cache to reset */
-	hypertable_cache_invalidate_callback();
+	ts_hypertable_cache_invalidate_callback();
 }
 
 void
@@ -57,7 +57,7 @@ _guc_init(void)
 	/* Main database to connect to. */
 	DefineCustomBoolVariable("timescaledb.disable_optimizations", "Disable all timescale query optimizations",
 							 NULL,
-							 &guc_disable_optimizations,
+							 &ts_guc_disable_optimizations,
 							 false,
 							 PGC_USERSET,
 							 0,
@@ -66,7 +66,7 @@ _guc_init(void)
 							 NULL);
 	DefineCustomBoolVariable("timescaledb.optimize_non_hypertables", "Apply timescale query optimization to plain tables",
 							 "Apply timescale query optimization to plain tables in addition to hypertables",
-							 &guc_optimize_non_hypertables,
+							 &ts_guc_optimize_non_hypertables,
 							 false,
 							 PGC_USERSET,
 							 0,
@@ -76,7 +76,7 @@ _guc_init(void)
 
 	DefineCustomBoolVariable("timescaledb.restoring", "Install timescale in restoring mode",
 							 "Used for running pg_restore",
-							 &guc_restoring,
+							 &ts_guc_restoring,
 							 false,
 							 PGC_SUSET,
 							 0,
@@ -86,7 +86,7 @@ _guc_init(void)
 
 	DefineCustomBoolVariable("timescaledb.constraint_aware_append", "Enable constraint-aware append scans",
 							 "Enable constraint exclusion at execution time",
-							 &guc_constraint_aware_append,
+							 &ts_guc_constraint_aware_append,
 							 true,
 							 PGC_USERSET
 							 ,
@@ -98,7 +98,7 @@ _guc_init(void)
 	DefineCustomIntVariable("timescaledb.max_open_chunks_per_insert",
 							"Maximum open chunks per insert",
 							"Maximum number of open chunk tables per insert",
-							&guc_max_open_chunks_per_insert,
+							&ts_guc_max_open_chunks_per_insert,
 							work_mem * 1024L / 25000L,	/* Measurements via
 														 * `MemoryContextStats(TopMemoryContext)`
 														 * show chunk insert
@@ -117,7 +117,7 @@ _guc_init(void)
 	DefineCustomIntVariable("timescaledb.max_cached_chunks_per_hypertable",
 							"Maximum cached chunks",
 							"Maximum number of chunks stored in the cache",
-							&guc_max_cached_chunks_per_hypertable,
+							&ts_guc_max_cached_chunks_per_hypertable,
 							100,
 							0,
 							65536,
@@ -129,7 +129,7 @@ _guc_init(void)
 	DefineCustomEnumVariable("timescaledb.telemetry_level",
 							 "Telemetry settings level",
 							 "Level used to determine which telemetry to send",
-							 &guc_telemetry_level,
+							 &ts_guc_telemetry_level,
 							 TELEMETRY_BASIC,
 							 telemetry_level_options,
 							 PGC_USERSET,

--- a/src/guc.h
+++ b/src/guc.h
@@ -9,15 +9,15 @@
 
 #include <postgres.h>
 
-extern bool telemetry_on(void);
+extern bool ts_telemetry_on(void);
 
-extern bool guc_disable_optimizations;
-extern bool guc_optimize_non_hypertables;
-extern bool guc_constraint_aware_append;
-extern bool guc_restoring;
-extern int	guc_max_open_chunks_per_insert;
-extern int	guc_max_cached_chunks_per_hypertable;
-extern int	guc_telemetry_level;
+extern bool ts_guc_disable_optimizations;
+extern bool ts_guc_optimize_non_hypertables;
+extern bool ts_guc_constraint_aware_append;
+extern bool ts_guc_restoring;
+extern int	ts_guc_max_open_chunks_per_insert;
+extern int	ts_guc_max_cached_chunks_per_hypertable;
+extern int	ts_guc_telemetry_level;
 
 void		_guc_init(void);
 void		_guc_fini(void);

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -28,14 +28,14 @@ typedef struct Hypercube
 	(sizeof(Hypercube) + sizeof(DimensionSlice *) * (num_dimensions))
 
 
-extern Hypercube *hypercube_alloc(int16 num_dimensions);
-extern void hypercube_free(Hypercube *hc);
-extern void hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
-extern Hypercube *hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
-extern Hypercube *hypercube_calculate_from_point(Hyperspace *hs, Point *p);
-extern bool hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
-extern DimensionSlice *hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id);
-extern Hypercube *hypercube_copy(Hypercube *hc);
-extern void hypercube_slice_sort(Hypercube *hc);
+extern Hypercube *ts_hypercube_alloc(int16 num_dimensions);
+extern void ts_hypercube_free(Hypercube *hc);
+extern void ts_hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
+extern Hypercube *ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
+extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p);
+extern bool ts_hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
+extern DimensionSlice *ts_hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id);
+extern Hypercube *ts_hypercube_copy(Hypercube *hc);
+extern void ts_hypercube_slice_sort(Hypercube *hc);
 
 #endif							/* TIMESCALEDB_HYPERCUBE_H */

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -43,38 +43,38 @@ enum Anum_create_hypertable
 #define Natts_create_hypertable \
 	(_Anum_create_hypertable_max - 1)
 
-extern int	number_of_hypertables(void);
+extern int	ts_number_of_hypertables(void);
 
-extern Oid	rel_get_owner(Oid relid);
-extern List *hypertable_get_all(void);
-extern Hypertable *hypertable_get_by_id(int32 hypertable_id);
-extern Hypertable *hypertable_get_by_name(char *schema, char *name);
-extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
-extern Oid	hypertable_permissions_check(Oid hypertable_oid, Oid userid);
-extern Hypertable *hypertable_from_tuple(HeapTuple tuple, MemoryContext mctx);
-extern int	hypertable_scan_with_memory_context(const char *schema, const char *table, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock, MemoryContext mctx);
-extern int	hypertable_scan_relid(Oid table_relid, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock);
-extern HTSU_Result hypertable_lock_tuple(Oid table_relid);
-extern bool hypertable_lock_tuple_simple(Oid table_relid);
-extern int	hypertable_update(Hypertable *ht);
-extern int	hypertable_set_name(Hypertable *ht, const char *newname);
-extern int	hypertable_set_schema(Hypertable *ht, const char *newname);
-extern int	hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
-extern int	hypertable_delete_by_name(const char *schema_name, const char *table_name);
-extern int	hypertable_reset_associated_schema_name(const char *associated_schema);
-extern Oid	hypertable_id_to_relid(int32 hypertable_id);
-extern Chunk *hypertable_get_chunk(Hypertable *h, Point *point);
-extern Oid	hypertable_relid(RangeVar *rv);
-extern bool is_hypertable(Oid relid);
-extern bool hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid);
-extern Tablespace *hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
-extern char *hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
-extern Tablespace *hypertable_get_tablespace_at_offset_from(Hypertable *ht, Oid tablespace_oid, int16 offset);
-extern bool hypertable_has_tuples(Oid table_relid, LOCKMODE lockmode);
-extern void hypertables_rename_schema_name(const char *old_name, const char *new_name);
+extern Oid	ts_rel_get_owner(Oid relid);
+extern List *ts_hypertable_get_all(void);
+extern Hypertable *ts_hypertable_get_by_id(int32 hypertable_id);
+extern Hypertable *ts_hypertable_get_by_name(char *schema, char *name);
+extern bool ts_hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
+extern Oid	ts_hypertable_permissions_check(Oid hypertable_oid, Oid userid);
+extern Hypertable *ts_hypertable_from_tuple(HeapTuple tuple, MemoryContext mctx);
+extern int	ts_hypertable_scan_with_memory_context(const char *schema, const char *table, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock, MemoryContext mctx);
+extern int	ts_hypertable_scan_relid(Oid table_relid, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock);
+extern HTSU_Result ts_hypertable_lock_tuple(Oid table_relid);
+extern bool ts_hypertable_lock_tuple_simple(Oid table_relid);
+extern int	ts_hypertable_update(Hypertable *ht);
+extern int	ts_hypertable_set_name(Hypertable *ht, const char *newname);
+extern int	ts_hypertable_set_schema(Hypertable *ht, const char *newname);
+extern int	ts_hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
+extern int	ts_hypertable_delete_by_name(const char *schema_name, const char *table_name);
+extern int	ts_hypertable_reset_associated_schema_name(const char *associated_schema);
+extern Oid	ts_hypertable_id_to_relid(int32 hypertable_id);
+extern Chunk *ts_hypertable_get_chunk(Hypertable *h, Point *point);
+extern Oid	ts_hypertable_relid(RangeVar *rv);
+extern bool ts_is_hypertable(Oid relid);
+extern bool ts_hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid);
+extern Tablespace *ts_hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
+extern char *ts_hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
+extern Tablespace *ts_hypertable_get_tablespace_at_offset_from(Hypertable *ht, Oid tablespace_oid, int16 offset);
+extern bool ts_hypertable_has_tuples(Oid table_relid, LOCKMODE lockmode);
+extern void ts_hypertables_rename_schema_name(const char *old_name, const char *new_name);
 
 #define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock) \
-	hypertable_scan_with_memory_context(schema, table, tuple_found, data, lockmode, tuplock, CurrentMemoryContext)
+	ts_hypertable_scan_with_memory_context(schema, table, tuple_found, data, lockmode, tuplock, CurrentMemoryContext)
 
 #define hypertable_adaptive_chunking_enabled(ht)						\
 	(OidIsValid((ht)->chunk_sizing_func) && (ht)->fd.chunk_target_size > 0)

--- a/src/hypertable_cache.c
+++ b/src/hypertable_cache.c
@@ -66,7 +66,7 @@ hypertable_cache_create()
 
 	*cache = template;
 
-	cache_init(cache);
+	ts_cache_init(cache);
 
 	return cache;
 }
@@ -78,7 +78,7 @@ hypertable_tuple_found(TupleInfo *ti, void *data)
 {
 	HypertableCacheEntry *entry = data;
 
-	entry->hypertable = hypertable_from_tuple(ti->tuple, ti->mctx);
+	entry->hypertable = ts_hypertable_from_tuple(ti->tuple, ti->mctx);
 	return SCAN_DONE;
 }
 
@@ -95,13 +95,13 @@ hypertable_cache_create_entry(Cache *cache, CacheQuery *query)
 	if (NULL == hq->table)
 		hq->table = get_rel_name(hq->relid);
 
-	number_found = hypertable_scan_with_memory_context(hq->schema,
-													   hq->table,
-													   hypertable_tuple_found,
-													   query->result,
-													   AccessShareLock,
-													   false,
-													   cache_memory_ctx(cache));
+	number_found = ts_hypertable_scan_with_memory_context(hq->schema,
+														  hq->table,
+														  hypertable_tuple_found,
+														  query->result,
+														  AccessShareLock,
+														  false,
+														  ts_cache_memory_ctx(cache));
 
 	switch (number_found)
 	{
@@ -122,51 +122,51 @@ hypertable_cache_create_entry(Cache *cache, CacheQuery *query)
 }
 
 void
-hypertable_cache_invalidate_callback(void)
+ts_hypertable_cache_invalidate_callback(void)
 {
-	cache_invalidate(hypertable_cache_current);
+	ts_cache_invalidate(hypertable_cache_current);
 	hypertable_cache_current = hypertable_cache_create();
 }
 
 /* Get hypertable cache entry. If the entry is not in the cache, add it. */
 Hypertable *
-hypertable_cache_get_entry(Cache *cache, Oid relid)
+ts_hypertable_cache_get_entry(Cache *cache, Oid relid)
 {
 	if (!OidIsValid(relid))
 		return NULL;
 
-	return hypertable_cache_get_entry_with_table(cache, relid, NULL, NULL);
+	return ts_hypertable_cache_get_entry_with_table(cache, relid, NULL, NULL);
 }
 
 Hypertable *
-hypertable_cache_get_entry_rv(Cache *cache, RangeVar *rv)
+ts_hypertable_cache_get_entry_rv(Cache *cache, RangeVar *rv)
 {
-	return hypertable_cache_get_entry(cache, RangeVarGetRelid(rv, NoLock, true));
+	return ts_hypertable_cache_get_entry(cache, RangeVarGetRelid(rv, NoLock, true));
 }
 
 Hypertable *
-hypertable_cache_get_entry_by_id(Cache *cache, int32 hypertable_id)
+ts_hypertable_cache_get_entry_by_id(Cache *cache, int32 hypertable_id)
 {
-	return hypertable_cache_get_entry(cache, hypertable_id_to_relid(hypertable_id));
+	return ts_hypertable_cache_get_entry(cache, ts_hypertable_id_to_relid(hypertable_id));
 }
 
 Hypertable *
-hypertable_cache_get_entry_with_table(Cache *cache, Oid relid, const char *schema, const char *table)
+ts_hypertable_cache_get_entry_with_table(Cache *cache, Oid relid, const char *schema, const char *table)
 {
 	HypertableCacheQuery query = {
 		.relid = relid,
 		.schema = schema,
 		.table = table,
 	};
-	HypertableCacheEntry *entry = cache_fetch(cache, &query.q);
+	HypertableCacheEntry *entry = ts_cache_fetch(cache, &query.q);
 
 	return entry->hypertable;
 }
 
 extern Cache *
-hypertable_cache_pin()
+ts_hypertable_cache_pin()
 {
-	return cache_pin(hypertable_cache_current);
+	return ts_cache_pin(hypertable_cache_current);
 }
 
 void
@@ -179,5 +179,5 @@ _hypertable_cache_init(void)
 void
 _hypertable_cache_fini(void)
 {
-	cache_invalidate(hypertable_cache_current);
+	ts_cache_invalidate(hypertable_cache_current);
 }

--- a/src/hypertable_cache.h
+++ b/src/hypertable_cache.h
@@ -11,14 +11,14 @@
 #include "cache.h"
 #include "hypertable.h"
 
-extern Hypertable *hypertable_cache_get_entry(Cache *cache, Oid relid);
-extern Hypertable *hypertable_cache_get_entry_rv(Cache *cache, RangeVar *rv);
-extern Hypertable *hypertable_cache_get_entry_with_table(Cache *cache, Oid relid, const char *schema, const char *table);
-extern Hypertable *hypertable_cache_get_entry_by_id(Cache *cache, int32 hypertable_id);
+extern Hypertable *ts_hypertable_cache_get_entry(Cache *cache, Oid relid);
+extern Hypertable *ts_hypertable_cache_get_entry_rv(Cache *cache, RangeVar *rv);
+extern Hypertable *ts_hypertable_cache_get_entry_with_table(Cache *cache, Oid relid, const char *schema, const char *table);
+extern Hypertable *ts_hypertable_cache_get_entry_by_id(Cache *cache, int32 hypertable_id);
 
-extern void hypertable_cache_invalidate_callback(void);
+extern void ts_hypertable_cache_invalidate_callback(void);
 
-extern Cache *hypertable_cache_pin(void);
+extern Cache *ts_hypertable_cache_pin(void);
 
 extern void _hypertable_cache_init(void);
 extern void _hypertable_cache_fini(void);

--- a/src/hypertable_insert.c
+++ b/src/hypertable_insert.c
@@ -56,7 +56,7 @@ hypertable_insert_begin(CustomScanState *node, EState *estate, int eflags)
 				{
 					ChunkDispatchState *cdstate = (ChunkDispatchState *) mtstate->mt_plans[i];
 
-					chunk_dispatch_state_set_parent(cdstate, mtstate);
+					ts_chunk_dispatch_state_set_parent(cdstate, mtstate);
 				}
 			}
 		}
@@ -107,7 +107,7 @@ static CustomScanMethods hypertable_insert_plan_methods = {
 };
 
 Plan *
-hypertable_insert_plan_create(ModifyTable *mt)
+ts_hypertable_insert_plan_create(ModifyTable *mt)
 {
 	CustomScan *cscan = makeNode(CustomScan);
 

--- a/src/hypertable_insert.h
+++ b/src/hypertable_insert.h
@@ -16,6 +16,6 @@ typedef struct HypertableInsertState
 	ModifyTable *mt;
 } HypertableInsertState;
 
-Plan	   *hypertable_insert_plan_create(ModifyTable *mt);
+extern Plan *ts_hypertable_insert_plan_create(ModifyTable *mt);
 
 #endif							/* TIMESCALEDB_HYPERTABLE_INSERT_H */

--- a/src/hypertable_restrict_info.h
+++ b/src/hypertable_restrict_info.h
@@ -14,15 +14,15 @@
  * range exclusion logic to figure out which chunks can match the description */
 typedef struct HypertableRestrictInfo HypertableRestrictInfo;
 
-extern HypertableRestrictInfo *hypertable_restrict_info_create(RelOptInfo *rel, Hypertable *ht);
+extern HypertableRestrictInfo *ts_hypertable_restrict_info_create(RelOptInfo *rel, Hypertable *ht);
 
 /* Add restrictions based on a List of RestrictInfo */
-extern void hypertable_restrict_info_add(HypertableRestrictInfo *hri, PlannerInfo *root, List *base_restrict_infos);
+extern void ts_hypertable_restrict_info_add(HypertableRestrictInfo *hri, PlannerInfo *root, List *base_restrict_infos);
 
 /* Some restrictions were added */
-extern bool hypertable_restrict_info_has_restrictions(HypertableRestrictInfo *hri);
+extern bool ts_hypertable_restrict_info_has_restrictions(HypertableRestrictInfo *hri);
 
 /* Get a list of chunk oids for chunks whose constraints match the restriction clauses */
-extern List *hypertable_restrict_info_get_chunk_oids(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockmode);
+extern List *ts_hypertable_restrict_info_get_chunk_oids(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockmode);
 
 #endif							/* TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H */

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -75,7 +75,7 @@ index_has_attribute(List *indexelems, const char *attrname)
  * the index columns.
  */
 void
-indexing_verify_columns(Hyperspace *hs, List *indexelems)
+ts_indexing_verify_columns(Hyperspace *hs, List *indexelems)
 {
 	int			i;
 
@@ -97,10 +97,10 @@ indexing_verify_columns(Hyperspace *hs, List *indexelems)
  * We only care about UNIQUE, PRIMARY KEY or EXCLUSION indexes.
  */
 void
-indexing_verify_index(Hyperspace *hs, IndexStmt *stmt)
+ts_indexing_verify_index(Hyperspace *hs, IndexStmt *stmt)
 {
 	if (stmt->unique || stmt->excludeOpNames != NULL)
-		indexing_verify_columns(hs, stmt->indexParams);
+		ts_indexing_verify_columns(hs, stmt->indexParams);
 }
 
 /*
@@ -187,8 +187,8 @@ static void
 indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_default, bool verify)
 {
 	Relation	tblrel = relation_open(ht->main_table_relid, AccessShareLock);
-	Dimension  *time_dim = hyperspace_get_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);
-	Dimension  *space_dim = hyperspace_get_dimension(ht->space, DIMENSION_TYPE_CLOSED, 0);
+	Dimension  *time_dim = ts_hyperspace_get_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);
+	Dimension  *space_dim = ts_hyperspace_get_dimension(ht->space, DIMENSION_TYPE_CLOSED, 0);
 	List	   *indexlist = RelationGetIndexList(tblrel);
 	bool		has_time_idx = false;
 	bool		has_time_space_idx = false;
@@ -199,7 +199,7 @@ indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_defaul
 		Relation	idxrel = relation_open(lfirst_oid(lc), AccessShareLock);
 
 		if (verify && (idxrel->rd_index->indisunique || idxrel->rd_index->indisexclusion))
-			indexing_verify_columns(ht->space, build_indexcolumn_list(idxrel));
+			ts_indexing_verify_columns(ht->space, build_indexcolumn_list(idxrel));
 
 		/* Check for existence of "default" indexes */
 		if (create_default && NULL != time_dim)
@@ -234,14 +234,14 @@ indexing_create_and_verify_hypertable_indexes(Hypertable *ht, bool create_defaul
 }
 
 void
-indexing_verify_indexes(Hypertable *ht)
+ts_indexing_verify_indexes(Hypertable *ht)
 {
 	indexing_create_and_verify_hypertable_indexes(ht, false, true);
 }
 
 
 void
-indexing_create_default_indexes(Hypertable *ht)
+ts_indexing_create_default_indexes(Hypertable *ht)
 {
 	indexing_create_and_verify_hypertable_indexes(ht, true, false);
 }

--- a/src/indexing.h
+++ b/src/indexing.h
@@ -13,9 +13,9 @@
 
 #include "dimension.h"
 
-extern void indexing_verify_columns(Hyperspace *hs, List *indexelems);
-extern void indexing_verify_index(Hyperspace *hs, IndexStmt *stmt);
-extern void indexing_verify_indexes(Hypertable *ht);
-extern void indexing_create_default_indexes(Hypertable *ht);
+extern void ts_indexing_verify_columns(Hyperspace *hs, List *indexelems);
+extern void ts_indexing_verify_index(Hyperspace *hs, IndexStmt *stmt);
+extern void ts_indexing_verify_indexes(Hypertable *ht);
+extern void ts_indexing_create_default_indexes(Hypertable *ht);
 
 #endif							/* TIMESCALEDB_INDEXING_H */

--- a/src/init.c
+++ b/src/init.c
@@ -64,9 +64,9 @@ _PG_init(void)
 	 * Check extension_is loaded to catch certain errors such as calls to
 	 * functions defined on the wrong extension version
 	 */
-	extension_check_version(TIMESCALEDB_VERSION_MOD);
-	extension_check_server_version();
-	bgw_check_loader_api_version();
+	ts_extension_check_version(TIMESCALEDB_VERSION_MOD);
+	ts_extension_check_server_version();
+	ts_bgw_check_loader_api_version();
 
 	_cache_init();
 	_hypertable_cache_init();

--- a/src/installation_metadata.c
+++ b/src/installation_metadata.c
@@ -98,7 +98,7 @@ installation_metadata_get_value_internal(Datum metadata_key,
 		.typeid = value_type,
 		.isnull = true,
 	};
-	Catalog    *catalog = catalog_get();
+	Catalog    *catalog = ts_catalog_get();
 	ScannerCtx	scanctx = {
 		.table = catalog_get_table_id(catalog, INSTALLATION_METADATA),
 		.index = catalog_get_index(catalog, INSTALLATION_METADATA, INSTALLATION_METADATA_PKEY_IDX),
@@ -113,7 +113,7 @@ installation_metadata_get_value_internal(Datum metadata_key,
 	ScanKeyInit(&scankey[0], Anum_installation_metadata_key,
 				BTEqualStrategyNumber, F_NAMEEQ, convert_type_to_name(metadata_key, key_type));
 
-	scanner_scan(&scanctx);
+	ts_scanner_scan(&scanctx);
 
 	if (NULL != isnull)
 		*isnull = dv.isnull;
@@ -122,10 +122,10 @@ installation_metadata_get_value_internal(Datum metadata_key,
 }
 
 Datum
-installation_metadata_get_value(Datum metadata_key,
-								Oid key_type,
-								Oid value_type,
-								bool *isnull)
+ts_installation_metadata_get_value(Datum metadata_key,
+								   Oid key_type,
+								   Oid value_type,
+								   bool *isnull)
 {
 	return installation_metadata_get_value_internal(metadata_key,
 													key_type,
@@ -143,13 +143,13 @@ installation_metadata_get_value(Datum metadata_key,
  *  the existing value if nothing was inserted.
  */
 Datum
-installation_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_value, Oid value_type)
+ts_installation_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_value, Oid value_type)
 {
 	Datum		existing_value;
 	Datum		values[Natts_installation_metadata];
 	bool		nulls[Natts_installation_metadata] = {false};
 	bool		isnull = false;
-	Catalog    *catalog = catalog_get();
+	Catalog    *catalog = ts_catalog_get();
 	Relation	rel;
 
 	rel = heap_open(catalog_get_table_id(catalog, INSTALLATION_METADATA), ShareRowExclusiveLock);
@@ -173,7 +173,7 @@ installation_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_va
 	values[AttrNumberGetAttrOffset(Anum_installation_metadata_value)] =
 		convert_type_to_text(metadata_value, value_type);
 
-	catalog_insert_values(rel, RelationGetDescr(rel), values, nulls);
+	ts_catalog_insert_values(rel, RelationGetDescr(rel), values, nulls);
 
 	heap_close(rel, ShareRowExclusiveLock);
 

--- a/src/installation_metadata.h
+++ b/src/installation_metadata.h
@@ -9,7 +9,7 @@
 
 #include <postgres.h>
 
-extern Datum installation_metadata_get_value(Datum metadata_key, Oid key_type, Oid value_type, bool *isnull);
-extern Datum installation_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_value, Oid value_type);
+extern Datum ts_installation_metadata_get_value(Datum metadata_key, Oid key_type, Oid value_type, bool *isnull);
+extern Datum ts_installation_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_value, Oid value_type);
 
 #endif							/* TIMESCALEDB_INSTALLATION_METADATA_H */

--- a/src/loader/bgw_counter.c
+++ b/src/loader/bgw_counter.c
@@ -20,7 +20,7 @@
 
 #define BGW_COUNTER_STATE_NAME "ts_bgw_counter_state"
 
-int			guc_max_background_workers = 8;
+int			ts_guc_max_background_workers = 8;
 
 /*
  * We need a bit of shared state here to deal with keeping track of the total
@@ -60,14 +60,14 @@ bgw_counter_state_init()
 }
 
 extern void
-bgw_counter_setup_gucs(void)
+ts_bgw_counter_setup_gucs(void)
 {
 
 	DefineCustomIntVariable("timescaledb.max_background_workers",
 							"Maximum background worker processes allocated to TimescaleDB",
 							"Max background worker processes allocated to TimescaleDB - set to at least 1 + number of databases in Postgres instance to use background workers ",
-							&guc_max_background_workers,
-							guc_max_background_workers,
+							&ts_guc_max_background_workers,
+							ts_guc_max_background_workers,
 							0,
 							1000,	/* no reasonable way to have more than
 									 * 1000 background workers */
@@ -83,19 +83,19 @@ bgw_counter_setup_gucs(void)
  * shared_preload_libraries time
  */
 extern void
-bgw_counter_shmem_alloc(void)
+ts_bgw_counter_shmem_alloc(void)
 {
 	RequestAddinShmemSpace(sizeof(CounterState));
 }
 
 extern void
-bgw_counter_shmem_startup(void)
+ts_bgw_counter_shmem_startup(void)
 {
 	bgw_counter_state_init();
 }
 
 extern void
-bgw_counter_reinit(void)
+ts_bgw_counter_reinit(void)
 {
 	/* set counter back to zero on startup */
 	SpinLockAcquire(&ct->mutex);
@@ -104,10 +104,10 @@ bgw_counter_reinit(void)
 }
 
 extern bool
-bgw_total_workers_increment_by(int increment_by)
+ts_bgw_total_workers_increment_by(int increment_by)
 {
 	bool		incremented = false;
-	int			max_workers = guc_max_background_workers;
+	int			max_workers = ts_guc_max_background_workers;
 
 	SpinLockAcquire(&ct->mutex);
 	if (ct->total_workers + increment_by <= max_workers)
@@ -120,13 +120,13 @@ bgw_total_workers_increment_by(int increment_by)
 }
 
 extern bool
-bgw_total_workers_increment()
+ts_bgw_total_workers_increment()
 {
-	return bgw_total_workers_increment_by(1);
+	return ts_bgw_total_workers_increment_by(1);
 }
 
 extern void
-bgw_total_workers_decrement_by(int decrement_by)
+ts_bgw_total_workers_decrement_by(int decrement_by)
 {
 	/*
 	 * Launcher is 1 worker, and when it dies we reinitialize, so we should
@@ -147,13 +147,13 @@ bgw_total_workers_decrement_by(int decrement_by)
 }
 
 extern void
-bgw_total_workers_decrement()
+ts_bgw_total_workers_decrement()
 {
-	bgw_total_workers_decrement_by(1);
+	ts_bgw_total_workers_decrement_by(1);
 }
 
 extern int
-bgw_total_workers_get()
+ts_bgw_total_workers_get()
 {
 	int			nworkers;
 

--- a/src/loader/bgw_counter.h
+++ b/src/loader/bgw_counter.h
@@ -12,19 +12,19 @@
 
 
 
-extern int	guc_max_background_workers;
+extern int	ts_guc_max_background_workers;
 
-extern void bgw_counter_shmem_alloc(void);
-extern void bgw_counter_shmem_startup(void);
+extern void ts_bgw_counter_shmem_alloc(void);
+extern void ts_bgw_counter_shmem_startup(void);
 
-extern void bgw_counter_setup_gucs(void);
+extern void ts_bgw_counter_setup_gucs(void);
 
-extern void bgw_counter_reinit(void);
-extern bool bgw_total_workers_increment(void);
-extern void bgw_total_workers_decrement(void);
-extern int	bgw_total_workers_get(void);
-extern bool bgw_total_workers_increment_by(int increment_by);
-extern void bgw_total_workers_decrement_by(int decrement_by);
+extern void ts_bgw_counter_reinit(void);
+extern bool ts_bgw_total_workers_increment(void);
+extern void ts_bgw_total_workers_decrement(void);
+extern int	ts_bgw_total_workers_get(void);
+extern bool ts_bgw_total_workers_increment_by(int increment_by);
+extern void ts_bgw_total_workers_decrement_by(int decrement_by);
 
 
 #endif							/* TIMESCALEDB_BGW_COUNTER_H */

--- a/src/loader/bgw_interface.c
+++ b/src/loader/bgw_interface.c
@@ -30,7 +30,7 @@ TS_FUNCTION_INFO_V1(ts_bgw_db_workers_stop);
 TS_FUNCTION_INFO_V1(ts_bgw_db_workers_restart);
 
 void
-bgw_interface_register_api_version()
+ts_bgw_interface_register_api_version()
 {
 	void	  **versionptr = find_rendezvous_variable(RENDEZVOUS_BGW_LOADER_API_VERSION);
 
@@ -41,13 +41,13 @@ bgw_interface_register_api_version()
 Datum
 ts_bgw_worker_reserve(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_BOOL(bgw_total_workers_increment());
+	PG_RETURN_BOOL(ts_bgw_total_workers_increment());
 }
 
 Datum
 ts_bgw_worker_release(PG_FUNCTION_ARGS)
 {
-	bgw_total_workers_decrement();
+	ts_bgw_total_workers_decrement();
 	PG_RETURN_VOID();
 }
 
@@ -56,7 +56,7 @@ ts_bgw_num_unreserved(PG_FUNCTION_ARGS)
 {
 	int			unreserved_workers;
 
-	unreserved_workers = guc_max_background_workers - bgw_total_workers_get();
+	unreserved_workers = ts_guc_max_background_workers - ts_bgw_total_workers_get();
 	PG_RETURN_INT32(unreserved_workers);
 }
 

--- a/src/loader/bgw_interface.h
+++ b/src/loader/bgw_interface.h
@@ -9,7 +9,7 @@
 
 #include <postgres.h>
 
-extern void bgw_interface_register_api_version(void);
+extern void ts_bgw_interface_register_api_version(void);
 extern const int32 ts_bgw_loader_api_version;
 
 #endif

--- a/src/loader/bgw_launcher.h
+++ b/src/loader/bgw_launcher.h
@@ -11,7 +11,7 @@
 #include <postgres.h>
 #include <fmgr.h>
 
-extern void bgw_cluster_launcher_register(void);
+extern void ts_bgw_cluster_launcher_register(void);
 
 /*called by postmaster at launcher bgw startup*/
 PGDLLEXPORT extern Datum ts_bgw_cluster_launcher_main(PG_FUNCTION_ARGS);

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -105,13 +105,13 @@ static void call_extension_post_parse_analyze_hook(ParseState *pstate,
 
 
 extern char *
-loader_extension_version(void)
+ts_loader_extension_version(void)
 {
 	return extension_version();
 }
 
 extern bool
-loader_extension_exists(void)
+ts_loader_extension_exists(void)
 {
 	return extension_exists();
 }
@@ -393,7 +393,7 @@ timescale_shmem_startup_hook(void)
 {
 	if (prev_shmem_startup_hook)
 		prev_shmem_startup_hook();
-	bgw_counter_shmem_startup();
+	ts_bgw_counter_shmem_startup();
 	bgw_message_queue_shmem_startup();
 }
 
@@ -416,11 +416,11 @@ _PG_init(void)
 
 	elog(INFO, "timescaledb loaded");
 
-	bgw_counter_shmem_alloc();
+	ts_bgw_counter_shmem_alloc();
 	bgw_message_queue_alloc();
-	bgw_cluster_launcher_register();
-	bgw_counter_setup_gucs();
-	bgw_interface_register_api_version();
+	ts_bgw_cluster_launcher_register();
+	ts_bgw_counter_setup_gucs();
+	ts_bgw_interface_register_api_version();
 
 	/* This is a safety-valve variable to prevent loading the full extension */
 	DefineCustomBoolVariable(GUC_DISABLE_LOAD_NAME, "Disable the loading of the actual extension",
@@ -550,7 +550,7 @@ extension_check()
 }
 
 extern void
-loader_extension_check(void)
+ts_loader_extension_check(void)
 {
 	extension_check();
 }

--- a/src/loader/loader.h
+++ b/src/loader/loader.h
@@ -9,10 +9,10 @@
 
 #include <postgres.h>
 
-extern char *loader_extension_version(void);
+extern char *ts_loader_extension_version(void);
 
-extern bool loader_extension_exists(void);
+extern bool ts_loader_extension_exists(void);
 
-extern void loader_extension_check(void);
+extern void ts_loader_extension_check(void);
 
 #endif							/* TIMESCALDB_LOADER_H */

--- a/src/net/conn.c
+++ b/src/net/conn.c
@@ -33,7 +33,7 @@ connection_internal_create(ConnectionType type, ConnOps *ops)
 }
 
 Connection *
-connection_create(ConnectionType type)
+ts_connection_create(ConnectionType type)
 {
 	Connection *conn;
 
@@ -67,7 +67,7 @@ connection_create(ConnectionType type)
  * 'servname' (e.g., 'http'), unless a valid port number is given.
  */
 int
-connection_connect(Connection *conn, const char *host, const char *servname, int port)
+ts_connection_connect(Connection *conn, const char *host, const char *servname, int port)
 {
 /* Windows defines 'connect()' as a macro, so we need to undef it here to use it in ops->connect */
 #ifdef WIN32
@@ -77,26 +77,26 @@ connection_connect(Connection *conn, const char *host, const char *servname, int
 }
 
 ssize_t
-connection_write(Connection *conn, const char *buf, size_t writelen)
+ts_connection_write(Connection *conn, const char *buf, size_t writelen)
 {
 	return conn->ops->write(conn, buf, writelen);
 }
 
 ssize_t
-connection_read(Connection *conn, char *buf, size_t buflen)
+ts_connection_read(Connection *conn, char *buf, size_t buflen)
 {
 	return conn->ops->read(conn, buf, buflen);
 }
 
 void
-connection_close(Connection *conn)
+ts_connection_close(Connection *conn)
 {
 	if (NULL != conn->ops)
 		conn->ops->close(conn);
 }
 
 int
-connection_set_timeout_millis(Connection *conn, unsigned long millis)
+ts_connection_set_timeout_millis(Connection *conn, unsigned long millis)
 {
 	if (NULL != conn->ops->set_timeout)
 		return conn->ops->set_timeout(conn, millis);
@@ -105,18 +105,18 @@ connection_set_timeout_millis(Connection *conn, unsigned long millis)
 }
 
 void
-connection_destroy(Connection *conn)
+ts_connection_destroy(Connection *conn)
 {
 	if (conn == NULL)
 		return;
 
-	connection_close(conn);
+	ts_connection_close(conn);
 	conn->ops = NULL;
 	pfree(conn);
 }
 
 int
-connection_register(ConnectionType type, ConnOps *ops)
+ts_connection_register(ConnectionType type, ConnOps *ops)
 {
 	if (type == _CONNECTION_MAX)
 		return -1;
@@ -127,7 +127,7 @@ connection_register(ConnectionType type, ConnOps *ops)
 }
 
 const char *
-connection_get_and_clear_error(Connection *conn)
+ts_connection_get_and_clear_error(Connection *conn)
 {
 	if (NULL != conn->ops->errmsg)
 		return conn->ops->errmsg(conn);

--- a/src/net/conn.h
+++ b/src/net/conn.h
@@ -31,17 +31,17 @@ typedef struct Connection
 	int			err;
 } Connection;
 
-extern Connection *connection_create(ConnectionType type);
-extern int	connection_connect(Connection *conn, const char *host, const char *servname, int port);
-extern ssize_t connection_read(Connection *conn, char *buf, size_t buflen);
-extern ssize_t connection_write(Connection *conn, const char *buf, size_t writelen);
-extern void connection_close(Connection *conn);
-extern void connection_destroy(Connection *conn);
-extern int	connection_set_timeout_millis(Connection *conn, unsigned long millis);
-extern const char *connection_get_and_clear_error(Connection *conn);
+extern Connection *ts_connection_create(ConnectionType type);
+extern int	ts_connection_connect(Connection *conn, const char *host, const char *servname, int port);
+extern ssize_t ts_connection_read(Connection *conn, char *buf, size_t buflen);
+extern ssize_t ts_connection_write(Connection *conn, const char *buf, size_t writelen);
+extern void ts_connection_close(Connection *conn);
+extern void ts_connection_destroy(Connection *conn);
+extern int	ts_connection_set_timeout_millis(Connection *conn, unsigned long millis);
+extern const char *ts_connection_get_and_clear_error(Connection *conn);
 
 /*  Called in init.c */
-extern void _connection_init(void);
-extern void _connection_fini(void);
+extern void ts_connection_init(void);
+extern void ts_connection_fini(void);
 
 #endif							/* TIMESCALEDB_NET_CONN_H */

--- a/src/net/conn_internal.h
+++ b/src/net/conn_internal.h
@@ -21,6 +21,6 @@ typedef struct ConnOps
 	const char *(*errmsg) (Connection *conn);
 } ConnOps;
 
-extern int	connection_register(ConnectionType type, ConnOps *ops);
+extern int	ts_connection_register(ConnectionType type, ConnOps *ops);
 
 #endif							/* TIMESCALEDB_CONN_INTERNAL_H */

--- a/src/net/conn_plain.c
+++ b/src/net/conn_plain.c
@@ -28,7 +28,7 @@ set_error(int err)
 
 /*  Create socket and connect */
 int
-plain_connect(Connection *conn, const char *host, const char *servname, int port)
+ts_plain_connect(Connection *conn, const char *host, const char *servname, int port)
 {
 	char		strport[6];
 	struct addrinfo *ainfo,
@@ -96,7 +96,7 @@ plain_connect(Connection *conn, const char *host, const char *servname, int port
 	 * Set send / recv timeout so that write and read don't block forever. Set
 	 * separately so that one of the actions failing doesn't block the other.
 	 */
-	if (plain_set_timeout(conn, DEFAULT_TIMEOUT_MSEC) < 0)
+	if (ts_plain_set_timeout(conn, DEFAULT_TIMEOUT_MSEC) < 0)
 	{
 		ret = SOCKET_ERROR;
 		goto out_addrinfo;
@@ -178,7 +178,7 @@ plain_read(Connection *conn, char *buf, size_t buflen)
 }
 
 void
-plain_close(Connection *conn)
+ts_plain_close(Connection *conn)
 {
 #ifdef WIN32
 	closesocket(conn->sock);
@@ -188,7 +188,7 @@ plain_close(Connection *conn)
 }
 
 int
-plain_set_timeout(Connection *conn, unsigned long millis)
+ts_plain_set_timeout(Connection *conn, unsigned long millis)
 {
 #ifdef WIN32
 	/* Timeout is in milliseconds on Windows */
@@ -220,7 +220,7 @@ plain_set_timeout(Connection *conn, unsigned long millis)
 }
 
 const char *
-plain_errmsg(Connection *conn)
+ts_plain_errmsg(Connection *conn)
 {
 	const char *errmsg = "no connection error";
 
@@ -240,11 +240,11 @@ plain_errmsg(Connection *conn)
 static ConnOps plain_ops = {
 	.size = sizeof(Connection),
 	.init = NULL,
-	.connect = plain_connect,
-	.close = plain_close,
+	.connect = ts_plain_connect,
+	.close = ts_plain_close,
 	.write = plain_write,
 	.read = plain_read,
-	.errmsg = plain_errmsg,
+	.errmsg = ts_plain_errmsg,
 };
 
 extern void _conn_plain_init(void);
@@ -271,7 +271,7 @@ _conn_plain_init(void)
 		return;
 	}
 #endif
-	connection_register(CONNECTION_PLAIN, &plain_ops);
+	ts_connection_register(CONNECTION_PLAIN, &plain_ops);
 }
 
 void

--- a/src/net/conn_plain.h
+++ b/src/net/conn_plain.h
@@ -16,9 +16,9 @@ typedef struct Connection Connection;
 #define IS_SOCKET_ERROR(err) (err < 0)
 #endif
 
-extern int	plain_connect(Connection *conn, const char *host, const char *servname, int port);
-extern void plain_close(Connection *conn);
-extern int	plain_set_timeout(Connection *conn, unsigned long millis);
-extern const char *plain_errmsg(Connection *conn);
+extern int	ts_plain_connect(Connection *conn, const char *host, const char *servname, int port);
+extern void ts_plain_close(Connection *conn);
+extern int	ts_plain_set_timeout(Connection *conn, unsigned long millis);
+extern const char *ts_plain_errmsg(Connection *conn);
 
 #endif							/* TIMESCALEDB_CONN_PLAIN_H */

--- a/src/net/conn_ssl.c
+++ b/src/net/conn_ssl.c
@@ -111,7 +111,7 @@ ssl_connect(Connection *conn, const char *host, const char *servname, int port)
 	int			ret;
 
 	/* First do the base connection setup */
-	ret = plain_connect(conn, host, servname, port);
+	ret = ts_plain_connect(conn, host, servname, port);
 
 	if (ret < 0)
 		return -1;
@@ -162,7 +162,7 @@ ssl_close(Connection *conn)
 		sslconn->ssl_ctx = NULL;
 	}
 
-	plain_close(conn);
+	ts_plain_close(conn);
 }
 
 static const char *
@@ -209,7 +209,7 @@ ssl_errmsg(Connection *conn)
 					{
 						/* reset error for plan_errmsg() */
 						conn->err = err;
-						return plain_errmsg(conn);
+						return ts_plain_errmsg(conn);
 					}
 					else
 						return "unknown SSL syscall error";
@@ -227,7 +227,7 @@ ssl_errmsg(Connection *conn)
 		{
 			/* reset error for plan_errmsg() */
 			conn->err = err;
-			return plain_errmsg(conn);
+			return ts_plain_errmsg(conn);
 		}
 
 		return "no SSL error";
@@ -250,7 +250,7 @@ static ConnOps ssl_ops = {
 	.close = ssl_close,
 	.write = ssl_write,
 	.read = ssl_read,
-	.set_timeout = plain_set_timeout,
+	.set_timeout = ts_plain_set_timeout,
 	.errmsg = ssl_errmsg,
 };
 
@@ -263,7 +263,7 @@ _conn_ssl_init(void)
 	SSL_library_init();
 	/* Always returns 1 */
 	SSL_load_error_strings();
-	connection_register(CONNECTION_SSL, &ssl_ops);
+	ts_connection_register(CONNECTION_SSL, &ssl_ops);
 }
 
 void

--- a/src/net/http.c
+++ b/src/net/http.c
@@ -28,13 +28,13 @@ static const char *http_version_strings[] = {
 };
 
 const char *
-http_strerror(HttpError http_errno)
+ts_http_strerror(HttpError http_errno)
 {
 	return http_error_strings[http_errno];
 }
 
 HttpVersion
-http_version_from_string(const char *version)
+ts_http_version_from_string(const char *version)
 {
 	int			i;
 
@@ -46,7 +46,7 @@ http_version_from_string(const char *version)
 }
 
 const char *
-http_version_string(HttpVersion version)
+ts_http_version_string(HttpVersion version)
 {
 	return http_version_strings[version];
 }
@@ -57,7 +57,7 @@ http_version_string(HttpVersion version)
  * Returns HTTP_ERROR_NONE (0) on success or a HTTP-specfic error on failure.
  */
 HttpError
-http_send_and_recv(Connection *conn, HttpRequest *req, HttpResponseState *state)
+ts_http_send_and_recv(Connection *conn, HttpRequest *req, HttpResponseState *state)
 {
 	const char *built_request;
 	size_t		request_len;
@@ -65,14 +65,14 @@ http_send_and_recv(Connection *conn, HttpRequest *req, HttpResponseState *state)
 	HttpError	err = HTTP_ERROR_NONE;
 	int			ret;
 
-	built_request = http_request_build(req, &request_len);
+	built_request = ts_http_request_build(req, &request_len);
 
 	if (NULL == built_request)
 		return HTTP_ERROR_REQUEST_BUILD;
 
 	while (request_len > 0)
 	{
-		ret = connection_write(conn, built_request + write_off, request_len);
+		ret = ts_connection_write(conn, built_request + write_off, request_len);
 
 		if (ret < 0 || ret > request_len)
 			return HTTP_ERROR_WRITE;
@@ -84,10 +84,10 @@ http_send_and_recv(Connection *conn, HttpRequest *req, HttpResponseState *state)
 		request_len -= ret;
 	}
 
-	while (err == HTTP_ERROR_NONE && !http_response_state_is_done(state))
+	while (err == HTTP_ERROR_NONE && !ts_http_response_state_is_done(state))
 	{
 		ssize_t		remaining = 0;
-		char	   *buf = http_response_state_next_buffer(state, &remaining);
+		char	   *buf = ts_http_response_state_next_buffer(state, &remaining);
 
 		if (remaining < 0)
 			err = HTTP_ERROR_INVALID_BUFFER_STATE;
@@ -95,14 +95,14 @@ http_send_and_recv(Connection *conn, HttpRequest *req, HttpResponseState *state)
 			err = HTTP_ERROR_RESPONSE_INCOMPLETE;
 		else
 		{
-			ssize_t		bytes_read = connection_read(conn, buf, remaining);
+			ssize_t		bytes_read = ts_connection_read(conn, buf, remaining);
 
 			if (bytes_read < 0)
 				err = HTTP_ERROR_READ;
 			/* Check for error or closed socket/EOF (ret == 0) */
 			else if (bytes_read == 0)
 				err = HTTP_ERROR_CONN_CLOSED;
-			else if (!http_response_state_parse(state, bytes_read))
+			else if (!ts_http_response_state_parse(state, bytes_read))
 				err = HTTP_ERROR_RESPONSE_PARSE;
 		}
 	}

--- a/src/net/http.h
+++ b/src/net/http.h
@@ -57,46 +57,46 @@ typedef enum HttpError
 typedef struct HttpRequest HttpRequest;
 typedef struct Connection Connection;
 
-HttpVersion http_version_from_string(const char *version);
-const char *http_version_string(HttpVersion version);
+extern HttpVersion ts_http_version_from_string(const char *version);
+extern const char *ts_http_version_string(HttpVersion version);
 
-void		http_request_init(HttpRequest *req, HttpRequestMethod method);
-HttpRequest *http_request_create(HttpRequestMethod method);
-void		http_request_destroy(HttpRequest *req);
+extern void ts_http_request_init(HttpRequest *req, HttpRequestMethod method);
+extern HttpRequest *ts_http_request_create(HttpRequestMethod method);
+extern void ts_http_request_destroy(HttpRequest *req);
 
 /* Assume that uri is null-terminated */
-void		http_request_set_uri(HttpRequest *req, const char *uri);
-void		http_request_set_version(HttpRequest *req, HttpVersion version);
+extern void ts_http_request_set_uri(HttpRequest *req, const char *uri);
+extern void ts_http_request_set_version(HttpRequest *req, HttpVersion version);
 
 /* Assume that name and value are null-terminated */
-void		http_request_set_header(HttpRequest *req, const char *name, const char *valuue);
-void		http_request_set_body(HttpRequest *req, const char *body, size_t body_len);
+extern void ts_http_request_set_header(HttpRequest *req, const char *name, const char *valuue);
+extern void ts_http_request_set_body(HttpRequest *req, const char *body, size_t body_len);
 
 /*  Serialize the request into char *dst. Return the length of request in optional size pointer*/
-const char *http_request_build(HttpRequest *req, size_t *buf_size);
+extern const char *ts_http_request_build(HttpRequest *req, size_t *buf_size);
 
 /******* http_response.c *******/
 
 typedef struct HttpResponseState HttpResponseState;
 
-void		http_response_state_init(HttpResponseState *state);
-HttpResponseState *http_response_state_create(void);
-void		http_response_state_destroy(HttpResponseState *state);
+extern void ts_http_response_state_init(HttpResponseState *state);
+extern HttpResponseState *ts_http_response_state_create(void);
+extern void ts_http_response_state_destroy(HttpResponseState *state);
 
 /*  Accessor Functions */
-bool		http_response_state_is_done(HttpResponseState *state);
-bool		http_response_state_valid_status(HttpResponseState *state);
-char	   *http_response_state_next_buffer(HttpResponseState *state, ssize_t *bufsize);
-ssize_t		http_response_state_buffer_remaining(HttpResponseState *state);
-const char *http_response_state_body_start(HttpResponseState *state);
-size_t		http_response_state_content_length(HttpResponseState *state);
-int			http_response_state_status_code(HttpResponseState *state);
-HttpHeader *http_response_state_headers(HttpResponseState *state);
+extern bool ts_http_response_state_is_done(HttpResponseState *state);
+extern bool ts_http_response_state_valid_status(HttpResponseState *state);
+extern char *ts_http_response_state_next_buffer(HttpResponseState *state, ssize_t *bufsize);
+extern ssize_t ts_http_response_state_buffer_remaining(HttpResponseState *state);
+extern const char *ts_http_response_state_body_start(HttpResponseState *state);
+extern size_t ts_http_response_state_content_length(HttpResponseState *state);
+extern int	ts_http_response_state_status_code(HttpResponseState *state);
+extern HttpHeader *ts_http_response_state_headers(HttpResponseState *state);
 
 /*  Returns false if encountered an error during parsing */
-bool		http_response_state_parse(HttpResponseState *state, size_t bytes);
+extern bool ts_http_response_state_parse(HttpResponseState *state, size_t bytes);
 
-const char *http_strerror(HttpError http_errno);
-HttpError	http_send_and_recv(Connection *conn, HttpRequest *req, HttpResponseState *state);
+extern const char *ts_http_strerror(HttpError http_errno);
+extern HttpError ts_http_send_and_recv(Connection *conn, HttpRequest *req, HttpResponseState *state);
 
 #endif							/* TIMESCALEDB_HTTP_H */

--- a/src/net/http_request.c
+++ b/src/net/http_request.c
@@ -16,18 +16,18 @@
 #define NEW_LINE	'\n'
 
 /*  So that http_response.c can find this function */
-HttpHeader *http_header_create(const char *name,
-				   size_t name_len,
-				   const char *value,
-				   size_t value_len,
-				   HttpHeader *next);
+HttpHeader *ts_http_header_create(const char *name,
+					  size_t name_len,
+					  const char *value,
+					  size_t value_len,
+					  HttpHeader *next);
 
 HttpHeader *
-http_header_create(const char *name,
-				   size_t name_len,
-				   const char *value,
-				   size_t value_len,
-				   HttpHeader *next)
+ts_http_header_create(const char *name,
+					  size_t name_len,
+					  const char *value,
+					  size_t value_len,
+					  HttpHeader *next)
 {
 	HttpHeader *new_header = palloc(sizeof(HttpHeader));
 
@@ -66,16 +66,16 @@ static const char *http_method_strings[] = {
 };
 
 #define METHOD_STRING(x)	http_method_strings[x]
-#define VERSION_STRING(x)	http_version_string(x)
+#define VERSION_STRING(x)	ts_http_version_string(x)
 
 void
-http_request_init(HttpRequest *req, HttpRequestMethod method)
+ts_http_request_init(HttpRequest *req, HttpRequestMethod method)
 {
 	req->method = method;
 }
 
 HttpRequest *
-http_request_create(HttpRequestMethod method)
+ts_http_request_create(HttpRequestMethod method)
 {
 	MemoryContext request_context = AllocSetContextCreate(CurrentMemoryContext,
 														  "Http Request",
@@ -84,20 +84,20 @@ http_request_create(HttpRequestMethod method)
 	HttpRequest *req = palloc0(sizeof(HttpRequest));
 
 	req->context = request_context;
-	http_request_init(req, method);
+	ts_http_request_init(req, method);
 
 	MemoryContextSwitchTo(old);
 	return req;
 }
 
 void
-http_request_destroy(HttpRequest *req)
+ts_http_request_destroy(HttpRequest *req)
 {
 	MemoryContextDelete(req->context);
 }
 
 void
-http_request_set_uri(HttpRequest *req, const char *uri)
+ts_http_request_set_uri(HttpRequest *req, const char *uri)
 {
 	MemoryContext old = MemoryContextSwitchTo(req->context);
 	int			uri_len = strlen(uri);
@@ -110,26 +110,26 @@ http_request_set_uri(HttpRequest *req, const char *uri)
 }
 
 void
-http_request_set_version(HttpRequest *req, HttpVersion version)
+ts_http_request_set_version(HttpRequest *req, HttpVersion version)
 {
 	req->version = version;
 }
 
 void
-http_request_set_header(HttpRequest *req, const char *name, const char *value)
+ts_http_request_set_header(HttpRequest *req, const char *name, const char *value)
 {
 	MemoryContext old = MemoryContextSwitchTo(req->context);
 	int			name_len = strlen(name);
 	int			value_len = strlen(value);
 	HttpHeader *new_header =
-	http_header_create(name, name_len, value, value_len, req->headers);
+	ts_http_header_create(name, name_len, value, value_len, req->headers);
 
 	req->headers = new_header;
 	MemoryContextSwitchTo(old);
 }
 
 void
-http_request_set_body(HttpRequest *req, const char *body, size_t body_len)
+ts_http_request_set_body(HttpRequest *req, const char *body, size_t body_len)
 {
 	MemoryContext old = MemoryContextSwitchTo(req->context);
 
@@ -194,7 +194,7 @@ http_header_get_content_length(HttpHeader *header)
 }
 
 const char *
-http_request_build(HttpRequest *req, size_t *buf_size)
+ts_http_request_build(HttpRequest *req, size_t *buf_size)
 {
 	/* serialize into this buf, which is allocated on caller's memory context */
 	StringInfoData buf;

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -74,7 +74,7 @@ partitioning_func_get(const char *schema, const char *funcname)
 }
 
 bool
-partitioning_func_is_valid(regproc funcoid)
+ts_partitioning_func_is_valid(regproc funcoid)
 {
 	HeapTuple	tuple;
 	bool		isvalid;
@@ -92,14 +92,14 @@ partitioning_func_is_valid(regproc funcoid)
 }
 
 Oid
-partitioning_func_get_default(void)
+ts_partitioning_func_get_default(void)
 {
 	return partitioning_func_get(DEFAULT_PARTITIONING_FUNC_SCHEMA,
 								 DEFAULT_PARTITIONING_FUNC_NAME);
 }
 
 bool
-partitioning_func_is_default(const char *schema, const char *funcname)
+ts_partitioning_func_is_default(const char *schema, const char *funcname)
 {
 	Assert(schema != NULL && funcname != NULL);
 
@@ -125,7 +125,7 @@ partitioning_func_set_func_fmgr(PartitioningFunc *pf)
 }
 
 List *
-partitioning_func_qualified_name(PartitioningFunc *pf)
+ts_partitioning_func_qualified_name(PartitioningFunc *pf)
 {
 	return list_make2(makeString(pf->schema), makeString(pf->name));
 }
@@ -152,10 +152,10 @@ find_text_coercion_func(Oid type)
 #define TYPECACHE_HASH_FLAGS (TYPECACHE_HASH_PROC | TYPECACHE_HASH_PROC_FINFO)
 
 PartitioningInfo *
-partitioning_info_create(const char *schema,
-						 const char *partfunc,
-						 const char *partcol,
-						 Oid relid)
+ts_partitioning_info_create(const char *schema,
+							const char *partfunc,
+							const char *partcol,
+							Oid relid)
 {
 	PartitioningInfo *pinfo;
 	TypeCacheEntry *tce;
@@ -186,7 +186,7 @@ partitioning_info_create(const char *schema,
 	columntype = get_atttype(relid, pinfo->column_attnum);
 	tce = lookup_type_cache(columntype, TYPECACHE_HASH_FLAGS);
 
-	if (tce->hash_proc == InvalidOid && partitioning_func_is_default(schema, partfunc))
+	if (tce->hash_proc == InvalidOid && ts_partitioning_func_is_default(schema, partfunc))
 		elog(ERROR, "could not find hash function for type %s", format_type_be(columntype));
 
 	partitioning_func_set_func_fmgr(&pinfo->partfunc);
@@ -219,13 +219,13 @@ partitioning_info_create(const char *schema,
  * We support partitioning functions with the signature (anyelement) -> int.
  */
 int32
-partitioning_func_apply(PartitioningInfo *pinfo, Datum value)
+ts_partitioning_func_apply(PartitioningInfo *pinfo, Datum value)
 {
 	return DatumGetInt32(FunctionCall1(&pinfo->partfunc.func_fmgr, value));
 }
 
 int32
-partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDesc desc)
+ts_partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDesc desc)
 {
 	Datum		value;
 	bool		isnull;
@@ -235,7 +235,7 @@ partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDes
 	if (isnull)
 		return 0;
 
-	return partitioning_func_apply(pinfo, value);
+	return ts_partitioning_func_apply(pinfo, value);
 }
 
 /*

--- a/src/partitioning.h
+++ b/src/partitioning.h
@@ -44,16 +44,16 @@ typedef struct PartitioningInfo
 } PartitioningInfo;
 
 
-extern Oid	partitioning_func_get_default(void);
-extern bool partitioning_func_is_default(const char *schema, const char *funcname);
-extern bool partitioning_func_is_valid(regproc funcoid);
+extern Oid	ts_partitioning_func_get_default(void);
+extern bool ts_partitioning_func_is_default(const char *schema, const char *funcname);
+extern bool ts_partitioning_func_is_valid(regproc funcoid);
 
-extern PartitioningInfo *partitioning_info_create(const char *schema,
-						 const char *partfunc,
-						 const char *partcol,
-						 Oid relid);
-extern List *partitioning_func_qualified_name(PartitioningFunc *pf);
-extern int32 partitioning_func_apply(PartitioningInfo *pinfo, Datum value);
-extern int32 partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDesc desc);
+extern PartitioningInfo *ts_partitioning_info_create(const char *schema,
+							const char *partfunc,
+							const char *partcol,
+							Oid relid);
+extern List *ts_partitioning_func_qualified_name(PartitioningFunc *pf);
+extern int32 ts_partitioning_func_apply(PartitioningInfo *pinfo, Datum value);
+extern int32 ts_partitioning_func_apply_tuple(PartitioningInfo *pinfo, HeapTuple tuple, TupleDesc desc);
 
 #endif							/* TIMESCALEDB_PARTITIONING_H */

--- a/src/plan_add_hashagg.h
+++ b/src/plan_add_hashagg.h
@@ -20,7 +20,7 @@
  * like time_bucket and date_trunc. This optimization fixes the statistics and adds the HashAggregate plan if appropriate.
  * */
 
-extern void plan_add_hashagg(PlannerInfo *root,
-				 RelOptInfo *input_rel,
-				 RelOptInfo *output_rel);
+extern void ts_plan_add_hashagg(PlannerInfo *root,
+					RelOptInfo *input_rel,
+					RelOptInfo *output_rel);
 #endif							/* TIMESCALEDB_PLAN_ADD_HASHAGG_H */

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -104,7 +104,7 @@ find_children_oids(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockmod
 	 * Using the HRI only makes sense if we are not using all the chunks,
 	 * otherwise using the cached inheritance hierarchy is faster.
 	 */
-	if (!hypertable_restrict_info_has_restrictions(hri))
+	if (!ts_hypertable_restrict_info_has_restrictions(hri))
 		return find_all_inheritors(ht->main_table_relid, lockmode, NULL);;
 
 	/* always include parent again, just as find_all_inheritors does */
@@ -112,14 +112,14 @@ find_children_oids(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockmod
 
 	/* add chunks */
 	result = list_concat(result,
-						 hypertable_restrict_info_get_chunk_oids(hri,
-																 ht,
-																 lockmode));
+						 ts_hypertable_restrict_info_get_chunk_oids(hri,
+																	ht,
+																	lockmode));
 	return result;
 }
 
 bool
-plan_expand_hypertable_valid_hypertable(Hypertable *ht, Query *parse, Index rti, RangeTblEntry *rte)
+ts_plan_expand_hypertable_valid_hypertable(Hypertable *ht, Query *parse, Index rti, RangeTblEntry *rte)
 {
 	if (ht == NULL ||
 	/* inheritance enabled */
@@ -136,11 +136,11 @@ plan_expand_hypertable_valid_hypertable(Hypertable *ht, Query *parse, Index rti,
 /* Inspired by expand_inherited_rtentry but expands
  * a hypertable chunks into an append relationship */
 void
-plan_expand_hypertable_chunks(Hypertable *ht,
-							  PlannerInfo *root,
-							  Oid parent_oid,
-							  bool inhparent,
-							  RelOptInfo *rel)
+ts_plan_expand_hypertable_chunks(Hypertable *ht,
+								 PlannerInfo *root,
+								 Oid parent_oid,
+								 bool inhparent,
+								 RelOptInfo *rel)
 {
 	RangeTblEntry *rte = rt_fetch(rel->relid, root->parse->rtable);
 	List	   *inh_oids;
@@ -174,8 +174,8 @@ plan_expand_hypertable_chunks(Hypertable *ht,
 	 * infrastructure to deduce the appropriate chunks using our range
 	 * exclusion
 	 */
-	hri = hypertable_restrict_info_create(rel, ht);
-	hypertable_restrict_info_add(hri, root, restrictinfo);
+	hri = ts_hypertable_restrict_info_create(rel, ht);
+	ts_hypertable_restrict_info_add(hri, root, restrictinfo);
 	inh_oids = find_children_oids(hri, ht, AccessShareLock);
 
 	/*
@@ -238,8 +238,8 @@ plan_expand_hypertable_chunks(Hypertable *ht,
 		appinfo->child_relid = child_rtindex;
 		appinfo->parent_reltype = oldrelation->rd_rel->reltype;
 		appinfo->child_reltype = newrelation->rd_rel->reltype;
-		make_inh_translation_list(oldrelation, newrelation, child_rtindex,
-								  &appinfo->translated_vars);
+		ts_make_inh_translation_list(oldrelation, newrelation, child_rtindex,
+									 &appinfo->translated_vars);
 		appinfo->parent_reloid = parent_oid;
 		appinfos = lappend(appinfos, appinfo);
 

--- a/src/plan_expand_hypertable.h
+++ b/src/plan_expand_hypertable.h
@@ -25,9 +25,9 @@
  * */
 
 /* Can we use hypertable expansion here */
-extern bool plan_expand_hypertable_valid_hypertable(Hypertable *ht, Query *parse, Index rti, RangeTblEntry *rte);
+extern bool ts_plan_expand_hypertable_valid_hypertable(Hypertable *ht, Query *parse, Index rti, RangeTblEntry *rte);
 
 /* Do the expansion */
-extern void plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, Oid relation_objectid, bool inhparent, RelOptInfo *rel);
+extern void ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, Oid relation_objectid, bool inhparent, RelOptInfo *rel);
 
 #endif							/* TIMESCALEDB_PLAN_EXPAND_HYPERTABLE_H */

--- a/src/planner_import.c
+++ b/src/planner_import.c
@@ -31,9 +31,9 @@
 
 /* copied verbatim from prepunion.c */
 void
-make_inh_translation_list(Relation oldrelation, Relation newrelation,
-						  Index newvarno,
-						  List **translated_vars)
+ts_make_inh_translation_list(Relation oldrelation, Relation newrelation,
+							 Index newvarno,
+							 List **translated_vars)
 {
 	List	   *vars = NIL;
 	TupleDesc	old_tupdesc = RelationGetDescr(oldrelation);
@@ -128,9 +128,9 @@ make_inh_translation_list(Relation oldrelation, Relation newrelation,
 
 /* copied exactly from planner.c */
 size_t
-estimate_hashagg_tablesize(struct Path *path,
-						   const struct AggClauseCosts *agg_costs,
-						   double dNumGroups)
+ts_estimate_hashagg_tablesize(struct Path *path,
+							  const struct AggClauseCosts *agg_costs,
+							  double dNumGroups)
 {
 	size_t		hashentrysize;
 
@@ -154,7 +154,7 @@ estimate_hashagg_tablesize(struct Path *path,
 
 /* copied verbatim from planner.c */
 struct PathTarget *
-make_partial_grouping_target(struct PlannerInfo *root, PathTarget *grouping_target)
+ts_make_partial_grouping_target(struct PlannerInfo *root, PathTarget *grouping_target)
 {
 	struct Query *parse = root->parse;
 	PathTarget *partial_target;
@@ -251,8 +251,8 @@ make_partial_grouping_target(struct PlannerInfo *root, PathTarget *grouping_targ
 #if PG96
 /* copied verbatim from selfuncs.c */
 bool
-get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
-				   Datum *min, Datum *max)
+ts_get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
+					  Datum *min, Datum *max)
 {
 	uintptr_t	tmin = 0;
 	uintptr_t	tmax = 0;
@@ -390,8 +390,8 @@ get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
 #else
 /* copied verbatim from selfuncs.c */
 bool
-get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
-				   Datum *min, Datum *max)
+ts_get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
+					  Datum *min, Datum *max)
 {
 	Datum		tmin = 0;
 	Datum		tmax = 0;

--- a/src/planner_import.h
+++ b/src/planner_import.h
@@ -18,17 +18,17 @@
  * manipulations.
  */
 
-extern void make_inh_translation_list(Relation oldrelation, Relation newrelation,
-						  Index newvarno,
-						  List **translated_vars);
-size_t estimate_hashagg_tablesize(struct Path *path,
-						   const struct AggClauseCosts *agg_costs,
-						   double dNumGroups);
+extern void ts_make_inh_translation_list(Relation oldrelation, Relation newrelation,
+							 Index newvarno,
+							 List **translated_vars);
+extern size_t ts_estimate_hashagg_tablesize(struct Path *path,
+							  const struct AggClauseCosts *agg_costs,
+							  double dNumGroups);
 
-struct PathTarget *make_partial_grouping_target(struct PlannerInfo *root,
-							 PathTarget *grouping_target);
+extern struct PathTarget *ts_make_partial_grouping_target(struct PlannerInfo *root,
+								PathTarget *grouping_target);
 
-bool get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
-				   Datum *min, Datum *max);
+extern bool ts_get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop,
+					  Datum *min, Datum *max);
 
 #endif							/* TIMESCALEDB_PLANNER_IMPORT_H */

--- a/src/planner_utils.c
+++ b/src/planner_utils.c
@@ -70,7 +70,7 @@ static void
 }
 
 void
-			planned_stmt_walker(PlannedStmt *stmt, void (*walker) (Plan **, void *), void *context)
+			ts_planned_stmt_walker(PlannedStmt *stmt, void (*walker) (Plan **, void *), void *context)
 {
 	ListCell   *lc;
 

--- a/src/planner_utils.h
+++ b/src/planner_utils.h
@@ -10,6 +10,6 @@
 #include <postgres.h>
 #include <nodes/plannodes.h>
 
-extern void planned_stmt_walker(PlannedStmt *stmt, void (*walker) (Plan **, void *), void *context);
+extern void ts_planned_stmt_walker(PlannedStmt *stmt, void (*walker) (Plan **, void *), void *context);
 
 #endif							/* TIMESCALEDB_PLANNER_UTILS_H */

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -10,6 +10,6 @@
 #include <postgres.h>
 #include <nodes/plannodes.h>
 
-extern void process_utility_set_expect_chunk_modification(bool expect);
+extern void ts_process_utility_set_expect_chunk_modification(bool expect);
 
 #endif							/* TIMESCALEDB_PROCESS_UTILITY_H */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -162,7 +162,7 @@ static Scanner scanners[] = {
  * Return the number of tuples that where found.
  */
 int
-scanner_scan(ScannerCtx *ctx)
+ts_scanner_scan(ScannerCtx *ctx)
 {
 	TupleDesc	tuple_desc;
 	bool		is_valid;
@@ -240,9 +240,9 @@ scanner_scan(ScannerCtx *ctx)
 }
 
 bool
-scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type)
+ts_scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type)
 {
-	int			num_found = scanner_scan(ctx);
+	int			num_found = ts_scanner_scan(ctx);
 
 	ctx->limit = 2;
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -103,8 +103,8 @@ typedef struct ScannerCtx
 
 /* Performs an index scan or heap scan and returns the number of matching
  * tuples. */
-int			scanner_scan(ScannerCtx *ctx);
-bool		scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type);
+extern int	ts_scanner_scan(ScannerCtx *ctx);
+extern bool ts_scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type);
 
 
 #endif							/* TIMESCALEDB_SCANNER_H */

--- a/src/sort_transform.c
+++ b/src/sort_transform.c
@@ -25,7 +25,7 @@
  * to an ordering on time.
  */
 
-extern void sort_transform_optimization(PlannerInfo *root, RelOptInfo *rel);
+extern void ts_sort_transform_optimization(PlannerInfo *root, RelOptInfo *rel);
 static Expr *sort_transform_expr(Expr *orig_expr);
 
 static Expr *
@@ -367,7 +367,7 @@ sort_transform_ec(PlannerInfo *root, EquivalenceClass *orig)
  *	an ordering of time.
  */
 void
-sort_transform_optimization(PlannerInfo *root, RelOptInfo *rel)
+ts_sort_transform_optimization(PlannerInfo *root, RelOptInfo *rel)
 {
 	/*
 	 * We attack this problem in three steps:

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -43,7 +43,7 @@ subspace_store_internal_node_create(bool last_internal_node)
 {
 	SubspaceStoreInternalNode *node = palloc(sizeof(SubspaceStoreInternalNode));
 
-	node->vector = dimension_vec_create(DIMENSION_VEC_DEFAULT_SIZE);
+	node->vector = ts_dimension_vec_create(DIMENSION_VEC_DEFAULT_SIZE);
 	node->descendants = 0;
 	node->last_internal_node = last_internal_node;
 	return node;
@@ -52,14 +52,14 @@ subspace_store_internal_node_create(bool last_internal_node)
 static inline void
 subspace_store_internal_node_free(void *node)
 {
-	dimension_vec_free(((SubspaceStoreInternalNode *) node)->vector);
+	ts_dimension_vec_free(((SubspaceStoreInternalNode *) node)->vector);
 	pfree(node);
 }
 
 static size_t
 subspace_store_internal_node_descendants(SubspaceStoreInternalNode *node, int index)
 {
-	DimensionSlice *slice = dimension_vec_get(node->vector, index);
+	DimensionSlice *slice = ts_dimension_vec_get(node->vector, index);
 
 	if (slice == NULL)
 		return 0;
@@ -71,7 +71,7 @@ subspace_store_internal_node_descendants(SubspaceStoreInternalNode *node, int in
 }
 
 SubspaceStore *
-subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items)
+ts_subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items)
 {
 	MemoryContext old = MemoryContextSwitchTo(mcxt);
 	SubspaceStore *sst = palloc(sizeof(SubspaceStore));
@@ -92,8 +92,8 @@ subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items)
 }
 
 void
-subspace_store_add(SubspaceStore *store, const Hypercube *hc,
-				   void *object, void (*object_free) (void *))
+ts_subspace_store_add(SubspaceStore *store, const Hypercube *hc,
+					  void *object, void (*object_free) (void *))
 {
 	SubspaceStoreInternalNode *node = store->origin;
 	DimensionSlice *last = NULL;
@@ -156,7 +156,7 @@ subspace_store_add(SubspaceStore *store, const Hypercube *hc,
 
 			Assert(store->max_items + 1 == node->descendants);
 
-			dimension_vec_remove_slice(&node->vector, i);
+			ts_dimension_vec_remove_slice(&node->vector, i);
 
 			/*
 			 * Note we would have to do this to ancestors if this was not the
@@ -165,7 +165,7 @@ subspace_store_add(SubspaceStore *store, const Hypercube *hc,
 			node->descendants -= items_removed;
 		}
 
-		match = dimension_vec_find_slice(node->vector, target->fd.range_start);
+		match = ts_dimension_vec_find_slice(node->vector, target->fd.range_start);
 
 		/* Do we have a slot in this vector for the new object? */
 		if (match == NULL)
@@ -176,9 +176,9 @@ subspace_store_add(SubspaceStore *store, const Hypercube *hc,
 			 * create a new copy of the range this slice covers, to store the
 			 * object in
 			 */
-			copy = dimension_slice_copy(target);
+			copy = ts_dimension_slice_copy(target);
 
-			dimension_vec_add_slice_sort(&node->vector, copy);
+			ts_dimension_vec_add_slice_sort(&node->vector, copy);
 			match = copy;
 		}
 
@@ -197,7 +197,7 @@ subspace_store_add(SubspaceStore *store, const Hypercube *hc,
 
 
 void *
-subspace_store_get(SubspaceStore *store, Point *target)
+ts_subspace_store_get(SubspaceStore *store, Point *target)
 {
 	int			i;
 	DimensionVec *vec = store->origin->vector;
@@ -207,7 +207,7 @@ subspace_store_get(SubspaceStore *store, Point *target)
 
 	for (i = 0; i < target->cardinality; i++)
 	{
-		match = dimension_vec_find_slice(vec, target->coordinates[i]);
+		match = ts_dimension_vec_find_slice(vec, target->coordinates[i]);
 
 		if (NULL == match)
 			return NULL;
@@ -219,14 +219,14 @@ subspace_store_get(SubspaceStore *store, Point *target)
 }
 
 void
-subspace_store_free(SubspaceStore *store)
+ts_subspace_store_free(SubspaceStore *store)
 {
 	subspace_store_internal_node_free(store->origin);
 	pfree(store);
 }
 
 MemoryContext
-subspace_store_mcxt(SubspaceStore *store)
+ts_subspace_store_mcxt(SubspaceStore *store)
 {
 	return store->mcxt;
 }

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -20,17 +20,17 @@ typedef struct Hypercube Hypercube;
 typedef struct Point Point;
 typedef struct SubspaceStore SubspaceStore;
 
-extern SubspaceStore *subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items);
+extern SubspaceStore *ts_subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items);
 
 /* Store an object associate with the subspace represented by a hypercube */
-extern void subspace_store_add(SubspaceStore *cache, const Hypercube *hc,
-				   void *object, void (*object_free) (void *));
+extern void ts_subspace_store_add(SubspaceStore *cache, const Hypercube *hc,
+					  void *object, void (*object_free) (void *));
 
 /* Get the object stored for the subspace that a point is in.
  * Return the object stored or NULL if this subspace is not in the store.
  */
-extern void *subspace_store_get(SubspaceStore *cache, Point *target);
-extern void subspace_store_free(SubspaceStore *cache);
-extern MemoryContext subspace_store_mcxt(SubspaceStore *cache);
+extern void *ts_subspace_store_get(SubspaceStore *cache, Point *target);
+extern void ts_subspace_store_free(SubspaceStore *cache);
+extern MemoryContext ts_subspace_store_mcxt(SubspaceStore *cache);
 
 #endif							/* TIMESCALEDB_SUBSPACE_STORE_H */

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -25,15 +25,15 @@ typedef struct Tablespaces
 	Tablespace *tablespaces;
 } Tablespaces;
 
-extern Tablespace *tablespaces_add(Tablespaces *tablespaces, FormData_tablespace *form, Oid tspc_oid);
-extern bool tablespaces_delete(Tablespaces *tspcs, Oid tspc_oid);
-extern int	tablespaces_clear(Tablespaces *tspcs);
-extern bool tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
-extern Tablespaces *tablespace_scan(int32 hypertable_id);
-extern void tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_attached);
-extern int	tablespace_delete(int32 hypertable_id, const char *tspcname);
-extern int	tablespace_count_attached(const char *tspcname);
-extern void tablespace_validate_revoke(GrantStmt *stmt);
-extern void tablespace_validate_revoke_role(GrantRoleStmt *stmt);
+extern Tablespace *ts_tablespaces_add(Tablespaces *tablespaces, FormData_tablespace *form, Oid tspc_oid);
+extern bool ts_tablespaces_delete(Tablespaces *tspcs, Oid tspc_oid);
+extern int	ts_tablespaces_clear(Tablespaces *tspcs);
+extern bool ts_tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
+extern Tablespaces *ts_tablespace_scan(int32 hypertable_id);
+extern void ts_tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_attached);
+extern int	ts_tablespace_delete(int32 hypertable_id, const char *tspcname);
+extern int	ts_tablespace_count_attached(const char *tspcname);
+extern void ts_tablespace_validate_revoke(GrantStmt *stmt);
+extern void ts_tablespace_validate_revoke_role(GrantRoleStmt *stmt);
 
 #endif							/* TIMESCALEDB_TABLESPACE_H */

--- a/src/telemetry/metadata.c
+++ b/src/telemetry/metadata.c
@@ -23,44 +23,44 @@ get_uuid_by_key(const char *key)
 	bool		isnull;
 	Datum		uuid;
 
-	uuid = installation_metadata_get_value(CStringGetDatum(key), CSTRINGOID, UUIDOID, &isnull);
+	uuid = ts_installation_metadata_get_value(CStringGetDatum(key), CSTRINGOID, UUIDOID, &isnull);
 
 	if (isnull)
-		uuid = installation_metadata_insert(CStringGetDatum(key),
-											CSTRINGOID,
-											UUIDPGetDatum(uuid_create()),
-											UUIDOID);
+		uuid = ts_installation_metadata_insert(CStringGetDatum(key),
+											   CSTRINGOID,
+											   UUIDPGetDatum(ts_uuid_create()),
+											   UUIDOID);
 	return uuid;
 }
 
 Datum
-metadata_get_uuid(void)
+ts_metadata_get_uuid(void)
 {
 	return get_uuid_by_key(INSTALLATION_METADATA_UUID_KEY_NAME);
 }
 
 Datum
-metadata_get_exported_uuid(void)
+ts_metadata_get_exported_uuid(void)
 {
 	return get_uuid_by_key(INSTALLATION_METADATA_EXPORTED_UUID_KEY_NAME);
 }
 
 Datum
-metadata_get_install_timestamp(void)
+ts_metadata_get_install_timestamp(void)
 {
 	bool		isnull;
 	Datum		timestamp;
 
-	timestamp = installation_metadata_get_value(CStringGetDatum(INSTALLATION_METADATA_TIMESTAMP_KEY_NAME),
-												CSTRINGOID,
-												TIMESTAMPTZOID,
-												&isnull);
+	timestamp = ts_installation_metadata_get_value(CStringGetDatum(INSTALLATION_METADATA_TIMESTAMP_KEY_NAME),
+												   CSTRINGOID,
+												   TIMESTAMPTZOID,
+												   &isnull);
 
 	if (isnull)
-		timestamp = installation_metadata_insert(CStringGetDatum(INSTALLATION_METADATA_TIMESTAMP_KEY_NAME),
-												 CSTRINGOID,
-												 TimestampTzGetDatum(GetCurrentTimestamp()),
-												 TIMESTAMPTZOID);
+		timestamp = ts_installation_metadata_insert(CStringGetDatum(INSTALLATION_METADATA_TIMESTAMP_KEY_NAME),
+													CSTRINGOID,
+													TimestampTzGetDatum(GetCurrentTimestamp()),
+													TIMESTAMPTZOID);
 
 	return timestamp;
 }

--- a/src/telemetry/metadata.h
+++ b/src/telemetry/metadata.h
@@ -9,8 +9,8 @@
 
 #include <postgres.h>
 
-extern Datum metadata_get_uuid(void);
-extern Datum metadata_get_exported_uuid(void);
-extern Datum metadata_get_install_timestamp(void);
+extern Datum ts_metadata_get_uuid(void);
+extern Datum ts_metadata_get_exported_uuid(void);
+extern Datum ts_metadata_get_install_timestamp(void);
 
 #endif							/* TIMESCALEDB_TELEMETRY_METADATA_H */

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -29,16 +29,16 @@ typedef struct VersionResult
 	const char *errhint;
 } VersionResult;
 
-HttpRequest *build_version_request(const char *host, const char *path);
-Connection *telemetry_connect(const char *host, const char *service);
-bool		validate_server_version(const char *json, VersionResult *result);
+extern HttpRequest *ts_build_version_request(const char *host, const char *path);
+extern Connection *ts_telemetry_connect(const char *host, const char *service);
+extern bool ts_validate_server_version(const char *json, VersionResult *result);
 
 /*
  *	This function is intended as the main function for a BGW.
  *  Its job is to send metrics and fetch the most up-to-date version of
  *  Timescale via HTTPS.
  */
-bool		telemetry_main(const char *host, const char *path, const char *service);
-bool		telemetry_main_wrapper(void);
+extern bool ts_telemetry_main(const char *host, const char *path, const char *service);
+extern bool ts_telemetry_main_wrapper(void);
 
 #endif							/* TIMESCALEDB_TELEMETRY_TELEMETRY_H */

--- a/src/telemetry/uuid.c
+++ b/src/telemetry/uuid.c
@@ -18,10 +18,10 @@
 /*
  * Generates a v4 UUID. Based on function pg_random_uuid() in the pgcrypto contrib module.
  *
- * Note that clib on Mac has a uuid_generate() function, so we call this uuid_create().
+ * Note that clib on Mac has a uuid_generate() function, so we call this ts_uuid_create().
  */
 pg_uuid_t *
-uuid_create(void)
+ts_uuid_create(void)
 {
 	/*
 	 * PG9.6 doesn't expose the internals of pg_uuid_t, so we just treat it as
@@ -61,5 +61,5 @@ TS_FUNCTION_INFO_V1(ts_uuid_generate);
 Datum
 ts_uuid_generate(PG_FUNCTION_ARGS)
 {
-	return UUIDPGetDatum(uuid_create());
+	return UUIDPGetDatum(ts_uuid_create());
 }

--- a/src/telemetry/uuid.h
+++ b/src/telemetry/uuid.h
@@ -10,6 +10,6 @@
 #include <postgres.h>
 #include <utils/uuid.h>
 
-extern pg_uuid_t *uuid_create(void);
+extern pg_uuid_t *ts_uuid_create(void);
 
 #endif							/* TIMESCALEDB_TELEMETRY_UUID_H */

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -50,7 +50,7 @@ trigger_by_name_relation(Relation rel, const char *trigname, bool missing_ok)
 }
 
 Trigger *
-trigger_by_name(Oid relid, const char *trigname, bool missing_ok)
+ts_trigger_by_name(Oid relid, const char *trigname, bool missing_ok)
 {
 	Relation	rel;
 	Trigger    *trigger;
@@ -75,7 +75,7 @@ trigger_by_name(Oid relid, const char *trigname, bool missing_ok)
  * checks.
  */
 void
-trigger_create_on_chunk(Oid trigger_oid, char *chunk_schema_name, char *chunk_table_name)
+ts_trigger_create_on_chunk(Oid trigger_oid, char *chunk_schema_name, char *chunk_table_name)
 {
 	Datum		datum_def = DirectFunctionCall1(pg_get_triggerdef, ObjectIdGetDatum(trigger_oid));
 	const char *def = TextDatumGetCString(datum_def);
@@ -154,9 +154,9 @@ create_trigger_handler(Trigger *trigger, void *arg)
 				 errmsg("hypertables do not support transition tables in triggers")));
 #endif
 	if (trigger_is_chunk_trigger(trigger))
-		trigger_create_on_chunk(trigger->tgoid,
-								NameStr(chunk->fd.schema_name),
-								NameStr(chunk->fd.table_name));
+		ts_trigger_create_on_chunk(trigger->tgoid,
+								   NameStr(chunk->fd.schema_name),
+								   NameStr(chunk->fd.table_name));
 
 	return true;
 }
@@ -174,7 +174,7 @@ create_trigger_handler(Trigger *trigger, void *arg)
  * chunk.
  */
 void
-trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk)
+ts_trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk)
 {
 	int			sec_ctx;
 	Oid			saved_uid;
@@ -219,7 +219,7 @@ check_for_transition_table(Trigger *trigger, void *arg)
 #endif
 
 bool
-relation_has_transition_table_trigger(Oid relid)
+ts_relation_has_transition_table_trigger(Oid relid)
 {
 	bool		found = false;
 

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -15,9 +15,9 @@
 #define trigger_is_chunk_trigger(trigger) \
 	((trigger) != NULL && TRIGGER_FOR_ROW((trigger)->tgtype) && !(trigger)->tgisinternal && strcmp((trigger)->tgname, INSERT_BLOCKER_NAME) != 0)
 
-extern Trigger *trigger_by_name(Oid relid, const char *name, bool missing_ok);
-extern void trigger_create_on_chunk(Oid trigger_oid, char *chunk_schema_name, char *chunk_table_name);
-extern void trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk);
-extern bool relation_has_transition_table_trigger(Oid relid);
+extern Trigger *ts_trigger_by_name(Oid relid, const char *name, bool missing_ok);
+extern void ts_trigger_create_on_chunk(Oid trigger_oid, char *chunk_schema_name, char *chunk_table_name);
+extern void ts_trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk);
+extern bool ts_relation_has_transition_table_trigger(Oid relid);
 
 #endif							/* TIMESCALEDB_TRIGGER_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -165,13 +165,13 @@ ts_time_to_internal(PG_FUNCTION_ARGS)
 	if (PG_ARGISNULL(0))
 		PG_RETURN_NULL();
 
-	PG_RETURN_INT64(time_value_to_internal(PG_GETARG_DATUM(0), get_fn_expr_argtype(fcinfo->flinfo, 0), false));
+	PG_RETURN_INT64(ts_time_value_to_internal(PG_GETARG_DATUM(0), get_fn_expr_argtype(fcinfo->flinfo, 0), false));
 }
 
 
 /* Convert valid timescale time column type to internal representation */
 int64
-time_value_to_internal(Datum time_val, Oid type_oid, bool failure_ok)
+ts_time_value_to_internal(Datum time_val, Oid type_oid, bool failure_ok)
 {
 	Datum		res,
 				tz;
@@ -203,7 +203,7 @@ time_value_to_internal(Datum time_val, Oid type_oid, bool failure_ok)
 
 			return DatumGetInt64(res);
 		default:
-			if (type_is_int8_binary_compatible(type_oid))
+			if (ts_type_is_int8_binary_compatible(type_oid))
 				return DatumGetInt64(time_val);
 			if (!failure_ok)
 				elog(ERROR, "unknown time type OID %d", type_oid);
@@ -219,7 +219,7 @@ time_value_to_internal(Datum time_val, Oid type_oid, bool failure_ok)
  * time to internal int64 representation
  */
 int64
-interval_from_now_to_internal(Datum interval, Oid type_oid)
+ts_interval_from_now_to_internal(Datum interval, Oid type_oid)
 {
 	TimestampTz now;
 	Datum		res;
@@ -254,14 +254,14 @@ interval_from_now_to_internal(Datum interval, Oid type_oid)
 			res = TimestampTzGetDatum(now);
 			res = DirectFunctionCall2(timestamptz_mi_interval, res, interval);
 
-			return time_value_to_internal(res, type_oid, false);
+			return ts_time_value_to_internal(res, type_oid, false);
 		case DATEOID:
 			res = TimestampTzGetDatum(now);
 
 			res = DirectFunctionCall2(timestamptz_mi_interval, res, interval);
 			res = DirectFunctionCall1(timestamp_date, res);
 
-			return time_value_to_internal(res, type_oid, false);
+			return ts_time_value_to_internal(res, type_oid, false);
 		case INT8OID:
 		case INT4OID:
 		case INT2OID:
@@ -286,7 +286,7 @@ interval_from_now_to_internal(Datum interval, Oid type_oid)
 
 /* Returns approximate period in microseconds */
 int64
-get_interval_period_approx(Interval *interval)
+ts_get_interval_period_approx(Interval *interval)
 {
 	return interval->time + (((interval->month * DAYS_PER_MONTH) + interval->day) * USECS_PER_DAY);
 }
@@ -299,7 +299,7 @@ get_interval_period_approx(Interval *interval)
 
 /* Returns approximate period in microseconds */
 int64
-date_trunc_interval_period_approx(text *units)
+ts_date_trunc_interval_period_approx(text *units)
 {
 	int			decode_type,
 				val;
@@ -350,7 +350,7 @@ date_trunc_interval_period_approx(text *units)
 }
 
 Oid
-inheritance_parent_relid(Oid relid)
+ts_inheritance_parent_relid(Oid relid)
 {
 	Relation	catalog;
 	SysScanDesc scan;
@@ -376,7 +376,7 @@ inheritance_parent_relid(Oid relid)
 
 
 bool
-type_is_int8_binary_compatible(Oid sourcetype)
+ts_type_is_int8_binary_compatible(Oid sourcetype)
 {
 	HeapTuple	tuple;
 	Form_pg_cast castForm;
@@ -399,7 +399,7 @@ type_is_int8_binary_compatible(Oid sourcetype)
  * that might have variable lengths.
  */
 void *
-create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size)
+ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size)
 {
 	void	   *struct_ptr = MemoryContextAllocZero(mctx, alloc_size);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -14,40 +14,40 @@
 #include <utils/datetime.h>
 #include <access/htup_details.h>
 
-extern bool type_is_int8_binary_compatible(Oid sourcetype);
+extern bool ts_type_is_int8_binary_compatible(Oid sourcetype);
 
 /*
  * Convert a column value into the internal time representation.
  */
-extern int64 time_value_to_internal(Datum time_val, Oid type, bool failure_ok);
+extern int64 ts_time_value_to_internal(Datum time_val, Oid type, bool failure_ok);
 
 /*
  * Convert the difference of interval and current timestamp to internal representation
  */
-extern int64 interval_from_now_to_internal(Datum time_val, Oid type);
+extern int64 ts_interval_from_now_to_internal(Datum time_val, Oid type);
 
 /*
  * Return the period in microseconds of the first argument to date_trunc.
  * This is approximate -- to be used for planning;
  */
-extern int64 date_trunc_interval_period_approx(text *units);
+extern int64 ts_date_trunc_interval_period_approx(text *units);
 
 /*
  * Return the interval period in microseconds.
  * This is approximate -- to be used for planning;
  */
-extern int64 get_interval_period_approx(Interval *interval);
+extern int64 ts_get_interval_period_approx(Interval *interval);
 
-extern Oid	inheritance_parent_relid(Oid relid);
+extern Oid	ts_inheritance_parent_relid(Oid relid);
 
-void	   *create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size);
+extern void *ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size);
 
 #define STRUCT_FROM_TUPLE(tuple, mctx, to_type, form_type) \
-      (to_type *) create_struct_from_tuple(tuple, mctx, sizeof(to_type), sizeof(form_type));
+      (to_type *) ts_create_struct_from_tuple(tuple, mctx, sizeof(to_type), sizeof(form_type));
 
 /* note PG10 has_superclass but PG96 does not so use this */
 #define is_inheritance_child(relid) \
-	(inheritance_parent_relid(relid) != InvalidOid)
+	(ts_inheritance_parent_relid(relid) != InvalidOid)
 
 #define is_inheritance_parent(relid) \
 	(find_inheritance_children(table_relid, AccessShareLock) != NIL)

--- a/src/version.c
+++ b/src/version.c
@@ -44,7 +44,7 @@ ts_get_git_commit(PG_FUNCTION_ARGS)
 #include <Windows.h>
 
 bool
-version_get_os_info(VersionOSInfo *info)
+ts_version_get_os_info(VersionOSInfo *info)
 {
 	DWORD		bufsize;
 	void	   *buffer;
@@ -84,7 +84,7 @@ error:
 #include <sys/utsname.h>
 
 bool
-version_get_os_info(VersionOSInfo *info)
+ts_version_get_os_info(VersionOSInfo *info)
 {
 	/* Get the OS name  */
 	struct utsname os_info;
@@ -100,7 +100,7 @@ version_get_os_info(VersionOSInfo *info)
 }
 #else
 bool
-version_get_os_info(VersionOSInfo *info)
+ts_version_get_os_info(VersionOSInfo *info)
 {
 	memset(info, 0, sizeof(VersionOSInfo));
 	return false;
@@ -124,7 +124,7 @@ ts_get_os_info(PG_FUNCTION_ARGS)
 				 errmsg("function returning record called in context "
 						"that cannot accept type record")));
 
-	if (version_get_os_info(&info))
+	if (ts_version_get_os_info(&info))
 	{
 		values[0] = CStringGetTextDatum(info.sysname);
 		values[1] = CStringGetTextDatum(info.version);

--- a/src/version.h
+++ b/src/version.h
@@ -18,6 +18,6 @@ typedef struct VersionOSInfo
 	char		release[VERSION_INFO_LEN];
 } VersionOSInfo;
 
-extern bool version_get_os_info(VersionOSInfo *info);
+extern bool ts_version_get_os_info(VersionOSInfo *info);
 
 #endif							/* TIMESCALEDB_VERSION_H */

--- a/test/src/bgw/log.c
+++ b/test/src/bgw/log.c
@@ -19,7 +19,7 @@
 static char *application_name = "unset";
 
 void
-bgw_log_set_application_name(char *name)
+ts_bgw_log_set_application_name(char *name)
 {
 	application_name = name;
 }
@@ -33,11 +33,11 @@ bgw_log_insert_relation(Relation rel, char *msg)
 	bool		nulls[4] = {false, false, false};
 
 	values[0] = Int32GetDatum(msg_no++);
-	values[1] = Int64GetDatum((int64) params_get()->current_time);
+	values[1] = Int64GetDatum((int64) ts_params_get()->current_time);
 	values[2] = CStringGetTextDatum(application_name);
 	values[3] = CStringGetTextDatum(msg);
 
-	catalog_insert_values(rel, desc, values, nulls);
+	ts_catalog_insert_values(rel, desc, values, nulls);
 
 	return true;
 }
@@ -111,7 +111,7 @@ emit_log_hook_callback(ErrorData *edata)
 }
 
 void
-register_emit_log_hook()
+ts_register_emit_log_hook()
 {
 	prev_emit_log_hook = emit_log_hook;
 	emit_log_hook = emit_log_hook_callback;

--- a/test/src/bgw/log.h
+++ b/test/src/bgw/log.h
@@ -7,7 +7,7 @@
 #ifndef TEST_BGW_LOG_H
 #define TEST_BGW_LOG_H
 
-void		bgw_log_set_application_name(char *name);
-void		register_emit_log_hook(void);
+extern void ts_bgw_log_set_application_name(char *name);
+extern void ts_register_emit_log_hook(void);
 
 #endif							/* TEST_BGW_LOG_H */

--- a/test/src/bgw/params.c
+++ b/test/src/bgw/params.c
@@ -56,7 +56,7 @@ params_register_dsm_handle(dsm_handle handle)
 	tuple = heap_copytuple(heap_getnext(scan, ForwardScanDirection));
 	fd = (FormData_bgw_dsm_handle *) GETSTRUCT(tuple);
 	fd->handle = handle;
-	catalog_update(rel, tuple);
+	ts_catalog_update(rel, tuple);
 	heap_freetuple(tuple);
 	heap_endscan(scan);
 	heap_close(rel, RowExclusiveLock);
@@ -139,7 +139,7 @@ params_close_wrapper(TestParamsWrapper *wrapper)
 }
 
 TestParams *
-params_get()
+ts_params_get()
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 	TestParams *res;
@@ -160,7 +160,7 @@ params_get()
 };
 
 void
-params_set_time(int64 new_val, bool set_latch)
+ts_params_set_time(int64 new_val, bool set_latch)
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 
@@ -177,7 +177,7 @@ params_set_time(int64 new_val, bool set_latch)
 }
 
 void
-initialize_timer_latch()
+ts_initialize_timer_latch()
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 
@@ -193,7 +193,7 @@ initialize_timer_latch()
 }
 
 void
-reset_and_wait_timer_latch()
+ts_reset_and_wait_timer_latch()
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 
@@ -225,7 +225,7 @@ TS_FUNCTION_INFO_V1(ts_bgw_params_reset_time);
 Datum
 ts_bgw_params_reset_time(PG_FUNCTION_ARGS)
 {
-	params_set_time(PG_GETARG_INT64(0), PG_GETARG_BOOL(1));
+	ts_params_set_time(PG_GETARG_INT64(0), PG_GETARG_BOOL(1));
 
 	PG_RETURN_VOID();
 }

--- a/test/src/bgw/params.h
+++ b/test/src/bgw/params.h
@@ -24,9 +24,9 @@ typedef struct TestParams
 	MockWaitType mock_wait_type;
 } TestParams;
 
-extern TestParams *params_get(void);
-extern void params_set_time(int64 new_val, bool set_latch);
-void		initialize_timer_latch(void);
-void		reset_and_wait_timer_latch(void);
+extern TestParams *ts_params_get(void);
+extern void ts_params_set_time(int64 new_val, bool set_latch);
+extern void ts_initialize_timer_latch(void);
+extern void ts_reset_and_wait_timer_latch(void);
 
 #endif							/* TEST_BGW_PARAMS_H */

--- a/test/src/bgw/test_job_refresh.c
+++ b/test/src/bgw/test_job_refresh.c
@@ -36,7 +36,7 @@ ts_test_job_refresh(PG_FUNCTION_ARGS)
 		TupleDesc	tupdesc;
 
 		/* Use top-level memory context to preserve the global static list */
-		cur_scheduled_jobs = update_scheduled_jobs_list(cur_scheduled_jobs, TopMemoryContext);
+		cur_scheduled_jobs = ts_update_scheduled_jobs_list(cur_scheduled_jobs, TopMemoryContext);
 
 		funcctx = SRF_FIRSTCALL_INIT();
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
@@ -67,7 +67,7 @@ ts_test_job_refresh(PG_FUNCTION_ARGS)
 		Datum	   *values = palloc(sizeof(*values) * funcctx->tuple_desc->natts);
 		bool	   *nulls = palloc(sizeof(*nulls) * funcctx->tuple_desc->natts);
 
-		populate_scheduled_job_tuple(lfirst(lc), values);
+		ts_populate_scheduled_job_tuple(lfirst(lc), values);
 		memset(nulls, 0, sizeof(*nulls) * funcctx->tuple_desc->natts);
 		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 

--- a/test/src/bgw/timer_mock.c
+++ b/test/src/bgw/timer_mock.c
@@ -47,9 +47,9 @@ timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle)
 static bool
 mock_wait(TimestampTz until)
 {
-	elog(WARNING, "[TESTING] Wait until %ld, started at %ld", until, params_get()->current_time);
+	elog(WARNING, "[TESTING] Wait until %ld, started at %ld", until, ts_params_get()->current_time);
 
-	switch (params_get()->mock_wait_type)
+	switch (ts_params_get()->mock_wait_type)
 	{
 		case WAIT_ON_JOB:
 			if (bgw_handle != NULL)
@@ -59,12 +59,12 @@ mock_wait(TimestampTz until)
 			}
 			/* Now fall through to set the time */
 		case IMMEDIATELY_SET_UNTIL:
-			params_set_time(until, false);
+			ts_params_set_time(until, false);
 			return true;
 		case WAIT_FOR_OTHER_TO_ADVANCE:
 			{
 				/* Wait for another process to set "next time" */
-				reset_and_wait_timer_latch();
+				ts_reset_and_wait_timer_latch();
 
 				return true;
 			}
@@ -76,5 +76,5 @@ mock_wait(TimestampTz until)
 static TimestampTz
 mock_current_time()
 {
-	return params_get()->current_time;
+	return ts_params_get()->current_time;
 }

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -30,20 +30,20 @@ extern void PGDLLEXPORT _PG_fini(void);
 
 post_parse_analyze_hook_type prev_post_parse_analyze_hook;
 
-bool		extension_invalidate(Oid relid);
-bool		extension_is_loaded(void);
-void		extension_check_version(const char *actual_version);
+bool		ts_extension_invalidate(Oid relid);
+bool		ts_extension_is_loaded(void);
+void		ts_extension_check_version(const char *actual_version);
 
 static void
 cache_invalidate_callback(Datum arg, Oid relid)
 {
-	extension_invalidate(relid);
+	ts_extension_invalidate(relid);
 }
 
 static void
 post_analyze_hook(ParseState *pstate, Query *query)
 {
-	if (extension_is_loaded())
+	if (ts_extension_is_loaded())
 		elog(WARNING, "mock post_analyze_hook " STR(TIMESCALEDB_VERSION_MOD));
 
 	/*
@@ -65,7 +65,7 @@ _PG_init(void)
 	 * Check extension_is loaded to catch certain errors such as calls to
 	 * functions defined on the wrong extension version
 	 */
-	extension_check_version(TIMESCALEDB_VERSION_MOD);
+	ts_extension_check_version(TIMESCALEDB_VERSION_MOD);
 	elog(WARNING, "mock init " STR(TIMESCALEDB_VERSION_MOD));
 	prev_post_parse_analyze_hook = post_parse_analyze_hook;
 
@@ -89,16 +89,16 @@ _PG_fini(void)
 }
 
 /* mock for extension.c */
-void		catalog_reset(void);
+void		ts_catalog_reset(void);
 void
-catalog_reset()
+ts_catalog_reset()
 {
 }
 
 /* mock for guc.c */
-void		hypertable_cache_invalidate_callback(void);
+void		ts_hypertable_cache_invalidate_callback(void);
 void
-hypertable_cache_invalidate_callback(void)
+ts_hypertable_cache_invalidate_callback(void)
 {
 }
 

--- a/test/src/net/conn_mock.c
+++ b/test/src/net/conn_mock.c
@@ -103,7 +103,7 @@ extern void _conn_mock_fini(void);
 void
 _conn_mock_init(void)
 {
-	connection_register(CONNECTION_MOCK, &mock_ops);
+	ts_connection_register(CONNECTION_MOCK, &mock_ops);
 }
 
 void

--- a/test/src/net/test_conn.c
+++ b/test/src/net/test_conn.c
@@ -30,51 +30,51 @@ ts_test_conn(PG_FUNCTION_ARGS)
 	char	   *host = "postman-echo.com";
 
 	/* Test connection_init/destroy */
-	conn = connection_create(CONNECTION_PLAIN);
-	connection_destroy(conn);
+	conn = ts_connection_create(CONNECTION_PLAIN);
+	ts_connection_destroy(conn);
 
 	/* Check pass NULL won't crash */
-	connection_destroy(NULL);
+	ts_connection_destroy(NULL);
 
 	/* Check that delays on the socket are properly handled */
-	conn = connection_create(CONNECTION_PLAIN);
+	conn = ts_connection_create(CONNECTION_PLAIN);
 
-	connection_set_timeout_millis(conn, 200);
+	ts_connection_set_timeout_millis(conn, 200);
 
 	/* This is a brittle assert function because we might not necessarily have */
 	/* connectivity on the server running this test? */
-	ret = connection_connect(conn, host, NULL, port);
+	ret = ts_connection_connect(conn, host, NULL, port);
 
 	if (ret < 0)
-		elog(ERROR, "%s", connection_get_and_clear_error(conn));
+		elog(ERROR, "%s", ts_connection_get_and_clear_error(conn));
 
 	/* should timeout */
-	ret = connection_read(conn, response, 1);
+	ret = ts_connection_read(conn, response, 1);
 
 	if (ret == 0)
 		elog(ERROR, "Expected timeout");
 
-	connection_close(conn);
-	connection_destroy(conn);
+	ts_connection_close(conn);
+	ts_connection_destroy(conn);
 
 #ifdef TS_USE_OPENSSL
 	/* Now test ssl_ops */
-	conn = connection_create(CONNECTION_SSL);
+	conn = ts_connection_create(CONNECTION_SSL);
 
-	connection_set_timeout_millis(conn, 200);
+	ts_connection_set_timeout_millis(conn, 200);
 
-	ret = connection_connect(conn, host, NULL, ssl_port);
+	ret = ts_connection_connect(conn, host, NULL, ssl_port);
 
 	if (ret < 0)
-		elog(ERROR, "%s", connection_get_and_clear_error(conn));
+		elog(ERROR, "%s", ts_connection_get_and_clear_error(conn));
 
-	ret = connection_read(conn, response, 1);
+	ret = ts_connection_read(conn, response, 1);
 
 	if (ret == 0)
 		elog(ERROR, "Expected timeout");
 
-	connection_close(conn);
-	connection_destroy(conn);
+	ts_connection_close(conn);
+	ts_connection_destroy(conn);
 #endif
 
 	PG_RETURN_NULL();

--- a/test/src/telemetry/metadata.c
+++ b/test/src/telemetry/metadata.c
@@ -20,18 +20,18 @@ TS_FUNCTION_INFO_V1(ts_test_install_timestamp);
 Datum
 ts_test_uuid(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_DATUM(metadata_get_uuid());
+	PG_RETURN_DATUM(ts_metadata_get_uuid());
 }
 
 Datum
 ts_test_exported_uuid(PG_FUNCTION_ARGS)
 
 {
-	PG_RETURN_DATUM(metadata_get_exported_uuid());
+	PG_RETURN_DATUM(ts_metadata_get_exported_uuid());
 }
 
 Datum
 ts_test_install_timestamp(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_DATUM(metadata_get_install_timestamp());
+	PG_RETURN_DATUM(ts_metadata_get_install_timestamp());
 }

--- a/test/src/telemetry/test_privacy.c
+++ b/test/src/telemetry/test_privacy.c
@@ -20,5 +20,5 @@ Datum
 ts_test_privacy(PG_FUNCTION_ARGS)
 {
 	/* This test should only run when timescaledb.telemetry_level=off */
-	PG_RETURN_BOOL(telemetry_main("", "", ""));
+	PG_RETURN_BOOL(ts_telemetry_main("", "", ""));
 }


### PR DESCRIPTION
Future proofing: if we ever want to make our functions available  to
others they’d need to be prefixed to prevent name collisions in the linker. In
order to avoid having some functions with the ts_ prefix and
others without, we’re adding the prefix to all non-static
functions now.

Only adds to functions not macros