### PR TITLE
Check that functions start with the ts_ prefix in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ jobs:
         - docker exec -it pgbuild /bin/bash -c 'diff -r -q /build/src /tmp/timescale_src'
         - docker exec -it pgbuild /bin/bash -c 'diff -r -q /build/test/src /tmp/timescale_test_src'
         - docker exec -it pgbuild /bin/bash -c 'cd /build/debug && make licensecheck'
+        - "test -z \"`./build/scripts/export_prefix_check.sh`\" || (echo \"functions missing 'ts_' prefix\"; ./build/scripts/export_prefix_check.sh; exit 1)"
 
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -11,4 +11,13 @@ if (OBJDUMP)
 else ()
   message(STATUS "Install objdump or gobjdump to be able to run pgindent")
 endif (OBJDUMP)
+
+find_program(NM NAMES nm PATHS /usr/bin /usr/local/bin /opt/local/bin)
+if(NM)
+  message(STATUS "Using nm ${NM}")
+else ()
+  message(STATUS "Install nm to be able to run export checks")
+endif (NM)
+
 configure_file(generate_typedefs.sh.in generate_typedefs.sh @ONLY)
+configure_file(export_prefix_check.sh.in export_prefix_check.sh @ONLY)

--- a/scripts/export_prefix_check.sh.in
+++ b/scripts/export_prefix_check.sh.in
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [ ! -x "@NM@" ];
+then
+  echo "Cannot check export format because nm is not installed" >&2
+  exit 1
+fi
+
+DEFINED_ONLY="--defined-only"
+EXTERN_ONLY="--extern-only"
+
+if nm --help | grep -q llvm; then
+    DEFINED_ONLY="-defined-only"
+    EXTERN_ONLY="-extern-only"
+fi
+
+# this script outputs all symbols not starting with an allowed prefix
+# exported symbols are allowed to start with
+#    ts_      for regular timescaledb functions
+#    pg_finfo for metadata defined by PG_FUNCTION_INFO_V1
+# we also whitelist a couple of special symbols
+#    _PG_init          the postgres extension startup function
+#    _PG_fini          the postgres extension shutdown function
+#    Pg_magic_func     used by postgres to check extension compatability
+#    timescaledb_hello used to test that our name collision resitsance works
+#    loader_hello      used to test that our name collision resitsance works
+# all of these symbols start with an additional leading '_' on macos
+find @CMAKE_BINARY_DIR@ -not -path '*/\.*' -name '*.so' -print0 \
+    | xargs -0 @NM@ ${DEFINED_ONLY} ${EXTERN_ONLY} \
+    | sed -e 's:^/.*$::' -e '/^$/d' -e 's/[a-f0-9]* [A-Za-z] //' \
+    | grep -v \
+        -e '^_\?ts_' \
+        -e '^_\?pg_finfo' \
+        -e '^_\?_.*_init$' \
+        -e '^_\?_.*_fini$' \
+        -e '^_\?Pg_magic_func$' \
+        -e '^_\?timescaledb_' \
+        -e '^_\?loader_hello$'


### PR DESCRIPTION
Makes sure our exported symbols are namespaced correctly.