### PR TITLE
Have prefix check verify all functions in headers and clean up missing ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # First build without OpenSSL
   - docker exec -it pgbuild /bin/sh -c "cd /build/debug-nossl && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=false -DPG_SOURCE_DIR=/postgres && make install"
   # Now build with OpenSSL
-  - docker exec -it pgbuild /bin/sh -c "cd /build/debug && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres && make install"
+  - docker exec -it pgbuild /bin/sh -c "cd /build/debug && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${ADDITIONAL_CMAKE_FLAGS:-} && make install"
   # Ensure postgres user has permissions
   - docker exec -it pgbuild /bin/bash -c "chown -R postgres:postgres /build/"
 script:
@@ -53,7 +53,7 @@ jobs:
       stage: test
       name: "pgindent and license check"
       env:
-        - PG_VERSION=10.2 PG_GIT_TAG=REL_10_2
+        - PG_VERSION=10.2 PG_GIT_TAG=REL_10_2 ADDITIONAL_CMAKE_FLAGS="-DUSE_DEFAULT_VISIBILITY=1"
       before_install:
         - git clone --branch ${PG_GIT_TAG} --depth 1 https://github.com/postgres/postgres.git /tmp/postgres
         - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres timescaledev/pgindent:10-alpine
@@ -66,7 +66,7 @@ jobs:
         - docker exec -it pgbuild /bin/bash -c 'diff -r -q /build/src /tmp/timescale_src'
         - docker exec -it pgbuild /bin/bash -c 'diff -r -q /build/test/src /tmp/timescale_test_src'
         - docker exec -it pgbuild /bin/bash -c 'cd /build/debug && make licensecheck'
-        - "test -z \"`./build/scripts/export_prefix_check.sh`\" || (echo \"functions missing 'ts_' prefix\"; ./build/scripts/export_prefix_check.sh; exit 1)"
+        - "test -z \"`./build/scripts/export_prefix_check.sh`\" || (echo \"functions missing 'ts_' prefix or should be static\"; ./build/scripts/export_prefix_check.sh; exit 1)"
 
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test
@@ -77,7 +77,7 @@ jobs:
       stage: test
       name: "Regression 10"
       env: PG_VERSION=10.2 PG_GIT_TAG=REL_10_2
-    
+
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test
       name: "Regression 11"
@@ -128,7 +128,7 @@ jobs:
       script:
         # There is a breakage of ABI between 10.1->10.2 so test starting at 10.2
         - PG_MAJOR=10 PG_MINOR_COMPILE=2 bash -x ./scripts/docker-run-abi-test.sh
-    
+
     - if: type = cron
       stage: test
       name: "ABI breakage smoketest 11"

--- a/scripts/export_prefix_check.sh.in
+++ b/scripts/export_prefix_check.sh.in
@@ -19,11 +19,12 @@ fi
 #    ts_      for regular timescaledb functions
 #    pg_finfo for metadata defined by PG_FUNCTION_INFO_V1
 # we also whitelist a couple of special symbols
-#    _PG_init          the postgres extension startup function
-#    _PG_fini          the postgres extension shutdown function
-#    Pg_magic_func     used by postgres to check extension compatability
-#    timescaledb_hello used to test that our name collision resitsance works
-#    loader_hello      used to test that our name collision resitsance works
+#    _.*_init             module startup functions
+#    _.*_fini             module shutdown functions
+#    Pg_magic_func        used by postgres to check extension compatability
+#    timescaledb_hello    used to test that our name collision resitsance works
+#    loader_hello         used to test that our name collision resitsance works
+#    test_symbol_conflict used to test that our name collision resitsance works
 # all of these symbols start with an additional leading '_' on macos
 find @CMAKE_BINARY_DIR@ -not -path '*/\.*' -name '*.so' -print0 \
     | xargs -0 @NM@ ${DEFINED_ONLY} ${EXTERN_ONLY} \
@@ -35,4 +36,5 @@ find @CMAKE_BINARY_DIR@ -not -path '*/\.*' -name '*.so' -print0 \
         -e '^_\?_.*_fini$' \
         -e '^_\?Pg_magic_func$' \
         -e '^_\?timescaledb_' \
-        -e '^_\?loader_hello$'
+        -e '^_\?loader_hello$' \
+        -e '^_\?test_symbol_conflict$' \

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -24,7 +24,7 @@
 
 #define TELEMETRY_INITIAL_NUM_RUNS	12
 
-const char *job_type_names[_MAX_JOB_TYPE] = {
+static const char *job_type_names[_MAX_JOB_TYPE] = {
 	[JOB_TYPE_VERSION_CHECK] = "telemetry_and_version_check_if_enabled",
 	[JOB_TYPE_UNKNOWN] = "unknown"
 };

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -55,7 +55,7 @@ TS_FUNCTION_INFO_V1(ts_bgw_scheduler_main);
  * Global so the invalidate cache message can set. Don't need to protect
  * access with a lock because it's accessed only by the scheduler process.
  */
-bool		jobs_list_needs_update;
+static bool jobs_list_needs_update;
 
 /* has to be global to shutdown jobs on exit */
 static List *scheduled_jobs = NIL;

--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -1,5 +1,7 @@
 # Hide symbols by default in shared libraries
-set(CMAKE_C_VISIBILITY_PRESET "hidden")
+if(NOT USE_DEFAULT_VISIBILITY)
+  set(CMAKE_C_VISIBILITY_PRESET "hidden")
+endif()
 
 if (UNIX)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${PG_LIBDIR}")

--- a/src/loader/bgw_interface.c
+++ b/src/loader/bgw_interface.c
@@ -63,18 +63,18 @@ ts_bgw_num_unreserved(PG_FUNCTION_ARGS)
 Datum
 ts_bgw_db_workers_start(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_BOOL(bgw_message_send_and_wait(START, MyDatabaseId));
+	PG_RETURN_BOOL(ts_bgw_message_send_and_wait(START, MyDatabaseId));
 }
 
 Datum
 ts_bgw_db_workers_stop(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_BOOL(bgw_message_send_and_wait(STOP, MyDatabaseId));
+	PG_RETURN_BOOL(ts_bgw_message_send_and_wait(STOP, MyDatabaseId));
 }
 
 
 Datum
 ts_bgw_db_workers_restart(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_BOOL(bgw_message_send_and_wait(RESTART, MyDatabaseId));
+	PG_RETURN_BOOL(ts_bgw_message_send_and_wait(RESTART, MyDatabaseId));
 }

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -497,7 +497,7 @@ launcher_pre_shmem_cleanup(int code, Datum arg)
 	 * Reset our pid in the queue so that others know we've died and don't
 	 * wait forever
 	 */
-	bgw_message_queue_shmem_cleanup();
+	ts_bgw_message_queue_shmem_cleanup();
 }
 
 /*
@@ -609,7 +609,7 @@ message_restart_action(HTAB *db_htab, BgwMessage *message, VirtualTransactionId 
 static bool
 launcher_handle_message(HTAB *db_htab)
 {
-	BgwMessage *message = bgw_message_receive();
+	BgwMessage *message = ts_bgw_message_receive();
 	PGPROC	   *sender;
 	VirtualTransactionId vxid;
 	AckResult	action_result = ACK_FAILURE;
@@ -639,7 +639,7 @@ launcher_handle_message(HTAB *db_htab)
 			break;
 	}
 
-	bgw_message_send_ack(message, action_result);
+	ts_bgw_message_send_ack(message, action_result);
 	return true;
 }
 
@@ -703,7 +703,7 @@ ts_bgw_cluster_launcher_main(PG_FUNCTION_ARGS)
 	pgstat_report_appname(MyBgworkerEntry->bgw_name);
 	ereport(LOG, (errmsg("TimescaleDB background worker launcher connected to shared catalogs")));
 
-	bgw_message_queue_set_reader();
+	ts_bgw_message_queue_set_reader();
 	db_htab = init_database_htab();
 	populate_database_htab(db_htab);
 

--- a/src/loader/bgw_message_queue.c
+++ b/src/loader/bgw_message_queue.c
@@ -83,7 +83,7 @@ queue_init()
 /* This gets called when shared memory is initialized in a backend
  * (shmem_startup_hook) */
 extern void
-bgw_message_queue_shmem_startup(void)
+ts_bgw_message_queue_shmem_startup(void)
 {
 	queue_init();
 }
@@ -91,7 +91,7 @@ bgw_message_queue_shmem_startup(void)
 /* This is called in the loader during server startup to allocate a shared
  * memory segment*/
 extern void
-bgw_message_queue_alloc(void)
+ts_bgw_message_queue_alloc(void)
 {
 	RequestAddinShmemSpace(sizeof(MessageQueue));
 	RequestNamedLWLockTranche(BGW_MQ_TRANCHE_NAME, 1);
@@ -291,7 +291,7 @@ enqueue_message_wait_for_ack(MessageQueue *queue, BgwMessage *message, shm_mq_ha
  * consumes message and deallocates
  */
 extern bool
-bgw_message_send_and_wait(BgwMessageType message_type, Oid db_oid)
+ts_bgw_message_send_and_wait(BgwMessageType message_type, Oid db_oid)
 {
 	shm_mq	   *ack_queue;
 	dsm_segment *seg;
@@ -318,13 +318,13 @@ bgw_message_send_and_wait(BgwMessageType message_type, Oid db_oid)
  * Called only by the launcher
  */
 extern BgwMessage *
-bgw_message_receive(void)
+ts_bgw_message_receive(void)
 {
 	return queue_remove(mq);
 }
 
 extern void
-bgw_message_queue_set_reader(void)
+ts_bgw_message_queue_set_reader(void)
 {
 	queue_set_reader(mq);
 }
@@ -387,7 +387,7 @@ send_ack(dsm_segment *seg, bool success)
  * consumes message and deallocates
  */
 extern void
-bgw_message_send_ack(BgwMessage *message, bool success)
+ts_bgw_message_send_ack(BgwMessage *message, bool success)
 {
 	dsm_segment *seg;
 
@@ -432,7 +432,7 @@ queue_shmem_cleanup(MessageQueue *queue)
 }
 
 extern void
-bgw_message_queue_shmem_cleanup(void)
+ts_bgw_message_queue_shmem_cleanup(void)
 {
 	queue_shmem_cleanup(mq);
 }

--- a/src/loader/bgw_message_queue.h
+++ b/src/loader/bgw_message_queue.h
@@ -29,19 +29,19 @@ typedef struct BgwMessage
 
 } BgwMessage;
 
-extern bool bgw_message_send_and_wait(BgwMessageType message, Oid db_oid);
+extern bool ts_bgw_message_send_and_wait(BgwMessageType message, Oid db_oid);
 
 /* called only by the launcher*/
-extern void bgw_message_queue_set_reader(void);
-extern BgwMessage *bgw_message_receive(void);
-extern void bgw_message_send_ack(BgwMessage *message, bool success);
+extern void ts_bgw_message_queue_set_reader(void);
+extern BgwMessage *ts_bgw_message_receive(void);
+extern void ts_bgw_message_send_ack(BgwMessage *message, bool success);
 
 /*called at server startup*/
-extern void bgw_message_queue_alloc(void);
+extern void ts_bgw_message_queue_alloc(void);
 
 /*called in every backend during shmem startup hook*/
-extern void bgw_message_queue_shmem_startup(void);
-extern void bgw_message_queue_shmem_cleanup(void);
+extern void ts_bgw_message_queue_shmem_startup(void);
+extern void ts_bgw_message_queue_shmem_cleanup(void);
 
 
 #endif							/* TIMESCALEDB_BGW_MESSAGE_QUEUE_H */

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -328,7 +328,7 @@ stop_workers_on_db_drop(DropdbStmt *drop_db_statement)
 	if (dropped_db_oid != InvalidOid)
 	{
 		ereport(LOG, (errmsg("TimescaleDB background worker scheduler for database %u will be stopped", dropped_db_oid)));
-		bgw_message_send_and_wait(STOP, dropped_db_oid);
+		ts_bgw_message_send_and_wait(STOP, dropped_db_oid);
 	}
 	return;
 }
@@ -356,12 +356,12 @@ post_analyze_hook(ParseState *pstate, Query *query)
 					 * a rollback) the scheduler
 					 */
 				{
-					bgw_message_send_and_wait(RESTART, MyDatabaseId);
+					ts_bgw_message_send_and_wait(RESTART, MyDatabaseId);
 				}
 				break;
 			case T_DropOwnedStmt:
 				if (drop_owned_statement_drops_extension((DropOwnedStmt *) query->utilityStmt))
-					bgw_message_send_and_wait(RESTART, MyDatabaseId);
+					ts_bgw_message_send_and_wait(RESTART, MyDatabaseId);
 				break;
 			default:
 
@@ -394,7 +394,7 @@ timescale_shmem_startup_hook(void)
 	if (prev_shmem_startup_hook)
 		prev_shmem_startup_hook();
 	ts_bgw_counter_shmem_startup();
-	bgw_message_queue_shmem_startup();
+	ts_bgw_message_queue_shmem_startup();
 }
 
 static void
@@ -417,7 +417,7 @@ _PG_init(void)
 	elog(INFO, "timescaledb loaded");
 
 	ts_bgw_counter_shmem_alloc();
-	bgw_message_queue_alloc();
+	ts_bgw_message_queue_alloc();
 	ts_bgw_cluster_launcher_register();
 	ts_bgw_counter_setup_gucs();
 	ts_bgw_interface_register_api_version();

--- a/src/plan_add_hashagg.c
+++ b/src/plan_add_hashagg.c
@@ -165,7 +165,7 @@ static CustomEstimateForFunctionInfo custom_estimate_func_info[] =
 };
 #define _MAX_HASHAGG_FUNCTIONS (sizeof(custom_estimate_func_info)/sizeof(custom_estimate_func_info[0]))
 
-HTAB	   *custom_estimate_func_hash = NULL;
+static HTAB *custom_estimate_func_hash = NULL;
 
 static void
 initialize_custom_estimate_func_info()

--- a/src/plan_agg_bookend.c
+++ b/src/plan_agg_bookend.c
@@ -134,8 +134,8 @@ typedef struct FuncStrategy
 
 static Oid	first_last_arg_types[] = {ANYELEMENTOID, ANYOID};
 
-struct FuncStrategy first_func_strategy = {.func_oid = InvalidOid,.strategy = BTLessStrategyNumber};
-struct FuncStrategy last_func_strategy = {.func_oid = InvalidOid,.strategy = BTGreaterStrategyNumber};
+static struct FuncStrategy first_func_strategy = {.func_oid = InvalidOid,.strategy = BTLessStrategyNumber};
+static struct FuncStrategy last_func_strategy = {.func_oid = InvalidOid,.strategy = BTGreaterStrategyNumber};
 
 static Oid
 get_function_oid(char *name, int nargs, Oid arg_types[])

--- a/src/version.c
+++ b/src/version.c
@@ -20,7 +20,7 @@
 #define STR_EXPAND(x) #x
 #define STR(x) STR_EXPAND(x)
 
-const char *git_commit = STR(EXT_GIT_COMMIT);
+static const char *git_commit = STR(EXT_GIT_COMMIT);
 
 TS_FUNCTION_INFO_V1(ts_get_git_commit);
 

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -48,7 +48,7 @@ typedef enum TestJobType
 	_MAX_TEST_JOB_TYPE
 } TestJobType;
 
-const char *test_job_type_names[_MAX_TEST_JOB_TYPE] = {
+static const char *test_job_type_names[_MAX_TEST_JOB_TYPE] = {
 	[TEST_JOB_TYPE_JOB_1] = "bgw_test_job_1",
 	[TEST_JOB_TYPE_JOB_2_ERROR] = "bgw_test_job_2_error",
 	[TEST_JOB_TYPE_JOB_3_LONG] = "bgw_test_job_3_long",
@@ -118,13 +118,13 @@ ts_bgw_db_scheduler_test_main(PG_FUNCTION_ARGS)
 	ts_bgw_log_set_application_name("DB Scheduler");
 	ts_register_emit_log_hook();
 
-	ts_timer_set(&mock_timer);
+	ts_timer_set(&ts_mock_timer);
 
 	ts_bgw_job_set_job_entrypoint_function_name("ts_bgw_job_execute_test");
 
 	pgstat_report_appname("DB Scheduler Test");
 
-	ts_bgw_scheduler_process(ttl, timer_mock_register_bgw_handle);
+	ts_bgw_scheduler_process(ttl, ts_timer_mock_register_bgw_handle);
 
 	PG_RETURN_VOID();
 }
@@ -284,7 +284,7 @@ test_job_dispatcher(BgwJob *job)
 Datum
 ts_bgw_job_execute_test(PG_FUNCTION_ARGS)
 {
-	ts_timer_set(&mock_timer);
+	ts_timer_set(&ts_mock_timer);
 	ts_bgw_job_set_unknown_job_type_hook(test_job_dispatcher);
 
 	return ts_bgw_job_entrypoint(fcinfo);

--- a/test/src/bgw/timer_mock.c
+++ b/test/src/bgw/timer_mock.c
@@ -31,13 +31,13 @@ static BackgroundWorkerHandle *bgw_handle = NULL;
 static bool mock_wait(TimestampTz until);
 static TimestampTz mock_current_time(void);
 
-const Timer mock_timer = {
+const Timer ts_mock_timer = {
 	.get_current_timestamp = mock_current_time,
 	.wait = mock_wait,
 };
 
 void
-timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle)
+ts_timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle)
 {
 	elog(WARNING, "[TESTING] Registered new background worker");
 	bgw_handle = handle;

--- a/test/src/bgw/timer_mock.h
+++ b/test/src/bgw/timer_mock.h
@@ -12,8 +12,8 @@
 
 #include "bgw/timer.h"
 
-extern void timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle);
+extern void ts_timer_mock_register_bgw_handle(BackgroundWorkerHandle *handle);
 
-const Timer mock_timer;
+const Timer ts_mock_timer;
 
 #endif							/* tTIME_MOCK_H */

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -28,7 +28,7 @@ PG_MODULE_MAGIC;
 extern void PGDLLEXPORT _PG_init(void);
 extern void PGDLLEXPORT _PG_fini(void);
 
-post_parse_analyze_hook_type prev_post_parse_analyze_hook;
+static post_parse_analyze_hook_type prev_post_parse_analyze_hook;
 
 bool		ts_extension_invalidate(Oid relid);
 bool		ts_extension_is_loaded(void);

--- a/test/src/net/conn_mock.c
+++ b/test/src/net/conn_mock.c
@@ -85,7 +85,7 @@ static ConnOps mock_ops = {
 };
 
 ssize_t
-connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buf_len)
+ts_connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buf_len)
 {
 	MockConnection *mock = (MockConnection *) conn;
 

--- a/test/src/net/conn_mock.h
+++ b/test/src/net/conn_mock.h
@@ -11,6 +11,6 @@
 
 typedef struct Connection Connection;
 
-extern ssize_t connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buflen);
+extern ssize_t ts_connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buflen);
 
 #endif							/* TIMESCALEDB_CONN_MOCK_H */

--- a/test/src/net/test_http.c
+++ b/test/src/net/test_http.c
@@ -17,7 +17,7 @@
 
 /*  Tests for auxiliary HttpResponseState functions in http_parsing.h */
 
-const char *TEST_RESPONSES[] = {
+static const char *TEST_RESPONSES[] = {
 	"HTTP/1.1 200 OK\r\n"
 	"Content-Type: application/json; charset=utf-8\r\n"
 	"Date: Thu, 12 Jul 2018 18:33:04 GMT\r\n"
@@ -46,7 +46,7 @@ const char *TEST_RESPONSES[] = {
 	"{\"status\":201}",
 };
 
-const char *const BAD_RESPONSES[] = {
+static const char *const BAD_RESPONSES[] = {
 	"HTTP/1.1 200 OK\r\n"
 	"Content-Type: application/json; charset=utf-8\r\n"
 	"Date: Thu, 12 Jul 2018 18:33:04 GMT\r\n"
@@ -62,8 +62,8 @@ const char *const BAD_RESPONSES[] = {
 	NULL
 };
 
-int			TEST_LENGTHS[] = {14, 14, 14, 14};
-const char *MESSAGE_BODY[] = {"{\"status\":200}", "{\"status\":200}", "{\"status\":200}", "{\"status\":201}"};
+static int	TEST_LENGTHS[] = {14, 14, 14, 14};
+static const char *MESSAGE_BODY[] = {"{\"status\":200}", "{\"status\":200}", "{\"status\":200}", "{\"status\":201}"};
 
 TS_FUNCTION_INFO_V1(ts_test_http_parsing);
 TS_FUNCTION_INFO_V1(ts_test_http_parsing_full);

--- a/test/src/telemetry/test_telemetry.c
+++ b/test/src/telemetry/test_telemetry.c
@@ -73,7 +73,7 @@ test_factory(ConnectionType type, int status, char *host, int port)
 
 #ifdef TS_DEBUG
 	if (type == CONNECTION_MOCK)
-		connection_mock_set_recv_buf(conn, test_string, strlen(test_string));
+		ts_connection_mock_set_recv_buf(conn, test_string, strlen(test_string));
 #endif
 
 	req = build_request(status);


### PR DESCRIPTION
This commit makes four changes:
1. Adds the ts_ prefix to some functions that were missed in the last
   pass
2. Adds static to some variables that were confined to a single file but
   missing it
3. Adds the ability to disable using "hidden" visibility by default by
   setting the USE_DEFAULT_VISIBILITY variable
4. Switches the prefix-check in travis to use the flag defined in 3 so
   that the checker now checks all non-static symbols we define