### PR TITLE
Remove unused functions

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -154,12 +154,6 @@ ts_cache_memory_ctx(Cache *cache)
 	return cache->hctl.hcxt;
 }
 
-MemoryContext
-ts_cache_switch_to_memory_context(Cache *cache)
-{
-	return MemoryContextSwitchTo(cache->hctl.hcxt);
-}
-
 void *
 ts_cache_fetch(Cache *cache, CacheQuery *query)
 {

--- a/src/cache.h
+++ b/src/cache.h
@@ -48,7 +48,6 @@ extern void *ts_cache_fetch(Cache *cache, CacheQuery *query);
 extern bool ts_cache_remove(Cache *cache, void *key);
 
 extern MemoryContext ts_cache_memory_ctx(Cache *cache);
-extern MemoryContext ts_cache_switch_to_memory_context(Cache *cache);
 
 extern Cache *ts_cache_pin(Cache *cache);
 extern int	ts_cache_release(Cache *cache);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -694,15 +694,6 @@ chunk_tuple_found(TupleInfo *ti, void *arg)
 	return SCAN_DONE;
 }
 
-void
-ts_chunk_free(Chunk *chunk)
-{
-	if (NULL != chunk->cube)
-		ts_hypercube_free(chunk->cube);
-
-	pfree(chunk);
-}
-
 /* Fill in a chunk stub. The stub data structure needs the chunk ID and constraints set.
  * The rest of the fields will be filled in from the table data. */
 static Chunk *
@@ -1573,12 +1564,6 @@ ts_chunk_get_by_id(int32 id, int16 num_constraints, bool fail_if_not_found)
 						   num_constraints,
 						   CurrentMemoryContext,
 						   fail_if_not_found);
-}
-
-bool
-ts_chunk_exists(const char *schema_name, const char *table_name)
-{
-	return chunk_get_by_name(schema_name, table_name, 0, false) != NULL;
 }
 
 bool

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -70,14 +70,12 @@ typedef struct ChunkScanEntry
 
 extern Chunk *ts_chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
 extern Chunk *ts_chunk_create_stub(int32 id, int16 num_constraints);
-extern void ts_chunk_free(Chunk *chunk);
 extern Chunk *ts_chunk_find(Hyperspace *hs, Point *p);
 extern List *ts_chunk_find_all_oids(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode);
 extern Chunk *ts_chunk_copy(Chunk *chunk);
 extern Chunk *ts_chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name, int16 num_constraints, MemoryContext mctx, bool fail_if_not_found);
 extern Chunk *ts_chunk_get_by_relid(Oid relid, int16 num_constraints, bool fail_if_not_found);
 extern Chunk *ts_chunk_get_by_id(int32 id, int16 num_constraints, bool fail_if_not_found);
-extern bool ts_chunk_exists(const char *schema_name, const char *table_name);
 extern bool ts_chunk_exists_relid(Oid relid);
 extern void ts_chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
 extern int	ts_chunk_delete_by_relid(Oid chunk_oid);

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -653,28 +653,6 @@ chunk_index_name_and_schema_filter(TupleInfo *ti, void *data)
 }
 
 int
-ts_chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool should_drop)
-{
-	ScanKeyData scankey[2];
-	const char *indexname = get_rel_name(hypertable_indexrelid);
-
-	ChunkIndexDeleteData data = {
-		.drop_index = should_drop,
-	};
-
-	ScanKeyInit(&scankey[0],
-				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
-				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(ht->fd.id));
-	ScanKeyInit(&scankey[1],
-				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_index_name,
-				BTEqualStrategyNumber, F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum((indexname))));
-
-	return chunk_index_scan_update(CHUNK_INDEX_HYPERTABLE_ID_HYPERTABLE_INDEX_NAME_IDX,
-								   scankey, 2, chunk_index_tuple_delete, NULL, &data);
-}
-
-int
 ts_chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index)
 {
 	ScanKeyData scankey[2];
@@ -723,22 +701,6 @@ ts_chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index)
 				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(chunk_id));
 
 	return chunk_index_scan_update(CHUNK_INDEX_CHUNK_ID_INDEX_NAME_IDX,
-								   scankey, 1, chunk_index_tuple_delete, NULL, &data);
-}
-
-int
-ts_chunk_index_delete_by_hypertable_id(int32 hypertable_id, bool drop_index)
-{
-	ScanKeyData scankey[1];
-	ChunkIndexDeleteData data = {
-		.drop_index = drop_index,
-	};
-
-	ScanKeyInit(&scankey[0],
-				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_id,
-				BTEqualStrategyNumber, F_INT4EQ, Int32GetDatum(hypertable_id));
-
-	return chunk_index_scan_update(CHUNK_INDEX_HYPERTABLE_ID_HYPERTABLE_INDEX_NAME_IDX,
 								   scankey, 1, chunk_index_tuple_delete, NULL, &data);
 }
 

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -24,10 +24,8 @@ typedef struct ChunkIndexMapping
 
 extern void ts_chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid, int32 chunk_id, Oid chunkrelid);
 extern Oid	ts_chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid, int32 hypertable_id, Oid hypertable_indexrelid);
-extern int	ts_chunk_index_delete_children_of(Hypertable *ht, Oid hypertable_indexrelid, bool should_drop);
 extern int	ts_chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index);
 extern int	ts_chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
-extern int	ts_chunk_index_delete_by_hypertable_id(int32 hypertable_id, bool drop_index);
 extern void ts_chunk_index_delete_by_name(const char *schema, const char *index_name, bool drop_index);
 extern int	ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname);
 extern int	ts_chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *newname);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -369,21 +369,6 @@ ts_hypertable_scan_with_memory_context(const char *schema,
 										  mctx);
 }
 
-int
-ts_hypertable_scan_relid(Oid table_relid,
-						 tuple_found_func tuple_found,
-						 void *data,
-						 LOCKMODE lockmode,
-						 bool tuplock)
-{
-	return hypertable_scan(get_namespace_name(get_rel_namespace(table_relid)),
-						   get_rel_name(table_relid),
-						   tuple_found,
-						   data,
-						   lockmode,
-						   tuplock);
-}
-
 static ScanTupleResult
 hypertable_tuple_delete(TupleInfo *ti, void *data)
 {

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -53,7 +53,6 @@ extern bool ts_hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
 extern Oid	ts_hypertable_permissions_check(Oid hypertable_oid, Oid userid);
 extern Hypertable *ts_hypertable_from_tupleinfo(TupleInfo *ti);
 extern int	ts_hypertable_scan_with_memory_context(const char *schema, const char *table, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock, MemoryContext mctx);
-extern int	ts_hypertable_scan_relid(Oid table_relid, tuple_found_func tuple_found, void *data, LOCKMODE lockmode, bool tuplock);
 extern HTSU_Result ts_hypertable_lock_tuple(Oid table_relid);
 extern bool ts_hypertable_lock_tuple_simple(Oid table_relid);
 extern int	ts_hypertable_update(Hypertable *ht);

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -56,36 +56,6 @@ ts_tablespaces_add(Tablespaces *tspcs, FormData_tablespace *form, Oid tspc_oid)
 	return tspc;
 }
 
-int
-ts_tablespaces_clear(Tablespaces *tspcs)
-{
-	int			num = tspcs->num_tablespaces;
-
-	tspcs->num_tablespaces = 0;
-
-	return num;
-}
-
-bool
-ts_tablespaces_delete(Tablespaces *tspcs, Oid tspc_oid)
-{
-	int			i;
-
-	for (i = 0; i < tspcs->num_tablespaces; i++)
-	{
-		if (tspc_oid == tspcs->tablespaces[i].tablespace_oid)
-		{
-			memcpy(&tspcs->tablespaces[i],
-				   &tspcs->tablespaces[i + 1],
-				   sizeof(Tablespace) * (tspcs->num_tablespaces - i - 1));
-			tspcs->num_tablespaces--;
-			return true;
-		}
-	}
-
-	return false;
-}
-
 bool
 ts_tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid)
 {

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -26,8 +26,6 @@ typedef struct Tablespaces
 } Tablespaces;
 
 extern Tablespace *ts_tablespaces_add(Tablespaces *tablespaces, FormData_tablespace *form, Oid tspc_oid);
-extern bool ts_tablespaces_delete(Tablespaces *tspcs, Oid tspc_oid);
-extern int	ts_tablespaces_clear(Tablespaces *tspcs);
 extern bool ts_tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
 extern Tablespaces *ts_tablespace_scan(int32 hypertable_id);
 extern void ts_tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_attached);


### PR DESCRIPTION
Remove the following unused functions:
ts_cache_switch_to_memory_context
ts_chunk_free
ts_chunk_exists
ts_chunk_index_delete_children_of
ts_chunk_index_delete_by_hypertable_id
ts_hypertable_scan_relid
ts_tablespaces_clear
ts_tablespaces_delete