### PR TITLE
Avoid loading twice in parallel workers and load only from $libdir

### DIFF
--- a/src/bgw/launcher_interface.c
+++ b/src/bgw/launcher_interface.c
@@ -17,7 +17,7 @@
 extern bool
 ts_bgw_worker_reserve(void)
 {
-	PGFunction	reserve = load_external_function(EXTENSION_NAME, "ts_bgw_worker_reserve", true, NULL);
+	PGFunction	reserve = load_external_function(EXTENSION_SO, "ts_bgw_worker_reserve", true, NULL);
 
 	return DatumGetBool(DirectFunctionCall1(reserve, BoolGetDatum(false))); /* no function call zero */
 }
@@ -25,7 +25,7 @@ ts_bgw_worker_reserve(void)
 extern void
 ts_bgw_worker_release(void)
 {
-	PGFunction	release = load_external_function(EXTENSION_NAME, "ts_bgw_worker_release", true, NULL);
+	PGFunction	release = load_external_function(EXTENSION_SO, "ts_bgw_worker_release", true, NULL);
 
 	DirectFunctionCall1(release, BoolGetDatum(false));	/* no function call zero */
 }
@@ -33,7 +33,7 @@ ts_bgw_worker_release(void)
 extern int
 ts_bgw_num_unreserved(void)
 {
-	PGFunction	unreserved = load_external_function(EXTENSION_NAME, "ts_bgw_num_unreserved", true, NULL);
+	PGFunction	unreserved = load_external_function(EXTENSION_SO, "ts_bgw_num_unreserved", true, NULL);
 
 	return DatumGetInt32(DirectFunctionCall1(unreserved, BoolGetDatum(false))); /* no function call zero */
 }

--- a/src/extension_constants.h
+++ b/src/extension_constants.h
@@ -10,8 +10,10 @@
 /* No function definitions here, only potentially globally available defines as this is used by the loader*/
 
 #define EXTENSION_NAME "timescaledb"
+#define EXTENSION_SO "$libdir/"EXTENSION_NAME
 #define MAX_VERSION_LEN (NAMEDATALEN+1)
-#define MAX_SO_NAME_LEN (NAMEDATALEN+1+MAX_VERSION_LEN) /* extname+"-"+version */
+#define MAX_SO_NAME_LEN (8+NAMEDATALEN+1+MAX_VERSION_LEN)	/* "$libdir/"+extname+"-"+version
+															 * */
 
 #define CATALOG_SCHEMA_NAME "_timescaledb_catalog"
 #define INTERNAL_SCHEMA_NAME "_timescaledb_internal"

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -826,7 +826,7 @@ ts_bgw_db_scheduler_entrypoint(PG_FUNCTION_ARGS)
 		char		soname[MAX_SO_NAME_LEN];
 		PGFunction	versioned_scheduler_main;
 
-		snprintf(soname, MAX_SO_NAME_LEN, "%s-%s", EXTENSION_NAME, version);
+		snprintf(soname, MAX_SO_NAME_LEN, "%s-%s", EXTENSION_SO, version);
 		versioned_scheduler_main = load_external_function(soname, BGW_DB_SCHEDULER_FUNCNAME, false, NULL);
 		if (versioned_scheduler_main == NULL)
 			ereport(LOG, (errmsg("TimescaleDB version %s does not have a background worker, exiting", soname)));


### PR DESCRIPTION
We removed a parallel workers check a while back because there were problems
with the macro on Windows, we define a new macro that works on Windows as we
received reports of some instances in which the Timescale library appeared to
be loading twice in parallel workers. Parallel workers instead restore the
library state of their parent process via their normal pathway and the loader
will take no action.

Additionally, prepend "$libdir/" to all calls to .so's so that we don't end up
accidentally loading from a place different from where we've loaded when we
create functions, which all refer to $libdir. This would only affect users
who have multiple separate .so's in different directories, but could be another
case where multiple .so's were loaded.