### PR TITLE
Don't throw errors when extension is loaded but not installed yet

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -64,9 +64,8 @@ ts_extension_check_version(const char *so_version)
 {
 	char	   *sql_version;
 
-	if (!IsNormalProcessingMode() || !IsTransactionState())
+	if (!IsNormalProcessingMode() || !IsTransactionState() || !extension_exists())
 		return;
-
 	sql_version = extension_version();
 
 	if (strcmp(sql_version, so_version) != 0)


### PR DESCRIPTION
Throwing errors this way breaks pg_upgrade as it tries to check
that libraries that have functions associated with them are
available before copying data from the old cluster over to the new.