### PR TITLE
Add telemetry report test

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+ignore: "test/src"

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -283,3 +283,22 @@ WARNING:  telemetry could not connect to "noservice.timescale.com"
 (1 row)
 
 SET timescaledb.telemetry_level=off;
+select json_object_keys(get_telemetry_report()::json);
+  json_object_keys   
+---------------------
+ db_uuid
+ os_name
+ os_release
+ os_version
+ data_volume
+ build_os_name
+ install_method
+ installed_time
+ num_hypertables
+ build_os_version
+ exported_db_uuid
+ postgresql_version
+ related_extensions
+ timescaledb_version
+(14 rows)
+

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -120,3 +120,6 @@ SET timescaledb.telemetry_level=basic;
 -- Connect to a bogus host and path to test error handling in telemetry_main()
 SELECT _timescaledb_internal.test_telemetry_main_conn('noservice.timescale.com', 'path');
 SET timescaledb.telemetry_level=off;
+
+
+select json_object_keys(get_telemetry_report()::json);


### PR DESCRIPTION
We should really test that this function works, and we're outputting all
the fields we expect. Not testing the actual values as that changes
across installs and runs.

Should also improve our code coverage.