### PR TITLE
Use a fixed file for latest sql update script (alternate to Josh's with similar intent)

### DIFF
--- a/sql/updates/1.1.1--1.2.0-dev.sql
+++ b/sql/updates/1.1.1--1.2.0-dev.sql
@@ -1,0 +1,1 @@
+\ir latest--dev.sql

--- a/sql/updates/latest--dev.sql
+++ b/sql/updates/latest--dev.sql
@@ -1,0 +1,3 @@
+-- This file is where all updates for the next release should be included until
+-- they are ready to be released. At release time they will be moved to the proper
+-- versioned file. 


### PR DESCRIPTION
Introduce latest--dev.sql, which should be the file
for all update script changes until a release. Until release time
the versioned sql file will simply include the latest--dev.sql
file. At release time, all changes in the latest--dev.sql will be
moved from the latest--dev.sql file to the numbered script.

A further commit will prepare the repo for the next dev cycle
by introducing a file that includes latest--dev.sql this will
mean that changes that were outstanding when a release happened
will not end up in the wrong file, as they sometimes do now.