### PR TITLE
Fix time column handling in get_create_command

### DIFF
--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -149,7 +149,7 @@ BEGIN
         END IF;
     END LOOP;
 
-    ret := format($$SELECT create_hypertable('%I.%I', '%I'$$, schema_name, table_name, time_column);
+    ret := format($$SELECT create_hypertable('%I.%I', '%s'$$, schema_name, table_name, time_column);
     IF space_column IS NOT NULL THEN
         ret := ret || format($$, '%I', %s$$, space_column, space_partitions);
     END IF;

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -74,9 +74,9 @@ SELECT * FROM test.show_triggers('test_schema.test_table');
 (1 row)
 
 SELECT * FROM _timescaledb_internal.get_create_command('test_table');
-                                                                 get_create_command                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT create_hypertable('test_schema.test_table', '"time"', 'device_id', 2, chunk_time_interval => 2592000000000, create_default_indexes=>FALSE);
+                                                                get_create_command                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_table', 'time', 'device_id', 2, chunk_time_interval => 2592000000000, create_default_indexes=>FALSE);
 (1 row)
 
 --test adding one more closed dimension
@@ -270,9 +270,9 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_internal.get_create_command('test_1dim');
-                                                        get_create_command                                                        
-----------------------------------------------------------------------------------------------------------------------------------
- SELECT create_hypertable('test_schema.test_1dim', '"time"', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
+                                                       get_create_command                                                       
+--------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_1dim', 'time', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
 (1 row)
 
 \dt "test_schema".*
@@ -551,5 +551,35 @@ select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func
               add_dimension              
 -----------------------------------------
  (21,test_schema,test_partfunc,device,t)
+(1 row)
+
+-- check get_create_command produces valid command
+CREATE TABLE test_schema.test_sql_cmd(time TIMESTAMPTZ, temp FLOAT8, device_id TEXT, device_type TEXT, location TEXT, id INT, id2 INT);
+SELECT create_hypertable('test_schema.test_sql_cmd','time');
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (13,test_schema,test_sql_cmd,t)
+(1 row)
+
+SELECT * FROM _timescaledb_internal.get_create_command('test_sql_cmd');
+                                                        get_create_command                                                         
+-----------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_sql_cmd', 'time', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
+(1 row)
+
+SELECT _timescaledb_internal.get_create_command('test_sql_cmd') AS create_cmd; \gset
+                                                            create_cmd                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_sql_cmd', 'time', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
+(1 row)
+
+DROP TABLE test_schema.test_sql_cmd CASCADE;
+CREATE TABLE test_schema.test_sql_cmd(time TIMESTAMPTZ, temp FLOAT8, device_id TEXT, device_type TEXT, location TEXT, id INT, id2 INT);
+SELECT test.execute_sql(:'create_cmd');
+NOTICE:  adding not-null constraint to column "time"
+                                                            execute_sql                                                            
+-----------------------------------------------------------------------------------------------------------------------------------
+ SELECT create_hypertable('test_schema.test_sql_cmd', 'time', chunk_time_interval => 604800000000, create_default_indexes=>FALSE);
 (1 row)
 

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -10,7 +10,6 @@ create schema chunk_schema AUTHORIZATION :ROLE_DEFAULT_PERM_USER_2;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 create table test_schema.test_table(time BIGINT, temp float8, device_id text, device_type text, location text, id int, id2 int);
 
-
 \set ON_ERROR_STOP 0
 -- get_create_command should fail since hypertable isn't made yet
 SELECT * FROM _timescaledb_internal.get_create_command('test_table');
@@ -328,3 +327,13 @@ select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func
 
 -- A valid function should work:
 select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_valid');
+
+-- check get_create_command produces valid command
+CREATE TABLE test_schema.test_sql_cmd(time TIMESTAMPTZ, temp FLOAT8, device_id TEXT, device_type TEXT, location TEXT, id INT, id2 INT);
+SELECT create_hypertable('test_schema.test_sql_cmd','time');
+SELECT * FROM _timescaledb_internal.get_create_command('test_sql_cmd');
+SELECT _timescaledb_internal.get_create_command('test_sql_cmd') AS create_cmd; \gset
+DROP TABLE test_schema.test_sql_cmd CASCADE;
+CREATE TABLE test_schema.test_sql_cmd(time TIMESTAMPTZ, temp FLOAT8, device_id TEXT, device_type TEXT, location TEXT, id INT, id2 INT);
+SELECT test.execute_sql(:'create_cmd');
+

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -260,6 +260,14 @@ BEGIN
 END
 $BODY$;
 
+CREATE OR REPLACE FUNCTION test.execute_sql(cmd TEXT)
+RETURNS TEXT LANGUAGE PLPGSQL AS $BODY$
+BEGIN
+  EXECUTE cmd;
+  RETURN cmd;
+END
+$BODY$;
+
 -- Used to set a deterministic memory setting during tests
 CREATE OR REPLACE FUNCTION test.set_memory_cache_size(memory_amount text)
 RETURNS BIGINT AS :MODULE_PATHNAME, 'ts_set_memory_cache_size' LANGUAGE C VOLATILE STRICT;


### PR DESCRIPTION
Fixes get_create_command to produce a valid create_hypertable
call when the column name is a keyword
Add test.execute_sql helper function to test support functions