### PR TITLE
Reduce lock timeout on deadlock_dropchunkcs_select test

### DIFF
--- a/test/isolation/expected/deadlock_dropchunks_select.out
+++ b/test/isolation/expected/deadlock_dropchunks_select.out
@@ -30,7 +30,7 @@ drop_chunks
                
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ; <waiting ...>
 step s2a: <... completed>
-ERROR:  canceling statement due to user request
+ERROR:  canceling statement due to lock timeout
 step s2b: COMMIT;
 step s1b: COMMIT;
 
@@ -40,7 +40,7 @@ typ            loc            mtim
 
 step s1a: select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); <waiting ...>
 step s1a: <... completed>
-ERROR:  canceling statement due to user request
+ERROR:  canceling statement due to lock timeout
 step s1b: COMMIT;
 step s2b: COMMIT;
 

--- a/test/isolation/specs/deadlock_dropchunks_select.spec
+++ b/test/isolation/specs/deadlock_dropchunks_select.spec
@@ -12,16 +12,16 @@ setup
  SELECT 1,1, generate_series( '2018-12-01 00:00'::timestamp, '2018-12-31 12:00','1 minute') ;
 }
 
-teardown 
+teardown
 { DROP TABLE DT; DROP table ST; DROP table SL; }
 
 session "s1"
-setup	{ BEGIN;}
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
 step "s1a"	{ select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); }
 step "s1b"	{ COMMIT; }
 
 session "s2"
-setup	{ BEGIN;  }
+setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
 step "s2a"	{  SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ; }
 step "s2b"	{ COMMIT; }
 


### PR DESCRIPTION
Speeds up the test by detecting the deadlock due to the lock timeout instead of the test runner timeout. 

@gayyappan would you look at this? I don't _think_ it changes the semantics of the test, and should be a decent bit faster to run.