### PR TITLE
Add last_tuned guc and telemetry reporting for this

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -45,6 +45,8 @@ int			ts_guc_max_cached_chunks_per_hypertable = 10;
 int			ts_guc_telemetry_level = TELEMETRY_BASIC;
 
 TSDLLEXPORT char *ts_guc_license_key = TS_DEFAULT_LICENSE;
+char	   *ts_last_tune_time = NULL;
+char	   *ts_last_tune_version = NULL;
 
 static void
 assign_max_cached_chunks_per_hypertable_hook(int newval, void *extra)
@@ -149,6 +151,28 @@ _guc_init(void)
 							    /* flags= */ GUC_SUPERUSER_ONLY,
 							    /* check_hook= */ ts_license_update_check,
 							    /* assign_hook= */ ts_license_on_assign,
+							    /* show_hook= */ NULL);
+
+	DefineCustomStringVariable( /* name= */ "timescaledb.last_tuned",
+							    /* short_dec= */ "last tune run",
+							    /* long_dec= */ "records last time timescaledb-tune ran",
+							    /* valueAddr= */ &ts_last_tune_time,
+							    /* bootValue= */ NULL,
+							    /* context= */ PGC_BACKEND,
+							    /* flags= */ 0,
+							    /* check_hook= */ NULL,
+							    /* assign_hook= */ NULL,
+							    /* show_hook= */ NULL);
+
+	DefineCustomStringVariable( /* name= */ "timescaledb.last_tuned_version",
+							    /* short_dec= */ "version of timescaledb-tune",
+							    /* long_dec= */ "version of timescaledb-tune used to tune",
+							    /* valueAddr= */ &ts_last_tune_version,
+							    /* bootValue= */ NULL,
+							    /* context= */ PGC_BACKEND,
+							    /* flags= */ 0,
+							    /* check_hook= */ NULL,
+							    /* assign_hook= */ NULL,
 							    /* show_hook= */ NULL);
 }
 

--- a/src/guc.h
+++ b/src/guc.h
@@ -19,6 +19,8 @@ extern int	ts_guc_max_open_chunks_per_insert;
 extern int	ts_guc_max_cached_chunks_per_hypertable;
 extern int	ts_guc_telemetry_level;
 extern TSDLLEXPORT char *ts_guc_license_key;
+extern char *ts_last_tune_time;
+extern char *ts_last_tune_version;
 
 void		_guc_init(void);
 void		_guc_fini(void);

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -50,6 +50,8 @@
 #define REQ_LICENSE_INFO			"license"
 #define REQ_LICENSE_EDITION		    "edition"
 #define REQ_LICENSE_EDITION_APACHE	"apache_only"
+#define REQ_TS_LAST_TUNE_TIME			"last_tuned_time"
+#define REQ_TS_LAST_TUNE_VERSION		"last_tuned_version"
 
 #define PG_PROMETHEUS	"pg_prometheus"
 #define POSTGIS			"postgis"
@@ -250,6 +252,12 @@ build_version_body(void)
 	add_license_info(parseState);
 
 	result = pushJsonbValue(&parseState, WJB_END_OBJECT, NULL);
+
+	if (ts_last_tune_time != NULL)
+		ts_jsonb_add_str(parseState, REQ_TS_LAST_TUNE_TIME, ts_last_tune_time);
+
+	if (ts_last_tune_time != NULL)
+		ts_jsonb_add_str(parseState, REQ_TS_LAST_TUNE_VERSION, ts_last_tune_version);
 
 	jb = JsonbValueToJsonb(result);
 	jtext = makeStringInfo();


### PR DESCRIPTION
And guc recording the last time timescaledb-tuned
was run, and telemetry reporting for this guc.
This will tell us how many people actually run
timescaledb-tune.