### PR TITLE
Add dummy values to test last_tuned telemetry

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,6 +73,10 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "max_worker_processes=16"
 
+    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'"
+
+    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned_version='0.0.1'"
+
     # TODO removing the following line causes a stack overflow on appveyor
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.telemetry_level='off'"

--- a/src/jsonb_utils.c
+++ b/src/jsonb_utils.c
@@ -63,6 +63,7 @@ ts_jsonb_add_value(JsonbParseState *state, const char *key, JsonbValue *value)
 static void
 ts_jsonb_add_pair(JsonbParseState *state, JsonbValue *key, JsonbValue *value)
 {
+	Assert(state != NULL);
 	Assert(key != NULL);
 	if (value == NULL)
 		return;

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -245,20 +245,22 @@ build_version_body(void)
 	pushJsonbValue(&parseState, WJB_KEY, &ext_key);
 	add_related_extensions(parseState);
 
+	/* add license info, which is a nested JSON */
 	license_info_key.type = jbvString;
 	license_info_key.val.string.val = REQ_LICENSE_INFO;
 	license_info_key.val.string.len = strlen(REQ_LICENSE_INFO);
 	pushJsonbValue(&parseState, WJB_KEY, &license_info_key);
 	add_license_info(parseState);
 
-	result = pushJsonbValue(&parseState, WJB_END_OBJECT, NULL);
-
+	/* add tuned info, which is optional */
 	if (ts_last_tune_time != NULL)
 		ts_jsonb_add_str(parseState, REQ_TS_LAST_TUNE_TIME, ts_last_tune_time);
 
-	if (ts_last_tune_time != NULL)
+	if (ts_last_tune_version != NULL)
 		ts_jsonb_add_str(parseState, REQ_TS_LAST_TUNE_VERSION, ts_last_tune_version);
 
+	/* end of telemetry object */
+	result = pushJsonbValue(&parseState, WJB_END_OBJECT, NULL);
 	jb = JsonbValueToJsonb(result);
 	jtext = makeStringInfo();
 	JsonbToCString(jtext, &jb->root, VARSIZE(jb));

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -295,11 +295,13 @@ select json_object_keys(get_telemetry_report()::json);
  build_os_name
  install_method
  installed_time
+ last_tuned_time
  num_hypertables
  build_os_version
  exported_db_uuid
+ last_tuned_version
  postgresql_version
  related_extensions
  timescaledb_version
-(15 rows)
+(17 rows)
 

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -1,3 +1,5 @@
 shared_preload_libraries=timescaledb
 max_worker_processes=16
 timescaledb.telemetry_level=off
+timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'
+timescaledb.last_tuned_version='0.0.1'


### PR DESCRIPTION
Adds dummy values so that last_tuned telemetry gets
reported in our tests. Also moves the location of
the telemetry adding code to prevent a segfault.

Should have been part of PR #955.