### PR TITLE
Add include for compat.h to gapfill/interpolate.c

### DIFF
--- a/tsl/src/gapfill/interpolate.c
+++ b/tsl/src/gapfill/interpolate.c
@@ -10,6 +10,7 @@
 #include <utils/datum.h>
 #include <utils/typcache.h>
 
+#include "compat.h"
 #include "gapfill/interpolate.h"
 #include "gapfill/exec.h"
 


### PR DESCRIPTION
When compiling against Postgres 9.6 before 9.6.5 TupleDescAttr
is not defined, compat.h defines the macro for versions before 9.6.5