### PR TITLE
Ignore the generated plan_gapfill tsl tests

### DIFF
--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -1,0 +1,3 @@
+/plan_gapfill-9.6.sql
+/plan_gapfill-10.sql
+/plan_gapfill-11.sql


### PR DESCRIPTION
These tests should never be committed to version control
as they need to be generated based on the version of postgres
installed locally.