### PR TITLE
Make older_than / newer_than error message user friendly

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1118,7 +1118,7 @@ chunks_typecheck_and_find_all_in_range_limit(Hyperspace *hs,
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("When both older_than and newer_than are specified, "
-						"older_than must come after newer_than so that a valid overlapping range is specified")
+						"older_than must refer to a time that is more recent than newer_than so that a valid overlapping range is specified")
 				 ));
 
 	oldcontext = MemoryContextSwitchTo(multi_call_memory_ctx);

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -222,7 +222,7 @@ SELECT show_chunks('drop_chunk_test3', now());
 ERROR:  time constraint arguments of "show_chunks" should have same type as time column of the hypertable
 -- should error because of wrong relative order of time constraints
 SELECT show_chunks('drop_chunk_test1', older_than=>3, newer_than=>4);
-ERROR:  When both older_than and newer_than are specified, older_than must come after newer_than so that a valid overlapping range is specified
+ERROR:  When both older_than and newer_than are specified, older_than must refer to a time that is more recent than newer_than so that a valid overlapping range is specified
 \set ON_ERROR_STOP 1
 --should always work regardless of time column types of hypertables
 SELECT show_chunks();


### PR DESCRIPTION
This is a small improvement to the existing error message. We perceive that "more recent" is clearer than "after" and have adjusted the error message. 

This addresses the error message through by show_chunks and drop_chunks when both older_than and newer_than are specified as parameters.