### PR TITLE
Clean missing braces warning

### DIFF
--- a/tsl/src/license.c
+++ b/tsl/src/license.c
@@ -81,7 +81,7 @@ tsl_license_update_check(PG_FUNCTION_ARGS)
 	bool		license_deserialized;
 	char	   *license_key = NULL;
 	LicenseInfo **guc_extra = NULL;
-	LicenseInfo license_info = {0};
+	LicenseInfo license_info = {{0}};
 
 	Assert(!PG_ARGISNULL(0));
 	Assert(!PG_ARGISNULL(1));
@@ -115,7 +115,7 @@ tsl_license_update_check(PG_FUNCTION_ARGS)
 static bool
 license_deserialize_enterprise(char *license_key, LicenseInfo *license_out)
 {
-	LicenseInfo license_temp = {0};
+	LicenseInfo license_temp = {{0}};
 	const LicenseInfo *license_info = NULL;
 	size_t		license_key_len = strlen(license_key);
 


### PR DESCRIPTION
This shouldn't be needed, but it fixes a spurious warning for those of
us that enable more warnings.