### PR TITLE
Explicit chunk exclusion

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -34,3 +34,14 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.calculate_chunk_interval(
         dimension_coord BIGINT,
         chunk_target_size BIGINT
 ) RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_calculate_chunk_interval' LANGUAGE C;
+
+-- Function for explicit chunk exclusion. Supply a record and an array 
+-- of chunk ids as input.
+-- Intended to be used in WHERE clause.
+-- An example: SELECT * FROM hypertable WHERE chunks_in(hypertable, ARRAY[1,2]);
+--
+-- Use it with care as this function directly affects what chunks are being scanned for data.
+-- Although this function is immutable (always returns true), we declare it here as volatile
+-- so that the PostgreSQL optimizer does not try to evaluate/reduce it in the planner phase
+CREATE OR REPLACE FUNCTION chunks_in(record RECORD, chunks INTEGER[]) RETURNS BOOL
+AS '@MODULE_PATHNAME@', 'ts_chunks_in' LANGUAGE C VOLATILE STRICT;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -54,6 +54,7 @@
 
 TS_FUNCTION_INFO_V1(ts_chunk_show_chunks);
 TS_FUNCTION_INFO_V1(ts_chunk_drop_chunks);
+TS_FUNCTION_INFO_V1(ts_chunks_in);
 
 /* Used when processing scanned chunks */
 typedef enum ChunkResult
@@ -1950,4 +1951,19 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_NULL();
+}
+
+/**
+ * This function is used to explicitly specify chunks that are being scanned. It's being processed in the planning phase
+ * and removed from the query tree. This means that the actual function implementation will only be executed
+ * if something went wrong during explicit chunk exclusion.
+ */
+Datum
+ts_chunks_in(PG_FUNCTION_ARGS)
+{
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("illegal invocation of chunks_in function"),
+			 errhint("chunks_in function must appear in the WHERE clause and can only be combined with AND operator")));
+	pg_unreachable();
 }

--- a/src/extension.c
+++ b/src/extension.c
@@ -175,6 +175,11 @@ ts_extension_schema_oid(void)
 	return schema;
 }
 
+char *
+ts_extension_schema_name(void)
+{
+	return get_namespace_name(ts_extension_schema_oid());
+}
 
 /*
  *	Called upon all Relcache invalidate events.

--- a/src/extension.h
+++ b/src/extension.h
@@ -14,6 +14,7 @@ extern TSDLLEXPORT bool ts_extension_is_loaded(void);
 extern void ts_extension_check_version(const char *so_version);
 extern void ts_extension_check_server_version(void);
 extern Oid	ts_extension_schema_oid(void);
+extern char *ts_extension_schema_name(void);
 
 extern char *ts_extension_get_so_name(void);
 

--- a/src/plan_add_hashagg.c
+++ b/src/plan_add_hashagg.c
@@ -169,9 +169,6 @@ static void
 initialize_custom_estimate_func_info()
 {
 	int			i = 0;
-	Oid			extension_schema = ts_extension_schema_oid();
-	char	   *extension_schema_name = get_namespace_name(extension_schema);
-
 
 	HASHCTL		hashctl = {
 		.keysize = sizeof(Oid),
@@ -189,7 +186,7 @@ initialize_custom_estimate_func_info()
 		FuncCandidateList funclist;
 
 		if (def.extension_function)
-			funclist = FuncnameGetCandidates(list_make2(makeString(extension_schema_name), makeString(def.function_name)),
+			funclist = FuncnameGetCandidates(list_make2(makeString(ts_extension_schema_name()), makeString(def.function_name)),
 											 def.nargs, NIL, false, false, false);
 		else
 			funclist = FuncnameGetCandidates(list_make1(makeString(def.function_name)),

--- a/src/utils.c
+++ b/src/utils.c
@@ -334,3 +334,18 @@ ts_function_types_equal(Oid left[], Oid right[], int nargs)
 	}
 	return true;
 }
+
+Oid
+get_function_oid(char *name, char *schema_name, int nargs, Oid arg_types[])
+{
+	FuncCandidateList func_candidates;
+
+	func_candidates = FuncnameGetCandidates(list_make2(makeString(schema_name), makeString(name)), nargs, NIL, false, false, false);
+	while (func_candidates != NULL)
+	{
+		if (func_candidates->nargs == nargs && ts_function_types_equal(func_candidates->args, arg_types, nargs))
+			return func_candidates->oid;
+		func_candidates = func_candidates->next;
+	}
+	elog(ERROR, "failed to find function %s in schema %s with %d args", name, schema_name, nargs);
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -41,6 +41,8 @@ extern Oid	ts_inheritance_parent_relid(Oid relid);
 
 extern bool ts_function_types_equal(Oid left[], Oid right[], int nargs);
 
+extern Oid	get_function_oid(char *name, char *schema_name, int nargs, Oid arg_types[]);
+
 extern void *ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size, size_t copy_size);
 
 #define STRUCT_FROM_TUPLE(tuple, mctx, to_type, form_type) \

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -21,6 +21,7 @@ ORDER BY proname;
  attach_tablespace
  chunk_relation_size
  chunk_relation_size_pretty
+ chunks_in
  create_hypertable
  detach_tablespace
  detach_tablespaces
@@ -46,5 +47,5 @@ ORDER BY proname;
  show_tablespaces
  time_bucket
  time_bucket_gapfill
-(32 rows)
+(33 rows)
 

--- a/test/expected/plan_expand_hypertable_optimized.out
+++ b/test/expected/plan_expand_hypertable_optimized.out
@@ -1082,3 +1082,262 @@ SELECT * FROM cte ORDER BY value;
                Filter: (to_timestamp("time") < 'Wed Dec 31 16:00:04 1969 PST'::timestamp with time zone)
 (67 rows)
 
+\ir include/plan_expand_hypertable_chunks_in_query.sql
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+--we want to see how our logic excludes chunks
+--and not how much work constraint_exclusion does
+SET constraint_exclusion = 'off';
+:PREFIX SELECT * FROM hyper ORDER BY value;
+                 QUERY PLAN                 
+--------------------------------------------
+ Sort
+   Sort Key: hyper.value
+   ->  Append
+         ->  Seq Scan on hyper
+         ->  Seq Scan on _hyper_1_1_chunk
+         ->  Seq Scan on _hyper_1_2_chunk
+         ->  Seq Scan on _hyper_1_3_chunk
+         ->  Seq Scan on _hyper_1_4_chunk
+         ->  Seq Scan on _hyper_1_5_chunk
+         ->  Seq Scan on _hyper_1_6_chunk
+         ->  Seq Scan on _hyper_1_7_chunk
+         ->  Seq Scan on _hyper_1_8_chunk
+         ->  Seq Scan on _hyper_1_9_chunk
+         ->  Seq Scan on _hyper_1_10_chunk
+         ->  Seq Scan on _hyper_1_11_chunk
+         ->  Seq Scan on _hyper_1_12_chunk
+         ->  Seq Scan on _hyper_1_13_chunk
+         ->  Seq Scan on _hyper_1_14_chunk
+         ->  Seq Scan on _hyper_1_15_chunk
+         ->  Seq Scan on _hyper_1_16_chunk
+         ->  Seq Scan on _hyper_1_17_chunk
+         ->  Seq Scan on _hyper_1_18_chunk
+         ->  Seq Scan on _hyper_1_19_chunk
+         ->  Seq Scan on _hyper_1_20_chunk
+         ->  Seq Scan on _hyper_1_21_chunk
+         ->  Seq Scan on _hyper_1_22_chunk
+         ->  Seq Scan on _hyper_1_23_chunk
+         ->  Seq Scan on _hyper_1_24_chunk
+         ->  Seq Scan on _hyper_1_25_chunk
+         ->  Seq Scan on _hyper_1_26_chunk
+         ->  Seq Scan on _hyper_1_27_chunk
+         ->  Seq Scan on _hyper_1_28_chunk
+         ->  Seq Scan on _hyper_1_29_chunk
+         ->  Seq Scan on _hyper_1_30_chunk
+         ->  Seq Scan on _hyper_1_31_chunk
+         ->  Seq Scan on _hyper_1_32_chunk
+         ->  Seq Scan on _hyper_1_33_chunk
+         ->  Seq Scan on _hyper_1_34_chunk
+         ->  Seq Scan on _hyper_1_35_chunk
+         ->  Seq Scan on _hyper_1_36_chunk
+         ->  Seq Scan on _hyper_1_37_chunk
+         ->  Seq Scan on _hyper_1_38_chunk
+         ->  Seq Scan on _hyper_1_39_chunk
+         ->  Seq Scan on _hyper_1_40_chunk
+         ->  Seq Scan on _hyper_1_41_chunk
+         ->  Seq Scan on _hyper_1_42_chunk
+         ->  Seq Scan on _hyper_1_43_chunk
+         ->  Seq Scan on _hyper_1_44_chunk
+         ->  Seq Scan on _hyper_1_45_chunk
+         ->  Seq Scan on _hyper_1_46_chunk
+         ->  Seq Scan on _hyper_1_47_chunk
+         ->  Seq Scan on _hyper_1_48_chunk
+         ->  Seq Scan on _hyper_1_49_chunk
+         ->  Seq Scan on _hyper_1_50_chunk
+         ->  Seq Scan on _hyper_1_51_chunk
+         ->  Seq Scan on _hyper_1_52_chunk
+         ->  Seq Scan on _hyper_1_53_chunk
+         ->  Seq Scan on _hyper_1_54_chunk
+         ->  Seq Scan on _hyper_1_55_chunk
+         ->  Seq Scan on _hyper_1_56_chunk
+         ->  Seq Scan on _hyper_1_57_chunk
+         ->  Seq Scan on _hyper_1_58_chunk
+         ->  Seq Scan on _hyper_1_59_chunk
+         ->  Seq Scan on _hyper_1_60_chunk
+         ->  Seq Scan on _hyper_1_61_chunk
+         ->  Seq Scan on _hyper_1_62_chunk
+         ->  Seq Scan on _hyper_1_63_chunk
+         ->  Seq Scan on _hyper_1_64_chunk
+         ->  Seq Scan on _hyper_1_65_chunk
+         ->  Seq Scan on _hyper_1_66_chunk
+         ->  Seq Scan on _hyper_1_67_chunk
+         ->  Seq Scan on _hyper_1_68_chunk
+         ->  Seq Scan on _hyper_1_69_chunk
+         ->  Seq Scan on _hyper_1_70_chunk
+         ->  Seq Scan on _hyper_1_71_chunk
+         ->  Seq Scan on _hyper_1_72_chunk
+         ->  Seq Scan on _hyper_1_73_chunk
+         ->  Seq Scan on _hyper_1_74_chunk
+         ->  Seq Scan on _hyper_1_75_chunk
+         ->  Seq Scan on _hyper_1_76_chunk
+         ->  Seq Scan on _hyper_1_77_chunk
+         ->  Seq Scan on _hyper_1_78_chunk
+         ->  Seq Scan on _hyper_1_79_chunk
+         ->  Seq Scan on _hyper_1_80_chunk
+         ->  Seq Scan on _hyper_1_81_chunk
+         ->  Seq Scan on _hyper_1_82_chunk
+         ->  Seq Scan on _hyper_1_83_chunk
+         ->  Seq Scan on _hyper_1_84_chunk
+         ->  Seq Scan on _hyper_1_85_chunk
+         ->  Seq Scan on _hyper_1_86_chunk
+         ->  Seq Scan on _hyper_1_87_chunk
+         ->  Seq Scan on _hyper_1_88_chunk
+         ->  Seq Scan on _hyper_1_89_chunk
+         ->  Seq Scan on _hyper_1_90_chunk
+         ->  Seq Scan on _hyper_1_91_chunk
+         ->  Seq Scan on _hyper_1_92_chunk
+         ->  Seq Scan on _hyper_1_93_chunk
+         ->  Seq Scan on _hyper_1_94_chunk
+         ->  Seq Scan on _hyper_1_95_chunk
+         ->  Seq Scan on _hyper_1_96_chunk
+         ->  Seq Scan on _hyper_1_97_chunk
+         ->  Seq Scan on _hyper_1_98_chunk
+         ->  Seq Scan on _hyper_1_99_chunk
+         ->  Seq Scan on _hyper_1_100_chunk
+         ->  Seq Scan on _hyper_1_101_chunk
+         ->  Seq Scan on _hyper_1_102_chunk
+(106 rows)
+
+-- explicit chunk exclusion
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) ORDER BY value;
+                QUERY PLAN                
+------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+         ->  Seq Scan on _hyper_1_2_chunk
+(5 rows)
+
+:PREFIX SELECT * FROM (SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[1,2,3])) T ORDER BY value;
+                  QUERY PLAN                  
+----------------------------------------------
+ Sort
+   Sort Key: h.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk h
+         ->  Seq Scan on _hyper_1_2_chunk h_1
+         ->  Seq Scan on _hyper_1_3_chunk h_2
+(6 rows)
+
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2,3]) AND time < 10 ORDER BY value;
+                QUERY PLAN                
+------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk.value
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ("time" < 10)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ("time" < 10)
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ("time" < 10)
+(9 rows)
+
+:PREFIX SELECT * FROM hyper_ts WHERE device_id = 'dev1' AND time < to_timestamp(10) AND chunks_in(hyper_ts, ARRAY[116]) ORDER BY value;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_3_116_chunk.value
+   ->  Append
+         ->  Seq Scan on _hyper_3_116_chunk
+               Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
+(5 rows)
+
+:PREFIX SELECT * FROM hyper_ts h JOIN tag on (h.tag_id = tag.id ) WHERE chunks_in(h, ARRAY[116]) AND time < to_timestamp(10) AND device_id = 'dev1' ORDER BY value;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: h.value
+   ->  Hash Join
+         Hash Cond: (tag.id = h.tag_id)
+         ->  Seq Scan on tag
+         ->  Hash
+               ->  Append
+                     ->  Seq Scan on _hyper_3_116_chunk h
+                           Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE chunks_in(h1, ARRAY[104,105]) AND chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Sort
+   Sort Key: h1.value
+   ->  Hash Join
+         Hash Cond: (h2.device_id = h1.device_id)
+         ->  Append
+               ->  Seq Scan on _hyper_3_116_chunk h2
+               ->  Seq Scan on _hyper_3_117_chunk h2_1
+         ->  Hash
+               ->  Append
+                     ->  Seq Scan on _hyper_2_104_chunk h1
+                     ->  Seq Scan on _hyper_2_105_chunk h1_1
+(11 rows)
+
+:PREFIX SELECT * FROM hyper h1, hyper h2 WHERE chunks_in(h1, ARRAY[1,2]) AND chunks_in(h2, ARRAY[2,3]);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk h1
+         ->  Seq Scan on _hyper_1_2_chunk h1_1
+   ->  Materialize
+         ->  Append
+               ->  Seq Scan on _hyper_1_2_chunk h2
+               ->  Seq Scan on _hyper_1_3_chunk h2_1
+(8 rows)
+
+SET enable_seqscan=false;
+-- Should perform index-only scan. Since we pass whole row into the function it might block planner from using index-only scan.
+-- But since we'll remove the function from the query tree before planner decision it shouldn't affect index-only decision.
+:PREFIX SELECT time FROM hyper WHERE time=0 AND chunks_in(hyper, ARRAY[1]);
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_hyper_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" = 0)
+(3 rows)
+
+:PREFIX SELECT first(value, time) FROM hyper h WHERE chunks_in(h, ARRAY[1]);
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Merge Append
+                 Sort Key: h."time"
+                 ->  Index Scan Backward using _hyper_1_1_chunk_hyper_time_idx on _hyper_1_1_chunk h
+                       Index Cond: ("time" IS NOT NULL)
+(7 rows)
+
+\set ON_ERROR_STOP 0
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) AND chunks_in(hyper, ARRAY[2,3]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:24: ERROR:  only one chunks_in call is allowed per hypertable
+:PREFIX SELECT * FROM hyper WHERE chunks_in(2, ARRAY[1]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:25: ERROR:  function chunks_in(integer, integer[]) does not exist at character 48
+SELECT * FROM hyper WHERE time < 10 OR chunks_in(hyper, ARRAY[1,2]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:26: ERROR:  illegal invocation of chunks_in function
+SELECT chunks_in(hyper, ARRAY[1,2]) FROM hyper;
+psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  illegal invocation of chunks_in function
+-- non existing chunk id
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[123456789]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  chunk id 123456789 not found
+-- chunk that belongs to another hypertable
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[104]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 104 does not belong to hypertable "hyper"
+-- passing wrong row ref
+SELECT * FROM hyper WHERE chunks_in(ROW(1,2), ARRAY[104]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  illegal invocation of chunks_in function
+-- passing func as chunk id
+:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  second argument to chunk_in should contain only integer consts
+-- chunks_in is STRICT function and for NULL arguments a null result is returned
+SELECT * FROM hyper h WHERE chunks_in(h, NULL);
+ value | time 
+-------+------
+(0 rows)
+
+:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[NULL::int]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL

--- a/test/expected/utils.out
+++ b/test/expected/utils.out
@@ -1,0 +1,14 @@
+-- Copyright (c) 2016-2018  Timescale, Inc. All Rights Reserved.
+--
+-- This file is licensed under the Apache License,
+-- see LICENSE-APACHE at the top level directory.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION _timescaledb_internal.utils_test_list_cell_detach() RETURNS BOOL
+    AS :MODULE_PATHNAME, 'ts_test_list_cell_detach' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SELECT _timescaledb_internal.utils_test_list_cell_detach();
+ utils_test_list_cell_detach 
+-----------------------------
+ t
+(1 row)
+

--- a/test/sql/include/plan_expand_hypertable_chunks_in_query.sql
+++ b/test/sql/include/plan_expand_hypertable_chunks_in_query.sql
@@ -1,0 +1,38 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+--we want to see how our logic excludes chunks
+--and not how much work constraint_exclusion does
+SET constraint_exclusion = 'off';
+
+:PREFIX SELECT * FROM hyper ORDER BY value;
+-- explicit chunk exclusion
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) ORDER BY value;
+:PREFIX SELECT * FROM (SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[1,2,3])) T ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2,3]) AND time < 10 ORDER BY value;
+:PREFIX SELECT * FROM hyper_ts WHERE device_id = 'dev1' AND time < to_timestamp(10) AND chunks_in(hyper_ts, ARRAY[116]) ORDER BY value;
+:PREFIX SELECT * FROM hyper_ts h JOIN tag on (h.tag_id = tag.id ) WHERE chunks_in(h, ARRAY[116]) AND time < to_timestamp(10) AND device_id = 'dev1' ORDER BY value;
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE chunks_in(h1, ARRAY[104,105]) AND chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
+:PREFIX SELECT * FROM hyper h1, hyper h2 WHERE chunks_in(h1, ARRAY[1,2]) AND chunks_in(h2, ARRAY[2,3]);
+SET enable_seqscan=false;
+-- Should perform index-only scan. Since we pass whole row into the function it might block planner from using index-only scan.
+-- But since we'll remove the function from the query tree before planner decision it shouldn't affect index-only decision.
+:PREFIX SELECT time FROM hyper WHERE time=0 AND chunks_in(hyper, ARRAY[1]);
+:PREFIX SELECT first(value, time) FROM hyper h WHERE chunks_in(h, ARRAY[1]);
+\set ON_ERROR_STOP 0
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) AND chunks_in(hyper, ARRAY[2,3]);
+:PREFIX SELECT * FROM hyper WHERE chunks_in(2, ARRAY[1]);
+SELECT * FROM hyper WHERE time < 10 OR chunks_in(hyper, ARRAY[1,2]);
+SELECT chunks_in(hyper, ARRAY[1,2]) FROM hyper;
+-- non existing chunk id
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[123456789]);
+-- chunk that belongs to another hypertable
+:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[104]);
+-- passing wrong row ref
+SELECT * FROM hyper WHERE chunks_in(ROW(1,2), ARRAY[104]);
+-- passing func as chunk id
+:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+-- chunks_in is STRICT function and for NULL arguments a null result is returned
+SELECT * FROM hyper h WHERE chunks_in(h, NULL);
+:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[NULL::int]);

--- a/test/sql/plan_expand_hypertable_optimized.sql
+++ b/test/sql/plan_expand_hypertable_optimized.sql
@@ -6,3 +6,4 @@ SET timescaledb.disable_optimizations= 'off';
 \set PREFIX 'EXPLAIN (costs off) '
 \ir include/plan_expand_hypertable_load.sql
 \ir include/plan_expand_hypertable_query.sql
+\ir include/plan_expand_hypertable_chunks_in_query.sql


### PR DESCRIPTION
In some cases user might already know what chunks need to be scanned to answer
a particular query. Using `chunks_in` function we can skip calculating chunks
involved in particular query which should also result in better performances.
A simple example:

`SELECT * FROM hypertable WHERE chunks_in(hypertable, ARRAY[1,2])`