### PR TITLE
Log which chunks are dropped by background workers

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -74,7 +74,8 @@ CREATE OR REPLACE FUNCTION drop_chunks(
     table_name  NAME = NULL,
     schema_name NAME = NULL,
     cascade  BOOLEAN = FALSE,
-    newer_than "any" = NULL
+    newer_than "any" = NULL,
+    verbose BOOLEAN = FALSE
 ) RETURNS SETOF REGCLASS AS '@MODULE_PATHNAME@', 'ts_chunk_drop_chunks'
 LANGUAGE C STABLE PARALLEL SAFE;
 

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -3,14 +3,6 @@
 -- This file is licensed under the Apache License, see LICENSE-APACHE
 -- at the top level directory of the TimescaleDB distribution.
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_chunks_impl(
-    hypertable  REGCLASS = NULL,
-    older_than "any" = NULL,
-    newer_than "any" = NULL,
-	cascade BOOLEAN = FALSE
-) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_chunk_drop_chunks'
-LANGUAGE C STABLE PARALLEL SAFE;
-
 --documentation of these function located in chunk_index.h
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_index_clone(chunk_index_oid OID) RETURNS OID
 AS '@MODULE_PATHNAME@', 'ts_chunk_index_clone' LANGUAGE C VOLATILE STRICT;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -29,3 +29,6 @@ CREATE TABLE IF NOT EXISTS _timescaledb_internal.bgw_policy_chunk_stats (
 GRANT SELECT ON _timescaledb_config.bgw_policy_reorder TO PUBLIC;
 GRANT SELECT ON _timescaledb_config.bgw_policy_drop_chunks TO PUBLIC;
 GRANT SELECT ON _timescaledb_internal.bgw_policy_chunk_stats TO PUBLIC;
+
+DROP FUNCTION IF EXISTS _timescaledb_internal.drop_chunks_impl(REGCLASS, "any", "any", BOOLEAN);
+DROP FUNCTION IF EXISTS drop_chunks("any", NAME, NAME, BOOLEAN, "any");

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -86,7 +86,7 @@ extern bool ts_chunk_set_name(Chunk *chunk, const char *newname);
 extern bool ts_chunk_set_schema(Chunk *chunk, const char *newschema);
 extern List *ts_chunk_get_window(int32 dimension_id, int64 point, int count, MemoryContext mctx);
 extern void ts_chunks_rename_schema_name(char *old_schema, char *new_schema);
-extern TSDLLEXPORT void ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum, Datum newer_than_datum, Oid older_than_type, Oid newer_than_type, bool cascade);
+extern TSDLLEXPORT void ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum, Datum newer_than_datum, Oid older_than_type, Oid newer_than_type, bool cascade, int32 log_level);
 
 #define chunk_get_by_name(schema_name, table_name, num_constraints, fail_if_not_found) \
 	ts_chunk_get_by_name_with_memory_context(schema_name, table_name, num_constraints, \

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -13,7 +13,7 @@ $BODY$
           d.interval_length IS NOT NULL
 $BODY$;
 -- Make sure drop_chunks when there are no tables succeeds
-SELECT drop_chunks(INTERVAL '1 hour');
+SELECT drop_chunks(INTERVAL '1 hour', verbose => true);
  drop_chunks 
 -------------
  
@@ -421,8 +421,10 @@ SELECT * FROM _timescaledb_catalog.dimension_slice;
  24 |            3 |                    6 |                   7
 (23 rows)
 
-SELECT drop_chunks(2, CASCADE=>true);
+SELECT drop_chunks(2, CASCADE=>true, verbose => true);
+INFO:  dropping chunk _timescaledb_internal._hyper_1_1_chunk
 NOTICE:  drop cascades to view dependent_view
+INFO:  dropping chunk _timescaledb_internal._hyper_3_13_chunk
  drop_chunks 
 -------------
  
@@ -709,7 +711,8 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
 (8 rows)
 
 -- newer_than tests
-SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5);
+SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5, verbose => true);
+INFO:  dropping chunk _timescaledb_internal._hyper_1_5_chunk
  drop_chunks 
 -------------
  

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -15,7 +15,7 @@ $BODY$
 $BODY$;
 
 -- Make sure drop_chunks when there are no tables succeeds
-SELECT drop_chunks(INTERVAL '1 hour');
+SELECT drop_chunks(INTERVAL '1 hour', verbose => true);
 
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
@@ -142,7 +142,7 @@ FULL OUTER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.id = cc.dimension
 -- Only one dimension slice deleted
 SELECT * FROM _timescaledb_catalog.dimension_slice;
 
-SELECT drop_chunks(2, CASCADE=>true);
+SELECT drop_chunks(2, CASCADE=>true, verbose => true);
 
 SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
@@ -212,7 +212,7 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
 \dt "_timescaledb_internal"._hyper*
 
 -- newer_than tests
-SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5);
+SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5, verbose => true);
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -69,7 +69,7 @@ execute_reorder_policy(BgwJob *job, reorder_func reorder, bool fast_continue)
 	BgwPolicyReorder *args;
 	Hypertable *ht;
 	Chunk	   *chunk;
-	int32 job_id = job->fd.id;
+	int32		job_id = job->fd.id;
 
 	if (!IsTransactionOrTransactionBlock())
 	{
@@ -141,7 +141,8 @@ execute_drop_chunks_policy(int32 job_id)
 				 errmsg("could not run drop_chunks policy #%d because no args in policy table",
 						job_id)));
 
-	ts_chunk_do_drop_chunks(ts_hypertable_id_to_relid(args->fd.hypertable_id), IntervalPGetDatum(&args->fd.older_than), 0, INTERVALOID, InvalidOid, args->fd.cascade);
+	ts_chunk_do_drop_chunks(ts_hypertable_id_to_relid(args->fd.hypertable_id), IntervalPGetDatum(&args->fd.older_than), 0, INTERVALOID, InvalidOid, args->fd.cascade, LOG);
+	elog(LOG, "completed dropping chunks");
 
 	if (started)
 		CommitTransactionCommand();

--- a/tsl/src/license.c
+++ b/tsl/src/license.c
@@ -181,6 +181,7 @@ static bool
 license_info_init_from_base64(char *license_key, LicenseInfo *out)
 {
 	char	   *expanded = base64_decode(license_key);
+
 	if (expanded == NULL)
 		return false;
 
@@ -238,7 +239,8 @@ static TimestampTz json_get_end_time(Jsonb *license);
 static void
 license_info_init_from_jsonb(Jsonb *json_license, LicenseInfo *out)
 {
-	char *id_str = json_get_id(json_license);
+	char	   *id_str = json_get_id(json_license);
+
 	if (id_str == NULL)
 		elog(ERROR, "missing id in license key");
 	StrNCpy(out->id, id_str, sizeof(out->id));


### PR DESCRIPTION
We don't want to do this silently, so that users are
able to debug where their chunks went.

@davidkohn88 should we expose a `verbose` flag for the manual version also?