### PR TITLE
Ignore rolenames pgregress test

### DIFF
--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -24,9 +24,11 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testtablespace)
 
 # Tests to ignore
 set(PG_IGNORE_TESTS
+  rolenames
   rules
   opr_sanity
-  sanity_check)
+  sanity_check
+)
 
 # Modify the test schedule to ignore some tests
 foreach(IGNORE_TEST ${PG_IGNORE_TESTS})

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -74,10 +74,12 @@ set(SOLO_TESTS
 # on output of previous tests
 set(POST_TESTS
   agg_bookends_results_diff
+  append_x_diff
   alternate_users-9.6
   alternate_users-10
   alternate_users-11
-  append_x_diff
+  plan_expand_hypertable_results_diff
+  plan_hashagg_results_x_diff
   sql_query_results_x_diff
 )
 


### PR DESCRIPTION
The rolenames test seems to be fail quite often in CI, so we ignore
the result from that test for now.