### PR TITLE
Add ordered append optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ typedef.list
 **/GSYMS
 /.vs
 /test/sql/parallel-*.sql
+/test/sql/plan_ordered_append-*.sql
 /test/sql/plan_hashagg_optimized-*.sql
 /test/sql/agg_bookends_optimized-*.sql
 /test/sql/alternate_users-*.sql

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
   plan_expand_hypertable.c
   plan_add_hashagg.c
   plan_agg_bookend.c
+  plan_ordered_append.c
   planner_import.c
   process_utility.c
   scanner.c
@@ -47,7 +48,8 @@ set(SOURCES
   time_bucket.c
   trigger.c
   utils.c
-  version.c)
+  version.c
+)
 
 # Add test source code in Debug builds
 if (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -14,6 +14,18 @@ cmp_slices(const void *left, const void *right)
 	return ts_dimension_slice_cmp(left_slice, right_slice);
 }
 
+/*
+ * identical to cmp_slices except for reversed arguments to ts_dimension_slice_cmp
+ */
+static int
+cmp_slices_reverse(const void *left, const void *right)
+{
+	const DimensionSlice *left_slice = *((DimensionSlice **) left);
+	const DimensionSlice *right_slice = *((DimensionSlice **) right);
+
+	return ts_dimension_slice_cmp(right_slice, left_slice);
+}
+
 static int
 cmp_coordinate_and_slice(const void *left, const void *right)
 {
@@ -56,6 +68,16 @@ ts_dimension_vec_sort(DimensionVec **vecptr)
 	DimensionVec *vec = *vecptr;
 
 	qsort(vec->slices, vec->num_slices, sizeof(DimensionSlice *), cmp_slices);
+
+	return vec;
+}
+
+DimensionVec *
+ts_dimension_vec_sort_reverse(DimensionVec **vecptr)
+{
+	DimensionVec *vec = *vecptr;
+
+	qsort(vec->slices, vec->num_slices, sizeof(DimensionSlice *), cmp_slices_reverse);
 
 	return vec;
 }

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -29,6 +29,7 @@ typedef struct DimensionVec
 
 extern DimensionVec *ts_dimension_vec_create(int32 initial_num_slices);
 extern DimensionVec *ts_dimension_vec_sort(DimensionVec **vec);
+extern DimensionVec *ts_dimension_vec_sort_reverse(DimensionVec **vec);
 extern DimensionVec *ts_dimension_vec_add_slice_sort(DimensionVec **vec, DimensionSlice *slice);
 extern DimensionVec *ts_dimension_vec_add_slice(DimensionVec **vecptr, DimensionSlice *slice);
 extern DimensionVec *ts_dimension_vec_add_unique_slice(DimensionVec **vecptr, DimensionSlice *slice);

--- a/src/guc.c
+++ b/src/guc.c
@@ -40,6 +40,7 @@ bool		ts_guc_disable_optimizations = false;
 bool		ts_guc_optimize_non_hypertables = false;
 bool		ts_guc_restoring = false;
 bool		ts_guc_constraint_aware_append = true;
+bool		ts_guc_enable_ordered_append = true;
 int			ts_guc_max_open_chunks_per_insert = 10;
 int			ts_guc_max_cached_chunks_per_hypertable = 10;
 int			ts_guc_telemetry_level = TELEMETRY_BASIC;
@@ -96,8 +97,17 @@ _guc_init(void)
 							 "Enable constraint exclusion at execution time",
 							 &ts_guc_constraint_aware_append,
 							 true,
-							 PGC_USERSET
-							 ,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("timescaledb.enable_ordered_append", "Enable ordered append scans",
+							 "Enable ordered append optimization for queries that are ordered by the time dimension",
+							 &ts_guc_enable_ordered_append,
+							 true,
+							 PGC_USERSET,
 							 0,
 							 NULL,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -14,6 +14,7 @@ extern bool ts_telemetry_on(void);
 extern bool ts_guc_disable_optimizations;
 extern bool ts_guc_optimize_non_hypertables;
 extern bool ts_guc_constraint_aware_append;
+extern bool ts_guc_enable_ordered_append;
 extern bool ts_guc_restoring;
 extern int	ts_guc_max_open_chunks_per_insert;
 extern int	ts_guc_max_cached_chunks_per_hypertable;

--- a/src/hypertable_restrict_info.h
+++ b/src/hypertable_restrict_info.h
@@ -24,4 +24,6 @@ extern bool ts_hypertable_restrict_info_has_restrictions(HypertableRestrictInfo 
 /* Get a list of chunk oids for chunks whose constraints match the restriction clauses */
 extern List *ts_hypertable_restrict_info_get_chunk_oids(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockmode);
 
+extern List *ts_hypertable_restrict_info_get_chunk_oids_ordered(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockmode, bool reverse);
+
 #endif							/* TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H */

--- a/src/plan_ordered_append.c
+++ b/src/plan_ordered_append.c
@@ -1,0 +1,146 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <nodes/relation.h>
+#include <nodes/value.h>
+#include <optimizer/paths.h>
+#include <optimizer/pathnode.h>
+#include <optimizer/tlist.h>
+#include <utils/builtins.h>
+#include <utils/typcache.h>
+
+#include "compat.h"
+#include "guc.h"
+#include "hypertable.h"
+#include "hypertable_restrict_info.h"
+#include "constraint_aware_append.h"
+#include "planner.h"
+#include "plan_ordered_append.h"
+
+/*
+ * Check if conditions for doing ordered append optimization are fulfilled
+ */
+bool
+ts_ordered_append_should_optimize(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, bool *reverse)
+{
+	SortGroupClause *sort = linitial(root->parse->sortClause);
+	TargetEntry *tle = get_sortgroupref_tle(sort->tleSortGroupRef, root->parse->targetList);
+	RangeTblEntry *rte = root->simple_rte_array[rel->relid];
+	TypeCacheEntry *tce;
+	char	   *column;
+
+	/* these are checked in caller so we only Assert */
+	Assert(!ts_guc_disable_optimizations && ts_guc_enable_ordered_append);
+
+	/*
+	 * only do this optimization for hypertables with 1 dimension and queries
+	 * with an ORDER BY and LIMIT clause, caller checked this, so only
+	 * asserting
+	 */
+	Assert(ht->space->num_dimensions == 1 || root->parse->sortClause != NIL || root->limit_tuples != -1.0);
+
+	/*
+	 * check that the first element of the ORDER BY clause actually matches
+	 * the first dimension of the hypertable
+	 */
+
+	/* doublecheck rel actually refers to our hypertable */
+	Assert(ht->space->main_table_relid == rte->relid);
+
+	/*
+	 * check the ORDER BY column actually belonging to our hypertable
+	 * Unfortunately resorigtbl is not set for junk columns so we can't
+	 * doublecheck for those this way, but we are only dealing with single
+	 * relations at this level anyway so this should always match
+	 */
+	Assert(tle->resjunk == false || ht->space->main_table_relid != tle->resorigtbl);
+
+	/*
+	 * we only support direct column references for now
+	 */
+	if (!IsA(tle->expr, Var))
+		return false;
+
+	/* check dimension column is our ORDER BY column */
+	column = strVal(list_nth(rte->eref->colnames, AttrNumberGetAttrOffset(castNode(Var, tle->expr)->varattno)));
+	if (namestrcmp(&ht->space->dimensions[0].fd.column_name, column) != 0)
+		return false;
+
+	/*
+	 * check sort operation is either less than or greater than
+	 */
+	tce = lookup_type_cache(castNode(Var, tle->expr)->vartype, TYPECACHE_LT_OPR | TYPECACHE_GT_OPR);
+	if (sort->sortop != tce->lt_opr && sort->sortop != tce->gt_opr)
+		return false;
+
+	if (reverse != NULL)
+		*reverse = sort->sortop == tce->lt_opr ? false : true;
+
+	return true;
+}
+
+/*
+ * we use an existing MergeAppendPath here as starting point for creating
+ * our ordered AppendPath because it has all the required information we
+ * need to create our path. If pathkeys does not match the ORDER BY then
+ * we return the original MergeAppendPath
+ */
+Path *
+ts_ordered_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, MergeAppendPath *merge)
+{
+	ListCell   *lc;
+	List	   *sorted = NIL;
+	AppendPath *append;
+	bool		parallel_safe = rel->consider_parallel;
+
+	/*
+	 * double check pathkeys of the MergeAppendPath actually is compatible
+	 * with the order supplied in the query since that is what our children
+	 * will be ordered by.
+	 */
+	if (!pathkeys_contained_in(root->sort_pathkeys, merge->path.pathkeys))
+		return (Path *) merge;
+
+	/* create subpaths for our append node */
+	foreach(lc, merge->subpaths)
+	{
+		Path	   *child = lfirst(lc);
+
+		/*
+		 * AppendPath is parallel_safe if all children are parallel safe
+		 */
+		parallel_safe = parallel_safe && child->parallel_safe;
+
+		/*
+		 * Since we start from a MergeAppendPath all children should be sorted
+		 * in an order compatible with the order of the MergeAppendPath
+		 */
+		Assert(pathkeys_contained_in(merge->path.pathkeys, child->pathkeys));
+		sorted = lappend(sorted, child);
+	}
+
+	/*
+	 * we set subpaths as NIL initially to skip PostgreSQL cost calculation
+	 * for children
+	 */
+#if PG96
+	append = create_append_path(rel, NIL, PATH_REQ_OUTER(&merge->path), 0);
+#elif PG10
+	append = create_append_path(rel, NIL, PATH_REQ_OUTER(&merge->path), 0, merge->partitioned_rels);
+#else
+	append = create_append_path(root, rel, NIL, NULL, PATH_REQ_OUTER(&merge->path), 0, false, merge->partitioned_rels, root->limit_tuples);
+#endif
+
+	append->subpaths = sorted;
+	if (list_length(sorted) > 0)
+		append->path.startup_cost = ((Path *) linitial(sorted))->startup_cost;
+	append->path.pathkeys = merge->path.pathkeys;
+	append->path.parallel_aware = false;
+	append->path.parallel_safe = parallel_safe;
+
+	return (Path *) append;
+}

--- a/src/plan_ordered_append.h
+++ b/src/plan_ordered_append.h
@@ -1,0 +1,18 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_PLAN_ORDERED_APPEND_H
+#define TIMESCALEDB_PLAN_ORDERED_APPEND_H
+
+#include <postgres.h>
+#include <nodes/relation.h>
+
+#include "hypertable.h"
+#include "hypertable_restrict_info.h"
+
+bool		ts_ordered_append_should_optimize(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, bool *reverse);
+Path	   *ts_ordered_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, MergeAppendPath *merge);
+
+#endif							/* TIMESCALEDB_PLAN_ORDERED_APPEND_H */

--- a/src/planner.h
+++ b/src/planner.h
@@ -1,0 +1,14 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_PLANNER_H
+#define TIMESCALEDB_PLANNER_H
+
+typedef struct TimescaleDBPrivate
+{
+	bool		appends_ordered;
+} TimescaleDBPrivate;
+
+#endif							/* TIMESCALEDB_PLANNER_H */

--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -79,7 +79,6 @@ psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
                 QUERY PLAN                 
 -------------------------------------------
  Limit
@@ -123,11 +122,10 @@ psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
 (1 row)
 
 -- adding ORDER BY and LIMIT should turn the plan into an optimized
--- merge append plan
+-- ordered append plan
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
@@ -138,16 +136,14 @@ psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: append_test
          Chunks left after exclusion: 1
-         ->  Merge Append
-               Sort Key: _hyper_1_3_chunk."time"
+         ->  Append
                ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                      Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(8 rows)
+(7 rows)
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:72: NOTICE:  Stable function now_s() called!

--- a/test/expected/append_unoptimized.out
+++ b/test/expected/append_unoptimized.out
@@ -139,7 +139,7 @@ psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
 (1 row)
 
 -- adding ORDER BY and LIMIT should turn the plan into an optimized
--- merge append plan
+-- ordered append plan
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;

--- a/test/expected/append_x_diff.out
+++ b/test/expected/append_x_diff.out
@@ -31,14 +31,13 @@
 75,76d69
 < psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 < psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-89,90c82,84
+89,90c82,83
 <                                        QUERY PLAN                                       
 < ----------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
 >                 QUERY PLAN                 
 > -------------------------------------------
-92,102c86,89
+92,102c85,88
 <    ->  Merge Append
 <          Sort Key: append_test."time" DESC
 <          ->  Index Scan using append_test_time_idx on append_test
@@ -55,7 +54,7 @@
 >          Hypertable: append_test
 >          Chunks left after exclusion: 0
 > (4 rows)
-114,125c101,110
+114,125c100,109
 <                                     QUERY PLAN                                    
 < ----------------------------------------------------------------------------------
 <  Append
@@ -79,16 +78,15 @@
 >          ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (6 rows)
-135d119
+135d118
 < psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
-150,151c134,136
+150,151c133,134
 <                                            QUERY PLAN                                            
 < -------------------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
 >                                               QUERY PLAN                                               
 > -------------------------------------------------------------------------------------------------------
-153,163c138,145
+153,163c136,142
 <    ->  Merge Append
 <          Sort Key: append_test."time"
 <          ->  Index Scan Backward using append_test_time_idx on append_test
@@ -104,21 +102,21 @@
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: append_test
 >          Chunks left after exclusion: 1
->          ->  Merge Append
->                Sort Key: _hyper_1_3_chunk."time"
+>          ->  Append
 >                ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                      Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-> (8 rows)
-174,175d155
+> (7 rows)
+173,175d151
 < psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
 < psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
-188,189c168,169
+< psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+188,189c164,165
 <                                                           QUERY PLAN                                                          
 < ------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                             
 > ------------------------------------------------------------------------------------------------------------------------------------
-192,207c172,180
+192,207c168,176
 <    ->  Append
 <          ->  Seq Scan on append_test
 <                Filter: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
@@ -145,13 +143,13 @@
 >                      ->  Bitmap Index Scan on _hyper_1_3_chunk_append_test_time_idx
 >                            Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
 > (10 rows)
-216,217c189,190
+216,217c185,186
 <                             QUERY PLAN                             
 < -------------------------------------------------------------------
 ---
 >                                QUERY PLAN                                
 > -------------------------------------------------------------------------
-220,229c193,203
+220,229c189,199
 <    ->  Append
 <          ->  Seq Scan on append_test
 <                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
@@ -174,10 +172,10 @@
 >                ->  Seq Scan on _hyper_1_3_chunk
 >                      Filter: ("time" > (now_v() - '@ 2 mons'::interval))
 > (12 rows)
-255,256d228
+255,256d224
 < psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
 < psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
-264,276c236,246
+264,276c232,242
 <                                         QUERY PLAN                                         
 < -------------------------------------------------------------------------------------------
 <  Merge Append
@@ -203,30 +201,30 @@
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (7 rows)
-304a275
+304a271
 > psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
-311c282,284
+311c278,280
 <          ->  Result
 ---
 >          ->  Custom Scan (ConstraintAwareAppend)
 >                Hypertable: append_test
 >                Chunks left after exclusion: 2
-313,316d285
+313,316d281
 <                      ->  Seq Scan on append_test
 <                            Filter: ("time" > (now_s() - '@ 4 mons'::interval))
 <                      ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
 <                            Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-321c290
+321c286
 < (14 rows)
 ---
 > (12 rows)
-333,334c302,303
+333,334c298,299
 <                                                                                                              QUERY PLAN                                                                                                              
 < -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                               QUERY PLAN                               
 > -----------------------------------------------------------------------
-339,343c308,311
+339,343c304,307
 <          ->  Result
 <                ->  Append
 <                      ->  Seq Scan on append_test
@@ -237,36 +235,36 @@
 >                Hypertable: append_test
 >                Chunks left after exclusion: 0
 > (7 rows)
-388,389c356,358
+388,389c352,354
 <                                               QUERY PLAN                                               
 < -------------------------------------------------------------------------------------------------------
 ---
 > psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
 >                                                   QUERY PLAN                                                   
 > ---------------------------------------------------------------------------------------------------------------
-395c364,366
+395c360,362
 <            ->  Result
 ---
 >            ->  Custom Scan (ConstraintAwareAppend)
 >                  Hypertable: append_test
 >                  Chunks left after exclusion: 3
-397,399c368
+397,399c364
 <                        ->  Seq Scan on append_test
 <                              Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
 <                        ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
-402c371
+402c367
 <                        ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
-405c374
+405c370
 <                        ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
-440a410
+440a406
 > psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
-480,481c450,453
+480,481c446,449
 <                                          QUERY PLAN                                         
 < --------------------------------------------------------------------------------------------
 ---
@@ -274,7 +272,7 @@
 > psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
 >                                             QUERY PLAN                                            
 > --------------------------------------------------------------------------------------------------
-484,502c456,472
+484,502c452,468
 <    ->  Append
 <          ->  Seq Scan on append_test a
 <                Filter: ("time" > (now_s() - '@ 3 hours'::interval))

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -1,0 +1,448 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- we run these with analyze to confirm that nodes that are not
+-- needed to fulfill the limit are not executed
+-- unfortunately this doesn't work on PostgreSQL 9.6 which lacks
+-- the ability to turn off analyze timing summary so we run
+-- them without ANALYZE on PostgreSQL 9.6, but since LATERAL plans
+-- are different across versions we need version specific output
+-- here anyway.
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+\ir include/plan_ordered_append_load.sql
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- create a table where we create chunks in order
+CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append','time');
+      create_hypertable      
+-----------------------------
+ (1,public,ordered_append,t)
+(1 row)
+
+CREATE index on ordered_append(time DESC,device_id);
+INSERT INTO ordered_append VALUES('2000-01-01',1,1.0);
+INSERT INTO ordered_append VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append VALUES('2000-01-15',1,3.0);
+-- create a second table where we create chunks in reverse order
+CREATE TABLE ordered_append_reverse(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append_reverse','time');
+          create_hypertable          
+-------------------------------------
+ (2,public,ordered_append_reverse,t)
+(1 row)
+
+INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+\ir include/plan_ordered_append_query.sql
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- print chunks ordered by time to ensure ordering we want
+SELECT
+  ht.table_name AS hypertable,
+  c.table_name AS chunk,
+  ds.range_start
+FROM
+  _timescaledb_catalog.chunk c
+  INNER JOIN _timescaledb_catalog.chunk_constraint cc ON c.id = cc.chunk_id
+  INNER JOIN _timescaledb_catalog.dimension_slice ds ON ds.id=cc.dimension_slice_id
+  INNER JOIN _timescaledb_catalog.dimension d ON ds.dimension_id = d.id
+  INNER JOIN _timescaledb_catalog.hypertable ht ON d.hypertable_id = ht.id
+ORDER BY ht.table_name, range_start;
+       hypertable       |      chunk       |   range_start   
+------------------------+------------------+-----------------
+ ordered_append         | _hyper_1_1_chunk | 946512000000000
+ ordered_append         | _hyper_1_2_chunk | 947116800000000
+ ordered_append         | _hyper_1_3_chunk | 947721600000000
+ ordered_append_reverse | _hyper_2_6_chunk | 946512000000000
+ ordered_append_reverse | _hyper_2_5_chunk | 947116800000000
+ ordered_append_reverse | _hyper_2_4_chunk | 947721600000000
+(6 rows)
+
+-- test ASC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+(5 rows)
+
+-- test DESC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+(5 rows)
+
+-- test ASC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time ASC LIMIT 1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (never executed)
+         ->  Index Scan Backward using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk (never executed)
+(5 rows)
+
+-- test DESC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time DESC LIMIT 1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (never executed)
+         ->  Index Scan using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk (never executed)
+(5 rows)
+
+-- test query with ORDER BY column not in targetlist
+:PREFIX SELECT
+  device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+(5 rows)
+
+-- ORDER BY may include other columns after time column
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC, device_id LIMIT 1;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+(5 rows)
+
+-- queries with ORDER BY non-time column shouldn't use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id LIMIT 1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: ordered_append.device_id
+         Sort Method: top-N heapsort  Memory: 25kB
+         ->  Append (actual rows=3 loops=1)
+               ->  Seq Scan on ordered_append (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+(9 rows)
+
+-- time column must be primary sort order
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id, time LIMIT 1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: ordered_append.device_id, ordered_append."time"
+         Sort Method: top-N heapsort  Memory: 25kB
+         ->  Append (actual rows=3 loops=1)
+               ->  Seq Scan on ordered_append (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+(9 rows)
+
+-- queries without LIMIT shouldnt use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Merge Append (actual rows=3 loops=1)
+   Sort Key: ordered_append."time"
+   ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+   ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+   ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+(6 rows)
+
+-- queries without ORDER BY shouldnt use ordered append (still uses append though)
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+LIMIT 1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Seq Scan on ordered_append (actual rows=0 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (never executed)
+         ->  Seq Scan on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test interaction with constraint exclusion
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(6 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time DESC LIMIT 1;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(6 rows)
+
+-- min/max queries
+:PREFIX SELECT max(time) FROM ordered_append;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Append (actual rows=1 loops=1)
+                 ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 1
+                 ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+                 ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+(13 rows)
+
+:PREFIX SELECT min(time) FROM ordered_append;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Append (actual rows=1 loops=1)
+                 ->  Index Only Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 1
+                 ->  Index Only Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+                 ->  Index Only Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+(13 rows)
+
+-- test first/last (doesn't use ordered append yet)
+:PREFIX SELECT first(time, time) FROM ordered_append;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Result (actual rows=1 loops=1)
+                 ->  Merge Append (actual rows=1 loops=1)
+                       Sort Key: ordered_append."time"
+                       ->  Index Only Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 0
+                       ->  Index Only Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+(18 rows)
+
+:PREFIX SELECT last(time, time) FROM ordered_append;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Result (actual rows=1 loops=1)
+                 ->  Merge Append (actual rows=1 loops=1)
+                       Sort Key: ordered_append."time" DESC
+                       ->  Index Only Scan using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 0
+                       ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+(18 rows)
+
+-- test query with time_bucket
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, ordered_append."time"))
+               ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+(8 rows)
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time_bucket('1d',time) LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, ordered_append."time"))
+               ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+(8 rows)
+
+-- test query with now() should result in ordered append with constraint aware append
+:PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
+ORDER BY time DESC limit 1;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 3
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+(11 rows)
+
+-- test CTE
+:PREFIX WITH i AS (SELECT * FROM ordered_append WHERE time < now() ORDER BY time DESC limit 100)
+SELECT * FROM i;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ CTE Scan on i (actual rows=3 loops=1)
+   CTE i
+     ->  Limit (actual rows=3 loops=1)
+           ->  Custom Scan (ConstraintAwareAppend) (actual rows=3 loops=1)
+                 Hypertable: ordered_append
+                 Chunks left after exclusion: 3
+                 ->  Append (actual rows=3 loops=1)
+                       ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" < now())
+                       ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" < now())
+                       ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" < now())
+(13 rows)
+
+-- test LATERAL with ordered append in the outer query
+:PREFIX SELECT * FROM ordered_append, LATERAL(SELECT * FROM (VALUES (1),(2)) v) l ORDER BY time DESC limit 2;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=2 loops=1)
+   ->  Nested Loop (actual rows=2 loops=1)
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(7 rows)
+
+-- test LATERAL with ordered append in the lateral query
+:PREFIX SELECT * FROM (VALUES (1),(2)) v, LATERAL(SELECT * FROM ordered_append ORDER BY time DESC limit 2) l;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=4 loops=1)
+   ->  Limit (actual rows=2 loops=1)
+         ->  Append (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=2)
+(7 rows)
+

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -1,0 +1,450 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- we run these with analyze to confirm that nodes that are not
+-- needed to fulfill the limit are not executed
+-- unfortunately this doesn't work on PostgreSQL 9.6 which lacks
+-- the ability to turn off analyze timing summary so we run
+-- them without ANALYZE on PostgreSQL 9.6, but since LATERAL plans
+-- are different across versions we need version specific output
+-- here anyway.
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+\ir include/plan_ordered_append_load.sql
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- create a table where we create chunks in order
+CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append','time');
+      create_hypertable      
+-----------------------------
+ (1,public,ordered_append,t)
+(1 row)
+
+CREATE index on ordered_append(time DESC,device_id);
+INSERT INTO ordered_append VALUES('2000-01-01',1,1.0);
+INSERT INTO ordered_append VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append VALUES('2000-01-15',1,3.0);
+-- create a second table where we create chunks in reverse order
+CREATE TABLE ordered_append_reverse(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append_reverse','time');
+          create_hypertable          
+-------------------------------------
+ (2,public,ordered_append_reverse,t)
+(1 row)
+
+INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+\ir include/plan_ordered_append_query.sql
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- print chunks ordered by time to ensure ordering we want
+SELECT
+  ht.table_name AS hypertable,
+  c.table_name AS chunk,
+  ds.range_start
+FROM
+  _timescaledb_catalog.chunk c
+  INNER JOIN _timescaledb_catalog.chunk_constraint cc ON c.id = cc.chunk_id
+  INNER JOIN _timescaledb_catalog.dimension_slice ds ON ds.id=cc.dimension_slice_id
+  INNER JOIN _timescaledb_catalog.dimension d ON ds.dimension_id = d.id
+  INNER JOIN _timescaledb_catalog.hypertable ht ON d.hypertable_id = ht.id
+ORDER BY ht.table_name, range_start;
+       hypertable       |      chunk       |   range_start   
+------------------------+------------------+-----------------
+ ordered_append         | _hyper_1_1_chunk | 946512000000000
+ ordered_append         | _hyper_1_2_chunk | 947116800000000
+ ordered_append         | _hyper_1_3_chunk | 947721600000000
+ ordered_append_reverse | _hyper_2_6_chunk | 946512000000000
+ ordered_append_reverse | _hyper_2_5_chunk | 947116800000000
+ ordered_append_reverse | _hyper_2_4_chunk | 947721600000000
+(6 rows)
+
+-- test ASC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+(5 rows)
+
+-- test DESC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+(5 rows)
+
+-- test ASC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time ASC LIMIT 1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (never executed)
+         ->  Index Scan Backward using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk (never executed)
+(5 rows)
+
+-- test DESC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time DESC LIMIT 1;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (never executed)
+         ->  Index Scan using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk (never executed)
+(5 rows)
+
+-- test query with ORDER BY column not in targetlist
+:PREFIX SELECT
+  device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+(5 rows)
+
+-- ORDER BY may include other columns after time column
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC, device_id LIMIT 1;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+(5 rows)
+
+-- queries with ORDER BY non-time column shouldn't use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id LIMIT 1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: ordered_append.device_id
+         Sort Method: top-N heapsort  Memory: 25kB
+         ->  Append (actual rows=3 loops=1)
+               ->  Seq Scan on ordered_append (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+(9 rows)
+
+-- time column must be primary sort order
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id, time LIMIT 1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: ordered_append.device_id, ordered_append."time"
+         Sort Method: top-N heapsort  Memory: 25kB
+         ->  Append (actual rows=3 loops=1)
+               ->  Seq Scan on ordered_append (actual rows=0 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=1 loops=1)
+(9 rows)
+
+-- queries without LIMIT shouldnt use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Merge Append (actual rows=3 loops=1)
+   Sort Key: ordered_append."time"
+   ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+   ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+   ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+(6 rows)
+
+-- queries without ORDER BY shouldnt use ordered append (still uses append though)
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+LIMIT 1;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Seq Scan on ordered_append (actual rows=0 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (never executed)
+         ->  Seq Scan on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test interaction with constraint exclusion
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(6 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time DESC LIMIT 1;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(6 rows)
+
+-- min/max queries
+:PREFIX SELECT max(time) FROM ordered_append;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Append (actual rows=1 loops=1)
+                 ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 1
+                 ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+                 ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+(13 rows)
+
+:PREFIX SELECT min(time) FROM ordered_append;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Append (actual rows=1 loops=1)
+                 ->  Index Only Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 1
+                 ->  Index Only Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+                 ->  Index Only Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+                       Index Cond: ("time" IS NOT NULL)
+                       Heap Fetches: 0
+(13 rows)
+
+-- test first/last (doesn't use ordered append yet)
+:PREFIX SELECT first(time, time) FROM ordered_append;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Result (actual rows=1 loops=1)
+                 ->  Merge Append (actual rows=1 loops=1)
+                       Sort Key: ordered_append."time"
+                       ->  Index Only Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 0
+                       ->  Index Only Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+(18 rows)
+
+:PREFIX SELECT last(time, time) FROM ordered_append;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=1 loops=1)
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=1 loops=1)
+           ->  Result (actual rows=1 loops=1)
+                 ->  Merge Append (actual rows=1 loops=1)
+                       Sort Key: ordered_append."time" DESC
+                       ->  Index Only Scan using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 0
+                       ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+                       ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" IS NOT NULL)
+                             Heap Fetches: 1
+(18 rows)
+
+-- test query with time_bucket
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, ordered_append."time"))
+               ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+(8 rows)
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time_bucket('1d',time) LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1 loops=1)
+               Sort Key: (time_bucket('@ 1 day'::interval, ordered_append."time"))
+               ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append (actual rows=0 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+(8 rows)
+
+-- test query with now() should result in ordered append with constraint aware append
+:PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
+ORDER BY time DESC limit 1;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 3
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+(11 rows)
+
+-- test CTE
+:PREFIX WITH i AS (SELECT * FROM ordered_append WHERE time < now() ORDER BY time DESC limit 100)
+SELECT * FROM i;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ CTE Scan on i (actual rows=3 loops=1)
+   CTE i
+     ->  Limit (actual rows=3 loops=1)
+           ->  Custom Scan (ConstraintAwareAppend) (actual rows=3 loops=1)
+                 Hypertable: ordered_append
+                 Chunks left after exclusion: 3
+                 ->  Append (actual rows=3 loops=1)
+                       ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" < now())
+                       ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" < now())
+                       ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                             Index Cond: ("time" < now())
+(13 rows)
+
+-- test LATERAL with ordered append in the outer query
+:PREFIX SELECT * FROM ordered_append, LATERAL(SELECT * FROM (VALUES (1),(2)) v) l ORDER BY time DESC limit 2;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=2 loops=1)
+   ->  Nested Loop (actual rows=2 loops=1)
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+         ->  Materialize (actual rows=2 loops=1)
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(8 rows)
+
+-- test LATERAL with ordered append in the lateral query
+:PREFIX SELECT * FROM (VALUES (1),(2)) v, LATERAL(SELECT * FROM ordered_append ORDER BY time DESC limit 2) l;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=4 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Materialize (actual rows=2 loops=2)
+         ->  Limit (actual rows=2 loops=1)
+               ->  Append (actual rows=2 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+(8 rows)
+

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -1,0 +1,432 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- we run these with analyze to confirm that nodes that are not
+-- needed to fulfill the limit are not executed
+-- unfortunately this doesn't work on PostgreSQL 9.6 which lacks
+-- the ability to turn off analyze timing summary so we run
+-- them without ANALYZE on PostgreSQL 9.6, but since LATERAL plans
+-- are different across versions we need version specific output
+-- here anyway.
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+\ir include/plan_ordered_append_load.sql
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- create a table where we create chunks in order
+CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append','time');
+      create_hypertable      
+-----------------------------
+ (1,public,ordered_append,t)
+(1 row)
+
+CREATE index on ordered_append(time DESC,device_id);
+INSERT INTO ordered_append VALUES('2000-01-01',1,1.0);
+INSERT INTO ordered_append VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append VALUES('2000-01-15',1,3.0);
+-- create a second table where we create chunks in reverse order
+CREATE TABLE ordered_append_reverse(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append_reverse','time');
+          create_hypertable          
+-------------------------------------
+ (2,public,ordered_append_reverse,t)
+(1 row)
+
+INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+\ir include/plan_ordered_append_query.sql
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- print chunks ordered by time to ensure ordering we want
+SELECT
+  ht.table_name AS hypertable,
+  c.table_name AS chunk,
+  ds.range_start
+FROM
+  _timescaledb_catalog.chunk c
+  INNER JOIN _timescaledb_catalog.chunk_constraint cc ON c.id = cc.chunk_id
+  INNER JOIN _timescaledb_catalog.dimension_slice ds ON ds.id=cc.dimension_slice_id
+  INNER JOIN _timescaledb_catalog.dimension d ON ds.dimension_id = d.id
+  INNER JOIN _timescaledb_catalog.hypertable ht ON d.hypertable_id = ht.id
+ORDER BY ht.table_name, range_start;
+       hypertable       |      chunk       |   range_start   
+------------------------+------------------+-----------------
+ ordered_append         | _hyper_1_1_chunk | 946512000000000
+ ordered_append         | _hyper_1_2_chunk | 947116800000000
+ ordered_append         | _hyper_1_3_chunk | 947721600000000
+ ordered_append_reverse | _hyper_2_6_chunk | 946512000000000
+ ordered_append_reverse | _hyper_2_5_chunk | 947116800000000
+ ordered_append_reverse | _hyper_2_4_chunk | 947721600000000
+(6 rows)
+
+-- test ASC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+(5 rows)
+
+-- test DESC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+(5 rows)
+
+-- test ASC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time ASC LIMIT 1;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan Backward using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk
+         ->  Index Scan Backward using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk
+         ->  Index Scan Backward using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk
+(5 rows)
+
+-- test DESC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time DESC LIMIT 1;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk
+         ->  Index Scan using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk
+         ->  Index Scan using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk
+(5 rows)
+
+-- test query with ORDER BY column not in targetlist
+:PREFIX SELECT
+  device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+(5 rows)
+
+-- ORDER BY may include other columns after time column
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC, device_id LIMIT 1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+(5 rows)
+
+-- queries with ORDER BY non-time column shouldn't use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id LIMIT 1;
+                   QUERY PLAN                   
+------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: ordered_append.device_id
+         ->  Append
+               ->  Seq Scan on ordered_append
+               ->  Seq Scan on _hyper_1_1_chunk
+               ->  Seq Scan on _hyper_1_2_chunk
+               ->  Seq Scan on _hyper_1_3_chunk
+(8 rows)
+
+-- time column must be primary sort order
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id, time LIMIT 1;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: ordered_append.device_id, ordered_append."time"
+         ->  Append
+               ->  Seq Scan on ordered_append
+               ->  Seq Scan on _hyper_1_1_chunk
+               ->  Seq Scan on _hyper_1_2_chunk
+               ->  Seq Scan on _hyper_1_3_chunk
+(8 rows)
+
+-- queries without LIMIT shouldnt use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: ordered_append."time"
+   ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append
+   ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+   ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+   ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+(6 rows)
+
+-- queries without ORDER BY shouldnt use ordered append (still uses append though)
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+LIMIT 1;
+                QUERY PLAN                
+------------------------------------------
+ Limit
+   ->  Append
+         ->  Seq Scan on ordered_append
+         ->  Seq Scan on _hyper_1_1_chunk
+         ->  Seq Scan on _hyper_1_2_chunk
+         ->  Seq Scan on _hyper_1_3_chunk
+(6 rows)
+
+-- test interaction with constraint exclusion
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(6 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time DESC LIMIT 1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+               Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(6 rows)
+
+-- min/max queries
+:PREFIX SELECT max(time) FROM ordered_append;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Append
+                 ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+                       Index Cond: ("time" IS NOT NULL)
+(10 rows)
+
+:PREFIX SELECT min(time) FROM ordered_append;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Append
+                 ->  Index Only Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Only Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                       Index Cond: ("time" IS NOT NULL)
+                 ->  Index Only Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+                       Index Cond: ("time" IS NOT NULL)
+(10 rows)
+
+-- test first/last (doesn't use ordered append yet)
+:PREFIX SELECT first(time, time) FROM ordered_append;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Result
+                 ->  Merge Append
+                       Sort Key: ordered_append."time"
+                       ->  Index Only Scan Backward using ordered_append_time_device_id_idx on ordered_append
+                             Index Cond: ("time" IS NOT NULL)
+                       ->  Index Only Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+                             Index Cond: ("time" IS NOT NULL)
+                       ->  Index Only Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                             Index Cond: ("time" IS NOT NULL)
+                       ->  Index Only Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+                             Index Cond: ("time" IS NOT NULL)
+(14 rows)
+
+:PREFIX SELECT last(time, time) FROM ordered_append;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Result
+   InitPlan 1 (returns $0)
+     ->  Limit
+           ->  Result
+                 ->  Merge Append
+                       Sort Key: ordered_append."time" DESC
+                       ->  Index Only Scan using ordered_append_time_device_id_idx on ordered_append
+                             Index Cond: ("time" IS NOT NULL)
+                       ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+                             Index Cond: ("time" IS NOT NULL)
+                       ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                             Index Cond: ("time" IS NOT NULL)
+                       ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+                             Index Cond: ("time" IS NOT NULL)
+(14 rows)
+
+-- test query with time_bucket
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Result
+         ->  Append
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+(6 rows)
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Result
+         ->  Merge Append
+               Sort Key: (time_bucket('@ 1 day'::interval, ordered_append."time"))
+               ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+(8 rows)
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time_bucket('1d',time) LIMIT 1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Result
+         ->  Merge Append
+               Sort Key: (time_bucket('@ 1 day'::interval, ordered_append."time"))
+               ->  Index Scan Backward using ordered_append_time_device_id_idx on ordered_append
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+(8 rows)
+
+-- test query with now() should result in ordered append with constraint aware append
+:PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
+ORDER BY time DESC limit 1;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 3
+         ->  Append
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+                     Index Cond: ("time" < (now() + '@ 1 mon'::interval))
+(11 rows)
+
+-- test CTE
+:PREFIX WITH i AS (SELECT * FROM ordered_append WHERE time < now() ORDER BY time DESC limit 100)
+SELECT * FROM i;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ CTE Scan on i
+   CTE i
+     ->  Limit
+           ->  Custom Scan (ConstraintAwareAppend)
+                 Hypertable: ordered_append
+                 Chunks left after exclusion: 3
+                 ->  Append
+                       ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+                             Index Cond: ("time" < now())
+                       ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                             Index Cond: ("time" < now())
+                       ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+                             Index Cond: ("time" < now())
+(13 rows)
+
+-- test LATERAL with ordered append in the outer query
+:PREFIX SELECT * FROM ordered_append, LATERAL(SELECT * FROM (VALUES (1),(2)) v) l ORDER BY time DESC limit 2;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop
+         ->  Append
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+         ->  Values Scan on "*VALUES*"
+(7 rows)
+
+-- test LATERAL with ordered append in the lateral query
+:PREFIX SELECT * FROM (VALUES (1),(2)) v, LATERAL(SELECT * FROM ordered_append ORDER BY time DESC limit 2) l;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Limit
+         ->  Append
+               ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+               ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+               ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+   ->  Values Scan on "*VALUES*"
+(7 rows)
+

--- a/test/expected/plan_ordered_append_results_diff.out
+++ b/test/expected/plan_ordered_append_results_diff.out
@@ -1,0 +1,9 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\set ECHO errors
+ ?column? 
+----------
+ Done
+(1 row)
+

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -107,11 +107,9 @@ EXPLAIN (costs off) SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
-   ->  Merge Append
-         Sort Key: hyper_1."time" DESC
-         ->  Index Scan using time_plain on hyper_1
+   ->  Append
          ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(5 rows)
+(3 rows)
 
 SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
            time           | series_0 | series_1 |     series_2     

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -8,13 +8,23 @@
 ---
 > SET timescaledb.disable_optimizations= 'on';
 > SET max_parallel_workers_per_gather = 0; -- Disable parallel for this test
-142,143c143,144
+110c111,113
+<    ->  Append
+---
+>    ->  Merge Append
+>          Sort Key: hyper_1."time" DESC
+>          ->  Index Scan using time_plain on hyper_1
+112c115
+< (3 rows)
+---
+> (5 rows)
+140,141c143,144
 <                                         QUERY PLAN                                        
 < ------------------------------------------------------------------------------------------
 ---
 >                                 QUERY PLAN                                 
 > ---------------------------------------------------------------------------
-147,152c148,154
+145,150c148,154
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
@@ -29,13 +39,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-156,157c158,159
+154,155c158,159
 <                                                     QUERY PLAN                                                    
 < ------------------------------------------------------------------------------------------------------------------
 ---
 >                                               QUERY PLAN                                              
 > ------------------------------------------------------------------------------------------------------
-159,178c161,181
+157,176c161,181
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, (hyper_1_date."time")::timestamp with time zone))
 <          ->  Result
@@ -78,13 +88,13 @@
 >                            ->  Seq Scan on _hyper_4_17_chunk
 >                            ->  Seq Scan on _hyper_4_18_chunk
 > (21 rows)
-203,204c206,207
+201,202c206,207
 <                                                 QUERY PLAN                                                 
 < -----------------------------------------------------------------------------------------------------------
 ---
 >                                                       QUERY PLAN                                                       
 > -----------------------------------------------------------------------------------------------------------------------
-206,215c209,221
+204,213c209,221
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, hyper_1."time"))
 <          ->  Custom Scan (ConstraintAwareAppend)
@@ -109,13 +119,13 @@
 >                                  ->  Bitmap Index Scan on _hyper_1_1_chunk_time_plain
 >                                        Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (13 rows)
-324,325c330,331
+322,323c330,331
 <                                         QUERY PLAN                                        
 < ------------------------------------------------------------------------------------------
 ---
 >                                    QUERY PLAN                                    
 > ---------------------------------------------------------------------------------
-329,334c335,341
+327,332c335,341
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, hyper_1."time")) DESC
@@ -130,13 +140,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-346,347c353,354
+344,345c353,354
 <                                                                 QUERY PLAN                                                                 
 < -------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-351,356c358,364
+349,354c358,364
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: ((time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
@@ -151,13 +161,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-368,369c376,377
+366,367c376,377
 <                                                    QUERY PLAN                                                    
 < -----------------------------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-373,378c381,387
+371,376c381,387
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval))) DESC
@@ -172,13 +182,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-390,391c399,400
+388,389c399,400
 <                                                                 QUERY PLAN                                                                 
 < -------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-395,400c404,410
+393,398c404,410
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: ((time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
@@ -193,13 +203,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-412,413c422,423
+410,411c422,423
 <                                          QUERY PLAN                                          
 < ---------------------------------------------------------------------------------------------
 ---
 >                                      QUERY PLAN                                     
 > ------------------------------------------------------------------------------------
-417,422c427,433
+415,420c427,433
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, hyper_1_tz."time")) DESC
@@ -214,13 +224,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-434,435c445,446
+432,433c445,446
 <                                                        QUERY PLAN                                                        
 < -------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                     QUERY PLAN                                                     
 > -------------------------------------------------------------------------------------------------------------------
-439,444c450,456
+437,442c450,456
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket('@ 1 min'::interval, (hyper_1_tz."time")::timestamp without time zone)) DESC
@@ -235,13 +245,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-456,457c468,469
+454,455c468,469
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                              QUERY PLAN                             
 > --------------------------------------------------------------------
-461,468c473,481
+459,466c473,481
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket(10, hyper_1_int."time")) DESC
@@ -260,13 +270,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-480,481c493,494
+478,479c493,494
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                               QUERY PLAN                               
 > -----------------------------------------------------------------------
-485,492c498,506
+483,490c498,506
 <          ->  Result
 <                ->  Merge Append
 <                      Sort Key: (time_bucket(10, hyper_1_int."time", 2)) DESC
@@ -285,13 +295,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-545,546c559,560
+543,544c559,560
 <                                           QUERY PLAN                                           
 < -----------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-548,552c562,570
+546,550c562,570
 <    ->  GroupAggregate
 <          Group Key: date_trunc('minute'::text, "time")
 <          ->  Index Scan using time_plain_plain_table on plain_table
@@ -307,5 +317,5 @@
 >                      ->  Bitmap Index Scan on time_plain_plain_table
 >                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (9 rows)
-566a585
+564a585
 > RESET max_parallel_workers_per_gather;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_FILES
   plan_expand_hypertable_optimized.sql
   plan_expand_hypertable_results_diff.sql
   plan_hashagg_results_x_diff.sql
+  plan_ordered_append_results_diff.sql
   reindex.sql
   relocate_extension.sql
   reloptions.sql
@@ -133,6 +134,8 @@ set(TEST_TEMPLATES
   partitioning.sql.in
   #hashagg is different in 9.6 and 10 because of hashagg parallelism
   plan_hashagg_optimized.sql.in
+  # lateral plans are different across versions, explains run without analyze on 9.6
+  plan_ordered_append.sql.in
   )
 
 # Regression tests that vary with PostgreSQL version. Generated test

--- a/test/sql/include/append.sql
+++ b/test/sql/include/append.sql
@@ -62,7 +62,7 @@ SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
 
 -- adding ORDER BY and LIMIT should turn the plan into an optimized
--- merge append plan
+-- ordered append plan
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;

--- a/test/sql/include/plan_ordered_append_load.sql
+++ b/test/sql/include/plan_ordered_append_load.sql
@@ -1,0 +1,21 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- create a table where we create chunks in order
+CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append','time');
+CREATE index on ordered_append(time DESC,device_id);
+
+INSERT INTO ordered_append VALUES('2000-01-01',1,1.0);
+INSERT INTO ordered_append VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append VALUES('2000-01-15',1,3.0);
+
+-- create a second table where we create chunks in reverse order
+CREATE TABLE ordered_append_reverse(time timestamptz NOT NULL, device_id INT, value float);
+SELECT create_hypertable('ordered_append_reverse','time');
+
+INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
+INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+

--- a/test/sql/include/plan_ordered_append_query.sql
+++ b/test/sql/include/plan_ordered_append_query.sql
@@ -1,0 +1,132 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- print chunks ordered by time to ensure ordering we want
+SELECT
+  ht.table_name AS hypertable,
+  c.table_name AS chunk,
+  ds.range_start
+FROM
+  _timescaledb_catalog.chunk c
+  INNER JOIN _timescaledb_catalog.chunk_constraint cc ON c.id = cc.chunk_id
+  INNER JOIN _timescaledb_catalog.dimension_slice ds ON ds.id=cc.dimension_slice_id
+  INNER JOIN _timescaledb_catalog.dimension d ON ds.dimension_id = d.id
+  INNER JOIN _timescaledb_catalog.hypertable ht ON d.hypertable_id = ht.id
+ORDER BY ht.table_name, range_start;
+
+-- test ASC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+
+-- test DESC for ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+
+-- test ASC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time ASC LIMIT 1;
+
+-- test DESC for reverse ordered chunks
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append_reverse
+ORDER BY time DESC LIMIT 1;
+
+-- test query with ORDER BY column not in targetlist
+:PREFIX SELECT
+  device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+
+-- ORDER BY may include other columns after time column
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time DESC, device_id LIMIT 1;
+
+-- queries with ORDER BY non-time column shouldn't use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id LIMIT 1;
+
+-- time column must be primary sort order
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY device_id, time LIMIT 1;
+
+-- queries without LIMIT shouldnt use ordered append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+ORDER BY time ASC;
+
+-- queries without ORDER BY shouldnt use ordered append (still uses append though)
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+LIMIT 1;
+
+-- test interaction with constraint exclusion
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > '2000-01-07'
+ORDER BY time DESC LIMIT 1;
+
+-- min/max queries
+:PREFIX SELECT max(time) FROM ordered_append;
+
+:PREFIX SELECT min(time) FROM ordered_append;
+
+-- test first/last (doesn't use ordered append yet)
+:PREFIX SELECT first(time, time) FROM ordered_append;
+
+:PREFIX SELECT last(time, time) FROM ordered_append;
+
+-- test query with time_bucket
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time ASC LIMIT 1;
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+
+-- test query with order by time_bucket (should not use ordered append)
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY time_bucket('1d',time) LIMIT 1;
+
+-- test query with now() should result in ordered append with constraint aware append
+:PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
+ORDER BY time DESC limit 1;
+
+-- test CTE
+:PREFIX WITH i AS (SELECT * FROM ordered_append WHERE time < now() ORDER BY time DESC limit 100)
+SELECT * FROM i;
+
+-- test LATERAL with ordered append in the outer query
+:PREFIX SELECT * FROM ordered_append, LATERAL(SELECT * FROM (VALUES (1),(2)) v) l ORDER BY time DESC limit 2;
+
+-- test LATERAL with ordered append in the lateral query
+:PREFIX SELECT * FROM (VALUES (1),(2)) v, LATERAL(SELECT * FROM ordered_append ORDER BY time DESC limit 2) l;
+

--- a/test/sql/plan_ordered_append.sql.in
+++ b/test/sql/plan_ordered_append.sql.in
@@ -1,0 +1,23 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- we run these with analyze to confirm that nodes that are not
+-- needed to fulfill the limit are not executed
+-- unfortunately this doesn't work on PostgreSQL 9.6 which lacks
+-- the ability to turn off analyze timing summary so we run
+-- them without ANALYZE on PostgreSQL 9.6, but since LATERAL plans
+-- are different across versions we need version specific output
+-- here anyway.
+
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+
+\ir include/plan_ordered_append_load.sql
+\ir include/plan_ordered_append_query.sql
+

--- a/test/sql/plan_ordered_append_results_diff.sql
+++ b/test/sql/plan_ordered_append_results_diff.sql
@@ -1,0 +1,39 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\set ECHO errors
+\set TEST_BASE_NAME plan_ordered_append
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
+       format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
+       format('%s/results/%s_results_optimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_OPTIMIZED",
+       format('%s/results/%s_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNOPTIMIZED"
+\gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
+\gset
+
+
+\o /dev/null
+SET client_min_messages = 'error';
+\ir :TEST_LOAD_NAME
+RESET client_min_messages;
+\o
+
+--generate the results into two different files
+SET client_min_messages = 'error';
+\set ECHO none
+--make output contain query results
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+SET timescaledb.ordered_append = 'on';
+\ir :TEST_QUERY_NAME
+\o
+\o :TEST_RESULTS_UNOPTIMIZED
+SET timescaledb.ordered_append = 'off';
+\ir :TEST_QUERY_NAME
+\o
+RESET client_min_messages;
+
+:DIFF_CMD
+
+SELECT 'Done';


### PR DESCRIPTION
This optimization will replace the MergeAppendPath for queries on
hypertables ordered by the time partitioning column and with a
LIMIT clause with an ordered AppendPath. This optimization will
remove the need for last point queries to access every chunk of
a hypertable.