### PR TITLE
Disallow scheduled drop_chunks policies on non-time open dimensions

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -829,7 +829,7 @@ ts_dimension_interval_to_internal_test(PG_FUNCTION_ARGS)
  *	-	it is an INTERVAL and time column of hypertable is time or date
  *	-	it is the same as time column of hypertable
  */
-void
+TSDLLEXPORT void
 ts_dimension_open_typecheck(Oid arg_type, Oid time_column_type, char *caller_name)
 {
 	AssertArg(arg_type != InvalidOid);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -141,7 +141,7 @@ extern int	ts_dimension_set_name(Dimension *dim, const char *newname);
 extern int	ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
 extern Datum ts_dimension_transform_value(Dimension *dim, Datum value, Oid *restype);
 extern int	ts_dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete_slices);
-extern void ts_dimension_open_typecheck(Oid arg_type, Oid time_column_type, char *caller_name);
+extern TSDLLEXPORT void ts_dimension_open_typecheck(Oid arg_type, Oid time_column_type, char *caller_name);
 extern void ts_dimension_info_validate(DimensionInfo *info);
 extern void ts_dimension_add_from_info(DimensionInfo *info);
 extern void ts_dimensions_rename_schema_name(char *oldname, char *newname);

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -5,10 +5,14 @@
  */
 
 #include <postgres.h>
+#include <catalog/pg_type.h>
 #include <utils/builtins.h>
 #include <utils/timestamp.h>
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
+
+
+#include <hypertable_cache.h>
 
 #include "bgw/job.h"
 #include "bgw_policy/drop_chunks.h"
@@ -34,7 +38,8 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	NameData	drop_chunks_name;
 	int32		job_id;
 	BgwPolicyDropChunks *existing;
-
+	Hypertable *hypertable;
+	Cache	   *hcache;
 	Oid			ht_oid = PG_GETARG_OID(0);
 	Interval   *older_than = PG_GETARG_INTERVAL_P(1);
 	bool		cascade = PG_GETARG_BOOL(2);
@@ -51,32 +56,47 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	license_enforce_enterprise_enabled();
 	license_print_expiration_warning_if_needed();
 
+	hcache = ts_hypertable_cache_pin();
+	hypertable = ts_hypertable_cache_get_entry(hcache, ht_oid);
 	/* First verify that the hypertable corresponds to a valid table */
-	if (!ts_is_hypertable(ht_oid))
+	if (hypertable == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
 				 errmsg("could not add drop_chunks policy because \"%s\" is not a hypertable",
 						get_rel_name(ht_oid))));
 
 	/* Make sure that an existing policy doesn't exist on this hypertable */
-	existing = ts_bgw_policy_drop_chunks_find_by_hypertable(ts_hypertable_relid_to_id(ht_oid));
+	existing = ts_bgw_policy_drop_chunks_find_by_hypertable(hypertable->fd.id);
 
 	if (existing != NULL)
 	{
 		if (!if_not_exists)
+		{
+			ts_cache_release(hcache);
 			ereport(ERROR, (errcode(ERRCODE_DUPLICATE_OBJECT), errmsg("drop chunks policy already exists for hypertable \"%s\"", get_rel_name(ht_oid))));
+		}
 
 		if (!DatumGetBool(DirectFunctionCall2(interval_eq, IntervalPGetDatum(&existing->fd.older_than), IntervalPGetDatum(older_than))) ||
 			(existing->fd.cascade != cascade))
 		{
 			elog(WARNING, "could not add drop_chunks policy due to existing policy on hypertable with different arguments");
+			ts_cache_release(hcache);
 			return -1;
 		}
 
 		/* If all arguments are the same, do nothing */
 		ereport(NOTICE, (errmsg("drop chunks policy already exists on hypertable \"%s\", skipping", get_rel_name(ht_oid))));
+		ts_cache_release(hcache);
 		return -1;
 	}
+
+	/* validate that the open dimension uses a time type */
+	ts_dimension_open_typecheck(
+								INTERVALOID,
+								hyperspace_get_open_dimension(hypertable->space, 0)->fd.column_type,
+								"add_drop_chunks_policy");
+
+	ts_cache_release(hcache);
 
 	/* Next, insert a new job into jobs table */
 	namestrcpy(&application_name, "Drop Chunks Background Job");

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -420,3 +420,16 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 -- Should be noop again
 select * from test_reorder(:reorder_job_id) \gset  reorder_
 NOTICE:  no chunks need reordering for hypertable public.test_table
+CREATE TABLE test_table_int(time int);
+SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable      
+-----------------------------
+ (2,public,test_table_int,t)
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- we cannot add a drop_chunks policy on a table whose open dimension is not time
+select add_drop_chunks_policy('test_table_int', INTERVAL '4 months', true);
+ERROR:  can only use "add_drop_chunks_policy" with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/bgw_policy.sql
+++ b/tsl/test/sql/bgw_policy.sql
@@ -215,3 +215,11 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 
 -- Should be noop again
 select * from test_reorder(:reorder_job_id) \gset  reorder_
+
+CREATE TABLE test_table_int(time int);
+SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
+
+\set ON_ERROR_STOP 0
+-- we cannot add a drop_chunks policy on a table whose open dimension is not time
+select add_drop_chunks_policy('test_table_int', INTERVAL '4 months', true);
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Scheduled drop_chunks works by dropping chunks older than a certain
interval. Since we have no way to calculate what 'now()' is for non-time
dimensions, we currently cannot have a scheduled drop_chunks job that
works with them. Currently this causes an error when the policy attempts
to execute. This commit moves the error, so that it occurs when a user
tries to add the policy in the first place.