### PR TITLE
 Add tests of scheduled jobs within actual background workers

### DIFF
--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -71,7 +71,7 @@ bgw_job_stat_scan_job_id(int32 bgw_job_id, tuple_found_func tuple_found, tuple_f
 								 scankey, 1, tuple_found, tuple_filter, data, lockmode);
 }
 
-BgwJobStat *
+TSDLLEXPORT BgwJobStat *
 ts_bgw_job_stat_find(int32 bgw_job_id)
 {
 	BgwJobStat *job_stat = NULL;

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -20,7 +20,7 @@ typedef enum JobResult
 	JOB_SUCCESS = 1,
 } JobResult;
 
-extern BgwJobStat *ts_bgw_job_stat_find(int job_id);
+extern TSDLLEXPORT BgwJobStat *ts_bgw_job_stat_find(int job_id);
 extern void ts_bgw_job_stat_delete(int job_id);
 extern void ts_bgw_job_stat_mark_start(int32 bgw_job_id);
 extern void ts_bgw_job_stat_mark_end(BgwJob *job, JobResult result);

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -110,8 +110,11 @@ execute_reorder_policy(BgwJob *job, reorder_func reorder, bool fast_continue)
 	/* Now update chunk_stats table */
 	ts_bgw_policy_chunk_stats_record_job_run(args->fd.job_id, chunk_id, ts_timer_get_current_timestamp());
 
-	if (fast_continue && get_chunk_id_to_reorder(args->fd.job_id, ht) != -1)
-		ts_bgw_job_stat_set_next_start(job, GetCurrentTransactionStartTimestamp());
+	if (fast_continue && get_chunk_id_to_reorder(args->fd.job_id, ht) != -1) {
+		BgwJobStat *job_stat = ts_bgw_job_stat_find(job->fd.id);
+		ts_bgw_job_stat_set_next_start(job, job_stat->fd.last_start);
+		elog(LOG, "Fast catchup enabled on reorder");
+	}
 
 commit:
 	if (started)

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -6,10 +6,13 @@
 
 #include <postgres.h>
 #include <catalog/namespace.h>
+#include <catalog/pg_type.h>
 #include <utils/builtins.h>
 #include <utils/timestamp.h>
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
+
+#include <dimension.h>
 
 #include "bgw/job.h"
 #include "bgw_policy/reorder.h"
@@ -120,7 +123,7 @@ reorder_add_policy(PG_FUNCTION_ARGS)
 	 */
 	dim = hyperspace_get_open_dimension(ht->space, 0);
 
-	if (dim)
+	if (dim && IS_TIMESTAMP_TYPE(dim->fd.column_type))
 		default_schedule_interval = DatumGetIntervalP(DirectFunctionCall7(make_interval, Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Int32GetDatum(0), Float8GetDatum(dim->fd.interval_length / 2000000)));
 
 	job_id = ts_bgw_job_insert_relation(&application_name, &reorder_name, default_schedule_interval, DEFAULT_MAX_RUNTIME, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_PERIOD);

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -1,0 +1,554 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--
+-- Setup
+--
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_wait_for_scheduler_finish() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_params_create() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_params_destroy() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_bgw_params_reset_time(set_time BIGINT = 0, wait BOOLEAN = false) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set WAIT_ON_JOB 0
+\set IMMEDIATELY_SET_UNTIL 1
+\set WAIT_FOR_OTHER_TO_ADVANCE 2
+-- Remove any default jobs, e.g., telemetry
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+SELECT _timescaledb_internal.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE public.bgw_log(
+    msg_no INT,
+    mock_time BIGINT,
+    application_name TEXT,
+    msg TEXT
+);
+CREATE VIEW sorted_bgw_log AS
+    SELECT * FROM bgw_log ORDER BY mock_time, application_name COLLATE "C", msg_no;
+CREATE TABLE public.bgw_dsm_handle_store(
+    handle BIGINT
+);
+INSERT INTO public.bgw_dsm_handle_store VALUES (0);
+SELECT ts_bgw_params_create();
+ ts_bgw_params_create 
+----------------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_config.bgw_job;
+ id | application_name | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+----+------------------+----------+-------------------+-------------+-------------+--------------
+(0 rows)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+------------------------------
+-- test reorder policy runs --
+------------------------------
+CREATE TABLE test_reorder_table(time int, chunk_id int);
+SELECT create_hypertable('test_reorder_table', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (1,public,test_reorder_table,t)
+(1 row)
+
+-- These inserts should create 5 different chunks
+INSERT INTO test_reorder_table VALUES (1, 1);
+INSERT INTO test_reorder_table VALUES (2, 2);
+INSERT INTO test_reorder_table VALUES (3, 3);
+INSERT INTO test_reorder_table VALUES (4, 4);
+INSERT INTO test_reorder_table VALUES (5, 5);
+SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_reorder_table';
+ count 
+-------
+     5
+(1 row)
+
+select add_reorder_policy('test_reorder_table', 'test_reorder_table_time_idx') as reorder_job_id \gset
+WARNING:  Timescale License expired
+-- policy was created
+select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_id;
+ job_id | hypertable_id |    hypertable_index_name    
+--------+---------------+-----------------------------
+   1000 |             1 | test_reorder_table_time_idx
+(1 row)
+
+-- job was created
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+------+------------------------+----------+-------------------+-------------+-------------+--------------
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+(1 row)
+
+-- no stats
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    ORDER BY job_id;
+ job_id | next_start | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------+------------+------------------+------------+-----------------+----------------+---------------
+(0 rows)
+
+-- nothing clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+ indexrelid | indisclustered 
+------------+----------------
+(0 rows)
+
+-- run first time
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                    msg                     
+--------+-----------+------------------+--------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+(2 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+------+------------------------+----------+-------------------+-------------+-------------+--------------
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+(1 row)
+
+-- job ran once, successfully
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+ job_id |          next_start          |          until_next          | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------
+   1000 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | t                |          1 |               1 |              0 |             0
+(1 row)
+
+-- first chunk reordered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+                             indexrelid                             | indisclustered 
+--------------------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_1_chunk_test_reorder_table_time_idx | t
+(1 row)
+
+-- second call to scheduler should immediately run reorder again, due to catchup
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                     msg                      
+--------+-----------+------------------+----------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |     25000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
+(4 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+------+------------------------+----------+-------------------+-------------+-------------+--------------
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+(1 row)
+
+-- two runs
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+ job_id |            next_start            |            until_next            | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+----------------------------------+----------------------------------+------------------+------------+-----------------+----------------+---------------
+   1000 | Fri Dec 31 16:00:00.025 1999 PST | Fri Dec 31 16:00:00.025 1999 PST | t                |          2 |               2 |              0 |             0
+(1 row)
+
+-- two chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+                             indexrelid                             | indisclustered 
+--------------------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_1_chunk_test_reorder_table_time_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_test_reorder_table_time_idx | t
+(2 rows)
+
+-- third call to scheduler should immediately run reorder again, due to catchup
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+-- job info is gone
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                      msg                      
+--------+-----------+------------------+-----------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |     25000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
+      0 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     50000 | DB Scheduler     | [TESTING] Wait until 100000, started at 50000
+(6 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+------+------------------------+----------+-------------------+-------------+-------------+--------------
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+(1 row)
+
+SELECT *
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+ job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST | t                |          3 | @ 0            |               3 |              0 |             0 |                    0 |                   0
+(1 row)
+
+-- three chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+                             indexrelid                             | indisclustered 
+--------------------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_1_chunk_test_reorder_table_time_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_test_reorder_table_time_idx | t
+ _timescaledb_internal._hyper_1_3_chunk_test_reorder_table_time_idx | t
+(3 rows)
+
+-- running is a nop
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(100, 100);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                      msg                       
+--------+-----------+------------------+------------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |     25000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
+      0 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     50000 | DB Scheduler     | [TESTING] Wait until 100000, started at 50000
+      0 |    100000 | DB Scheduler     | [TESTING] Wait until 200000, started at 100000
+(7 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+------+------------------------+----------+-------------------+-------------+-------------+--------------
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+(1 row)
+
+SELECT *
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+ job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST | t                |          3 | @ 0            |               3 |              0 |             0 |                    0 |                   0
+(1 row)
+
+-- still have 3 chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+                             indexrelid                             | indisclustered 
+--------------------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_1_chunk_test_reorder_table_time_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_test_reorder_table_time_idx | t
+ _timescaledb_internal._hyper_1_3_chunk_test_reorder_table_time_idx | t
+(3 rows)
+
+-- test deleting the policy
+SELECT remove_reorder_policy('test_reorder_table');
+ remove_reorder_policy 
+-----------------------
+ 
+(1 row)
+
+select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_id;
+ job_id | hypertable_id | hypertable_index_name 
+--------+---------------+-----------------------
+(0 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+ id | application_name | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+----+------------------+----------+-------------------+-------------+-------------+--------------
+(0 rows)
+
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+ job_id | next_start | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------+------------+------------------+------------+-----------------+----------------+---------------
+(0 rows)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(125, 125);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                      msg                       
+--------+-----------+------------------+------------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |     25000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
+      0 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     50000 | DB Scheduler     | [TESTING] Wait until 100000, started at 50000
+      0 |    100000 | DB Scheduler     | [TESTING] Wait until 200000, started at 100000
+      0 |    200000 | DB Scheduler     | [TESTING] Wait until 325000, started at 200000
+(8 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+ id | application_name | job_type | schedule_interval | max_runtime | max_retries | retry_period 
+----+------------------+----------+-------------------+-------------+-------------+--------------
+(0 rows)
+
+-- still only 3 chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+                             indexrelid                             | indisclustered 
+--------------------------------------------------------------------+----------------
+ _timescaledb_internal._hyper_1_1_chunk_test_reorder_table_time_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_test_reorder_table_time_idx | t
+ _timescaledb_internal._hyper_1_3_chunk_test_reorder_table_time_idx | t
+(3 rows)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_config.bgw_job;
+SELECT ts_bgw_params_reset_time();
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-----------------------------------
+-- test drop chunnks policy runs --
+-----------------------------------
+CREATE TABLE test_drop_chunks_table(time timestamptz, drop_order int);
+SELECT create_hypertable('test_drop_chunks_table', 'time', chunk_time_interval => INTERVAL '1 week');
+NOTICE:  adding not-null constraint to column "time"
+          create_hypertable          
+-------------------------------------
+ (2,public,test_drop_chunks_table,t)
+(1 row)
+
+-- These inserts should create 5 different chunks
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '2 month',  4);
+INSERT INTO test_drop_chunks_table VALUES (now(),                       5);
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '6 months', 2);
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '4 months', 3);
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '8 months', 1);
+SELECT show_chunks('test_drop_chunks_table');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+(5 rows)
+
+SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_drop_chunks_table';
+ count 
+-------
+     5
+(1 row)
+
+SELECT add_drop_chunks_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
+WARNING:  Timescale License expired
+SELECT alter_policy_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
+            alter_policy_schedule            
+---------------------------------------------
+ (1001,"@ 1 sec","@ 5 mins",-1,"@ 12 hours")
+(1 row)
+
+select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
+ job_id | hypertable_id | older_than | cascade 
+--------+---------------+------------+---------
+   1001 |             2 | @ 4 mons   | t
+(1 row)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+  id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
+------+----------------------------+-------------+-------------------+-------------+-------------+--------------
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+(1 row)
+
+-- no stats
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    WHERE job_id=:drop_chunks_job_id;
+ job_id | next_start | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------+------------+------------------+------------+-----------------+----------------+---------------
+(0 rows)
+
+-- all chunks are there
+SELECT show_chunks('test_drop_chunks_table');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+(5 rows)
+
+-- run first time
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                    msg                     
+--------+-----------+------------------+--------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+(2 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+  id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
+------+----------------------------+-------------+-------------------+-------------+-------------+--------------
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+(1 row)
+
+-- job ran once, successfully
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:drop_chunks_job_id;
+ job_id |          next_start          |          until_next          | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------
+   1001 | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:00 1999 PST | t                |          1 |               1 |              0 |             0
+(1 row)
+
+-- chunks 8 and 10 dropped
+SELECT show_chunks('test_drop_chunks_table');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+
+-- job doesn't run again immediately
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                     msg                      
+--------+-----------+------------------+----------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
+(3 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+  id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
+------+----------------------------+-------------+-------------------+-------------+-------------+--------------
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+(1 row)
+
+-- still only 1 run
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:drop_chunks_job_id;
+ job_id |          next_start          |          until_next          | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------
+   1001 | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:00 1999 PST | t                |          1 |               1 |              0 |             0
+(1 row)
+
+-- same chunks
+SELECT show_chunks('test_drop_chunks_table');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+
+-- a new chunk older than the drop date will be dropped
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '12 months', 0);
+SELECT show_chunks('test_drop_chunks_table');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+(4 rows)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(10000, 25);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                        msg                        
+--------+-----------+------------------+---------------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
+      0 |     50000 | DB Scheduler     | [TESTING] Wait until 1000000, started at 50000
+      1 |   1000000 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |   1000000 | DB Scheduler     | [TESTING] Wait until 10050000, started at 1000000
+(6 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+  id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
+------+----------------------------+-------------+-------------------+-------------+-------------+--------------
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+(1 row)
+
+-- 2 runs
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:drop_chunks_job_id;
+ job_id |          next_start          |          until_next          | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------
+   1001 | Fri Dec 31 16:00:02 1999 PST | Fri Dec 31 16:00:01 1999 PST | t                |          2 |               2 |              0 |             0
+(1 row)
+
+SELECT show_chunks('test_drop_chunks_table');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_FILES
     bgw_policy.sql
+    bgw_reorder_drop_chunks.sql
     edition.sql
     gapfill.sql
     reorder.sql

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -1,0 +1,273 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+--
+-- Setup
+--
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_wait_for_scheduler_finish() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_params_create() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_params_destroy() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_params_reset_time(set_time BIGINT = 0, wait BOOLEAN = false) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+\set WAIT_ON_JOB 0
+\set IMMEDIATELY_SET_UNTIL 1
+\set WAIT_FOR_OTHER_TO_ADVANCE 2
+
+-- Remove any default jobs, e.g., telemetry
+SELECT _timescaledb_internal.stop_background_workers();
+DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+SELECT _timescaledb_internal.start_background_workers();
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE public.bgw_log(
+    msg_no INT,
+    mock_time BIGINT,
+    application_name TEXT,
+    msg TEXT
+);
+
+CREATE VIEW sorted_bgw_log AS
+    SELECT * FROM bgw_log ORDER BY mock_time, application_name COLLATE "C", msg_no;
+
+CREATE TABLE public.bgw_dsm_handle_store(
+    handle BIGINT
+);
+
+INSERT INTO public.bgw_dsm_handle_store VALUES (0);
+SELECT ts_bgw_params_create();
+
+SELECT * FROM _timescaledb_config.bgw_job;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+------------------------------
+-- test reorder policy runs --
+------------------------------
+
+CREATE TABLE test_reorder_table(time int, chunk_id int);
+SELECT create_hypertable('test_reorder_table', 'time', chunk_time_interval => 1);
+
+-- These inserts should create 5 different chunks
+INSERT INTO test_reorder_table VALUES (1, 1);
+INSERT INTO test_reorder_table VALUES (2, 2);
+INSERT INTO test_reorder_table VALUES (3, 3);
+INSERT INTO test_reorder_table VALUES (4, 4);
+INSERT INTO test_reorder_table VALUES (5, 5);
+
+SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_reorder_table';
+
+select add_reorder_policy('test_reorder_table', 'test_reorder_table_time_idx') as reorder_job_id \gset
+
+-- policy was created
+select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_id;
+
+-- job was created
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+
+-- no stats
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    ORDER BY job_id;
+
+-- nothing clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+
+-- run first time
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+
+-- job ran once, successfully
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+
+-- first chunk reordered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+
+-- second call to scheduler should immediately run reorder again, due to catchup
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+
+-- two runs
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+
+-- two chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+
+-- third call to scheduler should immediately run reorder again, due to catchup
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50, 50);
+
+-- job info is gone
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+
+SELECT *
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+
+-- three chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+
+
+-- running is a nop
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(100, 100);
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+
+SELECT *
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+
+-- still have 3 chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+
+-- test deleting the policy
+SELECT remove_reorder_policy('test_reorder_table');
+
+select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_id;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:reorder_job_id;
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(125, 125);
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
+
+-- still only 3 chunks clustered
+SELECT indexrelid::regclass, indisclustered
+    FROM pg_index
+    WHERE indisclustered = true ORDER BY 1;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+TRUNCATE bgw_log;
+TRUNCATE _timescaledb_internal.bgw_job_stat;
+DELETE FROM _timescaledb_config.bgw_job;
+SELECT ts_bgw_params_reset_time();
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-----------------------------------
+-- test drop chunnks policy runs --
+-----------------------------------
+
+
+CREATE TABLE test_drop_chunks_table(time timestamptz, drop_order int);
+SELECT create_hypertable('test_drop_chunks_table', 'time', chunk_time_interval => INTERVAL '1 week');
+
+-- These inserts should create 5 different chunks
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '2 month',  4);
+INSERT INTO test_drop_chunks_table VALUES (now(),                       5);
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '6 months', 2);
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '4 months', 3);
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '8 months', 1);
+
+
+SELECT show_chunks('test_drop_chunks_table');
+SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_drop_chunks_table';
+
+SELECT add_drop_chunks_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
+
+SELECT alter_policy_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
+
+select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+
+-- no stats
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    WHERE job_id=:drop_chunks_job_id;
+
+-- all chunks are there
+SELECT show_chunks('test_drop_chunks_table');
+
+-- run first time
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+
+-- job ran once, successfully
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:drop_chunks_job_id;
+
+-- chunks 8 and 10 dropped
+SELECT show_chunks('test_drop_chunks_table');
+
+-- job doesn't run again immediately
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25, 25);
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+
+-- still only 1 run
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:drop_chunks_job_id;
+
+-- same chunks
+SELECT show_chunks('test_drop_chunks_table');
+
+-- a new chunk older than the drop date will be dropped
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '12 months', 0);
+
+SELECT show_chunks('test_drop_chunks_table');
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(10000, 25);
+
+SELECT * FROM sorted_bgw_log;
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+
+-- 2 runs
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:drop_chunks_job_id;
+
+SELECT show_chunks('test_drop_chunks_table');


### PR DESCRIPTION
To date all our bgw tests run in the normal psql environment. This
commit adds tests that the jobs function correctly when run from actual
background workers. This should catch cases where the background worker
behaves differently than a normal connection.

This PR also contains minor fixes to the reorder job in order to allow it to function in this context:

1. It switches the fast-restart to use the previously scheduled time instead of `now()`. This allows fast-restart to work correctly with the mock scheduler.
3. It uses the default retry interval when the open dimension is not a time type.