### PR TITLE
Point the travis build badge at "history" instead of "current"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 |Linux/macOS|Windows|Coverity|Code Coverage|
 |:---:|:---:|:---:|:---:|
-|[![Build Status](https://travis-ci.org/timescale/timescaledb.svg?branch=master)](https://travis-ci.org/timescale/timescaledb)|[![Windows build status](https://ci.appveyor.com/api/projects/status/15sqkl900t04hywu/branch/master?svg=true)](https://ci.appveyor.com/project/timescale/timescaledb/branch/master)|[![Coverity Scan Build Status](https://scan.coverity.com/projects/timescale-timescaledb/badge.svg)](https://scan.coverity.com/projects/timescale-timescaledb)|[![Code Coverage](https://codecov.io/gh/timescale/timescaledb/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/timescale/timescaledb)
+|[![Build Status](https://travis-ci.org/timescale/timescaledb.svg?branch=master)](https://travis-ci.org/timescale/timescaledb/builds)|[![Windows build status](https://ci.appveyor.com/api/projects/status/15sqkl900t04hywu/branch/master?svg=true)](https://ci.appveyor.com/project/timescale/timescaledb/branch/master)|[![Coverity Scan Build Status](https://scan.coverity.com/projects/timescale-timescaledb/badge.svg)](https://scan.coverity.com/projects/timescale-timescaledb)|[![Code Coverage](https://codecov.io/gh/timescale/timescaledb/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/timescale/timescaledb)
 
 
 ## TimescaleDB


### PR DESCRIPTION
Right now, clicking the travis build badge directs the user to the
currently running travis job. Since this is usually a PR, and we gate PR
merges on travis anyway, it's not very useful for determining the health
of the project. This commit switches the link to point at the build
history, which shows the previously run cron jobs; the jobs that the
badge points at anyway.