### PR TITLE
Only use seqscans for reorder

### DIFF
--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -561,14 +561,13 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 								 MultiXactCutoff, use_wal);
 
 	/*
-	 * Decide whether to use an indexscan or seqscan-and-optional-sort to scan
-	 * the OldHeap.  We know how to use a sort to duplicate the ordering of a
-	 * btree index, and will use seqscan-and-sort for that case if the planner
-	 * tells us it's cheaper.  Otherwise, always indexscan if an index is
-	 * provided, else plain seqscan.
+	 * We know how to use a sort to duplicate the ordering of a
+	 * btree index, and will use seqscan-and-sort for that.  Otherwise, always
+	 * use an indexscan for other indexes or plain seqscan if no index is
+	 * supplied.
 	 */
 	if (OldIndex != NULL && OldIndex->rd_rel->relam == BTREE_AM_OID)
-		use_sort = plan_cluster_use_sort(OIDOldHeap, OIDOldIndex);
+		use_sort = true;
 	else
 		use_sort = false;
 

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -83,7 +83,7 @@ select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy
 -- Make a manual calls to reorder: make sure the correct chunk is called
 -- Chunk 5 should be first
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_5_chunk" using index scan on "_hyper_1_5_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_5_chunk" using sequential scan and sort
 INFO:  "_hyper_1_5_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
@@ -106,7 +106,7 @@ select check_index_oid(:reorder_index_oid, 'test_table'::REGCLASS);
 
 -- Chunk 3 is next
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_3_chunk" using index scan on "_hyper_1_3_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_3_chunk" using sequential scan and sort
 INFO:  "_hyper_1_3_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
@@ -129,7 +129,7 @@ select check_index_oid(:reorder_index_oid, 'test_table'::REGCLASS);
 
 -- Chunk 4 is next
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_4_chunk" using index scan on "_hyper_1_4_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_4_chunk" using sequential scan and sort
 INFO:  "_hyper_1_4_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
@@ -175,7 +175,7 @@ select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy
 INSERT INTO test_table VALUES (now() - INTERVAL '7 days', 6);
 -- This call should reorder chunk 1
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_1_chunk" using index scan on "_hyper_1_1_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
 INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
@@ -303,7 +303,7 @@ select count(*) from _timescaledb_internal.bgw_policy_chunk_stats where job_id=:
 -- Make a manual calls to reorder: make sure the correct (oldest) chunk is called
 select chunk_id from _timescaledb_catalog.dimension_slice as ds, _timescaledb_catalog.chunk_constraint as cc where ds.dimension_id=1 and ds.id=cc.dimension_slice_id ORDER BY ds.range_start LIMIT 1 \gset oldest_
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_13_chunk" using index scan on "_hyper_1_13_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_13_chunk" using sequential scan and sort
 INFO:  "_hyper_1_13_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats where job_id=:reorder_job_id and chunk_id=:oldest_chunk_id;
  job_id | chunk_id | num_times_job_run 
@@ -321,7 +321,7 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 -- Now run reorder again and pick the next oldest chunk
 select cc.chunk_id from _timescaledb_catalog.dimension_slice as ds, _timescaledb_catalog.chunk_constraint as cc where ds.dimension_id=1 and ds.id=cc.dimension_slice_id and cc.chunk_id NOT IN (select chunk_id from _timescaledb_internal.bgw_policy_chunk_stats) ORDER BY ds.range_start LIMIT 1 \gset oldest_
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_14_chunk" using index scan on "_hyper_1_14_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_14_chunk" using sequential scan and sort
 INFO:  "_hyper_1_14_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats where job_id=:reorder_job_id and chunk_id=:oldest_chunk_id;
  job_id | chunk_id | num_times_job_run 
@@ -339,7 +339,7 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 -- Again
 select cc.chunk_id from _timescaledb_catalog.dimension_slice as ds, _timescaledb_catalog.chunk_constraint as cc where ds.dimension_id=1 and ds.id=cc.dimension_slice_id and cc.chunk_id NOT IN (select chunk_id from _timescaledb_internal.bgw_policy_chunk_stats) ORDER BY ds.range_start LIMIT 1 \gset oldest_
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_10_chunk" using index scan on "_hyper_1_10_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_10_chunk" using sequential scan and sort
 INFO:  "_hyper_1_10_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats where job_id=:reorder_job_id and chunk_id=:oldest_chunk_id;
  job_id | chunk_id | num_times_job_run 
@@ -356,7 +356,7 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 -- Again
 select cc.chunk_id from _timescaledb_catalog.dimension_slice as ds, _timescaledb_catalog.chunk_constraint as cc where ds.dimension_id=1 and ds.id=cc.dimension_slice_id and cc.chunk_id NOT IN (select chunk_id from _timescaledb_internal.bgw_policy_chunk_stats) ORDER BY ds.range_start LIMIT 1 \gset oldest_
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_11_chunk" using index scan on "_hyper_1_11_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_11_chunk" using sequential scan and sort
 INFO:  "_hyper_1_11_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats where job_id=:reorder_job_id and chunk_id=:oldest_chunk_id;
  job_id | chunk_id | num_times_job_run 
@@ -373,7 +373,7 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 -- Again
 select cc.chunk_id from _timescaledb_catalog.dimension_slice as ds, _timescaledb_catalog.chunk_constraint as cc where ds.dimension_id=1 and ds.id=cc.dimension_slice_id and cc.chunk_id NOT IN (select chunk_id from _timescaledb_internal.bgw_policy_chunk_stats) ORDER BY ds.range_start LIMIT 1 \gset oldest_
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_12_chunk" using index scan on "_hyper_1_12_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_12_chunk" using sequential scan and sort
 INFO:  "_hyper_1_12_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats where job_id=:reorder_job_id and chunk_id=:oldest_chunk_id;
  job_id | chunk_id | num_times_job_run 
@@ -403,7 +403,7 @@ NOTICE:  no chunks need reordering for hypertable public.test_table
 INSERT INTO test_table VALUES (now() - INTERVAL '1 year', 1);
 select cc.chunk_id from _timescaledb_catalog.dimension_slice as ds, _timescaledb_catalog.chunk_constraint as cc where ds.dimension_id=1 and ds.id=cc.dimension_slice_id and cc.chunk_id NOT IN (select chunk_id from _timescaledb_internal.bgw_policy_chunk_stats) ORDER BY ds.range_start LIMIT 1 \gset oldest_
 select * from test_reorder(:reorder_job_id) \gset  reorder_
-INFO:  reordering "_timescaledb_internal._hyper_1_16_chunk" using index scan on "_hyper_1_16_chunk_test_table_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_16_chunk" using sequential scan and sort
 INFO:  "_hyper_1_16_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats where job_id=:reorder_job_id and chunk_id=:oldest_chunk_id;
  job_id | chunk_id | num_times_job_run 

--- a/tsl/test/expected/reorder.out
+++ b/tsl/test/expected/reorder.out
@@ -307,7 +307,7 @@ SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', bit
 COMMIT;
 -- reorder a chunk directly with an chunk index
 SELECT reorder_chunk('_timescaledb_internal._hyper_1_2_chunk', '_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', TRUE);
-INFO:  reordering "_timescaledb_internal._hyper_1_2_chunk" using index scan on "_hyper_1_2_chunk_cluster_test_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
 INFO:  "_hyper_1_2_chunk": found 0 removable, 5 nonremovable row versions in 1 pages
  reorder_chunk 
 ---------------
@@ -748,7 +748,7 @@ FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY ctid;
 
 -- can perform first reorder using a hypertable index (also test non-toast)
 SELECT reorder_chunk('_timescaledb_internal._hyper_1_1_chunk', 'cluster_test_time_idx', verbose => TRUE);
-INFO:  reordering "_timescaledb_internal._hyper_1_1_chunk" using index scan on "_hyper_1_1_chunk_cluster_test_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
 INFO:  "_hyper_1_1_chunk": found 0 removable, 5 nonremovable row versions in 1 pages
  reorder_chunk 
 ---------------
@@ -1219,7 +1219,7 @@ SET enable_seqscan=false;
 SET enable_indexscan=true;
 SET enable_bitmapscan=false;
 SELECT reorder_chunk('_timescaledb_internal._hyper_1_1_chunk', verbose => TRUE);
-INFO:  reordering "_timescaledb_internal._hyper_1_1_chunk" using index scan on "_hyper_1_1_chunk_cluster_test_time_idx"
+INFO:  reordering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
 INFO:  "_hyper_1_1_chunk": found 0 removable, 5 nonremovable row versions in 1 pages
  reorder_chunk 
 ---------------


### PR DESCRIPTION
In our workloads we expect that there will never be a case in which an
indexscan based reorder will perform better than a seqscan based one.
In order to prevent pessimization, disable indexscan based reordering.