### PR TITLE
Update telemetry with prettier os info

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -32,3 +32,5 @@ GRANT SELECT ON _timescaledb_internal.bgw_policy_chunk_stats TO PUBLIC;
 
 DROP FUNCTION IF EXISTS _timescaledb_internal.drop_chunks_impl(REGCLASS, "any", "any", BOOLEAN);
 DROP FUNCTION IF EXISTS drop_chunks("any", NAME, NAME, BOOLEAN, "any");
+
+DROP FUNCTION IF EXISTS _timescaledb_internal.get_os_info();

--- a/sql/version.sql
+++ b/sql/version.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
     AS '@MODULE_PATHNAME@', 'ts_get_git_commit' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_os_info()
-    RETURNS TABLE(sysname TEXT, version TEXT, release TEXT)
+    RETURNS TABLE(sysname TEXT, version TEXT, release TEXT, version_pretty TEXT)
     AS '@MODULE_PATHNAME@', 'ts_get_os_info' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION get_telemetry_report() RETURNS TEXT

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -40,6 +40,7 @@
 #define REQ_OS						"os_name"
 #define REQ_OS_VERSION				"os_version"
 #define REQ_OS_RELEASE				"os_release"
+#define REQ_OS_VERSION_PRETTY		"os_name_pretty"
 #define REQ_PS_VERSION				"postgresql_version"
 #define REQ_TS_VERSION				"timescaledb_version"
 #define REQ_BUILD_OS				"build_os_name"
@@ -223,6 +224,8 @@ build_version_body(void)
 		ts_jsonb_add_str(parseState, REQ_OS, osinfo.sysname);
 		ts_jsonb_add_str(parseState, REQ_OS_VERSION, osinfo.version);
 		ts_jsonb_add_str(parseState, REQ_OS_RELEASE, osinfo.release);
+		if (osinfo.has_pretty_version)
+			ts_jsonb_add_str(parseState, REQ_OS_VERSION_PRETTY, osinfo.pretty_version);
 	}
 	else
 		ts_jsonb_add_str(parseState, REQ_OS, "Unknown");

--- a/src/version.h
+++ b/src/version.h
@@ -15,6 +15,8 @@ typedef struct VersionOSInfo
 	char		sysname[VERSION_INFO_LEN];
 	char		version[VERSION_INFO_LEN];
 	char		release[VERSION_INFO_LEN];
+	char		pretty_version[VERSION_INFO_LEN];
+	bool		has_pretty_version;
 } VersionOSInfo;
 
 extern bool ts_version_get_os_info(VersionOSInfo *info);

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -282,8 +282,9 @@ WARNING:  telemetry could not connect to "noservice.timescale.com"
 (1 row)
 
 SET timescaledb.telemetry_level=off;
-select json_object_keys(get_telemetry_report()::json);
-  json_object_keys   
+SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
+WHERE key != 'os_name_pretty';
+         key         
 ---------------------
  db_uuid
  license

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -121,4 +121,5 @@ SELECT _timescaledb_internal.test_telemetry_main_conn('noservice.timescale.com',
 SET timescaledb.telemetry_level=off;
 
 
-select json_object_keys(get_telemetry_report()::json);
+SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
+WHERE key != 'os_name_pretty';


### PR DESCRIPTION
The info gotten from uname is difficult to work with, so read the os
name from /etc/os-release if it's available.