### PR TITLE
Mark Postgresql includes in cmake as SYSTEM includes.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,7 +94,7 @@ install(
 
 if (USE_OPENSSL)
   set(TS_USE_OPENSSL ${USE_OPENSSL})
-  target_include_directories(${PROJECT_NAME} PUBLIC ${OPENSSL_INCLUDE_DIR})
+  target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${OPENSSL_INCLUDE_DIR})
   target_link_libraries(${PROJECT_NAME} ${OPENSSL_LIBRARIES})
 endif (USE_OPENSSL)
 

--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -24,21 +24,22 @@ if(APACHE_ONLY)
   add_definitions(-DAPACHE_ONLY)
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${PG_INCLUDEDIR_SERVER})
+include_directories(${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
+include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER})
 
 # Only Windows and FreeBSD need the base include/ dir instead of include/server/, and including
 # both causes problems on Ubuntu where they frequently get out of sync
 if (WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
-  include_directories(${PG_INCLUDEDIR})
+  include_directories(SYSTEM ${PG_INCLUDEDIR})
 endif ()
 
 if (WIN32)
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${PG_LIBDIR}/postgres.lib ws2_32.lib Version.lib")
   set(CMAKE_C_FLAGS "-D_CRT_SECURE_NO_WARNINGS")
-  include_directories(${PG_INCLUDEDIR_SERVER}/port/win32)
+  include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER}/port/win32)
 
   if (MSVC)
-    include_directories(${PG_INCLUDEDIR_SERVER}/port/win32_msvc)
+    include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER}/port/win32_msvc)
   endif (MSVC)
 endif (WIN32)
 

--- a/tsl/src/build-defs.cmake
+++ b/tsl/src/build-defs.cmake
@@ -21,22 +21,24 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_SOURCE_DIR}/tsl/src
   ${PROJECT_BINARY_DIR}/src
-  ${PROJECT_BINARY_DIR}/tsl/src ${PG_INCLUDEDIR_SERVER})
+  ${PROJECT_BINARY_DIR}/tsl/src)
+
+include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER})
 
 # Only Windows and FreeBSD need the base include/ dir instead of include/server/, and including
 # both causes problems on Ubuntu where they frequently get out of sync
 if (WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
-  include_directories(${PG_INCLUDEDIR})
+  include_directories(SYSTEM ${PG_INCLUDEDIR})
 endif ()
 
 if (WIN32)
   link_directories(${PROJECT_BINARY_DIR}/src)
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${PG_LIBDIR}/postgres.lib ws2_32.lib Version.lib ${PROJECT_NAME}-${PROJECT_VERSION_MOD}.lib")
   set(CMAKE_C_FLAGS "-D_CRT_SECURE_NO_WARNINGS")
-  include_directories(${PG_INCLUDEDIR_SERVER}/port/win32)
+  include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER}/port/win32)
 
   if (MSVC)
-    include_directories(${PG_INCLUDEDIR_SERVER}/port/win32_msvc)
+    include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER}/port/win32_msvc)
   endif (MSVC)
 endif (WIN32)
 


### PR DESCRIPTION
This is needed for tools like include-what-you-use to decide
which files should be included with quotes vs carrots.
This is probably more correct anyway as postgres files are
included with carrots in our code.