### PR TITLE
Remove variable declaration in for loops

### DIFF
--- a/tsl/src/gapfill/exec.c
+++ b/tsl/src/gapfill/exec.c
@@ -200,6 +200,7 @@ gapfill_begin(CustomScanState *node, EState *estate, int eflags)
 	Datum		arg1,
 				arg3,
 				arg4;
+	int			i;
 
 	state->gapfill_typid = func->funcresulttype;
 	state->state = FETCHED_NONE;
@@ -244,7 +245,7 @@ gapfill_begin(CustomScanState *node, EState *estate, int eflags)
 	 * projection for gapfilled tuples so expressions like COALESCE work
 	 * correctly for gapfilled tuples.
 	 */
-	for (int i = 0; i < state->ncolumns; i++)
+	for (i = 0; i < state->ncolumns; i++)
 	{
 		if (state->columns[i]->ctype == NULL_COLUMN)
 		{
@@ -626,11 +627,12 @@ gapfill_state_initialize_columns(GapFillState *state)
 	CustomScan *cscan = castNode(CustomScan, state->csstate.ss.ps.plan);
 	TargetEntry *tle;
 	Expr	   *expr;
+	int			i;
 
 	state->ncolumns = tupledesc->natts;
 	state->columns = palloc(state->ncolumns * sizeof(GapFillColumnState *));
 
-	for (int i = 0; i < state->ncolumns; i++)
+	for (i = 0; i < state->ncolumns; i++)
 	{
 		tle = list_nth(cscan->custom_scan_tlist, i);
 		expr = list_nth(lthird(cscan->custom_private), i);

--- a/tsl/src/gapfill/planner.c
+++ b/tsl/src/gapfill/planner.c
@@ -127,6 +127,8 @@ gapfill_plan_create(PlannerInfo *root, RelOptInfo *rel, struct CustomPath *path,
 	TargetEntry *tle;
 	Expr	   *expr;
 	List	   *tl_exprs = NIL;
+	UpperRelationKind stage;
+	int			i;
 
 	cscan->scan.scanrelid = 0;
 	cscan->scan.plan.targetlist = tlist;
@@ -154,7 +156,7 @@ gapfill_plan_create(PlannerInfo *root, RelOptInfo *rel, struct CustomPath *path,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("gapfill functionality with window functions not supported")));
 
-	for (int i = 0; i < list_length(tlist); i++)
+	for (i = 0; i < list_length(tlist); i++)
 	{
 		tle = list_nth(tlist, i);
 		if (root->upper_targets[UPPERREL_WINDOW])
@@ -174,7 +176,7 @@ gapfill_plan_create(PlannerInfo *root, RelOptInfo *rel, struct CustomPath *path,
 	{
 		castNode(TargetEntry, lfirst(lc))->expr = gapfill_clean_expr(castNode(TargetEntry, lfirst(lc))->expr);
 	}
-	for (UpperRelationKind stage = UPPERREL_SETOP; stage <= UPPERREL_FINAL; stage++)
+	for (stage = UPPERREL_SETOP; stage <= UPPERREL_FINAL; stage++)
 	{
 		if (root->upper_targets[stage])
 		{


### PR DESCRIPTION
Since we add PostgreSQL CFLAGS to our own CFLAGS on some platforms
using variable declarations in for loops will generate compile
warnings, depending on the CFLAGS PostgreSQL is compiled with.