### PR TITLE
Moving chunks_in function to internal catalog

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -38,10 +38,10 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.calculate_chunk_interval(
 -- Function for explicit chunk exclusion. Supply a record and an array 
 -- of chunk ids as input.
 -- Intended to be used in WHERE clause.
--- An example: SELECT * FROM hypertable WHERE chunks_in(hypertable, ARRAY[1,2]);
+-- An example: SELECT * FROM hypertable WHERE _timescaledb_internal.chunks_in(hypertable, ARRAY[1,2]);
 --
 -- Use it with care as this function directly affects what chunks are being scanned for data.
 -- Although this function is immutable (always returns true), we declare it here as volatile
 -- so that the PostgreSQL optimizer does not try to evaluate/reduce it in the planner phase
-CREATE OR REPLACE FUNCTION chunks_in(record RECORD, chunks INTEGER[]) RETURNS BOOL
+CREATE OR REPLACE FUNCTION _timescaledb_internal.chunks_in(record RECORD, chunks INTEGER[]) RETURNS BOOL
 AS '@MODULE_PATHNAME@', 'ts_chunks_in' LANGUAGE C VOLATILE STRICT;

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -32,6 +32,7 @@
 #include "guc.h"
 #include "extension.h"
 #include "chunk.h"
+#include "extension_constants.h"
 
 typedef struct CollectQualCtx
 {
@@ -49,7 +50,7 @@ static void
 init_chunk_exclusion_func()
 {
 	if (chunk_exclusion_func == InvalidOid)
-		chunk_exclusion_func = get_function_oid(CHUNK_EXCL_FUNC_NAME, ts_extension_schema_name(), lengthof(ts_chunks_arg_types), ts_chunks_arg_types);
+		chunk_exclusion_func = get_function_oid(CHUNK_EXCL_FUNC_NAME, INTERNAL_SCHEMA_NAME, lengthof(ts_chunks_arg_types), ts_chunks_arg_types);
 	Assert(chunk_exclusion_func != InvalidOid);
 }
 

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -21,7 +21,6 @@ ORDER BY proname;
  attach_tablespace
  chunk_relation_size
  chunk_relation_size_pretty
- chunks_in
  create_hypertable
  detach_tablespace
  detach_tablespaces
@@ -47,5 +46,5 @@ ORDER BY proname;
  show_tablespaces
  time_bucket
  time_bucket_gapfill
-(33 rows)
+(32 rows)
 

--- a/test/expected/plan_expand_hypertable_optimized.out
+++ b/test/expected/plan_expand_hypertable_optimized.out
@@ -1201,7 +1201,7 @@ SET constraint_exclusion = 'off';
 (106 rows)
 
 -- explicit chunk exclusion
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) ORDER BY value;
                 QUERY PLAN                
 ------------------------------------------
  Sort
@@ -1211,7 +1211,7 @@ SET constraint_exclusion = 'off';
          ->  Seq Scan on _hyper_1_2_chunk
 (5 rows)
 
-:PREFIX SELECT * FROM (SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[1,2,3])) T ORDER BY value;
+:PREFIX SELECT * FROM (SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[1,2,3])) T ORDER BY value;
                   QUERY PLAN                  
 ----------------------------------------------
  Sort
@@ -1222,7 +1222,7 @@ SET constraint_exclusion = 'off';
          ->  Seq Scan on _hyper_1_3_chunk h_2
 (6 rows)
 
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2,3]) AND time < 10 ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2,3]) AND time < 10 ORDER BY value;
                 QUERY PLAN                
 ------------------------------------------
  Sort
@@ -1236,7 +1236,7 @@ SET constraint_exclusion = 'off';
                Filter: ("time" < 10)
 (9 rows)
 
-:PREFIX SELECT * FROM hyper_ts WHERE device_id = 'dev1' AND time < to_timestamp(10) AND chunks_in(hyper_ts, ARRAY[116]) ORDER BY value;
+:PREFIX SELECT * FROM hyper_ts WHERE device_id = 'dev1' AND time < to_timestamp(10) AND _timescaledb_internal.chunks_in(hyper_ts, ARRAY[116]) ORDER BY value;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -1246,7 +1246,7 @@ SET constraint_exclusion = 'off';
                Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
 (5 rows)
 
-:PREFIX SELECT * FROM hyper_ts h JOIN tag on (h.tag_id = tag.id ) WHERE chunks_in(h, ARRAY[116]) AND time < to_timestamp(10) AND device_id = 'dev1' ORDER BY value;
+:PREFIX SELECT * FROM hyper_ts h JOIN tag on (h.tag_id = tag.id ) WHERE _timescaledb_internal.chunks_in(h, ARRAY[116]) AND time < to_timestamp(10) AND device_id = 'dev1' ORDER BY value;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -1260,7 +1260,7 @@ SET constraint_exclusion = 'off';
                            Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
 (9 rows)
 
-:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE chunks_in(h1, ARRAY[104,105]) AND chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
                          QUERY PLAN                          
 -------------------------------------------------------------
  Sort
@@ -1276,7 +1276,7 @@ SET constraint_exclusion = 'off';
                      ->  Seq Scan on _hyper_2_105_chunk h1_1
 (11 rows)
 
-:PREFIX SELECT * FROM hyper h1, hyper h2 WHERE chunks_in(h1, ARRAY[1,2]) AND chunks_in(h2, ARRAY[2,3]);
+:PREFIX SELECT * FROM hyper h1, hyper h2 WHERE _timescaledb_internal.chunks_in(h1, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(h2, ARRAY[2,3]);
                      QUERY PLAN                      
 -----------------------------------------------------
  Nested Loop
@@ -1292,7 +1292,7 @@ SET constraint_exclusion = 'off';
 SET enable_seqscan=false;
 -- Should perform index-only scan. Since we pass whole row into the function it might block planner from using index-only scan.
 -- But since we'll remove the function from the query tree before planner decision it shouldn't affect index-only decision.
-:PREFIX SELECT time FROM hyper WHERE time=0 AND chunks_in(hyper, ARRAY[1]);
+:PREFIX SELECT time FROM hyper WHERE time=0 AND _timescaledb_internal.chunks_in(hyper, ARRAY[1]);
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Append
@@ -1300,7 +1300,7 @@ SET enable_seqscan=false;
          Index Cond: ("time" = 0)
 (3 rows)
 
-:PREFIX SELECT first(value, time) FROM hyper h WHERE chunks_in(h, ARRAY[1]);
+:PREFIX SELECT first(value, time) FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[1]);
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Result
@@ -1313,31 +1313,31 @@ SET enable_seqscan=false;
 (7 rows)
 
 \set ON_ERROR_STOP 0
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) AND chunks_in(hyper, ARRAY[2,3]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:24: ERROR:  only one chunks_in call is allowed per hypertable
-:PREFIX SELECT * FROM hyper WHERE chunks_in(2, ARRAY[1]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:25: ERROR:  function chunks_in(integer, integer[]) does not exist at character 48
-SELECT * FROM hyper WHERE time < 10 OR chunks_in(hyper, ARRAY[1,2]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:25: ERROR:  function _timescaledb_internal.chunks_in(integer, integer[]) does not exist at character 48
+SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:26: ERROR:  illegal invocation of chunks_in function
-SELECT chunks_in(hyper, ARRAY[1,2]) FROM hyper;
+SELECT _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) FROM hyper;
 psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  illegal invocation of chunks_in function
 -- non existing chunk id
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[123456789]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  chunk id 123456789 not found
 -- chunk that belongs to another hypertable
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[104]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 104 does not belong to hypertable "hyper"
 -- passing wrong row ref
-SELECT * FROM hyper WHERE chunks_in(ROW(1,2), ARRAY[104]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(ROW(1,2), ARRAY[104]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  illegal invocation of chunks_in function
 -- passing func as chunk id
-:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
 psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  second argument to chunk_in should contain only integer consts
 -- chunks_in is STRICT function and for NULL arguments a null result is returned
-SELECT * FROM hyper h WHERE chunks_in(h, NULL);
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
  value | time 
 -------+------
 (0 rows)
 
-:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[NULL::int]);
+:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL

--- a/test/sql/include/plan_expand_hypertable_chunks_in_query.sql
+++ b/test/sql/include/plan_expand_hypertable_chunks_in_query.sql
@@ -8,31 +8,31 @@ SET constraint_exclusion = 'off';
 
 :PREFIX SELECT * FROM hyper ORDER BY value;
 -- explicit chunk exclusion
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) ORDER BY value;
-:PREFIX SELECT * FROM (SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[1,2,3])) T ORDER BY value;
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2,3]) AND time < 10 ORDER BY value;
-:PREFIX SELECT * FROM hyper_ts WHERE device_id = 'dev1' AND time < to_timestamp(10) AND chunks_in(hyper_ts, ARRAY[116]) ORDER BY value;
-:PREFIX SELECT * FROM hyper_ts h JOIN tag on (h.tag_id = tag.id ) WHERE chunks_in(h, ARRAY[116]) AND time < to_timestamp(10) AND device_id = 'dev1' ORDER BY value;
-:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE chunks_in(h1, ARRAY[104,105]) AND chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
-:PREFIX SELECT * FROM hyper h1, hyper h2 WHERE chunks_in(h1, ARRAY[1,2]) AND chunks_in(h2, ARRAY[2,3]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) ORDER BY value;
+:PREFIX SELECT * FROM (SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[1,2,3])) T ORDER BY value;
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2,3]) AND time < 10 ORDER BY value;
+:PREFIX SELECT * FROM hyper_ts WHERE device_id = 'dev1' AND time < to_timestamp(10) AND _timescaledb_internal.chunks_in(hyper_ts, ARRAY[116]) ORDER BY value;
+:PREFIX SELECT * FROM hyper_ts h JOIN tag on (h.tag_id = tag.id ) WHERE _timescaledb_internal.chunks_in(h, ARRAY[116]) AND time < to_timestamp(10) AND device_id = 'dev1' ORDER BY value;
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
+:PREFIX SELECT * FROM hyper h1, hyper h2 WHERE _timescaledb_internal.chunks_in(h1, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(h2, ARRAY[2,3]);
 SET enable_seqscan=false;
 -- Should perform index-only scan. Since we pass whole row into the function it might block planner from using index-only scan.
 -- But since we'll remove the function from the query tree before planner decision it shouldn't affect index-only decision.
-:PREFIX SELECT time FROM hyper WHERE time=0 AND chunks_in(hyper, ARRAY[1]);
-:PREFIX SELECT first(value, time) FROM hyper h WHERE chunks_in(h, ARRAY[1]);
+:PREFIX SELECT time FROM hyper WHERE time=0 AND _timescaledb_internal.chunks_in(hyper, ARRAY[1]);
+:PREFIX SELECT first(value, time) FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[1]);
 \set ON_ERROR_STOP 0
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[1,2]) AND chunks_in(hyper, ARRAY[2,3]);
-:PREFIX SELECT * FROM hyper WHERE chunks_in(2, ARRAY[1]);
-SELECT * FROM hyper WHERE time < 10 OR chunks_in(hyper, ARRAY[1,2]);
-SELECT chunks_in(hyper, ARRAY[1,2]) FROM hyper;
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
+SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
+SELECT _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) FROM hyper;
 -- non existing chunk id
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[123456789]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
 -- chunk that belongs to another hypertable
-:PREFIX SELECT * FROM hyper WHERE chunks_in(hyper, ARRAY[104]);
+:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
 -- passing wrong row ref
-SELECT * FROM hyper WHERE chunks_in(ROW(1,2), ARRAY[104]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(ROW(1,2), ARRAY[104]);
 -- passing func as chunk id
-:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
 -- chunks_in is STRICT function and for NULL arguments a null result is returned
-SELECT * FROM hyper h WHERE chunks_in(h, NULL);
-:PREFIX SELECT * FROM hyper h WHERE chunks_in(h, ARRAY[NULL::int]);
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
+:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);


### PR DESCRIPTION
This function needs chunk ids as input which is TimescaleDB internal metadata. Due to that it feels more natural to make this function internal.