### PR TITLE
Add session locks to CLUSTER

### DIFF
--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -25,8 +25,6 @@ INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using index scan on "
 INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using index scan on "_hyper_1_1_chunk_cluster_test_time_idx"
 INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
-INFO:  clustering "public.cluster_test" using sequential scan and sort
-INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 -- Create a third chunk
 INSERT INTO cluster_test VALUES ('2017-01-22T09:00:01', 19.5, 3);
 -- Show clustered indexes
@@ -48,8 +46,6 @@ INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan
 INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
 INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
-INFO:  clustering "public.cluster_test" using sequential scan and sort
-INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 -- Show clustered indexes, including new chunk
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
@@ -66,12 +62,12 @@ WHERE indisclustered = true ORDER BY 1;
 CLUSTER VERBOSE;
 INFO:  clustering "_timescaledb_internal._hyper_1_3_chunk" using sequential scan and sort
 INFO:  "_hyper_1_3_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
-INFO:  clustering "public.cluster_test" using sequential scan and sort
-INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
 INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
 INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
+INFO:  clustering "public.cluster_test" using sequential scan and sort
+INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 -- Change the clustered index
 CREATE INDEX ON cluster_test (time, location);
 CLUSTER VERBOSE cluster_test using cluster_test_time_location_idx;
@@ -81,8 +77,6 @@ INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan
 INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
 INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
-INFO:  clustering "public.cluster_test" using sequential scan and sort
-INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 -- Show updated clustered indexes
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
@@ -116,8 +110,6 @@ INFO:  clustering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan
 INFO:  "_hyper_1_2_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
 INFO:  clustering "_timescaledb_internal._hyper_1_1_chunk" using sequential scan and sort
 INFO:  "_hyper_1_1_chunk": found 0 removable, 1 nonremovable row versions in 1 pages
-INFO:  clustering "public.cluster_test" using sequential scan and sort
-INFO:  "cluster_test": found 0 removable, 0 nonremovable row versions in 0 pages
 ALTER TABLE cluster_test SET WITHOUT CLUSTER;
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index


### PR DESCRIPTION
This prevents the cluster index from being deleted or altered while in
middle of the CLUSTER. (currently this causes a cache lookup failure)

While this does not cause the CLUSTER to succeed, it at least changes the error to `ERROR:  index "foo_index" for table "foo" does not exist`.