### PR TITLE
Fix upsert bug with incorrect tuple descriptors

### DIFF
--- a/src/chunk_dispatch.c
+++ b/src/chunk_dispatch.c
@@ -69,5 +69,6 @@ ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *point)
 	}
 
 	Assert(cis != NULL);
+	ts_chunk_insert_state_switch(cis);
 	return cis;
 }

--- a/src/chunk_dispatch_state.c
+++ b/src/chunk_dispatch_state.c
@@ -108,10 +108,16 @@ chunk_dispatch_exec(CustomScanState *node)
 		}
 
 		/* slot for the "existing" tuple in ON CONFLICT UPDATE IS chunk schema */
-		if (cis->tup_conv_map != NULL && state->parent->mt_existing != NULL)
-		{
-			TupleDesc	chunk_desc = cis->tup_conv_map->outdesc;
 
+		if (state->parent->mt_existing != NULL)
+		{
+			TupleDesc	chunk_desc;
+
+			if (cis->tup_conv_map && cis->tup_conv_map->outdesc)
+				chunk_desc = cis->tup_conv_map->outdesc;
+			else
+				chunk_desc = RelationGetDescr(cis->rel);
+			Assert(chunk_desc != NULL);
 			ExecSetSlotDescriptor(state->parent->mt_existing, chunk_desc);
 		}
 

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -211,7 +211,15 @@ create_chunk_result_relation_info(ChunkDispatch *dispatch, Relation rel, Index r
 	ResultRelInfo_OnConflictProjInfoCompat(rri) = ResultRelInfo_OnConflictProjInfoCompat(rri_orig);
 	ResultRelInfo_OnConflictWhereCompat(rri) = ResultRelInfo_OnConflictWhereCompat(rri_orig);
 #else
-	rri->ri_onConflict = rri_orig->ri_onConflict;
+	if (rri_orig->ri_onConflict != NULL)
+	{
+		rri->ri_onConflict = makeNode(OnConflictSetState);
+		rri->ri_onConflict->oc_ProjInfo = rri_orig->ri_onConflict->oc_ProjInfo;
+		rri->ri_onConflict->oc_WhereClause = rri_orig->ri_onConflict->oc_WhereClause;
+		rri->ri_onConflict->oc_ProjTupdesc = rri_orig->ri_onConflict->oc_ProjTupdesc;
+	}
+	else
+		rri->ri_onConflict = NULL;
 #endif
 
 	create_chunk_rri_constraint_expr(rri, rel);

--- a/src/chunk_insert_state.h
+++ b/src/chunk_insert_state.h
@@ -32,6 +32,9 @@ typedef struct ChunkDispatch ChunkDispatch;
 
 extern HeapTuple ts_chunk_insert_state_convert_tuple(ChunkInsertState *state, HeapTuple tuple, TupleTableSlot **existing_slot);
 extern ChunkInsertState *ts_chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch);
+extern void ts_chunk_insert_state_switch(ChunkInsertState *state);
+
+
 extern void ts_chunk_insert_state_destroy(ChunkInsertState *state);
 
 #endif							/* TIMESCALEDB_CHUNK_INSERT_STATE_H */

--- a/src/copy.c
+++ b/src/copy.c
@@ -286,6 +286,7 @@ timescaledb_CopyFrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht)
 			if (bistate->current_buf != InvalidBuffer)
 				ReleaseBuffer(bistate->current_buf);
 			bistate->current_buf = InvalidBuffer;
+			ts_chunk_insert_state_switch(cis);
 		}
 
 		/* Triggers and stuff need to be invoked in query context. */

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -285,3 +285,61 @@ SELECT * FROM CTE;
  Fri Jan 20 09:00:01 2017 | 25.9 | blue
 (1 row)
 
+--create table with one chunk that has a tup_conv_map and one that does not
+--to ensure this, create a chunk before altering the table this chunk will not have a tup_conv_map
+CREATE TABLE upsert_test_diffchunk(time timestamp, device_id char(20), to_drop int, temp float, color text);
+SELECT create_hypertable('upsert_test_diffchunk', 'time', chunk_time_interval=> interval '1 month');
+NOTICE:  adding not-null constraint to column "time"
+         create_hypertable          
+------------------------------------
+ (5,public,upsert_test_diffchunk,t)
+(1 row)
+
+CREATE UNIQUE INDEX time_device_idx ON upsert_test_diffchunk (time, device_id);
+--this is the chunk with no tup_conv_map
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 25.9, 'yellow') RETURNING *;
+           time           |      device_id       | to_drop | temp | color  
+--------------------------+----------------------+---------+------+--------
+ Fri Jan 20 09:00:01 2017 | dev1                 |         | 25.9 | yellow
+(1 row)
+
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev2', 25.9, 'yellow') RETURNING *;
+           time           |      device_id       | to_drop | temp | color  
+--------------------------+----------------------+---------+------+--------
+ Fri Jan 20 09:00:01 2017 | dev2                 |         | 25.9 | yellow
+(1 row)
+
+--alter the table
+ALTER TABLE upsert_test_diffchunk DROP to_drop;
+ALTER TABLE upsert_test_diffchunk ADD device_id_2 char(20);
+--new chunk that does have a tup conv map
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2019-01-20T09:00:01', 'dev1', 23.5, 'orange') ;
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2019-01-20T09:00:01', 'dev2', 23.5, 'orange') ;
+select * from upsert_test_diffchunk order by time, device_id;
+           time           |      device_id       | temp | color  | device_id_2 
+--------------------------+----------------------+------+--------+-------------
+ Fri Jan 20 09:00:01 2017 | dev1                 | 25.9 | yellow | 
+ Fri Jan 20 09:00:01 2017 | dev2                 | 25.9 | yellow | 
+ Sun Jan 20 09:00:01 2019 | dev1                 | 23.5 | orange | 
+ Sun Jan 20 09:00:01 2019 | dev2                 | 23.5 | orange | 
+(4 rows)
+
+--make sure current works
+INSERT INTO upsert_test_diffchunk as current (time, device_id, temp, color, device_id_2) VALUES
+ ('2019-01-20T09:00:01', 'dev1', 43.5, 'orange2', 'device-id-2'),
+ ('2017-01-20T09:00:01', 'dev1', 43.5, 'yellow2', 'device-id-2')
+--('2019-01-20T09:00:01', 'dev2', 43.5, 'orange2', 'device-id-2')
+ON CONFLICT (time, device_id)
+DO UPDATE SET
+device_id_2 = coalesce(excluded.device_id_2,current.device_id_2),
+temp = coalesce(excluded.temp,current.temp) ,
+color = coalesce(excluded.color,current.color);
+select * from upsert_test_diffchunk order by time, device_id;
+           time           |      device_id       | temp |  color  |     device_id_2      
+--------------------------+----------------------+------+---------+----------------------
+ Fri Jan 20 09:00:01 2017 | dev1                 | 43.5 | yellow2 | device-id-2         
+ Fri Jan 20 09:00:01 2017 | dev2                 | 25.9 | yellow  | 
+ Sun Jan 20 09:00:01 2019 | dev1                 | 43.5 | orange2 | device-id-2         
+ Sun Jan 20 09:00:01 2019 | dev2                 | 23.5 | orange  | 
+(4 rows)
+

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -250,6 +250,21 @@ DO UPDATE SET device_id_2 = 'device-id-2-new', color = 'orange10' RETURNING *;
  Fri Jan 20 09:00:01 2017 |  3.5 | orange10 | dev5                 | device-id-2-new     
 (1 row)
 
+--test inserting to to a chunk already in the chunk dispatch cache again.
+INSERT INTO upsert_test_space as current (time, device_id, temp, color, device_id_2) VALUES ('2017-01-20T09:00:01', 'dev5', 43.5, 'orange8', 'device-id-2'),
+('2018-01-20T09:00:01', 'dev5', 43.5, 'orange8', 'device-id-2'),
+('2017-01-20T09:00:01', 'dev3', 43.5, 'orange7', 'device-id-2'),
+('2018-01-21T09:00:01', 'dev5', 43.5, 'orange9', 'device-id-2')
+ON CONFLICT (time, device_id)
+DO UPDATE SET device_id_2 = coalesce(excluded.device_id_2,current.device_id_2), color = coalesce(excluded.color,current.color) RETURNING *;
+           time           | temp |  color  |      device_id       |     device_id_2      
+--------------------------+------+---------+----------------------+----------------------
+ Fri Jan 20 09:00:01 2017 |  3.5 | orange8 | dev5                 | device-id-2         
+ Sat Jan 20 09:00:01 2018 | 43.5 | orange8 | dev5                 | device-id-2         
+ Fri Jan 20 09:00:01 2017 | 23.5 | orange7 | dev3                 | device-id-2         
+ Sun Jan 21 09:00:01 2018 | 43.5 | orange9 | dev5                 | device-id-2         
+(4 rows)
+
 WITH CTE AS (
     INSERT INTO upsert_test_multi_unique
     VALUES ('2017-01-20T09:00:01', 25.9, 'purple')
@@ -326,9 +341,9 @@ select * from upsert_test_diffchunk order by time, device_id;
 
 --make sure current works
 INSERT INTO upsert_test_diffchunk as current (time, device_id, temp, color, device_id_2) VALUES
- ('2019-01-20T09:00:01', 'dev1', 43.5, 'orange2', 'device-id-2'),
- ('2017-01-20T09:00:01', 'dev1', 43.5, 'yellow2', 'device-id-2')
---('2019-01-20T09:00:01', 'dev2', 43.5, 'orange2', 'device-id-2')
+('2019-01-20T09:00:01', 'dev1', 43.5, 'orange2', 'device-id-2'),
+('2017-01-20T09:00:01', 'dev1', 43.5, 'yellow2', 'device-id-2'),
+('2019-01-20T09:00:01', 'dev2', 43.5, 'orange2', 'device-id-2')
 ON CONFLICT (time, device_id)
 DO UPDATE SET
 device_id_2 = coalesce(excluded.device_id_2,current.device_id_2),
@@ -340,6 +355,6 @@ select * from upsert_test_diffchunk order by time, device_id;
  Fri Jan 20 09:00:01 2017 | dev1                 | 43.5 | yellow2 | device-id-2         
  Fri Jan 20 09:00:01 2017 | dev2                 | 25.9 | yellow  | 
  Sun Jan 20 09:00:01 2019 | dev1                 | 43.5 | orange2 | device-id-2         
- Sun Jan 20 09:00:01 2019 | dev2                 | 23.5 | orange  | 
+ Sun Jan 20 09:00:01 2019 | dev2                 | 43.5 | orange2 | device-id-2         
 (4 rows)
 

--- a/test/sql/upsert.sql
+++ b/test/sql/upsert.sql
@@ -128,3 +128,32 @@ WITH CTE AS (
     RETURNING *
 )
 SELECT * FROM CTE;
+
+--create table with one chunk that has a tup_conv_map and one that does not
+--to ensure this, create a chunk before altering the table this chunk will not have a tup_conv_map
+CREATE TABLE upsert_test_diffchunk(time timestamp, device_id char(20), to_drop int, temp float, color text);
+SELECT create_hypertable('upsert_test_diffchunk', 'time', chunk_time_interval=> interval '1 month');
+CREATE UNIQUE INDEX time_device_idx ON upsert_test_diffchunk (time, device_id);
+--this is the chunk with no tup_conv_map
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 25.9, 'yellow') RETURNING *;
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev2', 25.9, 'yellow') RETURNING *;
+--alter the table
+ALTER TABLE upsert_test_diffchunk DROP to_drop;
+ALTER TABLE upsert_test_diffchunk ADD device_id_2 char(20);
+--new chunk that does have a tup conv map
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2019-01-20T09:00:01', 'dev1', 23.5, 'orange') ;
+INSERT INTO upsert_test_diffchunk (time, device_id, temp, color) VALUES ('2019-01-20T09:00:01', 'dev2', 23.5, 'orange') ;
+select * from upsert_test_diffchunk order by time, device_id;
+
+--make sure current works
+INSERT INTO upsert_test_diffchunk as current (time, device_id, temp, color, device_id_2) VALUES
+ ('2019-01-20T09:00:01', 'dev1', 43.5, 'orange2', 'device-id-2'),
+ ('2017-01-20T09:00:01', 'dev1', 43.5, 'yellow2', 'device-id-2')
+--('2019-01-20T09:00:01', 'dev2', 43.5, 'orange2', 'device-id-2')
+ON CONFLICT (time, device_id)
+DO UPDATE SET
+device_id_2 = coalesce(excluded.device_id_2,current.device_id_2),
+temp = coalesce(excluded.temp,current.temp) ,
+color = coalesce(excluded.color,current.color);
+select * from upsert_test_diffchunk order by time, device_id;
+


### PR DESCRIPTION
Previously we set the mt_existing and onConflictProjInfo slot
descriptors only when the current chunk had a tup_conv_map this
was based on a false assumption that these slot descriptors had the
hypertable's slot descriptor. In fact, since we are reusing these slots
across chunks, the slot descriptor will correspond to the previous
chunk's one. This led to an error if the previous chunk had a
tup_conv_map but the current one did not.
This PR merges the changes from @cevian and @gayyappan