### PR TITLE
Fix loading the tsl license in parallel workers

### DIFF
--- a/src/license_guc.c
+++ b/src/license_guc.c
@@ -85,10 +85,13 @@ current_license_can_downgrade_to_apache(void)
  * disable loading submodules until the post_load_init.
  */
 
-void
+TSDLLEXPORT void
 ts_license_enable_module_loading(void)
 {
 	int			result;
+
+	if (can_load)
+		return;
 
 	can_load = true;
 	/* re-set the license key to actually load the submodule if needed */

--- a/src/license_guc.h
+++ b/src/license_guc.h
@@ -71,6 +71,6 @@ typedef enum LicenseType
 extern bool ts_license_update_check(char **newval, void **extra, GucSource source);
 extern void ts_license_on_assign(const char *newval, void *extra);
 
-extern void ts_license_enable_module_loading(void);
+extern void TSDLLEXPORT ts_license_enable_module_loading(void);
 
 #endif							/* LICENSE_GUC */

--- a/tsl/test/expected/plan_gapfill-10.out
+++ b/tsl/test/expected/plan_gapfill-10.out
@@ -9,7 +9,7 @@ SELECT table_name FROM create_hypertable('gapfill_plan_test','time',chunk_time_i
  gapfill_plan_test
 (1 row)
 
-INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), random();
+INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), 1.0;
 -- simple example
 :EXPLAIN
 SELECT
@@ -189,4 +189,50 @@ ORDER BY 1;
                                        ->  Parallel Seq Scan on _hyper_1_3_chunk
                                        ->  Parallel Seq Scan on _hyper_1_4_chunk
 (16 rows)
+
+-- make sure we can run gapfill in parallel workers
+-- ensure this plan runs in parallel
+:EXPLAIN
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;
+                                                                                                                QUERY PLAN                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (interpolate(avg(value), NULL::record, NULL::record))
+         ->  Custom Scan (GapFill)
+               ->  Finalize GroupAggregate
+                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
+                     ->  Sort
+                           Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
+                           ->  Gather
+                                 Workers Planned: 1
+                                 ->  Partial HashAggregate
+                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
+                                       ->  Result
+                                             ->  Append
+                                                   ->  Parallel Seq Scan on gapfill_plan_test
+                                                   ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                                   ->  Parallel Seq Scan on _hyper_1_2_chunk
+                                                   ->  Parallel Seq Scan on _hyper_1_3_chunk
+                                                   ->  Parallel Seq Scan on _hyper_1_4_chunk
+(19 rows)
+
+-- actually run a parallel gapfill
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;
+     time_bucket_gapfill      | interpolate 
+------------------------------+-------------
+ Mon Jan 01 00:00:00 2018 PST |           1
+(1 row)
 

--- a/tsl/test/expected/plan_gapfill-11.out
+++ b/tsl/test/expected/plan_gapfill-11.out
@@ -9,7 +9,7 @@ SELECT table_name FROM create_hypertable('gapfill_plan_test','time',chunk_time_i
  gapfill_plan_test
 (1 row)
 
-INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), random();
+INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), 1.0;
 -- simple example
 :EXPLAIN
 SELECT
@@ -189,4 +189,50 @@ ORDER BY 1;
                                        ->  Parallel Seq Scan on _hyper_1_4_chunk
                                        ->  Parallel Seq Scan on gapfill_plan_test
 (16 rows)
+
+-- make sure we can run gapfill in parallel workers
+-- ensure this plan runs in parallel
+:EXPLAIN
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (interpolate(avg(value), NULL::record, NULL::record))
+         ->  Custom Scan (GapFill)
+               ->  Finalize GroupAggregate
+                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
+                     ->  Gather Merge
+                           Workers Planned: 2
+                           ->  Sort
+                                 Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
+                                 ->  Partial HashAggregate
+                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
+                                       ->  Result
+                                             ->  Parallel Append
+                                                   ->  Parallel Seq Scan on _hyper_1_2_chunk
+                                                   ->  Parallel Seq Scan on _hyper_1_3_chunk
+                                                   ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                                   ->  Parallel Seq Scan on _hyper_1_4_chunk
+                                                   ->  Parallel Seq Scan on gapfill_plan_test
+(19 rows)
+
+-- actually run a parallel gapfill
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;
+     time_bucket_gapfill      | interpolate 
+------------------------------+-------------
+ Mon Jan 01 00:00:00 2018 PST |           1
+(1 row)
 

--- a/tsl/test/expected/plan_gapfill-9.6.out
+++ b/tsl/test/expected/plan_gapfill-9.6.out
@@ -9,7 +9,7 @@ SELECT table_name FROM create_hypertable('gapfill_plan_test','time',chunk_time_i
  gapfill_plan_test
 (1 row)
 
-INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), random();
+INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), 1.0;
 -- simple example
 :EXPLAIN
 SELECT
@@ -177,4 +177,46 @@ ORDER BY 1;
                            ->  Seq Scan on _hyper_1_3_chunk
                            ->  Seq Scan on _hyper_1_4_chunk
 (12 rows)
+
+-- make sure we can run gapfill in parallel workers
+-- ensure this plan runs in parallel
+:EXPLAIN
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;
+                                                                                                          QUERY PLAN                                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (interpolate(avg(value), NULL::record, NULL::record))
+         ->  Custom Scan (GapFill)
+               ->  Sort
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
+                     ->  HashAggregate
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
+                           ->  Result
+                                 ->  Append
+                                       ->  Seq Scan on gapfill_plan_test
+                                       ->  Seq Scan on _hyper_1_1_chunk
+                                       ->  Seq Scan on _hyper_1_2_chunk
+                                       ->  Seq Scan on _hyper_1_3_chunk
+                                       ->  Seq Scan on _hyper_1_4_chunk
+(15 rows)
+
+-- actually run a parallel gapfill
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;
+     time_bucket_gapfill      | interpolate 
+------------------------------+-------------
+ Mon Jan 01 00:00:00 2018 PST |           1
+(1 row)
 

--- a/tsl/test/isolation/specs/.gitignore
+++ b/tsl/test/isolation/specs/.gitignore
@@ -1,4 +1,4 @@
-/recluster_deadlock.spec
+/reorder_deadlock.spec
 /reorder_vs_insert_other_chunk.spec
-/recluster_vs_insert.spec
-/recluster_vs_select.spec
+/reorder_vs_insert.spec
+/reorder_vs_select.spec

--- a/tsl/test/sql/plan_gapfill.sql.in
+++ b/tsl/test/sql/plan_gapfill.sql.in
@@ -7,7 +7,7 @@
 CREATE TABLE gapfill_plan_test(time timestamptz NOT NULL, value float);
 SELECT table_name FROM create_hypertable('gapfill_plan_test','time',chunk_time_interval=>'4 weeks'::interval);
 
-INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), random();
+INSERT INTO gapfill_plan_test SELECT generate_series('2018-01-01'::timestamptz,'2018-04-01'::timestamptz,'1m'::interval), 1.0;
 
 -- simple example
 :EXPLAIN
@@ -80,3 +80,22 @@ FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
 
+-- make sure we can run gapfill in parallel workers
+-- ensure this plan runs in parallel
+:EXPLAIN
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;
+
+-- actually run a parallel gapfill
+SELECT
+  time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)),
+  interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 2
+LIMIT 1;


### PR DESCRIPTION
Parallel workers have an unusual load path, which doesn't behave the
same as other processes. Since we don't have any obvious hooks we can
use to enable loading, and the library load order is already frozen
by the main process, fix this by adding a _PG_init which will enable
the tsl in background workers when needed.