### PR TITLE
Make code formatting cover TSL test source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ if (PGINDENT)
     COMMAND ${PGINDENT} -typedefs typedefs.list -excludes=${PROJECT_BINARY_DIR}/pgindent_excludes -code-base=${PROJECT_SOURCE_DIR}/src
     COMMAND ${PGINDENT} -typedefs typedefs.list -excludes=${PROJECT_BINARY_DIR}/pgindent_excludes -code-base=${PROJECT_SOURCE_DIR}/test/src
     COMMAND ${PGINDENT} -typedefs typedefs.list -excludes=${PROJECT_BINARY_DIR}/pgindent_excludes -code-base=${PROJECT_SOURCE_DIR}/tsl/src
+    COMMAND ${PGINDENT} -typedefs typedefs.list -excludes=${PROJECT_BINARY_DIR}/pgindent_excludes -code-base=${PROJECT_SOURCE_DIR}/tsl/test/src
     DEPENDS ${PROJECT_BINARY_DIR}/typedefs.list)
 else ()
   message(STATUS "Install pgindent to be able to format C code: https://github.com/postgres/postgres/tree/master/src/tools/pgindent")

--- a/tsl/src/gapfill/interpolate.c
+++ b/tsl/src/gapfill/interpolate.c
@@ -164,7 +164,7 @@ gapfill_interpolate_calculate(GapFillInterpolateColumnState *column, GapFillStat
 	y0 = column->prev.value;
 	y1 = column->next.value;
 
-	x  = time;
+	x = time;
 	x0 = column->prev.time;
 	x1 = column->next.time;
 

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -561,10 +561,9 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 								 MultiXactCutoff, use_wal);
 
 	/*
-	 * We know how to use a sort to duplicate the ordering of a
-	 * btree index, and will use seqscan-and-sort for that.  Otherwise, always
-	 * use an indexscan for other indexes or plain seqscan if no index is
-	 * supplied.
+	 * We know how to use a sort to duplicate the ordering of a btree index,
+	 * and will use seqscan-and-sort for that.  Otherwise, always use an
+	 * indexscan for other indexes or plain seqscan if no index is supplied.
 	 */
 	if (OldIndex != NULL && OldIndex->rd_rel->relam == BTREE_AM_OID)
 		use_sort = true;

--- a/tsl/test/isolation/specs/reorder_deadlock.spec
+++ b/tsl/test/isolation/specs/reorder_deadlock.spec
@@ -12,7 +12,7 @@ setup {
       index REGCLASS=NULL,
       verbose BOOLEAN=FALSE,
       wait_on REGCLASS=NULL
-  ) RETURNS VOID AS '$libdir/timescaledb-1.2.0-dev', 'ts_reorder_chunk' LANGUAGE C VOLATILE;
+  ) RETURNS VOID AS '$libdir/timescaledb-1.3.0-dev', 'ts_reorder_chunk' LANGUAGE C VOLATILE;
 }
 
 teardown {

--- a/tsl/test/isolation/specs/reorder_vs_insert.spec
+++ b/tsl/test/isolation/specs/reorder_vs_insert.spec
@@ -15,7 +15,7 @@ setup
      index REGCLASS=NULL,
      verbose BOOLEAN=FALSE,
      wait_on REGCLASS=NULL
- ) RETURNS VOID AS '$libdir/timescaledb-1.2.0-dev', 'ts_reorder_chunk' LANGUAGE C VOLATILE;
+ ) RETURNS VOID AS '$libdir/timescaledb-1.3.0-dev', 'ts_reorder_chunk' LANGUAGE C VOLATILE;
 }
 
 teardown {

--- a/tsl/test/isolation/specs/reorder_vs_select.spec
+++ b/tsl/test/isolation/specs/reorder_vs_select.spec
@@ -14,7 +14,7 @@ setup {
      index REGCLASS=NULL,
      verbose BOOLEAN=FALSE,
      wait_on REGCLASS=NULL
- ) RETURNS VOID AS '$libdir/timescaledb-1.2.0-dev', 'ts_reorder_chunk' LANGUAGE C VOLATILE;
+ ) RETURNS VOID AS '$libdir/timescaledb-1.3.0-dev', 'ts_reorder_chunk' LANGUAGE C VOLATILE;
 }
 
 teardown {

--- a/tsl/test/src/test_auto_policy.c
+++ b/tsl/test/src/test_auto_policy.c
@@ -19,10 +19,12 @@
 TS_FUNCTION_INFO_V1(ts_test_auto_reorder);
 TS_FUNCTION_INFO_V1(ts_test_auto_drop_chunks);
 
-static Oid chunk_oid;
-static Oid index_oid;
+static Oid	chunk_oid;
+static Oid	index_oid;
 
-static void dummy_reorder_func(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id) {
+static void
+dummy_reorder_func(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id)
+{
 	chunk_oid = tableOid;
 	index_oid = indexOid;
 	reorder_chunk(tableOid, indexOid, true, wait_id);
@@ -31,19 +33,19 @@ static void dummy_reorder_func(Oid tableOid, Oid indexOid, bool verbose, Oid wai
 Datum
 ts_test_auto_reorder(PG_FUNCTION_ARGS)
 {
-	TupleDesc tupdesc;
+	TupleDesc	tupdesc;
 	HeapTuple	tuple;
-	int32 job_id = PG_GETARG_INT32(0);
-	Datum	   values[NUM_REORDER_RET_VALS];
-	bool	   nulls[NUM_REORDER_RET_VALS] = {false};
-	BgwJob	   job = { .fd = {.id = job_id} };
+	int32		job_id = PG_GETARG_INT32(0);
+	Datum		values[NUM_REORDER_RET_VALS];
+	bool		nulls[NUM_REORDER_RET_VALS] = {false};
+	BgwJob		job = {.fd = {.id = job_id}};
 
 	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("function returning record called in context "
-					 "that cannot accept type record")));
+						"that cannot accept type record")));
 	}
 
 	execute_reorder_policy(&job, dummy_reorder_func, false);

--- a/tsl/test/src/test_chunk_stats.c
+++ b/tsl/test/src/test_chunk_stats.c
@@ -19,9 +19,9 @@ TS_FUNCTION_INFO_V1(ts_test_bgw_job_delete_by_id);
 Datum
 ts_test_chunk_stats_insert(PG_FUNCTION_ARGS)
 {
-	int32 job_id = PG_GETARG_INT32(0);
-	int32 chunk_id = PG_GETARG_INT32(1);
-	int32 num_times_run = PG_GETARG_INT32(2);
+	int32		job_id = PG_GETARG_INT32(0);
+	int32		chunk_id = PG_GETARG_INT32(1);
+	int32		num_times_run = PG_GETARG_INT32(2);
 	TimestampTz last_time_run = PG_ARGISNULL(3) ? 0 : PG_GETARG_TIMESTAMPTZ(3);
 
 	BgwPolicyChunkStats stat = {
@@ -34,12 +34,13 @@ ts_test_chunk_stats_insert(PG_FUNCTION_ARGS)
 	};
 
 	ts_bgw_policy_chunk_stats_insert(&stat);
-	
+
 	PG_RETURN_NULL();
 }
 
 Datum
-ts_test_bgw_job_delete_by_id(PG_FUNCTION_ARGS) {
+ts_test_bgw_job_delete_by_id(PG_FUNCTION_ARGS)
+{
 	ts_bgw_job_delete_by_id(PG_GETARG_INT32(0));
 	PG_RETURN_NULL();
 }


### PR DESCRIPTION
This change makes code formatting (`pgindent`) cover the TSL test
sources under `tsl/test/src/`. It also addresses some minor formatting
issues with existing sources in other directories.