### PR TITLE
Add cron a pre-release Release mode testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,22 @@ jobs:
       name: "ApacheOnly regression tests 9.6.6"
       env: PG_VERSION=9.6.6 PG_GIT_TAG=REL9_6_6 OTHER_CMAKE_FLAGS="-DAPACHE_ONLY=true"
 
+    # Release mode regression tests
+    - if: (type = cron) OR (branch = prerelease_test)
+      stage: test
+      name: "Release regression tests 11"
+      env: PG_VERSION=11.0 PG_GIT_TAG=REL_11_0 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
+
+    - if: (type = cron) OR (branch = prerelease_test)
+      stage: test
+      name: "Release regression tests 10.2"
+      env: PG_VERSION=10.2 PG_GIT_TAG=REL_10_2 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
+
+    - if: (type = cron) OR (branch = prerelease_test)
+      stage: test
+      name: "Release regression tests 9.6.6"
+      env: PG_VERSION=9.6.6 PG_GIT_TAG=REL9_6_6 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
+
     # Memory spike test when running out of order random inserts into timescaledb database
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test


### PR DESCRIPTION
Most of our testing is performed with Debug enabled. This is desired
as it enables more assertions, and helps ensure that our code is
correct. Still, it's good to ensure we're not accidentally depending
on Debug code in Release builds, so run tests in that mode nightly
and before each release.