### PR TITLE
Stop background worker on rename database

### DIFF
--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -438,3 +438,11 @@ SELECT wait_worker_counts(1,1,0,0);
 -- clean up additional database
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE :TEST_DBNAME_2;
+-- test rename database
+CREATE DATABASE db_rename_test;
+\c db_rename_test :ROLE_SUPERUSER
+SET client_min_messages=error;
+CREATE EXTENSION timescaledb;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE db_rename_test RENAME TO db_rename_test2;
+DROP DATABASE db_rename_test2;

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -214,3 +214,13 @@ SELECT wait_worker_counts(1,1,0,0);
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE :TEST_DBNAME_2;
 
+-- test rename database
+CREATE DATABASE db_rename_test;
+
+\c db_rename_test :ROLE_SUPERUSER
+SET client_min_messages=error;
+CREATE EXTENSION timescaledb;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+ALTER DATABASE db_rename_test RENAME TO db_rename_test2;
+DROP DATABASE db_rename_test2;
+


### PR DESCRIPTION
When background workers are running RENAME DATABASE will not work
because there are still active sessions to that database open.
This stops background workers on RENAME DATABASE so databases can
be renamed without manually stopping background workers.

Fixes #1034