### PR TITLE
Explicitly check  for NULL pointer in ts_bookend_finalfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 1.2.1 (unreleased)
+
+**Notable commits**
+
+**Thanks**
+
+* @jamessewell for reporting and helping debug a segfault in last()
+
 ## 1.2.0 (2019-01-29)
 
 **This is our first release to include Timescale-Licensed features, in addition to new Apache-2 capabilities.**

--- a/src/agg_bookend.c
+++ b/src/agg_bookend.c
@@ -516,12 +516,9 @@ ts_bookend_finalfunc(PG_FUNCTION_ARGS)
 		elog(ERROR, "ts_bookend_finalfunc called in non-aggregate context");
 	}
 
+	state = PG_ARGISNULL(0) ? NULL : (InternalCmpAggStore *) PG_GETARG_POINTER(0);
 
-	if (PG_ARGISNULL(0))
-		PG_RETURN_NULL();
-
-	state = (InternalCmpAggStore *) PG_GETARG_POINTER(0);
-	if (state->value.is_null || state->cmp.is_null)
+	if (state == NULL || state->value.is_null || state->cmp.is_null)
 		PG_RETURN_NULL();
 
 	PG_RETURN_DATUM(state->value.datum);

--- a/src/histogram.c
+++ b/src/histogram.c
@@ -191,10 +191,11 @@ ts_hist_finalfunc(PG_FUNCTION_ARGS)
 		elog(ERROR, "ts_hist_finalfunc called in non-aggregate context");
 	}
 
-	if (PG_ARGISNULL(0))
+	state = PG_ARGISNULL(0) ? NULL : PG_GETARG_BYTEA_P(0);
+
+	if (state == NULL)
 		PG_RETURN_NULL();
 
-	state = PG_GETARG_BYTEA_P(0);
 	hist = (Datum *) VARDATA(state);
 
 	dims[0] = HIST_LEN(state);


### PR DESCRIPTION
When the sfunc is never called to initialize InternalCmpAggStore
state can be NULL even though PG_ARGISNULL is false, so we check
for that condition here.