### PR TITLE
Fix group handling in time_bucket_gapfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ accidentally triggering the load of a previous DB version.**
 **Thanks**
 
 * @jamessewell for reporting and helping debug a segfault in last()
+* @piscopoc for reporting a segfault in time_bucket_gapfill
 
 ## 1.2.0 (2019-01-29)
 

--- a/tsl/src/gapfill/exec.c
+++ b/tsl/src/gapfill/exec.c
@@ -401,7 +401,17 @@ gapfill_exec(CustomScanState *node)
 				gapfill_state_set_next(state, slot);
 			}
 			else
-				state->state = FETCHED_LAST;
+			{
+				/*
+				 * if GROUP BY has non time_bucket_gapfill columns but the
+				 * query has not initialized the groups there is nothing we
+				 * can do here
+				 */
+				if (state->multigroup && !state->groups_initialized)
+					return NULL;
+				else
+					state->state = FETCHED_LAST;
+			}
 		}
 
 		/* return any subplan tuples before gapfill_start */

--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -237,6 +237,22 @@ GROUP BY 1 ORDER BY 1;
                    4 |    
 (5 rows)
 
+-- test gap fill without rows in resultset
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  min(time)
+FROM (VALUES (1),(2),(3)) v(time)
+WHERE false
+GROUP BY 1 ORDER BY 1;
+ time_bucket_gapfill | min 
+---------------------+-----
+                   0 |    
+                   1 |    
+                   2 |    
+                   3 |    
+                   4 |    
+(5 rows)
+
 -- test coalesce
 SELECT
   time_bucket_gapfill(1,time,0,5),
@@ -371,6 +387,18 @@ GROUP BY 1,id ORDER BY 2,1;
     4 |  2 |  
 (10 rows)
 
+-- test grouping by non-time columns with no rows in resultset
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  id,
+  min(value) as m
+FROM (VALUES (1,1,1),(2,2,2)) v(time,id,value)
+WHERE false
+GROUP BY 1,id ORDER BY 2,1;
+ time | id | m 
+------+----+---
+(0 rows)
+
 -- test duplicate columns in GROUP BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,
@@ -433,6 +461,18 @@ GROUP BY 1,color ORDER BY 2,1;
     3 | red   |  
     4 | red   |  
 (10 rows)
+
+-- test grouping by non-time columns with text columns with no rows in resultset
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  color,
+  min(value) as m
+FROM (VALUES (1,'blue',1),(2,'red',2)) v(time,color,value)
+WHERE false
+GROUP BY 1,color ORDER BY 2,1;
+ time | color | m 
+------+-------+---
+(0 rows)
 
 -- test insert into SELECT
 CREATE TABLE insert_test(id INT);

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -166,6 +166,14 @@ SELECT
 FROM (VALUES (1),(2),(3)) v(time)
 GROUP BY 1 ORDER BY 1;
 
+-- test gap fill without rows in resultset
+SELECT
+  time_bucket_gapfill(1,time,0,5),
+  min(time)
+FROM (VALUES (1),(2),(3)) v(time)
+WHERE false
+GROUP BY 1 ORDER BY 1;
+
 -- test coalesce
 SELECT
   time_bucket_gapfill(1,time,0,5),
@@ -230,6 +238,15 @@ SELECT
 FROM (VALUES (1,1,1),(2,2,2)) v(time,id,value)
 GROUP BY 1,id ORDER BY 2,1;
 
+-- test grouping by non-time columns with no rows in resultset
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  id,
+  min(value) as m
+FROM (VALUES (1,1,1),(2,2,2)) v(time,id,value)
+WHERE false
+GROUP BY 1,id ORDER BY 2,1;
+
 -- test duplicate columns in GROUP BY
 SELECT
   time_bucket_gapfill(1,time,0,5) as time,
@@ -252,6 +269,15 @@ SELECT
   color,
   min(value) as m
 FROM (VALUES (1,'blue',1),(2,'red',2)) v(time,color,value)
+GROUP BY 1,color ORDER BY 2,1;
+
+-- test grouping by non-time columns with text columns with no rows in resultset
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  color,
+  min(value) as m
+FROM (VALUES (1,'blue',1),(2,'red',2)) v(time,color,value)
+WHERE false
 GROUP BY 1,color ORDER BY 2,1;
 
 -- test insert into SELECT


### PR DESCRIPTION
When time_bucket_gapfill is used with multiple groups
but the query returned no rows we can not generate any
rows in the gapfill node.

Fixes #1046