### PR TITLE
Fix tlist on hypertable inserts inside CTEs

### DIFF
--- a/src/hypertable_insert.c
+++ b/src/hypertable_insert.c
@@ -118,7 +118,7 @@ static CustomScanMethods hypertable_insert_plan_methods = {
  * that the top-level target list reflects the projection done in a RETURNING
  * statement.
  */
-Plan *
+void
 ts_hypertable_insert_fixup_tlist(Plan *plan)
 {
 	if (IsA(plan, CustomScan))
@@ -136,7 +136,7 @@ ts_hypertable_insert_fixup_tlist(Plan *plan)
 		}
 	}
 
-	return plan;
+	return;
 }
 
 static Plan *

--- a/src/hypertable_insert.h
+++ b/src/hypertable_insert.h
@@ -23,7 +23,7 @@ typedef struct HypertableInsertState
 	ModifyTable *mt;
 } HypertableInsertState;
 
-extern Plan *ts_hypertable_insert_fixup_tlist(Plan *plan);
+extern void ts_hypertable_insert_fixup_tlist(Plan *plan);
 extern Path *ts_hypertable_insert_path_create(PlannerInfo *root, ModifyTablePath *mtpath);
 
 #endif /* TIMESCALEDB_HYPERTABLE_INSERT_H */

--- a/src/planner.c
+++ b/src/planner.c
@@ -125,6 +125,7 @@ static PlannedStmt *
 timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 {
 	PlannedStmt *stmt;
+	ListCell *lc;
 
 	if (ts_extension_is_loaded() && !ts_guc_disable_optimizations && parse->resultRelation == 0)
 	{
@@ -154,8 +155,13 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 	 * standard_planner. Therefore, we fixup the final target list for
 	 * HypertableInsert here.
 	 */
-	stmt->planTree = ts_hypertable_insert_fixup_tlist(stmt->planTree);
+	ts_hypertable_insert_fixup_tlist(stmt->planTree);
+	foreach (lc, stmt->subplans)
+	{
+		Plan *subplan = (Plan *) lfirst(lc);
 
+		ts_hypertable_insert_fixup_tlist(subplan);
+	}
 	return stmt;
 }
 

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -377,3 +377,63 @@ select * from upsert_test_diffchunk order by time, device_id;
  Sun Jan 20 09:00:01 2019 | dev2                 | 43.5 | orange2 | device-id-2         
 (4 rows)
 
+--arbiter index tests
+CREATE TABLE upsert_test_arbiter(time timestamp, to_drop int);
+SELECT create_hypertable('upsert_test_arbiter', 'time', chunk_time_interval=> interval '1 month');
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable         
+----------------------------------
+ (6,public,upsert_test_arbiter,t)
+(1 row)
+
+--this is the chunk with no tup_conv_map
+INSERT INTO upsert_test_arbiter (time, to_drop) VALUES ('2017-01-20T09:00:01', 1) RETURNING *;
+           time           | to_drop 
+--------------------------+---------
+ Fri Jan 20 09:00:01 2017 |       1
+(1 row)
+
+INSERT INTO upsert_test_arbiter (time, to_drop) VALUES ('2017-01-21T09:00:01', 2) RETURNING *;
+           time           | to_drop 
+--------------------------+---------
+ Sat Jan 21 09:00:01 2017 |       2
+(1 row)
+
+INSERT INTO upsert_test_arbiter (time, to_drop) VALUES ('2017-03-20T09:00:01', 3) RETURNING *;
+           time           | to_drop 
+--------------------------+---------
+ Mon Mar 20 09:00:01 2017 |       3
+(1 row)
+
+--alter the table
+ALTER TABLE upsert_test_arbiter DROP to_drop;
+ALTER TABLE upsert_test_arbiter ADD device_id char(20) DEFAULT 'dev1';
+CREATE UNIQUE INDEX arbiter_time_device_idx ON upsert_test_arbiter (time, device_id);
+INSERT INTO upsert_test_arbiter as current (time, device_id) VALUES
+    ('2018-01-21T09:00:01', 'dev1'),
+    ('2017-01-20T09:00:01', 'dev1'),
+    ('2017-01-21T09:00:01', 'dev2'),
+    ('2018-01-21T09:00:01', 'dev2')
+ ON CONFLICT (time, device_id) DO UPDATE SET device_id = coalesce(excluded.device_id,current.device_id)
+RETURNING *;
+           time           |      device_id       
+--------------------------+----------------------
+ Sun Jan 21 09:00:01 2018 | dev1                
+ Fri Jan 20 09:00:01 2017 | dev1                
+ Sat Jan 21 09:00:01 2017 | dev2                
+ Sun Jan 21 09:00:01 2018 | dev2                
+(4 rows)
+
+with cte as (
+INSERT INTO upsert_test_arbiter (time, device_id) VALUES
+    ('2017-01-21T09:00:01', 'dev2'),
+    ('2018-01-21T09:00:01', 'dev2')
+ ON CONFLICT (time, device_id) DO UPDATE SET device_id = 'dev3'
+RETURNING *)
+select * from cte;
+           time           |      device_id       
+--------------------------+----------------------
+ Sat Jan 21 09:00:01 2017 | dev3                
+ Sun Jan 21 09:00:01 2018 | dev3                
+(2 rows)
+


### PR DESCRIPTION
Previously, hypertable insert tlists were only fixed
for the top-level plan. We also need to fix the tlist
for hypertable inserts that appear inside ctes