### PR TITLE
Fix displayed error when an arbiter index is missing.

### DIFF
--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -471,7 +471,13 @@ chunk_insert_state_set_arbiter_indexes(ChunkInsertState *state, ChunkDispatch *d
 		Chunk *chunk = ts_chunk_get_by_relid(RelationGetRelid(chunk_rel), 0, true);
 		ChunkIndexMapping cim;
 
-		ts_chunk_index_get_by_hypertable_indexrelid(chunk, hypertable_index, &cim);
+		if (ts_chunk_index_get_by_hypertable_indexrelid(chunk, hypertable_index, &cim) < 1)
+		{
+			elog(ERROR,
+				 "could not find arbiter index for hypertable index \"%s\" on chunk \"%s\"",
+				 get_rel_name(hypertable_index),
+				 get_rel_name(RelationGetRelid(chunk_rel)));
+		}
 
 		state->arbiter_indexes = lappend_oid(state->arbiter_indexes, cim.indexoid);
 	}

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -300,6 +300,25 @@ SELECT * FROM CTE;
  Fri Jan 20 09:00:01 2017 | 25.9 | blue
 (1 row)
 
+--test error conditions when an index is dropped on a chunk
+DROP INDEX _timescaledb_internal._hyper_3_3_chunk_multi_time_color_idx;
+--everything is ok if not used as an arbiter index
+INSERT INTO upsert_test_multi_unique
+VALUES ('2017-01-20T09:00:01', 25.9, 'purple')
+ON CONFLICT DO NOTHING
+RETURNING *;
+ time | temp | color 
+------+------+-------
+(0 rows)
+
+--errors out if used as an arbiter index
+\set ON_ERROR_STOP 0
+INSERT INTO upsert_test_multi_unique
+VALUES ('2017-01-20T09:00:01', 25.9, 'purple')
+ON CONFLICT (time, color) DO NOTHING
+RETURNING *;
+ERROR:  could not find arbiter index for hypertable index "multi_time_color_idx" on chunk "_hyper_3_3_chunk"
+\set ON_ERROR_STOP 1
 --create table with one chunk that has a tup_conv_map and one that does not
 --to ensure this, create a chunk before altering the table this chunk will not have a tup_conv_map
 CREATE TABLE upsert_test_diffchunk(time timestamp, device_id char(20), to_drop int, temp float, color text);

--- a/test/sql/upsert.sql
+++ b/test/sql/upsert.sql
@@ -136,6 +136,23 @@ WITH CTE AS (
 )
 SELECT * FROM CTE;
 
+--test error conditions when an index is dropped on a chunk
+DROP INDEX _timescaledb_internal._hyper_3_3_chunk_multi_time_color_idx;
+
+--everything is ok if not used as an arbiter index
+INSERT INTO upsert_test_multi_unique
+VALUES ('2017-01-20T09:00:01', 25.9, 'purple')
+ON CONFLICT DO NOTHING
+RETURNING *;
+
+--errors out if used as an arbiter index
+\set ON_ERROR_STOP 0
+INSERT INTO upsert_test_multi_unique
+VALUES ('2017-01-20T09:00:01', 25.9, 'purple')
+ON CONFLICT (time, color) DO NOTHING
+RETURNING *;
+\set ON_ERROR_STOP 1
+
 --create table with one chunk that has a tup_conv_map and one that does not
 --to ensure this, create a chunk before altering the table this chunk will not have a tup_conv_map
 CREATE TABLE upsert_test_diffchunk(time timestamp, device_id char(20), to_drop int, temp float, color text);


### PR DESCRIPTION
When doing an upsert, we expect to be able to translate a
hypertable index used as an arbiter to a chunk index. But,
it is possible that the corresponding chunk index has been dropped.
Previously this resulted in a postgres generated error like
"unexpected failure to find arbiter index". We now handle
this more gracefully.