### PR TITLE
Fix issues discovered by sanitizers and add santizer based cron tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,71 +198,17 @@ jobs:
       script:
         - bash ./scripts/docker-run-memory-test.sh
 
-    # Valgrind test #1 : first 40 excluding plan_hashagg_optimized* and plan_hashagg_results*
-    - if: (branch = prerelease_test)
+    # Sanitizer tests
+    - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "Valgrind test #1"
+      name: "ASAN and UBSAN tests"
       before_install:
       install:
       after_failure:
       before_script:
-        # clone valgrind test script
-        - git clone https://$USR:$PASSWORD@bitbucket.org/440-labs/tsdb-dev-tools.git /tmp/tsdb-dev-tools
-        - bash -c 'while true; do echo -e "keepalive\n"; sleep 60; done' & # print line every 60 minutes to avoid Travis timeout
       script:
         # TEST_MAX specifies the maximum test # to go up to
-        - cd /tmp/tsdb-dev-tools; USE_REMOTE=true TIMESCALE_DIR=$TRAVIS_BUILD_DIR TEST_MAX=35 EXCLUDE_PATTERN='plan_hashagg_optimized*|plan_hashagg_results*' bash ./test_valgrind.sh
-      after_script:
-        - kill $(jobs -p) # kill job that prints repeatedly
-
-    # Valgrind test #2: tests matching plan_hashagg_optimized*
-    - if: (branch = prerelease_test)
-      stage: test
-      name: "Valgrind test #2"
-      before_install:
-      install:
-      after_failure:
-      before_script:
-        # clone valgrind test script
-        - git clone https://$USR:$PASSWORD@bitbucket.org/440-labs/tsdb-dev-tools.git /tmp/tsdb-dev-tools
-        - bash -c 'while true; do echo -e "keepalive\n"; sleep 60; done' & # print line every 60 minutes to avoid Travis timeout
-      script:
-        # TEST_MAX specifies the maximum test # to go up to
-        - cd /tmp/tsdb-dev-tools; USE_REMOTE=true TIMESCALE_DIR=$TRAVIS_BUILD_DIR INCLUDE_PATTERN='plan_hashagg_optimized*' bash ./test_valgrind.sh
-      after_script:
-        - kill $(jobs -p) # kill job that prints repeatedly
-
-    # Valgrind test #3: tests matching plan_hashagg_results*
-    - if: (branch = prerelease_test)
-      stage: test
-      name: "Valgrind test #3"
-      before_install:
-      install:
-      after_failure:
-      before_script:
-        # clone valgrind test script
-        - git clone https://$USR:$PASSWORD@bitbucket.org/440-labs/tsdb-dev-tools.git /tmp/tsdb-dev-tools
-        - bash -c 'while true; do echo -e "keepalive\n"; sleep 60; done' & # print line every 60 minutes to avoid Travis timeout
-      script:
-        # TEST_MAX specifies the maximum test # to go up to
-        - cd /tmp/tsdb-dev-tools; USE_REMOTE=true TIMESCALE_DIR=$TRAVIS_BUILD_DIR INCLUDE_PATTERN='plan_hashagg_results*' bash ./test_valgrind.sh
-      after_script:
-        - kill $(jobs -p) # kill job that prints repeatedly
-
-    # Valgrind test #4 : tests from #41 to end excluding plan_hashagg_optimized* and plan_hashagg_results*
-    - if: (branch = prerelease_test)
-      stage: test
-      name: "Valgrind test #4"
-      before_install:
-      install:
-      after_failure:
-      before_script:
-        # clone valgrind test script
-        - git clone https://$USR:$PASSWORD@bitbucket.org/440-labs/tsdb-dev-tools.git /tmp/tsdb-dev-tools
-        - bash -c 'while true; do echo -e "keepalive\n"; sleep 60; done' & # print line every 60 minutes to avoid Travis timeout
-      script:
-        # TEST_MIN specifies the minimum test # to go start from
-        - cd /tmp/tsdb-dev-tools; USE_REMOTE=true TIMESCALE_DIR=$TRAVIS_BUILD_DIR TEST_MIN=36 EXCLUDE_PATTERN='plan_hashagg_optimized*|plan_hashagg_results*' bash ./test_valgrind.sh
+        - TIMESCALE_DIR=$TRAVIS_BUILD_DIR bash ./scripts/test_sanitizers.sh
       after_script:
         - kill $(jobs -p) # kill job that prints repeatedly
 

--- a/scripts/suppressions/Readme.md
+++ b/scripts/suppressions/Readme.md
@@ -1,0 +1,10 @@
+# Suppressions for Clang Sanitizers #
+
+This folder contains [supression files](https://clang.llvm.org/docs/SanitizerSpecialCaseList.html) for
+running timescale using Clang's [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
+and [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), which
+we use as part of timescale's regission suite. There are a few places OSs have UB and where postgres
+has benign memory leaks, in order to run these sanitizers, we suppress these warning.
+
+For ease of use, we provide a script in [/scripts/test_sanitizers.sh] to run our regression tests with
+sanitizers enabled.

--- a/scripts/suppressions/suppr_asan.txt
+++ b/scripts/suppressions/suppr_asan.txt
@@ -1,0 +1,2 @@
+#suppress getaddrinfo due to internal error on macos
+interceptor_via_fun:getaddrinfo

--- a/scripts/suppressions/suppr_leak.txt
+++ b/scripts/suppressions/suppr_leak.txt
@@ -1,0 +1,19 @@
+leak:save_ps_display_args
+leak:psql/startup.c
+#don't care about the frontend leaks
+leak:fe_memutils.c
+leak:initdb.c
+#annoingly have to supress strdup because it leaks in PostmasterMain -D option
+leak:strdup
+leak:ProcessConfigFileInternal
+leak:internal_load_library
+
+leak:pg_timezone_abbrev_initialize
+leak:check_session_authorization
+leak:InitializeGUCOptions
+leak:CheckMyDatabase
+
+
+#pg_dump
+leak:getSchemaData
+leak:dumpDumpableObject

--- a/scripts/suppressions/suppr_ub.txt
+++ b/scripts/suppressions/suppr_ub.txt
@@ -1,0 +1,13 @@
+alignment:pg_comp_crc32c_sse42
+alignment:array_cmp
+alignment:array_iter_setup
+alignment:array_out
+alignment:array_eq
+alignment:AllocSetCheck
+nonnull-attribute:TransactionIdSetPageStatus
+nonnull-attribute:SerializeTransactionState
+nonnull-attribute:initscan
+nonnull-attribute:SetTransactionSnapshot
+nonnull-attribute:/usr/src/postgresql/src/fe_utils/print.c
+#division by 0, looks like a real postgres ug
+float-divide-by-zero:_bt_vacuum_needs_cleanup

--- a/scripts/test_sanitizers.sh
+++ b/scripts/test_sanitizers.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+DO_CLEANUP=true
+SCRIPT_DIR=${SCRIPT_DIR:-$(dirname $0)}
+EXCLUDE_PATTERN=${EXCLUDE_PATTERN:-'^$'} # tests matching regex pattern will be excluded
+INCLUDE_PATTERN=${INCLUDE_PATTERN:-'.*'} # tests matching regex pattern will be included
+TEST_MAX=${TEST_MAX:-$((2**16))}
+TEST_MIN=${TEST_MIN:-$((-1))}
+USE_REMOTE=${USE_REMOTE:-false}
+REMOTE_TAG=${REMOTE_TAG:-'latest'}
+PUSH_IMAGE=${PUSH_IMAGE:-false}
+REMOTE_ORG=${REMOTE_ORG:-'timescaledev'}
+REMOTE_NAME=${REMOTE_NAME:-'postgres-dev-clang'}
+TIMESCALE_DIR=${TIMESCALE_DIR:-${PWD}/${SCRIPT_DIR}/..}
+
+while getopts "d" opt;
+do
+    case $opt in
+        d)
+            DO_CLEANUP=false
+            echo "!!Debug mode: Containers and temporary directory will be left on disk"
+            echo
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if "$DO_CLEANUP" = "true"; then
+    trap cleanup EXIT
+fi
+
+cleanup() {
+    # Save status here so that we can return the status of the last
+    # command in the script and not the last command of the cleanup
+    # function
+    status="$?"
+    set +e # do not exit immediately on failure in cleanup handler
+
+    if [[ $status -eq 0 ]]; then
+        echo "All tests passed"
+        docker rm -vf timescaledb-san 2>/dev/null
+    else
+        # docker logs timescaledb-san
+        docker_exec timescaledb-san "cat /tsdb_build/timescaledb/build/test/regression.diffs"
+        docker_exec timescaledb-san "cat /tsdb_build/timescaledb/build/test/log/postmaster.log"
+    fi
+
+    echo "Exit status is $status"
+    exit $status
+}
+
+docker_exec() {
+    # Echo to stderr
+    >&2 echo -e "\033[1m$1\033[0m: $2"
+    docker exec -it $1 /bin/bash -c "$2"
+}
+
+wait_for_pg() {
+    set +e
+    for i in {1..30}; do
+        sleep 2
+
+        docker_exec $1 "pg_isready -U postgres"
+
+        if [[ $? == 0 ]] ; then
+            # this makes the test less flaky, although not
+            # ideal. Apperently, pg_isready is not always a good
+            # indication of whether the DB is actually ready to accept
+            # queries
+            sleep 1
+            set -e
+            return 0
+        fi
+    done
+    exit 1
+}
+
+
+docker rm -f timescaledb-san 2>/dev/null || true
+
+docker run -d --privileged --name timescaledb-san -v ${TIMESCALE_DIR}:/timescaledb ${REMOTE_ORG}/${REMOTE_NAME}:${REMOTE_TAG}
+
+docker exec timescaledb-san /bin/bash -c "mkdir /tsdb_build && chown postgres /tsdb_build"
+
+docker exec -u postgres timescaledb-san /bin/bash -c "cp -R /timescaledb tsdb_build"
+
+docker exec -u postgres \
+    -e CFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+    -e CMAKE_BUILD_TYPE="Debug" \
+    -e PG_SOURCE_DIR="/usr/src/postgresql/" \
+    timescaledb-san /bin/bash -c \
+    "cd /tsdb_build/timescaledb && BUILD_FORCE_REMOVE=true ./bootstrap && cd build && make"
+
+wait_for_pg timescaledb-san
+
+docker exec timescaledb-san /bin/bash -c "cd /tsdb_build/timescaledb/build && make install"
+
+echo "Testing"
+
+# Echo to stderr
+>&2 echo -e "\033[1m$1\033[0m: $2"
+docker exec -u postgres \
+    timescaledb-san /bin/bash -c \
+    "cd /tsdb_build/timescaledb/build \
+        && PATH=\$PATH make regresscheck regresscheck-t"

--- a/test/src/bgw/log.c
+++ b/test/src/bgw/log.c
@@ -9,6 +9,7 @@
 #include <utils/builtins.h>
 #include <utils/lsyscache.h>
 #include <postmaster/bgworker.h>
+#include <storage/proc.h>
 
 #include "log.h"
 #include "scanner.h"
@@ -62,6 +63,12 @@ static void
 emit_log_hook_callback(ErrorData *edata)
 {
 	bool started_txn = false;
+
+	/*
+	 * once proc_exit has started we may no longer be able to start transactions
+	 */
+	if (MyProc == NULL)
+		return;
 
 	/*
 	 * Block signals so we don't lose messages generated during signal


### PR DESCRIPTION
The first commit fixes three issues:
1. It is technically UB to pass in NULL as the data argument to appendBinaryStringInfo
   We fix this by providing a wrapper function which checks if len == 0 before calling
   appendBinaryStringInfo.
2. It is technically UB to pass in NULL as any argument for memcopy, we use a similar
   fix as in 1.
3. The Datum array in histogram was misaligned; Datums require 8 byte alignment, while
   the data in a bytea is only guaranteed to be aligned to 4. We fix this by switching
   to a better-typed internal histogram type. This will use approximately double the
   memory for serialization, but is much simpler to read, and more morally correct.

The second PR adds sanitizer run script, and updates travis to run it in our nightly builds. Valgrind has been very slow and unstable, so much so that we only run it during pre-release tests, and even then it doesn't necessarily provide useful output. The sanitizer tests run about 10x faster, and seem stable.

We currently only run ASan and UBSan, as MSan has too many issues within postgres's own initialization functions. As MSan cannot be added to a binary that enables ASan, it would require separate jobs anyway.

An example passing run can be seen [here](https://travis-ci.org/timescale/timescaledb/jobs/492907583).
