### PR TITLE
Exclude hidden and CMake directories when formatting code

### DIFF
--- a/scripts/clang_format_all.sh
+++ b/scripts/clang_format_all.sh
@@ -5,4 +5,5 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 BASE_DIR=$(dirname $SCRIPT_DIR)
 
 find ${BASE_DIR} \( -path "${BASE_DIR}/src/*" -or -path "${BASE_DIR}/test/*" -or -path "${BASE_DIR}/tsl/*" \) \
+    -and -not \( -path "*/.*" -or -path "*CMake*" \) \
     -and \( -name '*.c' -or -name '*.h' \) -print | xargs ${SCRIPT_DIR}/clang_format_wrapper.sh -style=file -i


### PR DESCRIPTION
The script for running clang-format on the source code now properly
excludes hidden directories and CMake directories from the source code
scan. Including these directories may otherwise break clang-format
because hidden directories are often used for IDE/tools caches (e.g.,
`cquery`) where the cache files have the same ending as the source
code.