### PR TITLE
Fix chunk exclusion constraint type inference

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -656,7 +656,7 @@ ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval)
  * the restype parameter.
  */
 Datum
-ts_dimension_transform_value(Dimension *dim, Datum value, Oid *restype)
+ts_dimension_transform_value(Dimension *dim, Datum value, Oid const_datum_type, Oid *restype)
 {
 	if (NULL != dim->partitioning)
 		value = ts_partitioning_func_apply(dim->partitioning, value);
@@ -665,6 +665,8 @@ ts_dimension_transform_value(Dimension *dim, Datum value, Oid *restype)
 	{
 		if (NULL != dim->partitioning)
 			*restype = dim->partitioning->partfunc.rettype;
+		else if (const_datum_type != InvalidOid)
+			*restype = const_datum_type;
 		else
 			*restype = dim->fd.column_type;
 	}

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -135,7 +135,8 @@ extern int32 ts_dimension_get_hypertable_id(int32 dimension_id);
 extern int ts_dimension_set_type(Dimension *dim, Oid newtype);
 extern int ts_dimension_set_name(Dimension *dim, const char *newname);
 extern int ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
-extern Datum ts_dimension_transform_value(Dimension *dim, Datum value, Oid *restype);
+extern Datum ts_dimension_transform_value(Dimension *dim, Datum value, Oid const_datum_type,
+										  Oid *restype);
 extern int ts_dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete_slices);
 extern TSDLLEXPORT void ts_dimension_open_typecheck(Oid arg_type, Oid time_column_type,
 													char *caller_name);

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -100,6 +100,7 @@ dimension_restrict_info_open_add(DimensionRestrictInfoOpen *dri, StrategyNumber 
 		Oid restype;
 		Datum datum = ts_dimension_transform_value(dri->base.dimension,
 												   PointerGetDatum(lfirst(item)),
+												   dimvalues->type,
 												   &restype);
 		int64 value = ts_time_value_to_internal(datum, restype, false);
 
@@ -146,8 +147,10 @@ dimension_restrict_info_get_partitions(DimensionRestrictInfoClosed *dri, List *v
 
 	foreach (item, values)
 	{
-		Datum value =
-			ts_dimension_transform_value(dri->base.dimension, PointerGetDatum(lfirst(item)), NULL);
+		Datum value = ts_dimension_transform_value(dri->base.dimension,
+												   PointerGetDatum(lfirst(item)),
+												   InvalidOid,
+												   NULL);
 
 		partitions = list_append_unique_int(partitions, DatumGetInt32(value));
 	}


### PR DESCRIPTION
The existing constraint exclusion code creates issues on 32bit processors when constraint given
in a query does not exactly match the type of the table dimension but could be promoted to it.
For example, if hyper_w_space has bigint time type, the following query will pass 10 as
Const variable of type int32 (that has Oid INT4OID).

SELECT * FROM hyper_w_space WHERE time < 10

If this type info is not propagated correctly, later Const variable type is inferred as bigint (int64) and
DatumGetInt64 is used to get its value. In 64 bit systems, DatumGetInt32 and DatumGetInt64 are identical and so there
are no issues, however this makes a difference in 32 bit systems as there 32 bit values are passed by value while
64 bit values are passed by reference.