### PR TITLE
Fix sort_transform optimization

### DIFF
--- a/test/expected/sort_optimization.out
+++ b/test/expected/sort_optimization.out
@@ -1,0 +1,78 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+--
+\set PREFIX 'EXPLAIN (COSTS OFF) '
+CREATE TABLE order_test(time int NOT NULL, device_id int, value float);
+CREATE INDEX ON order_test(time,device_id);
+CREATE INDEX ON order_test(device_id,time);
+SELECT create_hypertable('order_test','time',chunk_time_interval:=1000);
+    create_hypertable    
+-------------------------
+ (1,public,order_test,t)
+(1 row)
+
+INSERT INTO order_test SELECT 0,10,0.5;
+INSERT INTO order_test SELECT 1,9,0.5;
+INSERT INTO order_test SELECT 2,8,0.5;
+-- test sort optimization with single member order by
+SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
+ time_bucket | device_id | value 
+-------------+-----------+-------
+           0 |        10 |   0.5
+           0 |         9 |   0.5
+           0 |         8 |   0.5
+(3 rows)
+
+-- should use index scan
+:PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Result
+   ->  Merge Append
+         Sort Key: (time_bucket(10, order_test."time"))
+         ->  Index Scan Backward using order_test_time_idx on order_test
+         ->  Index Scan Backward using _hyper_1_1_chunk_order_test_time_idx on _hyper_1_1_chunk
+(5 rows)
+
+-- test sort optimization with ordering by multiple columns and time_bucket not last
+SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1,2;
+ time_bucket | device_id | value 
+-------------+-----------+-------
+           0 |         8 |   0.5
+           0 |         9 |   0.5
+           0 |        10 |   0.5
+(3 rows)
+
+-- must not use index scan
+:PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1,2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket(10, order_test."time")), order_test.device_id
+   ->  Result
+         ->  Append
+               ->  Seq Scan on order_test
+               ->  Seq Scan on _hyper_1_1_chunk
+(6 rows)
+
+-- test sort optimization with ordering by multiple columns and time_bucket as last member
+SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 2,1;
+ time_bucket | device_id | value 
+-------------+-----------+-------
+           0 |         8 |   0.5
+           0 |         9 |   0.5
+           0 |        10 |   0.5
+(3 rows)
+
+-- should use index scan
+:PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 2,1;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result
+   ->  Merge Append
+         Sort Key: order_test.device_id, (time_bucket(10, order_test."time"))
+         ->  Index Scan using order_test_device_id_time_idx on order_test
+         ->  Index Scan using _hyper_1_1_chunk_order_test_device_id_time_idx on _hyper_1_1_chunk
+(5 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TEST_FILES
   relocate_extension.sql
   reloptions.sql
   size_utils.sql
+  sort_optimization.sql
   sql_query_results_optimized.sql
   sql_query_results_unoptimized.sql
   sql_query_results_x_diff.sql

--- a/test/sql/sort_optimization.sql
+++ b/test/sql/sort_optimization.sql
@@ -1,0 +1,32 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+--
+
+\set PREFIX 'EXPLAIN (COSTS OFF) '
+
+CREATE TABLE order_test(time int NOT NULL, device_id int, value float);
+CREATE INDEX ON order_test(time,device_id);
+CREATE INDEX ON order_test(device_id,time);
+
+SELECT create_hypertable('order_test','time',chunk_time_interval:=1000);
+
+INSERT INTO order_test SELECT 0,10,0.5;
+INSERT INTO order_test SELECT 1,9,0.5;
+INSERT INTO order_test SELECT 2,8,0.5;
+
+-- test sort optimization with single member order by
+SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
+-- should use index scan
+:PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
+
+-- test sort optimization with ordering by multiple columns and time_bucket not last
+SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1,2;
+-- must not use index scan
+:PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1,2;
+
+-- test sort optimization with ordering by multiple columns and time_bucket as last member
+SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 2,1;
+-- should use index scan
+:PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 2,1;
+


### PR DESCRIPTION
The sort transform optimization to enable index usage are only
safe transformations when the modified PathKey is either the last
member of pathkeys or the only member.