### PR TITLE
Make constraint aware append parallel safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ accidentally triggering the load of a previous DB version.**
 ## 1.3.0 (unreleased)
 
 **Minor Features**
+* PR #1062 Make constraint aware append parallel safe
 * PR #1005 Enable creating indexes with one transaction per chunk
-* [] Remove parent oid from find_children_oids result
-* [b6d4202] Infer time_bucket_gapfill arguments from WHERE clause
-* [33ef1de] Add treat_null_as_missing option to locf
+* PR #1007 Remove parent oid from find_children_oids result
+* PR #1038 Infer time_bucket_gapfill arguments from WHERE clause
+* PR #1067 Add treat_null_as_missing option to locf
 
 **Bugfixes**
 * [5a3edfd] Fix chunk exclusion constraint type inference

--- a/src/constraint_aware_append.h
+++ b/src/constraint_aware_append.h
@@ -26,4 +26,6 @@ typedef struct Hypertable Hypertable;
 
 Path *ts_constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath);
 
+void _constraint_aware_append_init(void);
+
 #endif /* TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H */

--- a/src/init.c
+++ b/src/init.c
@@ -19,6 +19,7 @@
 #include "compat.h"
 #include "config.h"
 #include "license_guc.h"
+#include "constraint_aware_append.h"
 
 #ifdef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -75,6 +76,7 @@ _PG_init(void)
 	_hypertable_cache_init();
 	_cache_invalidate_init();
 	_planner_init();
+	_constraint_aware_append_init();
 	_event_trigger_init();
 	_process_utility_init();
 	_guc_init();

--- a/src/planner.c
+++ b/src/planner.c
@@ -307,6 +307,25 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 					break;
 			}
 		}
+
+		foreach (lc, rel->partial_pathlist)
+		{
+			Path **pathptr = (Path **) &lfirst(lc);
+
+			switch (nodeTag(*pathptr))
+			{
+				case T_AppendPath:
+					if (should_optimize_append(*pathptr))
+						*pathptr = ts_constraint_aware_append_path_create(root, ht, *pathptr);
+					break;
+				case T_MergeAppendPath:
+					if (should_optimize_append(*pathptr))
+						*pathptr = ts_constraint_aware_append_path_create(root, ht, *pathptr);
+					break;
+				default:
+					break;
+			}
+		}
 	}
 
 out_release:

--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -54,6 +54,8 @@ psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
              QUERY PLAN              
 -------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -66,6 +68,8 @@ psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
  time | temp | colorid 
 ------+------+---------
 (0 rows)
@@ -74,6 +78,8 @@ psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() + '1 month'
 ORDER BY time DESC limit 1;
+psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
@@ -96,6 +102,8 @@ psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -108,6 +116,8 @@ psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
+psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
@@ -127,6 +137,8 @@ psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Limit
@@ -141,6 +153,8 @@ psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
+psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
@@ -214,6 +228,8 @@ psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -221,6 +237,8 @@ psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
 
 EXPLAIN (costs off)
 EXECUTE query_opt;
+psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
@@ -244,6 +262,8 @@ psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
               t               | avg  
 ------------------------------+------
  Sun Jan 01 00:00:00 2017 PST | 28.5
@@ -255,6 +275,8 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
+psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
@@ -333,6 +355,8 @@ psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Merge Left Join
@@ -386,6 +410,8 @@ psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
             btime             | value 
 ------------------------------+-------
  Fri Mar 03 16:00:00 2017 PST |  22.5
@@ -425,6 +451,10 @@ psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Nested Loop
@@ -437,19 +467,17 @@ psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
    ->  Custom Scan (ConstraintAwareAppend)
          Hypertable: join_test
-         Chunks left after exclusion: 3
+         Chunks left after exclusion: 1
          ->  Append
-               ->  Index Scan using _hyper_2_4_chunk_join_test_time_idx on _hyper_2_4_chunk j_1
+               ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1
                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
-               ->  Index Scan using _hyper_2_5_chunk_join_test_time_idx on _hyper_2_5_chunk j_2
-                     Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
-               ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_3
-                     Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
-(18 rows)
+(14 rows)
 
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
+psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
 psql:include/append.sql:196: NOTICE:  Stable function now_s() called!

--- a/test/expected/append_x_diff.out
+++ b/test/expected/append_x_diff.out
@@ -7,7 +7,7 @@
 < SET timescaledb.disable_optimizations = ON;
 ---
 > SET timescaledb.disable_optimizations = OFF;
-57,68c57,62
+57,68c57,64
 <                                     QUERY PLAN                                    
 < ----------------------------------------------------------------------------------
 <  Append
@@ -21,23 +21,25 @@
 <          Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
 < (9 rows)
 ---
+> psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 >              QUERY PLAN              
 > -------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
 >    Hypertable: append_test
 >    Chunks left after exclusion: 0
 > (3 rows)
-75,77d68
+77d72
 < psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-90,91c81,82
+90,91c85,88
 <                                        QUERY PLAN                                       
 < ----------------------------------------------------------------------------------------
 ---
+> psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
 >                 QUERY PLAN                 
 > -------------------------------------------
-93,103c84,87
+93,103c90,93
 <    ->  Merge Append
 <          Sort Key: append_test."time" DESC
 <          ->  Index Scan using append_test_time_idx on append_test
@@ -54,7 +56,7 @@
 >          Hypertable: append_test
 >          Chunks left after exclusion: 0
 > (4 rows)
-115,126c99,107
+115,126c105,115
 <                                     QUERY PLAN                                    
 < ----------------------------------------------------------------------------------
 <  Append
@@ -68,6 +70,8 @@
 <          Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 < (9 rows)
 ---
+> psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 >                                        QUERY PLAN                                       
 > ----------------------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
@@ -77,16 +81,15 @@
 >          ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (6 rows)
-135,136d115
-< psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-151,152c130,131
+151,152c140,143
 <                                            QUERY PLAN                                            
 < -------------------------------------------------------------------------------------------------
 ---
+> psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
 >                                               QUERY PLAN                                               
 > -------------------------------------------------------------------------------------------------------
-154,164c133,139
+154,164c145,151
 <    ->  Merge Append
 <          Sort Key: append_test."time"
 <          ->  Index Scan Backward using append_test_time_idx on append_test
@@ -106,11 +109,9 @@
 >                ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                      Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (7 rows)
-174,176d148
+176d162
 < psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-189,201c161,170
+189,201c175,184
 <                                                     QUERY PLAN                                                    
 < ------------------------------------------------------------------------------------------------------------------
 <  Merge Append
@@ -135,7 +136,7 @@
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
 > (7 rows)
-210,222c179,192
+210,222c193,206
 <                                         QUERY PLAN                                         
 < -------------------------------------------------------------------------------------------
 <  Merge Append
@@ -164,11 +165,9 @@
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
 > (11 rows)
-247,249d216
+249d232
 < psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-257,269c224,234
+257,269c240,252
 <                                         QUERY PLAN                                         
 < -------------------------------------------------------------------------------------------
 <  Merge Append
@@ -184,6 +183,8 @@
 < (10 rows)
 ---
 > psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
 >                                            QUERY PLAN                                            
 > -------------------------------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
@@ -194,38 +195,41 @@
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (7 rows)
-282d246
-< psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-304c268,270
+282a266
+> psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
+297a282,283
+> psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
+304c290,292
 <          ->  Result
 ---
 >          ->  Custom Scan (ConstraintAwareAppend)
 >                Hypertable: append_test
 >                Chunks left after exclusion: 2
-306,309d271
+306,309d293
 <                      ->  Seq Scan on append_test
 <                            Filter: ("time" > (now_s() - '@ 4 mons'::interval))
 <                      ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
 <                            Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-314c276
+314c298
 < (14 rows)
 ---
 > (12 rows)
-326,327c288,289
+326,327c310,311
 <                                                                                                              QUERY PLAN                                                                                                              
 < -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                         QUERY PLAN                         
 > -----------------------------------------------------------
-329c291
+329c313
 <    Group Key: (date_trunc('year'::text, append_test."time"))
 ---
 >    Group Key: (date_trunc('year'::text, "time"))
-331c293
+331c315
 <          Sort Key: (date_trunc('year'::text, append_test."time")) DESC
 ---
 >          Sort Key: (date_trunc('year'::text, "time")) DESC
-333,336c295,296
+333,336c317,318
 <                ->  Append
 <                      ->  Seq Scan on append_test
 <                            Filter: (("time" < 'Tue Mar 22 00:00:00 2016 PDT'::timestamp with time zone) AND (date_part('dow'::text, "time") >= '1'::double precision) AND (date_part('dow'::text, "time") <= '5'::double precision))
@@ -233,49 +237,58 @@
 ---
 >                One-Time Filter: false
 > (6 rows)
-349,351c309
+349,351c331
 <    Sort Key: append_test."time"
 <    ->  Index Scan Backward using append_test_time_idx on append_test
 <          Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
 ---
 >    Sort Key: _hyper_1_3_chunk."time"
-354c312
+354c334
 < (6 rows)
 ---
 > (4 rows)
-378,379c336,337
+378,379c358,361
 <                                               QUERY PLAN                                               
 < -------------------------------------------------------------------------------------------------------
 ---
+> psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
 >                                                   QUERY PLAN                                                   
 > ---------------------------------------------------------------------------------------------------------------
-385c343,345
+385c367,369
 <            ->  Result
 ---
 >            ->  Custom Scan (ConstraintAwareAppend)
 >                  Hypertable: append_test
 >                  Chunks left after exclusion: 3
-387,389c347
+387,389c371
 <                        ->  Seq Scan on append_test
 <                              Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
 <                        ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
-392c350
+392c374
 <                        ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
-395c353
+395c377
 <                        ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
-470,471c428,429
+430a413,414
+> psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
+470,471c454,459
 <                                          QUERY PLAN                                         
 < --------------------------------------------------------------------------------------------
 ---
+> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
 >                                             QUERY PLAN                                            
 > --------------------------------------------------------------------------------------------------
-474,492c432,448
+474,492c462,474
 <    ->  Append
 <          ->  Seq Scan on append_test a
 <                Filter: ("time" > (now_s() - '@ 3 hours'::interval))
@@ -304,15 +317,8 @@
 >                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
 >    ->  Custom Scan (ConstraintAwareAppend)
 >          Hypertable: join_test
->          Chunks left after exclusion: 3
+>          Chunks left after exclusion: 1
 >          ->  Append
->                ->  Index Scan using _hyper_2_4_chunk_join_test_time_idx on _hyper_2_4_chunk j_1
+>                ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1
 >                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
->                ->  Index Scan using _hyper_2_5_chunk_join_test_time_idx on _hyper_2_5_chunk j_2
->                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
->                ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_3
->                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
-> (18 rows)
-497,498d452
-< psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-< psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
+> (14 rows)

--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -3,6 +3,13 @@
 -- LICENSE-APACHE for a copy of the license.
 --parallel queries require big-ish tables so collect them all here
 --so that we need to generate queries only once.
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 NOTICE:  adding not-null constraint to column "i"
@@ -17,20 +24,21 @@ SET client_min_messages = 'error';
 --avoid warning polluting output
 ANALYZE;
 RESET client_min_messages;
+SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
-EXPLAIN (costs off)
-SELECT first(i, j) FROM "test";
-                          QUERY PLAN                           
----------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather
+:PREFIX SELECT first(i, j) FROM "test";
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
-         ->  Partial Aggregate
-               ->  Append
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk
-(7 rows)
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Append (actual rows=333333 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=166667 loops=3)
+(8 rows)
 
 SELECT first(i, j) FROM "test";
  first 
@@ -38,18 +46,18 @@ SELECT first(i, j) FROM "test";
      0
 (1 row)
 
-EXPLAIN (costs off)
-SELECT last(i, j) FROM "test";
-                          QUERY PLAN                           
----------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather
+:PREFIX SELECT last(i, j) FROM "test";
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
-         ->  Partial Aggregate
-               ->  Append
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk
-(7 rows)
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Append (actual rows=333333 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=166667 loops=3)
+(8 rows)
 
 SELECT last(i, j) FROM "test";
   last  
@@ -57,8 +65,8 @@ SELECT last(i, j) FROM "test";
  999999
 (1 row)
 
-EXPLAIN (costs off)
-SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- we dont run this with analyze because the sort memory usage is not stable
+EXPLAIN (costs off) SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 GROUP BY sec
 ORDER BY sec
@@ -166,4 +174,98 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 -------------------------------------------
  {10,19998,19998,19998,19998,19998,900000}
 (1 row)
+
+-- test constraint aware append
+:PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather (actual rows=1000000 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   Single Copy: true
+   ->  Result (actual rows=1000000 loops=1)
+         One-Time Filter: (length(version()) > 0)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+               Hypertable: test
+               Chunks left after exclusion: 2
+               ->  Append (actual rows=1000000 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+(12 rows)
+
+-- test constraint aware append with parallel aggregation
+:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
+         Workers Planned: 2
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Result (actual rows=333333 loops=3)
+                     One-Time Filter: (length(version()) > 0)
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=333333 loops=3)
+                           Hypertable: test
+                           Chunks left after exclusion: 2
+                           ->  Append (actual rows=333333 loops=3)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=166667 loops=3)
+(13 rows)
+
+SELECT count(*) FROM "test" WHERE length(version()) > 0;
+  count  
+---------
+ 1000000
+(1 row)
+
+-- now() is not marked parallel safe in PostgreSQL < 12 so using now()
+-- in a query will prevent parallelism but CURRENT_TIMESTAMP and
+-- transaction_timestamp() are marked parallel safe
+:PREFIX SELECT i FROM "test" WHERE ts < CURRENT_TIMESTAMP;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather (actual rows=1000000 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   Single Copy: true
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+         Hypertable: test
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1000000 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < CURRENT_TIMESTAMP)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < CURRENT_TIMESTAMP)
+(12 rows)
+
+:PREFIX SELECT i FROM "test" WHERE ts < transaction_timestamp();
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather (actual rows=1000000 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   Single Copy: true
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+         Hypertable: test
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1000000 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < transaction_timestamp())
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < transaction_timestamp())
+(12 rows)
+
+-- this won't be parallel query because now() is parallel restricted in PG < 12
+:PREFIX SELECT i FROM "test" WHERE ts < now();
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+   Hypertable: test
+   Chunks left after exclusion: 2
+   ->  Append (actual rows=1000000 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+               Filter: (ts < now())
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+               Filter: (ts < now())
+(8 rows)
 

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -3,6 +3,13 @@
 -- LICENSE-APACHE for a copy of the license.
 --parallel queries require big-ish tables so collect them all here
 --so that we need to generate queries only once.
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 NOTICE:  adding not-null constraint to column "i"
@@ -17,20 +24,21 @@ SET client_min_messages = 'error';
 --avoid warning polluting output
 ANALYZE;
 RESET client_min_messages;
+SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
-EXPLAIN (costs off)
-SELECT first(i, j) FROM "test";
-                          QUERY PLAN                           
----------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather
+:PREFIX SELECT first(i, j) FROM "test";
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
-         ->  Partial Aggregate
-               ->  Parallel Append
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk
-(7 rows)
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Parallel Append (actual rows=333333 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+(8 rows)
 
 SELECT first(i, j) FROM "test";
  first 
@@ -38,18 +46,18 @@ SELECT first(i, j) FROM "test";
      0
 (1 row)
 
-EXPLAIN (costs off)
-SELECT last(i, j) FROM "test";
-                          QUERY PLAN                           
----------------------------------------------------------------
- Finalize Aggregate
-   ->  Gather
+:PREFIX SELECT last(i, j) FROM "test";
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
-         ->  Partial Aggregate
-               ->  Parallel Append
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk
-(7 rows)
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Parallel Append (actual rows=333333 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+(8 rows)
 
 SELECT last(i, j) FROM "test";
   last  
@@ -57,8 +65,8 @@ SELECT last(i, j) FROM "test";
  999999
 (1 row)
 
-EXPLAIN (costs off)
-SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- we dont run this with analyze because the sort memory usage is not stable
+EXPLAIN (costs off) SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 GROUP BY sec
 ORDER BY sec
@@ -166,4 +174,98 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 -------------------------------------------
  {10,19998,19998,19998,19998,19998,900000}
 (1 row)
+
+-- test constraint aware append
+:PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather (actual rows=1000000 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   Single Copy: true
+   ->  Result (actual rows=1000000 loops=1)
+         One-Time Filter: (length(version()) > 0)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+               Hypertable: test
+               Chunks left after exclusion: 2
+               ->  Append (actual rows=1000000 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+(12 rows)
+
+-- test constraint aware append with parallel aggregation
+:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
+         Workers Planned: 2
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Result (actual rows=333333 loops=3)
+                     One-Time Filter: (length(version()) > 0)
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=333333 loops=3)
+                           Hypertable: test
+                           Chunks left after exclusion: 2
+                           ->  Parallel Append (actual rows=333333 loops=3)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+(13 rows)
+
+SELECT count(*) FROM "test" WHERE length(version()) > 0;
+  count  
+---------
+ 1000000
+(1 row)
+
+-- now() is not marked parallel safe in PostgreSQL < 12 so using now()
+-- in a query will prevent parallelism but CURRENT_TIMESTAMP and
+-- transaction_timestamp() are marked parallel safe
+:PREFIX SELECT i FROM "test" WHERE ts < CURRENT_TIMESTAMP;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather (actual rows=1000000 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   Single Copy: true
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+         Hypertable: test
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1000000 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < CURRENT_TIMESTAMP)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < CURRENT_TIMESTAMP)
+(12 rows)
+
+:PREFIX SELECT i FROM "test" WHERE ts < transaction_timestamp();
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather (actual rows=1000000 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   Single Copy: true
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+         Hypertable: test
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1000000 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < transaction_timestamp())
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                     Filter: (ts < transaction_timestamp())
+(12 rows)
+
+-- this won't be parallel query because now() is parallel restricted in PG < 12
+:PREFIX SELECT i FROM "test" WHERE ts < now();
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=1000000 loops=1)
+   Hypertable: test
+   Chunks left after exclusion: 2
+   ->  Append (actual rows=1000000 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+               Filter: (ts < now())
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+               Filter: (ts < now())
+(8 rows)
 

--- a/test/expected/parallel-9.6.out
+++ b/test/expected/parallel-9.6.out
@@ -3,6 +3,13 @@
 -- LICENSE-APACHE for a copy of the license.
 --parallel queries require big-ish tables so collect them all here
 --so that we need to generate queries only once.
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 NOTICE:  adding not-null constraint to column "i"
@@ -17,10 +24,10 @@ SET client_min_messages = 'error';
 --avoid warning polluting output
 ANALYZE;
 RESET client_min_messages;
+SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
-EXPLAIN (costs off)
-SELECT first(i, j) FROM "test";
+:PREFIX SELECT first(i, j) FROM "test";
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Finalize Aggregate
@@ -38,8 +45,7 @@ SELECT first(i, j) FROM "test";
      0
 (1 row)
 
-EXPLAIN (costs off)
-SELECT last(i, j) FROM "test";
+:PREFIX SELECT last(i, j) FROM "test";
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Finalize Aggregate
@@ -57,8 +63,8 @@ SELECT last(i, j) FROM "test";
  999999
 (1 row)
 
-EXPLAIN (costs off)
-SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- we dont run this with analyze because the sort memory usage is not stable
+EXPLAIN (costs off) SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 GROUP BY sec
 ORDER BY sec
@@ -165,4 +171,91 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 -------------------------------------------
  {10,19998,19998,19998,19998,19998,900000}
 (1 row)
+
+-- test constraint aware append
+:PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Gather
+   Workers Planned: 1
+   Single Copy: true
+   ->  Result
+         One-Time Filter: (length(version()) > 0)
+         ->  Custom Scan (ConstraintAwareAppend)
+               Hypertable: test
+               Chunks left after exclusion: 2
+               ->  Append
+                     ->  Seq Scan on _hyper_1_1_chunk
+                     ->  Seq Scan on _hyper_1_2_chunk
+(11 rows)
+
+-- test constraint aware append with parallel aggregation
+:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Result
+                     One-Time Filter: (length(version()) > 0)
+                     ->  Custom Scan (ConstraintAwareAppend)
+                           Hypertable: test
+                           Chunks left after exclusion: 2
+                           ->  Append
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk
+(12 rows)
+
+SELECT count(*) FROM "test" WHERE length(version()) > 0;
+  count  
+---------
+ 1000000
+(1 row)
+
+-- now() is not marked parallel safe in PostgreSQL < 12 so using now()
+-- in a query will prevent parallelism but CURRENT_TIMESTAMP and
+-- transaction_timestamp() are marked parallel safe
+:PREFIX SELECT i FROM "test" WHERE ts < CURRENT_TIMESTAMP;
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: test
+   Chunks left after exclusion: 2
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (ts < now())
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (ts < now())
+(8 rows)
+
+:PREFIX SELECT i FROM "test" WHERE ts < transaction_timestamp();
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather
+   Workers Planned: 1
+   Single Copy: true
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: test
+         Chunks left after exclusion: 2
+         ->  Append
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: (ts < transaction_timestamp())
+               ->  Seq Scan on _hyper_1_2_chunk
+                     Filter: (ts < transaction_timestamp())
+(11 rows)
+
+-- this won't be parallel query because now() is parallel restricted in PG < 12
+:PREFIX SELECT i FROM "test" WHERE ts < now();
+                QUERY PLAN                
+------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: test
+   Chunks left after exclusion: 2
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (ts < now())
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (ts < now())
+(8 rows)
 

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -19,6 +19,15 @@ SELECT
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+-- create a now() function for repeatable testing that always returns
+-- the same timestamp. It needs to be marked STABLE
+CREATE OR REPLACE FUNCTION now_s()
+RETURNS timestamptz LANGUAGE PLPGSQL STABLE AS
+$BODY$
+BEGIN
+    RETURN '2000-01-08T0:00:00+0'::timestamptz;
+END;
+$BODY$;
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');
@@ -244,6 +253,76 @@ ORDER BY time DESC LIMIT 1;
          ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
 (6 rows)
+
+-- test interaction with constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s()
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" > now_s())
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+                     Index Cond: ("time" > now_s())
+(9 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s()
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" < now_s())
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                     Index Cond: ("time" < now_s())
+(9 rows)
+
+-- test interaction withi constraint exclusion and constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s() AND time < '2000-01-10'
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 1
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: (("time" > now_s()) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s() AND time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 1
+         ->  Append (actual rows=0 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Index Cond: (("time" < now_s()) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
 
 -- min/max queries
 :PREFIX SELECT max(time) FROM ordered_append;

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -19,6 +19,15 @@ SELECT
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+-- create a now() function for repeatable testing that always returns
+-- the same timestamp. It needs to be marked STABLE
+CREATE OR REPLACE FUNCTION now_s()
+RETURNS timestamptz LANGUAGE PLPGSQL STABLE AS
+$BODY$
+BEGIN
+    RETURN '2000-01-08T0:00:00+0'::timestamptz;
+END;
+$BODY$;
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');
@@ -244,6 +253,76 @@ ORDER BY time DESC LIMIT 1;
          ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
 (6 rows)
+
+-- test interaction with constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s()
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" > now_s())
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (never executed)
+                     Index Cond: ("time" > now_s())
+(9 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s()
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 2
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" < now_s())
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+                     Index Cond: ("time" < now_s())
+(9 rows)
+
+-- test interaction withi constraint exclusion and constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s() AND time < '2000-01-10'
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=1 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 1
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: (("time" > now_s()) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s() AND time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 1
+         ->  Append (actual rows=0 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Index Cond: (("time" < now_s()) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
 
 -- min/max queries
 :PREFIX SELECT max(time) FROM ordered_append;

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -19,6 +19,15 @@ SELECT
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+-- create a now() function for repeatable testing that always returns
+-- the same timestamp. It needs to be marked STABLE
+CREATE OR REPLACE FUNCTION now_s()
+RETURNS timestamptz LANGUAGE PLPGSQL STABLE AS
+$BODY$
+BEGIN
+    RETURN '2000-01-08T0:00:00+0'::timestamptz;
+END;
+$BODY$;
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');
@@ -242,6 +251,76 @@ ORDER BY time DESC LIMIT 1;
          ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
 (6 rows)
+
+-- test interaction with constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s()
+ORDER BY time ASC LIMIT 1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 2
+         ->  Append
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                     Index Cond: ("time" > now_s())
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk
+                     Index Cond: ("time" > now_s())
+(9 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s()
+ORDER BY time ASC LIMIT 1;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 2
+         ->  Append
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
+                     Index Cond: ("time" < now_s())
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                     Index Cond: ("time" < now_s())
+(9 rows)
+
+-- test interaction withi constraint exclusion and constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s() AND time < '2000-01-10'
+ORDER BY time ASC LIMIT 1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 1
+         ->  Append
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                     Index Cond: (("time" > now_s()) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s() AND time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: ordered_append
+         Chunks left after exclusion: 1
+         ->  Append
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
+                     Index Cond: (("time" < now_s()) AND ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
 
 -- min/max queries
 :PREFIX SELECT max(time) FROM ordered_append;

--- a/test/sql/include/append.sql
+++ b/test/sql/include/append.sql
@@ -195,4 +195,3 @@ WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 h
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
 
-

--- a/test/sql/include/plan_ordered_append_load.sql
+++ b/test/sql/include/plan_ordered_append_load.sql
@@ -2,6 +2,16 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+-- create a now() function for repeatable testing that always returns
+-- the same timestamp. It needs to be marked STABLE
+CREATE OR REPLACE FUNCTION now_s()
+RETURNS timestamptz LANGUAGE PLPGSQL STABLE AS
+$BODY$
+BEGIN
+    RETURN '2000-01-08T0:00:00+0'::timestamptz;
+END;
+$BODY$;
+
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');

--- a/test/sql/include/plan_ordered_append_query.sql
+++ b/test/sql/include/plan_ordered_append_query.sql
@@ -88,6 +88,32 @@ FROM ordered_append
 WHERE time > '2000-01-07'
 ORDER BY time DESC LIMIT 1;
 
+-- test interaction with constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s()
+ORDER BY time ASC LIMIT 1;
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s()
+ORDER BY time ASC LIMIT 1;
+
+-- test interaction withi constraint exclusion and constraint aware append
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time > now_s() AND time < '2000-01-10'
+ORDER BY time ASC LIMIT 1;
+
+:PREFIX SELECT
+  time, device_id, value
+FROM ordered_append
+WHERE time < now_s() AND time > '2000-01-07'
+ORDER BY time ASC LIMIT 1;
+
 -- min/max queries
 :PREFIX SELECT max(time) FROM ordered_append;
 

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -5,6 +5,14 @@
 --parallel queries require big-ish tables so collect them all here
 --so that we need to generate queries only once.
 
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 --has to be big enough to force at least 2 workers below.
@@ -15,19 +23,18 @@ SET client_min_messages = 'error';
 ANALYZE;
 RESET client_min_messages;
 
+SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
 
-EXPLAIN (costs off)
-SELECT first(i, j) FROM "test";
+:PREFIX SELECT first(i, j) FROM "test";
 SELECT first(i, j) FROM "test";
 
-EXPLAIN (costs off)
-SELECT last(i, j) FROM "test";
+:PREFIX SELECT last(i, j) FROM "test";
 SELECT last(i, j) FROM "test";
 
-EXPLAIN (costs off)
-SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- we dont run this with analyze because the sort memory usage is not stable
+EXPLAIN (costs off) SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 GROUP BY sec
 ORDER BY sec
@@ -51,3 +58,21 @@ SELECT histogram(i, 0, 100000, 5) FROM "test";
 
 EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
 SELECT histogram(i, 10, 100000, 5) FROM "test";
+
+-- test constraint aware append
+:PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
+
+-- test constraint aware append with parallel aggregation
+:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
+SELECT count(*) FROM "test" WHERE length(version()) > 0;
+
+-- now() is not marked parallel safe in PostgreSQL < 12 so using now()
+-- in a query will prevent parallelism but CURRENT_TIMESTAMP and
+-- transaction_timestamp() are marked parallel safe
+:PREFIX SELECT i FROM "test" WHERE ts < CURRENT_TIMESTAMP;
+
+:PREFIX SELECT i FROM "test" WHERE ts < transaction_timestamp();
+
+-- this won't be parallel query because now() is parallel restricted in PG < 12
+:PREFIX SELECT i FROM "test" WHERE ts < now();
+


### PR DESCRIPTION
Constraint aware append used some planner data structures in the
executor which cannot be serialized so they will not be available
in parallel workers, this patch refactors this and marks the
constraint aware append node as parallel safe when the subpath is
parallel safe. The additional function executions in the test output
are because the constify is run once per chunk now, previously it run
only once and the result was copied to the restrictinfo of every chunk
and then adjusted for the chunk, but since the adjustment for the chunk
has to happen in the planner because it needs access to appendrelinfo
we now create per chunk restrictinfo in the planner and constify each of
these in the executor.

On PostgreSQL < 12 now() is not parallel safe
and using now() in a query will prevent parallelism as a workaround
transaction_timestamp() or CURRENT_TIMESTAMP can be used which
will not prevent parallelism.