### PR TITLE
Add .editorconfig for better github display

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.{c,h}]
+indent_style = tab
+indent_size = 4
+
+[*.out]
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
Our code uses a tabwidth = 4. By default, github displays everything
with tabwidth = 8. But github respects .editorconfig files. So
this commit adds the appropriate .editorconfig.