### PR TITLE
Fix off by 1 error in gapfill/exec.c:foreach_column

### DIFF
--- a/tsl/src/gapfill/exec.c
+++ b/tsl/src/gapfill/exec.c
@@ -45,8 +45,10 @@ typedef union GapFillColumnStateUnion
 } GapFillColumnStateUnion;
 
 #define foreach_column(column, index, state)                                                       \
-	for ((index) = 0, (column) = (state)->columns[index]; (index) < (state)->ncolumns;             \
-		 (index)++, (column) = (state)->columns[index])
+	Assert((state)->ncolumns > 0);                                                                 \
+	for ((index) = 0, (column) = (state)->columns[index];                                          \
+		 (index) < (state)->ncolumns && ((column) = (state)->columns[index], true);                \
+		 (index)++)
 
 static void gapfill_begin(CustomScanState *node, EState *estate, int eflags);
 static void gapfill_end(CustomScanState *node);


### PR DESCRIPTION
We cannot access the column array in the increment; at that point we do
not yet know if the access is in bounds. Fixed by moving it to the
condition