### PR TITLE
Force sanitizer tests to run serially

### DIFF
--- a/scripts/test_sanitizers.sh
+++ b/scripts/test_sanitizers.sh
@@ -93,7 +93,7 @@ docker exec -u postgres \
     -e CMAKE_BUILD_TYPE="Debug" \
     -e PG_SOURCE_DIR="/usr/src/postgresql/" \
     timescaledb-san /bin/bash -c \
-    "cd /tsdb_build/timescaledb && BUILD_FORCE_REMOVE=true ./bootstrap && cd build && make"
+    "cd /tsdb_build/timescaledb && BUILD_FORCE_REMOVE=true ./bootstrap -DTEST_GROUP_SIZE=1 && cd build && make"
 
 wait_for_pg timescaledb-san
 

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -160,7 +160,14 @@ endforeach(TEMPLATE_FILE)
 
 list(SORT TEST_FILES)
 file(REMOVE ${TEST_SCHEDULE})
-set(PARALLEL_GROUP_SIZE 20)
+
+if(NOT TEST_GROUP_SIZE)
+  set(PARALLEL_GROUP_SIZE 20)
+else()
+  set(PARALLEL_GROUP_SIZE ${TEST_GROUP_SIZE})
+endif()
+
+message("PGC ${PARALLEL_GROUP_SIZE} ${TEST_GROUP_SIZE}")
 
 # append solo tests to schedule first
 foreach(TEST_FILE ${TEST_FILES})
@@ -183,11 +190,16 @@ foreach(TEST_FILE ${TEST_FILES})
 endforeach(TEST_FILE)
 file(APPEND ${TEST_SCHEDULE} "\n")
 
-file(APPEND ${TEST_SCHEDULE} "test: ")
+
+set(GROUP_MEMBERS 0)
 foreach(TEST_FILE ${TEST_FILES})
   string(REGEX REPLACE "(.+)\.sql" "\\1" TESTS_TO_RUN ${TEST_FILE})
   if(TESTS_TO_RUN IN_LIST POST_TESTS)
+    if(GROUP_MEMBERS EQUAL 0)
+      file(APPEND ${TEST_SCHEDULE} "\ntest: ")
+    endif()
     file(APPEND ${TEST_SCHEDULE} "${TESTS_TO_RUN} ")
+    MATH(EXPR GROUP_MEMBERS "(${GROUP_MEMBERS}+1)%${PARALLEL_GROUP_SIZE}")
   endif()
 endforeach(TEST_FILE)
 file(APPEND ${TEST_SCHEDULE} "\n")


### PR DESCRIPTION
With the forthcoming new sanitizer image running tests in parallel
causes machines to run out of resources, and fail tests spuriously
This commit forces test_sanitizers.sh to run tests sequentially to
prevent this.