### PR TITLE
Fix compatibility with extensions that define planner_hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ accidentally triggering the load of a previous DB version.**
 * PR #1067 Add treat_null_as_missing option to locf
 
 **Bugfixes**
+* PR #1089 Fix compatibility with extensions that define planner_hook
 * [5a3edfd] Fix chunk exclusion constraint type inference
 * [8e86bda] Fix sort_transform optimization
+
+**Thanks**
+* @esatterwhite for reporting a bug when using timescaledb with zombodb
+* @eeeebbbbrrrr for fixing compatibility with extensions that also define planner_hook
 
 ## 1.2.1 (2019-02-11)
 

--- a/src/planner.c
+++ b/src/planner.c
@@ -143,10 +143,10 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 
 	if (prev_planner_hook != NULL)
 		/* Call any earlier hooks */
-		return (prev_planner_hook)(parse, cursor_opts, bound_params);
-
-	/* Call the standard planner */
-	stmt = standard_planner(parse, cursor_opts, bound_params);
+		stmt = (prev_planner_hook)(parse, cursor_opts, bound_params);
+	else
+		/* Call the standard planner */
+		stmt = standard_planner(parse, cursor_opts, bound_params);
 
 	/*
 	 * Our top-level HypertableInsert plan node that wraps ModifyTable needs


### PR DESCRIPTION
When using timescaledb with extensions that define their own
planner_hook the targetlist adjustments required for hypertable
inserts to work would never run. This patch fixes compatibility
with extensions that define their own planner_hook.

Fixes #1083 