### PR TITLE
Add post_standard_planner_hook to ts_cm_functions

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -168,6 +168,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.remove_drop_chunks_policy = error_no_default_fn_pg_enterprise,
 	.remove_reorder_policy = error_no_default_fn_pg_enterprise,
 	.create_upper_paths_hook = NULL,
+	.post_standard_planner_hook = NULL,
 	.gapfill_marker = error_no_default_fn_pg_community,
 	.gapfill_int16_time_bucket = error_no_default_fn_pg_community,
 	.gapfill_int32_time_bucket = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -42,6 +42,7 @@ typedef struct CrossModuleFunctions
 	Datum (*remove_drop_chunks_policy)(PG_FUNCTION_ARGS);
 	Datum (*remove_reorder_policy)(PG_FUNCTION_ARGS);
 	void (*create_upper_paths_hook)(PlannerInfo *, UpperRelationKind, RelOptInfo *, RelOptInfo *);
+	void (*post_standard_planner_hook)(PlannedStmt *, Query *, int, ParamListInfo);
 	PGFunction gapfill_marker;
 	PGFunction gapfill_int16_time_bucket;
 	PGFunction gapfill_int32_time_bucket;

--- a/src/planner.c
+++ b/src/planner.c
@@ -148,6 +148,9 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 		/* Call the standard planner */
 		stmt = standard_planner(parse, cursor_opts, bound_params);
 
+	if (ts_cm_functions->post_standard_planner_hook != NULL)
+		ts_cm_functions->post_standard_planner_hook(stmt, parse, cursor_opts, bound_params);
+
 	/*
 	 * Our top-level HypertableInsert plan node that wraps ModifyTable needs
 	 * to have a final target list that is the same as the ModifyTable plan

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -57,6 +57,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.add_reorder_policy = reorder_add_policy,
 	.remove_drop_chunks_policy = drop_chunks_remove_policy,
 	.remove_reorder_policy = reorder_remove_policy,
+	.post_standard_planner_hook = post_standard_planner_hook,
 	.create_upper_paths_hook = tsl_create_upper_paths_hook,
 	.gapfill_marker = gapfill_marker,
 	.gapfill_int16_time_bucket = gapfill_int16_time_bucket,

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -14,3 +14,9 @@ tsl_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptIn
 	if (UPPERREL_GROUP_AGG == stage)
 		plan_add_gapfill(root, output_rel);
 }
+
+void
+post_standard_planner_hook(PlannedStmt *stmt, Query *parse, int cursor_opts,
+						   ParamListInfo bound_params)
+{
+}

--- a/tsl/src/planner.h
+++ b/tsl/src/planner.h
@@ -9,5 +9,7 @@
 #include <optimizer/planner.h>
 
 void tsl_create_upper_paths_hook(PlannerInfo *, UpperRelationKind, RelOptInfo *, RelOptInfo *);
+void post_standard_planner_hook(PlannedStmt *stmt, Query *parse, int cursor_opts,
+								ParamListInfo bound_params);
 
 #endif /* TIMESCALEDB_TSL_PLANNER_H */


### PR DESCRIPTION
Add a new hook post_standard_planner_hook to enable tsl code
to modify the plan after PostgreSQL set_plan_refs has run.