### PR TITLE
Set random_page_cost to 1.0 for tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,6 +73,8 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "max_worker_processes=16"
 
+    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "random_page_cost=1.0"
+
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'"
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned_version='0.0.1'"

--- a/test/expected/agg_bookends_optimized-10.out
+++ b/test/expected/agg_bookends_optimized-10.out
@@ -23,13 +23,12 @@ INSERT INTO "btest" VALUES('2017-01-20T09:00:21', '2017-01-20T09:00:56', 2, 30.2
 --TOASTED;
 INSERT INTO "btest" VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1, repeat('xyz', 1000000) );
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
-                QUERY PLAN                
-------------------------------------------
- Sort
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Merge Append
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Append
-         ->  Seq Scan on _hyper_1_1_chunk
-(4 rows)
+   ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk
+(3 rows)
 
 :PREFIX SELECT last(temp, time) FROM "btest";
                                         QUERY PLAN                                        

--- a/test/expected/agg_bookends_optimized-9.6.out
+++ b/test/expected/agg_bookends_optimized-9.6.out
@@ -23,13 +23,12 @@ INSERT INTO "btest" VALUES('2017-01-20T09:00:21', '2017-01-20T09:00:56', 2, 30.2
 --TOASTED;
 INSERT INTO "btest" VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1, repeat('xyz', 1000000) );
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
-                QUERY PLAN                
-------------------------------------------
- Sort
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Merge Append
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Append
-         ->  Seq Scan on _hyper_1_1_chunk
-(4 rows)
+   ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk
+(3 rows)
 
 :PREFIX SELECT last(temp, time) FROM "btest";
                                         QUERY PLAN                                        

--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -6,7 +6,6 @@ SET timescaledb.disable_optimizations = OFF;
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
-SET random_page_cost TO 1.0;
 -- create a now() function for repeatable testing that always returns
 -- the same timestamp. It needs to be marked STABLE
 CREATE OR REPLACE FUNCTION now_s()
@@ -35,7 +34,7 @@ END;
 $BODY$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:36: NOTICE:  adding not-null constraint to column "time"
+psql:include/append.sql:35: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,append_test,t)
@@ -50,12 +49,12 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
 -- query should exclude all chunks with optimization on
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() + '1 month';
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
              QUERY PLAN              
 -------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -64,12 +63,12 @@ psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 (3 rows)
 
 SELECT * FROM append_test WHERE time > now_s() + '1 month';
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
  time | temp | colorid 
 ------+------+---------
 (0 rows)
@@ -78,12 +77,12 @@ psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() + '1 month'
 ORDER BY time DESC limit 1;
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
                 QUERY PLAN                 
 -------------------------------------------
  Limit
@@ -98,12 +97,12 @@ psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
 -- cannot hold tuples
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -116,13 +115,13 @@ psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -133,12 +132,12 @@ psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Limit
@@ -153,13 +152,13 @@ psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -171,7 +170,7 @@ psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:80: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:79: NOTICE:  Immutable function now_i() called!
                                                        QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -207,11 +206,11 @@ ORDER BY time;
 
 SELECT * FROM append_test WHERE time > now_v() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -223,13 +222,13 @@ PREPARE query_opt AS
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time;
 EXECUTE query_opt;
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -237,9 +236,9 @@ psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
 
 EXPLAIN (costs off)
 EXECUTE query_opt;
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:101: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:101: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:101: NOTICE:  Stable function now_s() called!
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
@@ -256,14 +255,14 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
               t               | avg  
 ------------------------------+------
  Sun Jan 01 00:00:00 2017 PST | 28.5
@@ -275,12 +274,12 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -324,7 +323,7 @@ PREPARE query_param AS
 SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 EXPLAIN (costs off)
 EXECUTE query_param(now_s() - interval '2 months');
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:134: NOTICE:  Stable function now_s() called!
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Merge Append
@@ -351,12 +350,12 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Merge Left Join
@@ -403,15 +402,15 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
             btime             | value 
 ------------------------------+-------
  Fri Mar 03 16:00:00 2017 PST |  22.5
@@ -425,7 +424,7 @@ psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:177: NOTICE:  adding not-null constraint to column "time"
+psql:include/append.sql:176: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -443,18 +442,18 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
  Nested Loop
@@ -476,20 +475,20 @@ psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
              time             | temp | colorid |             time             | temp | colorid 
 ------------------------------+------+---------+------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3 | Tue Aug 22 09:18:22 2017 PDT | 23.1 |       3

--- a/test/expected/append_unoptimized.out
+++ b/test/expected/append_unoptimized.out
@@ -6,7 +6,6 @@ SET timescaledb.disable_optimizations = ON;
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
-SET random_page_cost TO 1.0;
 -- create a now() function for repeatable testing that always returns
 -- the same timestamp. It needs to be marked STABLE
 CREATE OR REPLACE FUNCTION now_s()
@@ -35,7 +34,7 @@ END;
 $BODY$;
 CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:36: NOTICE:  adding not-null constraint to column "time"
+psql:include/append.sql:35: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
  (1,public,append_test,t)
@@ -50,10 +49,10 @@ INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
 -- query should exclude all chunks with optimization on
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() + '1 month';
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
  Append
@@ -68,13 +67,13 @@ psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
 (9 rows)
 
 SELECT * FROM append_test WHERE time > now_s() + '1 month';
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
  time | temp | colorid 
 ------+------+---------
 (0 rows)
@@ -83,10 +82,10 @@ psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() + '1 month'
 ORDER BY time DESC limit 1;
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Limit
@@ -108,10 +107,10 @@ psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
 -- cannot hold tuples
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
                                     QUERY PLAN                                    
 ----------------------------------------------------------------------------------
  Append
@@ -127,13 +126,13 @@ psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
 
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months';
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:62: NOTICE:  Stable function now_s() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -144,10 +143,10 @@ psql:include/append.sql:63: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit
@@ -166,14 +165,14 @@ psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
 -- the expected output should be the same as the non-optimized query
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time LIMIT 3;
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -185,7 +184,7 @@ psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
 EXPLAIN (costs off)
 SELECT * FROM append_test WHERE time > now_i() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:80: NOTICE:  Immutable function now_i() called!
+psql:include/append.sql:79: NOTICE:  Immutable function now_i() called!
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Merge Append
@@ -223,11 +222,11 @@ ORDER BY time;
 
 SELECT * FROM append_test WHERE time > now_v() - interval '2 months'
 ORDER BY time;
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
-psql:include/append.sql:91: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
+psql:include/append.sql:90: NOTICE:  Volatile function now_v() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -239,14 +238,14 @@ PREPARE query_opt AS
 SELECT * FROM append_test WHERE time > now_s() - interval '2 months'
 ORDER BY time;
 EXECUTE query_opt;
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
              time             | temp | colorid 
 ------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3
@@ -273,13 +272,13 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
               t               | avg  
 ------------------------------+------
  Sun Jan 01 00:00:00 2017 PST | 28.5
@@ -291,10 +290,10 @@ SELECT date_trunc('year', time) t, avg(temp) FROM append_test
 WHERE time > now_s() - interval '4 months'
 GROUP BY t
 ORDER BY t DESC;
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
                                              QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Sort
@@ -342,7 +341,7 @@ PREPARE query_param AS
 SELECT * FROM append_test WHERE time > $1 ORDER BY time;
 EXPLAIN (costs off)
 EXECUTE query_param(now_s() - interval '2 months');
-psql:include/append.sql:135: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:134: NOTICE:  Stable function now_s() called!
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Merge Append
@@ -371,10 +370,10 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Merge Left Join
@@ -421,13 +420,13 @@ SELECT period.btime, VALUE
     FROM period
     LEFT JOIN DATA USING (btime)
     ORDER BY period.btime;
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
             btime             | value 
 ------------------------------+-------
  Fri Mar 03 16:00:00 2017 PST |  22.5
@@ -441,7 +440,7 @@ psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
-psql:include/append.sql:177: NOTICE:  adding not-null constraint to column "time"
+psql:include/append.sql:176: NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
  (2,public,join_test,t)
@@ -459,14 +458,14 @@ set enable_material = 'off';
 EXPLAIN (costs off)
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
                                          QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Nested Loop
@@ -494,20 +493,20 @@ psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
 -- result should be the same as when optimizations are turned off
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
-psql:include/append.sql:196: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
+psql:include/append.sql:195: NOTICE:  Stable function now_s() called!
              time             | temp | colorid |             time             | temp | colorid 
 ------------------------------+------+---------+------------------------------+------+---------
  Tue Aug 22 09:18:22 2017 PDT | 34.1 |       3 | Tue Aug 22 09:18:22 2017 PDT | 23.1 |       3

--- a/test/expected/append_x_diff.out
+++ b/test/expected/append_x_diff.out
@@ -7,7 +7,7 @@
 < SET timescaledb.disable_optimizations = ON;
 ---
 > SET timescaledb.disable_optimizations = OFF;
-57,68c57,64
+56,67c56,63
 <                                     QUERY PLAN                                    
 < ----------------------------------------------------------------------------------
 <  Append
@@ -21,25 +21,25 @@
 <          Index Cond: ("time" > (now_s() + '@ 1 mon'::interval))
 < (9 rows)
 ---
-> psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:46: NOTICE:  Stable function now_s() called!
 >              QUERY PLAN              
 > -------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
 >    Hypertable: append_test
 >    Chunks left after exclusion: 0
 > (3 rows)
-77d72
-< psql:include/append.sql:48: NOTICE:  Stable function now_s() called!
-90,91c85,88
+76d71
+< psql:include/append.sql:47: NOTICE:  Stable function now_s() called!
+89,90c84,87
 <                                        QUERY PLAN                                       
 < ----------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:53: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:52: NOTICE:  Stable function now_s() called!
 >                 QUERY PLAN                 
 > -------------------------------------------
-93,103c90,93
+92,102c89,92
 <    ->  Merge Append
 <          Sort Key: append_test."time" DESC
 <          ->  Index Scan using append_test_time_idx on append_test
@@ -56,7 +56,7 @@
 >          Hypertable: append_test
 >          Chunks left after exclusion: 0
 > (4 rows)
-115,126c105,115
+114,125c104,114
 <                                     QUERY PLAN                                    
 < ----------------------------------------------------------------------------------
 <  Append
@@ -70,8 +70,8 @@
 <          Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 < (9 rows)
 ---
-> psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:60: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:59: NOTICE:  Stable function now_s() called!
 >                                        QUERY PLAN                                       
 > ----------------------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
@@ -81,15 +81,15 @@
 >          ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (6 rows)
-151,152c140,143
+150,151c139,142
 <                                            QUERY PLAN                                            
 < -------------------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:69: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:68: NOTICE:  Stable function now_s() called!
 >                                               QUERY PLAN                                               
 > -------------------------------------------------------------------------------------------------------
-154,164c145,151
+153,163c144,150
 <    ->  Merge Append
 <          Sort Key: append_test."time"
 <          ->  Index Scan Backward using append_test_time_idx on append_test
@@ -109,9 +109,9 @@
 >                ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                      Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (7 rows)
-176d162
-< psql:include/append.sql:73: NOTICE:  Stable function now_s() called!
-189,201c175,184
+175d161
+< psql:include/append.sql:72: NOTICE:  Stable function now_s() called!
+188,200c174,183
 <                                                     QUERY PLAN                                                    
 < ------------------------------------------------------------------------------------------------------------------
 <  Merge Append
@@ -136,7 +136,7 @@
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
 > (7 rows)
-210,222c193,206
+209,221c192,205
 <                                         QUERY PLAN                                         
 < -------------------------------------------------------------------------------------------
 <  Merge Append
@@ -165,9 +165,9 @@
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
 > (11 rows)
-249d232
-< psql:include/append.sql:99: NOTICE:  Stable function now_s() called!
-257,269c240,252
+248d231
+< psql:include/append.sql:98: NOTICE:  Stable function now_s() called!
+256,268c239,251
 <                                         QUERY PLAN                                         
 < -------------------------------------------------------------------------------------------
 <  Merge Append
@@ -182,9 +182,9 @@
 <          Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 < (10 rows)
 ---
-> psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:102: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:101: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:101: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:101: NOTICE:  Stable function now_s() called!
 >                                            QUERY PLAN                                            
 > -------------------------------------------------------------------------------------------------
 >  Custom Scan (ConstraintAwareAppend)
@@ -195,41 +195,41 @@
 >          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 >                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
 > (7 rows)
-282a266
-> psql:include/append.sql:108: NOTICE:  Stable function now_s() called!
-297a282,283
-> psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:115: NOTICE:  Stable function now_s() called!
-304c290,292
+281a265
+> psql:include/append.sql:107: NOTICE:  Stable function now_s() called!
+296a281,282
+> psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:114: NOTICE:  Stable function now_s() called!
+303c289,291
 <          ->  Result
 ---
 >          ->  Custom Scan (ConstraintAwareAppend)
 >                Hypertable: append_test
 >                Chunks left after exclusion: 2
-306,309d293
+305,308d292
 <                      ->  Seq Scan on append_test
 <                            Filter: ("time" > (now_s() - '@ 4 mons'::interval))
 <                      ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
 <                            Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-314c298
+313c297
 < (14 rows)
 ---
 > (12 rows)
-326,327c310,311
+325,326c309,310
 <                                                                                                              QUERY PLAN                                                                                                              
 < -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                         QUERY PLAN                         
 > -----------------------------------------------------------
-329c313
+328c312
 <    Group Key: (date_trunc('year'::text, append_test."time"))
 ---
 >    Group Key: (date_trunc('year'::text, "time"))
-331c315
+330c314
 <          Sort Key: (date_trunc('year'::text, append_test."time")) DESC
 ---
 >          Sort Key: (date_trunc('year'::text, "time")) DESC
-333,336c317,318
+332,335c316,317
 <                ->  Append
 <                      ->  Seq Scan on append_test
 <                            Filter: (("time" < 'Tue Mar 22 00:00:00 2016 PDT'::timestamp with time zone) AND (date_part('dow'::text, "time") >= '1'::double precision) AND (date_part('dow'::text, "time") <= '5'::double precision))
@@ -237,58 +237,58 @@
 ---
 >                One-Time Filter: false
 > (6 rows)
-349,351c331
+348,350c330
 <    Sort Key: append_test."time"
 <    ->  Index Scan Backward using append_test_time_idx on append_test
 <          Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
 ---
 >    Sort Key: _hyper_1_3_chunk."time"
-354c334
+353c333
 < (6 rows)
 ---
 > (4 rows)
-378,379c358,361
+377,378c357,360
 <                                               QUERY PLAN                                               
 < -------------------------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:154: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:153: NOTICE:  Stable function now_s() called!
 >                                                   QUERY PLAN                                                   
 > ---------------------------------------------------------------------------------------------------------------
-385c367,369
+384c366,368
 <            ->  Result
 ---
 >            ->  Custom Scan (ConstraintAwareAppend)
 >                  Hypertable: append_test
 >                  Chunks left after exclusion: 3
-387,389c371
+386,388c370
 <                        ->  Seq Scan on append_test
 <                              Filter: ((colorid > 0) AND ("time" > (now_s() - '@ 400 days'::interval)))
 <                        ->  Index Scan using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
-392c374
+391c373
 <                        ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
-395c377
+394c376
 <                        ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
 ---
 >                        ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
-430a413,414
-> psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:171: NOTICE:  Stable function now_s() called!
-470,471c454,459
+429a412,413
+> psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:170: NOTICE:  Stable function now_s() called!
+469,470c453,458
 <                                          QUERY PLAN                                         
 < --------------------------------------------------------------------------------------------
 ---
-> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
-> psql:include/append.sql:192: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
+> psql:include/append.sql:191: NOTICE:  Stable function now_s() called!
 >                                             QUERY PLAN                                            
 > --------------------------------------------------------------------------------------------------
-474,492c462,474
+473,491c461,473
 <    ->  Append
 <          ->  Seq Scan on append_test a
 <                Filter: ("time" > (now_s() - '@ 3 hours'::interval))

--- a/test/expected/ddl_alter_column.out
+++ b/test/expected/ddl_alter_column.out
@@ -47,18 +47,14 @@ SELECT * FROM _timescaledb_catalog.dimension;
 
 EXPLAIN (costs off)
 SELECT * FROM alter_test WHERE time > '2017-05-20T10:00:01';
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Append
-   ->  Bitmap Heap Scan on _hyper_1_2_chunk
-         Recheck Cond: ("time" > 'Sat May 20 10:00:01 2017 PDT'::timestamp with time zone)
-         ->  Bitmap Index Scan on _hyper_1_2_chunk_alter_test_time_idx
-               Index Cond: ("time" > 'Sat May 20 10:00:01 2017 PDT'::timestamp with time zone)
-   ->  Bitmap Heap Scan on _hyper_1_3_chunk
-         Recheck Cond: ("time" > 'Sat May 20 10:00:01 2017 PDT'::timestamp with time zone)
-         ->  Bitmap Index Scan on _hyper_1_3_chunk_alter_test_time_idx
-               Index Cond: ("time" > 'Sat May 20 10:00:01 2017 PDT'::timestamp with time zone)
-(9 rows)
+   ->  Index Scan using _hyper_1_2_chunk_alter_test_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" > 'Sat May 20 10:00:01 2017 PDT'::timestamp with time zone)
+   ->  Index Scan using _hyper_1_3_chunk_alter_test_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" > 'Sat May 20 10:00:01 2017 PDT'::timestamp with time zone)
+(5 rows)
 
 -- rename column and change its type
 ALTER TABLE alter_test RENAME COLUMN time TO time_us;

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -439,14 +439,12 @@ INSERT INTO index_expr_test VALUES ('2017-01-20T09:00:01', 17.5, '{"field": "val
 INSERT INTO index_expr_test VALUES ('2017-01-20T09:00:01', 17.5, '{"field": "value2"}');
 EXPLAIN (verbose, costs off)
 SELECT * FROM index_expr_test WHERE meta ->> 'field' = 'value1';
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Bitmap Heap Scan on public.index_expr_test
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Index Scan using index_expr_test_expr_idx on public.index_expr_test
    Output: "time", temp, meta
-   Recheck Cond: ((index_expr_test.meta ->> 'field'::text) = 'value1'::text)
-   ->  Bitmap Index Scan on index_expr_test_expr_idx
-         Index Cond: ((index_expr_test.meta ->> 'field'::text) = 'value1'::text)
-(5 rows)
+   Index Cond: ((index_expr_test.meta ->> 'field'::text) = 'value1'::text)
+(3 rows)
 
 SELECT * FROM index_expr_test WHERE meta ->> 'field' = 'value1';
              time             | temp |        meta         

--- a/test/expected/plan_expand_hypertable_optimized-11.out
+++ b/test/expected/plan_expand_hypertable_optimized-11.out
@@ -858,14 +858,15 @@ SELECT * FROM cte ORDER BY value;
 ----------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: _hyper_3_116_chunk.value
-   ->  Hash Join
-         Hash Cond: (tag.id = _hyper_3_116_chunk.tag_id)
-         ->  Seq Scan on tag
-         ->  Hash
+   ->  Merge Join
+         Merge Cond: (tag.id = _hyper_3_116_chunk.tag_id)
+         ->  Index Scan using tag_pkey on tag
+         ->  Sort
+               Sort Key: _hyper_3_116_chunk.tag_id
                ->  Append
                      ->  Seq Scan on _hyper_3_116_chunk
                            Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
-(9 rows)
+(10 rows)
 
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE tag.name = 'tag1' and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
                                                             QUERY PLAN                                                            
@@ -1139,14 +1140,15 @@ SET constraint_exclusion = 'off';
 ----------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: h.value
-   ->  Hash Join
-         Hash Cond: (tag.id = h.tag_id)
-         ->  Seq Scan on tag
-         ->  Hash
+   ->  Merge Join
+         Merge Cond: (tag.id = h.tag_id)
+         ->  Index Scan using tag_pkey on tag
+         ->  Sort
+               Sort Key: h.tag_id
                ->  Append
                      ->  Seq Scan on _hyper_3_116_chunk h
                            Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
-(9 rows)
+(10 rows)
 
 :PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
                          QUERY PLAN                          

--- a/test/expected/rowsecurity-10.out
+++ b/test/expected/rowsecurity-10.out
@@ -114,11 +114,11 @@ CREATE POLICY p1r ON document AS RESTRICTIVE TO regress_rls_dave
                     |          |       | =arwdDxt/regress_rls_alice                  |                   |   (u): (dlevel <= ( SELECT uaccount.seclv +
                     |          |       |                                             |                   |    FROM uaccount                          +
                     |          |       |                                             |                   |   WHERE (uaccount.pguser = CURRENT_USER)))+
-                    |          |       |                                             |                   | p2r (RESTRICTIVE):                        +
-                    |          |       |                                             |                   |   (u): ((cid <> 44) AND (cid < 50))       +
-                    |          |       |                                             |                   |   to: regress_rls_dave                    +
                     |          |       |                                             |                   | p1r (RESTRICTIVE):                        +
                     |          |       |                                             |                   |   (u): (cid <> 44)                        +
+                    |          |       |                                             |                   |   to: regress_rls_dave                    +
+                    |          |       |                                             |                   | p2r (RESTRICTIVE):                        +
+                    |          |       |                                             |                   |   (u): ((cid <> 44) AND (cid < 50))       +
                     |          |       |                                             |                   |   to: regress_rls_dave
  regress_rls_schema | uaccount | table | regress_rls_alice=arwdDxt/regress_rls_alice+|                   | 
                     |          |       | =r/regress_rls_alice                        |                   | 
@@ -497,29 +497,28 @@ EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 (16 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Hash Join
-   Hash Cond: (category.cid = document.cid)
-   ->  Seq Scan on category
-   ->  Hash
-         ->  Custom Scan (ConstraintAwareAppend)
-               Hypertable: document
-               Chunks left after exclusion: 6
-               ->  Append
-                     ->  Seq Scan on _hyper_1_1_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_2_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_3_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_4_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_5_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_6_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-(20 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Nested Loop
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: document
+         Chunks left after exclusion: 6
+         ->  Append
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_2_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_3_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_4_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_5_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_6_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+   ->  Index Scan using category_pkey on category
+         Index Cond: (cid = document.cid)
+(19 rows)
 
 -- interaction of FK/PK constraints
 SET SESSION AUTHORIZATION regress_rls_alice;
@@ -2227,42 +2226,30 @@ CREATE VIEW bv1 WITH (security_barrier) AS SELECT * FROM b1 WHERE a > 0 WITH CHE
 GRANT ALL ON bv1 TO regress_rls_carol;
 SET SESSION AUTHORIZATION regress_rls_carol;
 EXPLAIN (COSTS OFF) SELECT * FROM bv1 WHERE f_leak(b);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Subquery Scan on bv1
    Filter: f_leak(bv1.b)
    ->  Append
-         ->  Bitmap Heap Scan on _hyper_8_43_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_43_chunk_b1_a_idx on _hyper_8_43_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_43_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_42_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_42_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_39_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_39_chunk_b1_a_idx on _hyper_8_39_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_39_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_40_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_40_chunk_b1_a_idx on _hyper_8_40_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_40_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_41_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_41_chunk_b1_a_idx on _hyper_8_41_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_41_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_44_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_44_chunk_b1_a_idx on _hyper_8_44_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_44_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-(33 rows)
+(21 rows)
 
 SELECT * FROM bv1 WHERE f_leak(b);
 NOTICE:  f_leak => c9f0f895fb98ab9159f51fd0297e236d
@@ -2285,36 +2272,32 @@ INSERT INTO bv1 VALUES (11, 'xxx'); -- should fail RLS check
 ERROR:  new row violates row-level security policy for table "b1"
 INSERT INTO bv1 VALUES (12, 'xxx'); -- ok
 EXPLAIN (COSTS OFF) UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Update on b1
    Update on b1
    Update on _hyper_8_41_chunk
    ->  Seq Scan on b1
          Filter: ((a > 0) AND (a = 4) AND ((a % 2) = 0) AND f_leak(b))
-   ->  Bitmap Heap Scan on _hyper_8_41_chunk
-         Recheck Cond: ((a > 0) AND (a = 4))
+   ->  Index Scan using _hyper_8_41_chunk_b1_a_idx on _hyper_8_41_chunk
+         Index Cond: ((a > 0) AND (a = 4))
          Filter: (((a % 2) = 0) AND f_leak(b))
-         ->  Bitmap Index Scan on _hyper_8_41_chunk_b1_a_idx
-               Index Cond: ((a > 0) AND (a = 4))
-(10 rows)
+(8 rows)
 
 UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
 NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 EXPLAIN (COSTS OFF) DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Delete on b1
    Delete on b1
    Delete on _hyper_8_42_chunk
    ->  Seq Scan on b1
          Filter: ((a > 0) AND (a = 6) AND ((a % 2) = 0) AND f_leak(b))
-   ->  Bitmap Heap Scan on _hyper_8_42_chunk
-         Recheck Cond: ((a > 0) AND (a = 6))
+   ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk
+         Index Cond: ((a > 0) AND (a = 6))
          Filter: (((a % 2) = 0) AND f_leak(b))
-         ->  Bitmap Index Scan on _hyper_8_42_chunk_b1_a_idx
-               Index Cond: ((a > 0) AND (a = 6))
-(10 rows)
+(8 rows)
 
 DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
 NOTICE:  f_leak => 1679091c5a880faf6fb5e6087eb1b2dc
@@ -3141,18 +3124,16 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE VIEW rls_sbv WITH (security_barrier) AS
     SELECT * FROM y1 WHERE f_leak(b);
 EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: y1
    Chunks left after exclusion: 1
    ->  Append
-         ->  Bitmap Heap Scan on _hyper_12_57_chunk
-               Recheck Cond: (a = 1)
+         ->  Index Scan using _hyper_12_57_chunk_y1_a_idx on _hyper_12_57_chunk
+               Index Cond: (a = 1)
                Filter: f_leak(b)
-               ->  Bitmap Index Scan on _hyper_12_57_chunk_y1_a_idx
-                     Index Cond: (a = 1)
-(9 rows)
+(7 rows)
 
 DROP VIEW rls_sbv;
 -- Create view as role that does not own table.  RLS should be applied.
@@ -3160,18 +3141,16 @@ SET SESSION AUTHORIZATION regress_rls_bob;
 CREATE VIEW rls_sbv WITH (security_barrier) AS
     SELECT * FROM y1 WHERE f_leak(b);
 EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: y1
    Chunks left after exclusion: 1
    ->  Append
-         ->  Bitmap Heap Scan on _hyper_12_57_chunk
-               Recheck Cond: (a = 1)
+         ->  Index Scan using _hyper_12_57_chunk_y1_a_idx on _hyper_12_57_chunk
+               Index Cond: (a = 1)
                Filter: (((a > 2) OR ((a % 2) = 0)) AND f_leak(b))
-               ->  Bitmap Index Scan on _hyper_12_57_chunk_y1_a_idx
-                     Index Cond: (a = 1)
-(9 rows)
+(7 rows)
 
 DROP VIEW rls_sbv;
 --

--- a/test/expected/rowsecurity-11.out
+++ b/test/expected/rowsecurity-11.out
@@ -115,11 +115,11 @@ CREATE POLICY p1r ON document AS RESTRICTIVE TO regress_rls_dave
                     |          |       | =arwdDxt/regress_rls_alice                  |                   |   (u): (dlevel <= ( SELECT uaccount.seclv +
                     |          |       |                                             |                   |    FROM uaccount                          +
                     |          |       |                                             |                   |   WHERE (uaccount.pguser = CURRENT_USER)))+
-                    |          |       |                                             |                   | p2r (RESTRICTIVE):                        +
-                    |          |       |                                             |                   |   (u): ((cid <> 44) AND (cid < 50))       +
-                    |          |       |                                             |                   |   to: regress_rls_dave                    +
                     |          |       |                                             |                   | p1r (RESTRICTIVE):                        +
                     |          |       |                                             |                   |   (u): (cid <> 44)                        +
+                    |          |       |                                             |                   |   to: regress_rls_dave                    +
+                    |          |       |                                             |                   | p2r (RESTRICTIVE):                        +
+                    |          |       |                                             |                   |   (u): ((cid <> 44) AND (cid < 50))       +
                     |          |       |                                             |                   |   to: regress_rls_dave
  regress_rls_schema | uaccount | table | regress_rls_alice=arwdDxt/regress_rls_alice+|                   | 
                     |          |       | =r/regress_rls_alice                        |                   | 
@@ -508,31 +508,30 @@ EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 (18 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Hash Join
-   Hash Cond: (category.cid = document.cid)
-   ->  Seq Scan on category
-   ->  Hash
-         ->  Custom Scan (ConstraintAwareAppend)
-               Hypertable: document
-               Chunks left after exclusion: 7
-               ->  Append
-                     ->  Seq Scan on document document_1
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_1_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_2_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_3_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_4_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_5_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-                     ->  Seq Scan on _hyper_1_6_chunk
-                           Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
-(22 rows)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Nested Loop
+   ->  Custom Scan (ConstraintAwareAppend)
+         Hypertable: document
+         Chunks left after exclusion: 7
+         ->  Append
+               ->  Seq Scan on document document_1
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_1_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_2_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_3_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_4_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_5_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+               ->  Seq Scan on _hyper_1_6_chunk
+                     Filter: ((dauthor = CURRENT_USER) AND f_leak(dtitle))
+   ->  Index Scan using category_pkey on category
+         Index Cond: (cid = document.cid)
+(21 rows)
 
 -- interaction of FK/PK constraints
 SET SESSION AUTHORIZATION regress_rls_alice;
@@ -2263,44 +2262,32 @@ CREATE VIEW bv1 WITH (security_barrier) AS SELECT * FROM b1 WHERE a > 0 WITH CHE
 GRANT ALL ON bv1 TO regress_rls_carol;
 SET SESSION AUTHORIZATION regress_rls_carol;
 EXPLAIN (COSTS OFF) SELECT * FROM bv1 WHERE f_leak(b);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Subquery Scan on bv1
    Filter: f_leak(bv1.b)
    ->  Append
          ->  Seq Scan on b1
                Filter: ((a > 0) AND ((a % 2) = 0))
-         ->  Bitmap Heap Scan on _hyper_8_39_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_39_chunk_b1_a_idx on _hyper_8_39_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_39_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_40_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_40_chunk_b1_a_idx on _hyper_8_40_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_40_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_41_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_41_chunk_b1_a_idx on _hyper_8_41_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_41_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_42_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_42_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_43_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_43_chunk_b1_a_idx on _hyper_8_43_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_43_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_44_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_44_chunk_b1_a_idx on _hyper_8_44_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_44_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-(35 rows)
+(23 rows)
 
 SELECT * FROM bv1 WHERE f_leak(b);
 NOTICE:  f_leak => c81e728d9d4c2f636f067f89cc14862c
@@ -2323,36 +2310,32 @@ INSERT INTO bv1 VALUES (11, 'xxx'); -- should fail RLS check
 ERROR:  new row violates row-level security policy for table "b1"
 INSERT INTO bv1 VALUES (12, 'xxx'); -- ok
 EXPLAIN (COSTS OFF) UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Update on b1
    Update on b1
    Update on _hyper_8_41_chunk
    ->  Seq Scan on b1
          Filter: ((a > 0) AND (a = 4) AND ((a % 2) = 0) AND f_leak(b))
-   ->  Bitmap Heap Scan on _hyper_8_41_chunk
-         Recheck Cond: ((a > 0) AND (a = 4))
+   ->  Index Scan using _hyper_8_41_chunk_b1_a_idx on _hyper_8_41_chunk
+         Index Cond: ((a > 0) AND (a = 4))
          Filter: (((a % 2) = 0) AND f_leak(b))
-         ->  Bitmap Index Scan on _hyper_8_41_chunk_b1_a_idx
-               Index Cond: ((a > 0) AND (a = 4))
-(10 rows)
+(8 rows)
 
 UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
 NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 EXPLAIN (COSTS OFF) DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Delete on b1
    Delete on b1
    Delete on _hyper_8_42_chunk
    ->  Seq Scan on b1
          Filter: ((a > 0) AND (a = 6) AND ((a % 2) = 0) AND f_leak(b))
-   ->  Bitmap Heap Scan on _hyper_8_42_chunk
-         Recheck Cond: ((a > 0) AND (a = 6))
+   ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk
+         Index Cond: ((a > 0) AND (a = 6))
          Filter: (((a % 2) = 0) AND f_leak(b))
-         ->  Bitmap Index Scan on _hyper_8_42_chunk_b1_a_idx
-               Index Cond: ((a > 0) AND (a = 6))
-(10 rows)
+(8 rows)
 
 DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
 NOTICE:  f_leak => 1679091c5a880faf6fb5e6087eb1b2dc
@@ -3229,20 +3212,18 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE VIEW rls_sbv WITH (security_barrier) AS
     SELECT * FROM y1 WHERE f_leak(b);
 EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: y1
    Chunks left after exclusion: 2
    ->  Append
          ->  Seq Scan on y1 y1_1
                Filter: (f_leak(b) AND (a = 1))
-         ->  Bitmap Heap Scan on _hyper_12_57_chunk
-               Recheck Cond: (a = 1)
+         ->  Index Scan using _hyper_12_57_chunk_y1_a_idx on _hyper_12_57_chunk
+               Index Cond: (a = 1)
                Filter: f_leak(b)
-               ->  Bitmap Index Scan on _hyper_12_57_chunk_y1_a_idx
-                     Index Cond: (a = 1)
-(11 rows)
+(9 rows)
 
 DROP VIEW rls_sbv;
 -- Create view as role that does not own table.  RLS should be applied.
@@ -3250,20 +3231,18 @@ SET SESSION AUTHORIZATION regress_rls_bob;
 CREATE VIEW rls_sbv WITH (security_barrier) AS
     SELECT * FROM y1 WHERE f_leak(b);
 EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: y1
    Chunks left after exclusion: 2
    ->  Append
          ->  Seq Scan on y1 y1_1
                Filter: ((a = 1) AND ((a > 2) OR ((a % 2) = 0)) AND f_leak(b))
-         ->  Bitmap Heap Scan on _hyper_12_57_chunk
-               Recheck Cond: (a = 1)
+         ->  Index Scan using _hyper_12_57_chunk_y1_a_idx on _hyper_12_57_chunk
+               Index Cond: (a = 1)
                Filter: (((a > 2) OR ((a % 2) = 0)) AND f_leak(b))
-               ->  Bitmap Index Scan on _hyper_12_57_chunk_y1_a_idx
-                     Index Cond: (a = 1)
-(11 rows)
+(9 rows)
 
 DROP VIEW rls_sbv;
 --

--- a/test/expected/rowsecurity-9.6.out
+++ b/test/expected/rowsecurity-9.6.out
@@ -322,31 +322,30 @@ EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 (18 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Hash Join
-   Hash Cond: (category.cid = document.cid)
-   ->  Seq Scan on category
-   ->  Hash
-         ->  Subquery Scan on document
-               Filter: f_leak(document.dtitle)
-               ->  Custom Scan (ConstraintAwareAppend)
-                     Hypertable: document
-                     Chunks left after exclusion: 6
-                     ->  Append
-                           ->  Seq Scan on _hyper_1_1_chunk
-                                 Filter: (dauthor = "current_user"())
-                           ->  Seq Scan on _hyper_1_2_chunk
-                                 Filter: (dauthor = "current_user"())
-                           ->  Seq Scan on _hyper_1_3_chunk
-                                 Filter: (dauthor = "current_user"())
-                           ->  Seq Scan on _hyper_1_4_chunk
-                                 Filter: (dauthor = "current_user"())
-                           ->  Seq Scan on _hyper_1_5_chunk
-                                 Filter: (dauthor = "current_user"())
-                           ->  Seq Scan on _hyper_1_6_chunk
-                                 Filter: (dauthor = "current_user"())
-(22 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Nested Loop
+   ->  Subquery Scan on document
+         Filter: f_leak(document.dtitle)
+         ->  Custom Scan (ConstraintAwareAppend)
+               Hypertable: document
+               Chunks left after exclusion: 6
+               ->  Append
+                     ->  Seq Scan on _hyper_1_1_chunk
+                           Filter: (dauthor = "current_user"())
+                     ->  Seq Scan on _hyper_1_2_chunk
+                           Filter: (dauthor = "current_user"())
+                     ->  Seq Scan on _hyper_1_3_chunk
+                           Filter: (dauthor = "current_user"())
+                     ->  Seq Scan on _hyper_1_4_chunk
+                           Filter: (dauthor = "current_user"())
+                     ->  Seq Scan on _hyper_1_5_chunk
+                           Filter: (dauthor = "current_user"())
+                     ->  Seq Scan on _hyper_1_6_chunk
+                           Filter: (dauthor = "current_user"())
+   ->  Index Scan using category_pkey on category
+         Index Cond: (cid = document.cid)
+(21 rows)
 
 -- interaction of FK/PK constraints
 SET SESSION AUTHORIZATION regress_rls_alice;
@@ -1376,9 +1375,9 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 DROP POLICY p3 on s1;
 ALTER POLICY p2 ON s2 USING (x % 2 = 0);
 SET SESSION AUTHORIZATION regress_rls_bob;
-SELECT * FROM s1 WHERE f_leak(b);	-- OK
-NOTICE:  f_leak => c81e728d9d4c2f636f067f89cc14862c
+SELECT * FROM s1 WHERE f_leak(b) ORDER BY a;	-- OK
 NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
+NOTICE:  f_leak => c81e728d9d4c2f636f067f89cc14862c
  a |                b                 
 ---+----------------------------------
  2 | c81e728d9d4c2f636f067f89cc14862c
@@ -1426,45 +1425,54 @@ NOTICE:  f_leak => 1679091c5a880faf6fb5e6087eb1b2dc
 (2 rows)
 
 EXPLAIN (COSTS OFF) SELECT * FROM s1 WHERE f_leak(b);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Subquery Scan on s1
    Filter: f_leak(s1.b)
-   ->  Hash Join
-         Hash Cond: (_hyper_6_13_chunk.a = s2.x)
+   ->  Nested Loop
+         ->  HashAggregate
+               Group Key: s2.x
+               ->  Subquery Scan on s2
+                     Filter: (s2.y ~~ '%af%'::text)
+                     ->  Append
+                           ->  Seq Scan on _hyper_7_24_chunk
+                                 Filter: ((x % 2) = 0)
+                           ->  Seq Scan on _hyper_7_25_chunk
+                                 Filter: ((x % 2) = 0)
+                           ->  Seq Scan on _hyper_7_26_chunk
+                                 Filter: ((x % 2) = 0)
+                           ->  Seq Scan on _hyper_7_27_chunk
+                                 Filter: ((x % 2) = 0)
+                           ->  Seq Scan on _hyper_7_28_chunk
+                                 Filter: ((x % 2) = 0)
+                           ->  Seq Scan on _hyper_7_29_chunk
+                                 Filter: ((x % 2) = 0)
+                           ->  Seq Scan on _hyper_7_30_chunk
+                                 Filter: ((x % 2) = 0)
          ->  Append
-               ->  Seq Scan on _hyper_6_13_chunk
-               ->  Seq Scan on _hyper_6_14_chunk
-               ->  Seq Scan on _hyper_6_15_chunk
-               ->  Seq Scan on _hyper_6_16_chunk
-               ->  Seq Scan on _hyper_6_17_chunk
-               ->  Seq Scan on _hyper_6_18_chunk
-               ->  Seq Scan on _hyper_6_19_chunk
-               ->  Seq Scan on _hyper_6_20_chunk
-               ->  Seq Scan on _hyper_6_21_chunk
-               ->  Seq Scan on _hyper_6_22_chunk
-               ->  Seq Scan on _hyper_6_23_chunk
-         ->  Hash
-               ->  HashAggregate
-                     Group Key: s2.x
-                     ->  Subquery Scan on s2
-                           Filter: (s2.y ~~ '%af%'::text)
-                           ->  Append
-                                 ->  Seq Scan on _hyper_7_24_chunk
-                                       Filter: ((x % 2) = 0)
-                                 ->  Seq Scan on _hyper_7_25_chunk
-                                       Filter: ((x % 2) = 0)
-                                 ->  Seq Scan on _hyper_7_26_chunk
-                                       Filter: ((x % 2) = 0)
-                                 ->  Seq Scan on _hyper_7_27_chunk
-                                       Filter: ((x % 2) = 0)
-                                 ->  Seq Scan on _hyper_7_28_chunk
-                                       Filter: ((x % 2) = 0)
-                                 ->  Seq Scan on _hyper_7_29_chunk
-                                       Filter: ((x % 2) = 0)
-                                 ->  Seq Scan on _hyper_7_30_chunk
-                                       Filter: ((x % 2) = 0)
-(36 rows)
+               ->  Index Scan using _hyper_6_13_chunk_s1_a_idx on _hyper_6_13_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_14_chunk_s1_a_idx on _hyper_6_14_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_15_chunk_s1_a_idx on _hyper_6_15_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_16_chunk_s1_a_idx on _hyper_6_16_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_17_chunk_s1_a_idx on _hyper_6_17_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_18_chunk_s1_a_idx on _hyper_6_18_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_19_chunk_s1_a_idx on _hyper_6_19_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_20_chunk_s1_a_idx on _hyper_6_20_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_21_chunk_s1_a_idx on _hyper_6_21_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_22_chunk_s1_a_idx on _hyper_6_22_chunk
+                     Index Cond: (a = s2.x)
+               ->  Index Scan using _hyper_6_23_chunk_s1_a_idx on _hyper_6_23_chunk
+                     Index Cond: (a = s2.x)
+(45 rows)
 
 SELECT (SELECT x FROM s1 LIMIT 1) xx, * FROM s2 WHERE y like '%28%';
  xx | x  |                y                 
@@ -2047,42 +2055,30 @@ CREATE VIEW bv1 WITH (security_barrier) AS SELECT * FROM b1 WHERE a > 0 WITH CHE
 GRANT ALL ON bv1 TO regress_rls_carol;
 SET SESSION AUTHORIZATION regress_rls_carol;
 EXPLAIN (COSTS OFF) SELECT * FROM bv1 WHERE f_leak(b);
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Subquery Scan on bv1
    Filter: f_leak(bv1.b)
    ->  Append
-         ->  Bitmap Heap Scan on _hyper_8_36_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_36_chunk_b1_a_idx on _hyper_8_36_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_36_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_38_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_38_chunk_b1_a_idx on _hyper_8_38_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_38_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_39_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_39_chunk_b1_a_idx on _hyper_8_39_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_39_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_40_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_40_chunk_b1_a_idx on _hyper_8_40_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_40_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_41_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_41_chunk_b1_a_idx on _hyper_8_41_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_41_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-         ->  Bitmap Heap Scan on _hyper_8_37_chunk
-               Recheck Cond: (a > 0)
+         ->  Index Scan using _hyper_8_37_chunk_b1_a_idx on _hyper_8_37_chunk
+               Index Cond: (a > 0)
                Filter: ((a % 2) = 0)
-               ->  Bitmap Index Scan on _hyper_8_37_chunk_b1_a_idx
-                     Index Cond: (a > 0)
-(33 rows)
+(21 rows)
 
 SELECT * FROM bv1 WHERE f_leak(b);
 NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
@@ -2105,8 +2101,8 @@ INSERT INTO bv1 VALUES (11, 'xxx'); -- should fail RLS check
 ERROR:  new row violates row-level security policy for table "b1"
 INSERT INTO bv1 VALUES (12, 'xxx'); -- ok
 EXPLAIN (COSTS OFF) UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Update on b1 b1_13
    Update on b1 b1_13
    Update on _hyper_8_31_chunk b1
@@ -2131,117 +2127,93 @@ EXPLAIN (COSTS OFF) UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
          Filter: f_leak(b1_1.b)
          ->  Subquery Scan on b1_16
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_31_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_31_chunk_b1_a_idx on _hyper_8_31_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_31_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_2
          Filter: f_leak(b1_2.b)
          ->  Subquery Scan on b1_17
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_32_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_32_chunk_b1_a_idx on _hyper_8_32_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_32_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_3
          Filter: f_leak(b1_3.b)
          ->  Subquery Scan on b1_18
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_33_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_33_chunk_b1_a_idx on _hyper_8_33_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_33_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_4
          Filter: f_leak(b1_4.b)
          ->  Subquery Scan on b1_19
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_34_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_34_chunk_b1_a_idx on _hyper_8_34_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_34_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_5
          Filter: f_leak(b1_5.b)
          ->  Subquery Scan on b1_20
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_35_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_35_chunk_b1_a_idx on _hyper_8_35_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_35_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_6
          Filter: f_leak(b1_6.b)
          ->  Subquery Scan on b1_21
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_36_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_36_chunk_b1_a_idx on _hyper_8_36_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_36_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_7
          Filter: f_leak(b1_7.b)
          ->  Subquery Scan on b1_22
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_37_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_37_chunk_b1_a_idx on _hyper_8_37_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_37_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_8
          Filter: f_leak(b1_8.b)
          ->  Subquery Scan on b1_23
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_38_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_38_chunk_b1_a_idx on _hyper_8_38_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_38_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_9
          Filter: f_leak(b1_9.b)
          ->  Subquery Scan on b1_24
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_39_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_39_chunk_b1_a_idx on _hyper_8_39_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_39_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_10
          Filter: f_leak(b1_10.b)
          ->  Subquery Scan on b1_25
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_40_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_40_chunk_b1_a_idx on _hyper_8_40_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_40_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_11
          Filter: f_leak(b1_11.b)
          ->  Subquery Scan on b1_26
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_41_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_41_chunk_b1_a_idx on _hyper_8_41_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_41_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
    ->  Subquery Scan on b1_12
          Filter: f_leak(b1_12.b)
          ->  Subquery Scan on b1_27
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_42_chunk
-                           Recheck Cond: ((a > 0) AND (a = 4))
+                     ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk
+                           Index Cond: ((a > 0) AND (a = 4))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_42_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 4))
-(128 rows)
+(104 rows)
 
 UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
 NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 EXPLAIN (COSTS OFF) DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Delete on b1 b1_13
    Delete on b1 b1_13
    Delete on _hyper_8_31_chunk b1
@@ -2266,111 +2238,87 @@ EXPLAIN (COSTS OFF) DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
          Filter: f_leak(b1_1.b)
          ->  Subquery Scan on b1_16
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_31_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_31_chunk_b1_a_idx on _hyper_8_31_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_31_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_2
          Filter: f_leak(b1_2.b)
          ->  Subquery Scan on b1_17
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_32_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_32_chunk_b1_a_idx on _hyper_8_32_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_32_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_3
          Filter: f_leak(b1_3.b)
          ->  Subquery Scan on b1_18
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_33_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_33_chunk_b1_a_idx on _hyper_8_33_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_33_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_4
          Filter: f_leak(b1_4.b)
          ->  Subquery Scan on b1_19
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_34_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_34_chunk_b1_a_idx on _hyper_8_34_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_34_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_5
          Filter: f_leak(b1_5.b)
          ->  Subquery Scan on b1_20
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_35_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_35_chunk_b1_a_idx on _hyper_8_35_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_35_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_6
          Filter: f_leak(b1_6.b)
          ->  Subquery Scan on b1_21
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_36_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_36_chunk_b1_a_idx on _hyper_8_36_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_36_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_7
          Filter: f_leak(b1_7.b)
          ->  Subquery Scan on b1_22
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_37_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_37_chunk_b1_a_idx on _hyper_8_37_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_37_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_8
          Filter: f_leak(b1_8.b)
          ->  Subquery Scan on b1_23
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_38_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_38_chunk_b1_a_idx on _hyper_8_38_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_38_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_9
          Filter: f_leak(b1_9.b)
          ->  Subquery Scan on b1_24
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_39_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_39_chunk_b1_a_idx on _hyper_8_39_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_39_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_10
          Filter: f_leak(b1_10.b)
          ->  Subquery Scan on b1_25
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_40_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_40_chunk_b1_a_idx on _hyper_8_40_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_40_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_11
          Filter: f_leak(b1_11.b)
          ->  Subquery Scan on b1_26
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_41_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_41_chunk_b1_a_idx on _hyper_8_41_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_41_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
    ->  Subquery Scan on b1_12
          Filter: f_leak(b1_12.b)
          ->  Subquery Scan on b1_27
                ->  LockRows
-                     ->  Bitmap Heap Scan on _hyper_8_42_chunk
-                           Recheck Cond: ((a > 0) AND (a = 6))
+                     ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk
+                           Index Cond: ((a > 0) AND (a = 6))
                            Filter: ((a % 2) = 0)
-                           ->  Bitmap Index Scan on _hyper_8_42_chunk_b1_a_idx
-                                 Index Cond: ((a > 0) AND (a = 6))
-(128 rows)
+(104 rows)
 
 DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
 NOTICE:  f_leak => 1679091c5a880faf6fb5e6087eb1b2dc
@@ -3177,18 +3125,16 @@ SET SESSION AUTHORIZATION regress_rls_alice;
 CREATE VIEW rls_sbv WITH (security_barrier) AS
     SELECT * FROM y1 WHERE f_leak(b);
 EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Custom Scan (ConstraintAwareAppend)
    Hypertable: y1
    Chunks left after exclusion: 1
    ->  Append
-         ->  Bitmap Heap Scan on _hyper_12_54_chunk
-               Recheck Cond: (a = 1)
+         ->  Index Scan using _hyper_12_54_chunk_y1_a_idx on _hyper_12_54_chunk
+               Index Cond: (a = 1)
                Filter: f_leak(b)
-               ->  Bitmap Index Scan on _hyper_12_54_chunk_y1_a_idx
-                     Index Cond: (a = 1)
-(9 rows)
+(7 rows)
 
 DROP VIEW rls_sbv;
 -- Create view as role that does not own table.  RLS should be applied.
@@ -3196,17 +3142,15 @@ SET SESSION AUTHORIZATION regress_rls_bob;
 CREATE VIEW rls_sbv WITH (security_barrier) AS
     SELECT * FROM y1 WHERE f_leak(b);
 EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
-                             QUERY PLAN                             
---------------------------------------------------------------------
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
  Subquery Scan on y1
    Filter: f_leak(y1.b)
    ->  Append
-         ->  Bitmap Heap Scan on _hyper_12_54_chunk
-               Recheck Cond: (a = 1)
+         ->  Index Scan using _hyper_12_54_chunk_y1_a_idx on _hyper_12_54_chunk
+               Index Cond: (a = 1)
                Filter: ((a > 2) OR ((a % 2) = 0))
-               ->  Bitmap Index Scan on _hyper_12_54_chunk_y1_a_idx
-                     Index Cond: (a = 1)
-(8 rows)
+(6 rows)
 
 DROP VIEW rls_sbv;
 --

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -71,34 +71,28 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE devi
                                                                                         QUERY PLAN                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append
-   ->  Bitmap Heap Scan on _timescaledb_internal._hyper_1_4_chunk
+   ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx" on _timescaledb_internal._hyper_1_4_chunk
          Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
-         Recheck Cond: (_hyper_1_4_chunk.device_id = 'dev2'::text)
-         ->  Bitmap Index Scan on "_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx"
-               Index Cond: (_hyper_1_4_chunk.device_id = 'dev2'::text)
-(6 rows)
+         Index Cond: (_hyper_1_4_chunk.device_id = 'dev2'::text)
+(4 rows)
 
 EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE device_id = 'dev'||'2';
                                                                                         QUERY PLAN                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append
-   ->  Bitmap Heap Scan on _timescaledb_internal._hyper_1_4_chunk
+   ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx" on _timescaledb_internal._hyper_1_4_chunk
          Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
-         Recheck Cond: (_hyper_1_4_chunk.device_id = 'dev2'::text)
-         ->  Bitmap Index Scan on "_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx"
-               Index Cond: (_hyper_1_4_chunk.device_id = 'dev2'::text)
-(6 rows)
+         Index Cond: (_hyper_1_4_chunk.device_id = 'dev2'::text)
+(4 rows)
 
 EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE 'dev'||'2' = device_id;
                                                                                         QUERY PLAN                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append
-   ->  Bitmap Heap Scan on _timescaledb_internal._hyper_1_4_chunk
+   ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx" on _timescaledb_internal._hyper_1_4_chunk
          Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
-         Recheck Cond: ('dev2'::text = _hyper_1_4_chunk.device_id)
-         ->  Bitmap Index Scan on "_hyper_1_4_chunk_two_Partitions_device_id_timeCustom_idx"
-               Index Cond: ('dev2'::text = _hyper_1_4_chunk.device_id)
-(6 rows)
+         Index Cond: ('dev2'::text = _hyper_1_4_chunk.device_id)
+(4 rows)
 
 --test integer partition key
 CREATE TABLE "int_part"(time timestamp, object_id int, temp float);
@@ -127,15 +121,13 @@ SELECT * FROM "int_part" WHERE object_id = 1;
 
 --make sure this touches only one partititon
 EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Append
-   ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_5_chunk
+   ->  Index Scan using _hyper_2_5_chunk_int_part_object_id_time_idx on _timescaledb_internal._hyper_2_5_chunk
          Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.object_id, _hyper_2_5_chunk.temp
-         Recheck Cond: (_hyper_2_5_chunk.object_id = 1)
-         ->  Bitmap Index Scan on _hyper_2_5_chunk_int_part_object_id_time_idx
-               Index Cond: (_hyper_2_5_chunk.object_id = 1)
-(6 rows)
+         Index Cond: (_hyper_2_5_chunk.object_id = 1)
+(4 rows)
 
 --TODO: handle this later?
 --EXPLAIN (verbose ON, costs off) SELECT * FROM "two_Partitions" WHERE device_id IN ('dev2', 'dev21');

--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -232,8 +232,8 @@ WHERE to_timestamp(time) < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time"))) DESC
@@ -241,11 +241,9 @@ LIMIT 2;
                Group Key: date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time"))
                ->  Result
                      ->  Append
-                           ->  Bitmap Heap Scan on _hyper_5_19_chunk
-                                 Recheck Cond: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                                 ->  Bitmap Index Scan on _hyper_5_19_chunk_time_plain_timefunc
-                                       Index Cond: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(11 rows)
+                           ->  Index Scan using _hyper_5_19_chunk_time_plain_timefunc on _hyper_5_19_chunk
+                                 Index Cond: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(9 rows)
 
 SELECT date_trunc('minute', to_timestamp(time)) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_timefunc
@@ -490,18 +488,16 @@ WHERE time < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (date_trunc('minute'::text, "time")) DESC
          ->  HashAggregate
                Group Key: date_trunc('minute'::text, "time")
-               ->  Bitmap Heap Scan on plain_table
-                     Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                     ->  Bitmap Index Scan on time_plain_plain_table
-                           Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(9 rows)
+               ->  Index Scan using time_plain_plain_table on plain_table
+                     Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(7 rows)
 
 SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM plain_table

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -203,8 +203,8 @@ WHERE time < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
@@ -214,11 +214,9 @@ LIMIT 2;
                      ->  Append
                            ->  Seq Scan on hyper_1
                                  Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                           ->  Bitmap Heap Scan on _hyper_1_1_chunk
-                                 Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                                 ->  Bitmap Index Scan on _hyper_1_1_chunk_time_plain
-                                       Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(13 rows)
+                           ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+                                 Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(11 rows)
 
 SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_1
@@ -243,8 +241,8 @@ WHERE to_timestamp(time) < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (date_trunc('minute'::text, to_timestamp(hyper_timefunc."time"))) DESC
@@ -254,11 +252,9 @@ LIMIT 2;
                      ->  Append
                            ->  Seq Scan on hyper_timefunc
                                  Filter: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                           ->  Bitmap Heap Scan on _hyper_5_19_chunk
-                                 Recheck Cond: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                                 ->  Bitmap Index Scan on _hyper_5_19_chunk_time_plain_timefunc
-                                       Index Cond: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(13 rows)
+                           ->  Index Scan using _hyper_5_19_chunk_time_plain_timefunc on _hyper_5_19_chunk
+                                 Index Cond: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(11 rows)
 
 SELECT date_trunc('minute', to_timestamp(time)) t, avg(series_0), min(series_1), avg(series_2)
 FROM hyper_timefunc
@@ -521,18 +517,16 @@ WHERE time < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (date_trunc('minute'::text, "time")) DESC
          ->  HashAggregate
                Group Key: date_trunc('minute'::text, "time")
-               ->  Bitmap Heap Scan on plain_table
-                     Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                     ->  Bitmap Index Scan on time_plain_plain_table
-                           Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(9 rows)
+               ->  Index Scan using time_plain_plain_table on plain_table
+                     Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(7 rows)
 
 SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
 FROM plain_table
@@ -556,18 +550,16 @@ BEGIN;
     GROUP BY t
     ORDER BY t DESC
     LIMIT 2;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (date_trunc('minute'::text, "time")) DESC
          ->  HashAggregate
                Group Key: date_trunc('minute'::text, "time")
-               ->  Bitmap Heap Scan on plain_table
-                     Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-                     ->  Bitmap Index Scan on time_plain_plain_table
-                           Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(9 rows)
+               ->  Index Scan using time_plain_plain_table on plain_table
+                     Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(7 rows)
 
     SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
     FROM plain_table

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -101,9 +101,9 @@
 <                                                 QUERY PLAN                                                 
 < -----------------------------------------------------------------------------------------------------------
 ---
->                                                       QUERY PLAN                                                       
-> -----------------------------------------------------------------------------------------------------------------------
-201,210c209,221
+>                                                    QUERY PLAN                                                    
+> -----------------------------------------------------------------------------------------------------------------
+201,210c209,219
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, hyper_1."time"))
 <          ->  Custom Scan (ConstraintAwareAppend)
@@ -123,59 +123,57 @@
 >                      ->  Append
 >                            ->  Seq Scan on hyper_1
 >                                  Filter: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
->                            ->  Bitmap Heap Scan on _hyper_1_1_chunk
->                                  Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
->                                  ->  Bitmap Index Scan on _hyper_1_1_chunk_time_plain
->                                        Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-> (13 rows)
-239c250
+>                            ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+>                                  Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+> (11 rows)
+239c248
 <          Sort Key: (date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time"))) DESC
 ---
 >          Sort Key: (date_trunc('minute'::text, to_timestamp(hyper_timefunc."time"))) DESC
-241c252
+241c250
 <                Group Key: date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time"))
 ---
 >                Group Key: date_trunc('minute'::text, to_timestamp(hyper_timefunc."time"))
-243a255,256
+243a253,254
 >                            ->  Seq Scan on hyper_timefunc
 >                                  Filter: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-248c261
-< (11 rows)
+246c257
+< (9 rows)
 ---
-> (13 rows)
-274c287
+> (11 rows)
+272c283
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 ---
 >          Group Key: (date_trunc('minute'::text, hyper_1."time"))
-277c290,291
+275c286,287
 <                      Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
 ---
 >                      Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
 >                      ->  Index Scan Backward using time_trunc on hyper_1
-279c293
+277c289
 < (7 rows)
 ---
 > (8 rows)
-299c313
+297c309
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 ---
 >          Group Key: (date_trunc('minute'::text, hyper_1."time"))
-302c316,317
+300c312,313
 <                      Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
 ---
 >                      Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
 >                      ->  Index Scan Backward using time_trunc on hyper_1
-304c319
+302c315
 < (7 rows)
 ---
 > (8 rows)
-315,316c330,331
+313,314c326,327
 <                                            QUERY PLAN                                           
 < ------------------------------------------------------------------------------------------------
 ---
 >                                    QUERY PLAN                                    
 > ---------------------------------------------------------------------------------
-319,324c334,341
+317,322c330,337
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
 <          ->  Result
 <                ->  Merge Append
@@ -191,13 +189,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-336,337c353,354
+334,335c349,350
 <                                                                      QUERY PLAN                                                                     
 < ----------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-340,345c357,364
+338,343c353,360
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
 <                ->  Merge Append
@@ -213,13 +211,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-357,358c376,377
+355,356c372,373
 <                                                         QUERY PLAN                                                        
 < --------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-361,366c380,387
+359,364c376,383
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
 <          ->  Result
 <                ->  Merge Append
@@ -235,13 +233,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-378,379c399,400
+376,377c395,396
 <                                                                      QUERY PLAN                                                                     
 < ----------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-382,387c403,410
+380,385c399,406
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
 <                ->  Merge Append
@@ -257,13 +255,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-399,400c422,423
+397,398c418,419
 <                                            QUERY PLAN                                           
 < ------------------------------------------------------------------------------------------------
 ---
 >                                      QUERY PLAN                                     
 > ------------------------------------------------------------------------------------
-403,408c426,433
+401,406c422,429
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
 <          ->  Result
 <                ->  Merge Append
@@ -279,13 +277,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-420,421c445,446
+418,419c441,442
 <                                                           QUERY PLAN                                                           
 < -------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                     QUERY PLAN                                                     
 > -------------------------------------------------------------------------------------------------------------------
-424,429c449,456
+422,427c445,452
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_2_2_chunk."time")::timestamp without time zone))
 <          ->  Result
 <                ->  Merge Append
@@ -301,13 +299,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-441,442c468,469
+439,440c464,465
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                              QUERY PLAN                             
 > --------------------------------------------------------------------
-445,452c472,481
+443,450c468,477
 <          Group Key: (time_bucket(10, _hyper_3_3_chunk."time"))
 <          ->  Result
 <                ->  Merge Append
@@ -327,13 +325,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-464,465c493,494
+462,463c489,490
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                               QUERY PLAN                               
 > -----------------------------------------------------------------------
-468,475c497,506
+466,473c493,502
 <          Group Key: (time_bucket(10, _hyper_3_3_chunk."time", 2))
 <          ->  Result
 <                ->  Merge Append
@@ -353,13 +351,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-528,529c559,560
+524,525c553,554
 <                                           QUERY PLAN                                           
 < -----------------------------------------------------------------------------------------------
 ---
->                                                 QUERY PLAN                                                 
-> -----------------------------------------------------------------------------------------------------------
-531,535c562,570
+>                                              QUERY PLAN                                              
+> -----------------------------------------------------------------------------------------------------
+527,531c556,562
 <    ->  GroupAggregate
 <          Group Key: date_trunc('minute'::text, "time")
 <          ->  Index Scan using time_plain_plain_table on plain_table
@@ -370,10 +368,8 @@
 >          Sort Key: (date_trunc('minute'::text, "time")) DESC
 >          ->  HashAggregate
 >                Group Key: date_trunc('minute'::text, "time")
->                ->  Bitmap Heap Scan on plain_table
->                      Recheck Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
->                      ->  Bitmap Index Scan on time_plain_plain_table
->                            Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-> (9 rows)
-549a585
+>                ->  Index Scan using time_plain_plain_table on plain_table
+>                      Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+> (7 rows)
+545a577
 > RESET max_parallel_workers_per_gather;

--- a/test/pgtest.conf
+++ b/test/pgtest.conf
@@ -1,0 +1,3 @@
+# postgresql.conf settings for PostgreSQL test suite
+shared_preload_libraries=timescaledb
+timescaledb.telemetry_level=off

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_target(pginstallcheck
   ${PG_REGRESS}
   ${PG_REGRESS_OPTS_BASE}
   ${PG_REGRESS_OPTS_PGTEST}
-  ${PG_REGRESS_OPTS_TEMP_INSTANCE}
+  ${PG_REGRESS_OPTS_TEMP_INSTANCE_PGTEST}
   USES_TERMINAL)
 
 add_custom_target(pginstallchecklocal

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -1,5 +1,6 @@
 shared_preload_libraries=timescaledb
 max_worker_processes=16
+random_page_cost=1.0
 timescaledb.telemetry_level=off
 timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'
 timescaledb.last_tuned_version='0.0.1'

--- a/test/sql/include/append.sql
+++ b/test/sql/include/append.sql
@@ -2,7 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-SET random_page_cost TO 1.0;
 -- create a now() function for repeatable testing that always returns
 -- the same timestamp. It needs to be marked STABLE
 CREATE OR REPLACE FUNCTION now_s()

--- a/test/sql/rowsecurity-9.6.sql
+++ b/test/sql/rowsecurity-9.6.sql
@@ -512,7 +512,7 @@ DROP POLICY p3 on s1;
 ALTER POLICY p2 ON s2 USING (x % 2 = 0);
 
 SET SESSION AUTHORIZATION regress_rls_bob;
-SELECT * FROM s1 WHERE f_leak(b);	-- OK
+SELECT * FROM s1 WHERE f_leak(b) ORDER BY a;	-- OK
 EXPLAIN (COSTS OFF) SELECT * FROM only s1 WHERE f_leak(b);
 
 SET SESSION AUTHORIZATION regress_rls_alice;

--- a/test/test-defs.cmake
+++ b/test/test-defs.cmake
@@ -42,7 +42,14 @@ set(PG_ISOLATION_REGRESS_OPTS_INOUT
 set(PG_REGRESS_OPTS_TEMP_INSTANCE
   --port=${TEST_PGPORT_TEMP_INSTANCE}
   --temp-instance=${TEST_CLUSTER}
-  --temp-config=${TEST_INPUT_DIR}/postgresql.conf)
+  --temp-config=${TEST_INPUT_DIR}/postgresql.conf
+)
+
+set(PG_REGRESS_OPTS_TEMP_INSTANCE_PGTEST
+  --port=${TEST_PGPORT_TEMP_INSTANCE}
+  --temp-instance=${TEST_CLUSTER}
+  --temp-config=${TEST_INPUT_DIR}/pgtest.conf
+)
 
 set(PG_REGRESS_OPTS_LOCAL_INSTANCE
   --port=${TEST_PGPORT_LOCAL})

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -531,14 +531,14 @@ NOTICE:  adding not-null constraint to column "time"
 CREATE INDEX second_index on test_table (time);
 insert into test_table values (now(), 1);
 insert into test_table values (now() - INTERVAL '5 weeks', 123);
-select c.id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table';
+select c.id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table' ORDER BY c.id;
  id 
 ----
   1
   2
 (2 rows)
 
-select c.id as chunk_id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table' LIMIT 1 \gset
+select c.id as chunk_id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table' ORDER BY c.id LIMIT 1 \gset
 select add_reorder_policy('test_table', 'second_index') as job_id \gset
 WARNING:  Timescale License expired
 -- Simulate reorder job running and setting this stat row

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -208,9 +208,9 @@ CREATE INDEX second_index on test_table (time);
 insert into test_table values (now(), 1);
 insert into test_table values (now() - INTERVAL '5 weeks', 123);
 
-select c.id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table';
+select c.id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table' ORDER BY c.id;
 
-select c.id as chunk_id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table' LIMIT 1 \gset
+select c.id as chunk_id from _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as h where c.hypertable_id=h.id and h.table_name='test_table' ORDER BY c.id LIMIT 1 \gset
 
 select add_reorder_policy('test_table', 'second_index') as job_id \gset
 -- Simulate reorder job running and setting this stat row


### PR DESCRIPTION
Set random_page_cost to 1.0 to produce more reasonable plans.
This is similar to what timescaledb-tune would set.