### PR TITLE
[WIP] Disallow moving catalog tables and functions out of our internal schemas

### DIFF
--- a/src/extension_constants.h
+++ b/src/extension_constants.h
@@ -24,10 +24,22 @@
 #define CONFIG_SCHEMA_NAME "_timescaledb_config"
 #define RENDEZVOUS_BGW_LOADER_API_VERSION "timescaledb.bgw_loader_api_version"
 
-static const char *const timescaledb_schema_names[] = {
-	CATALOG_SCHEMA_NAME, INTERNAL_SCHEMA_NAME, CACHE_SCHEMA_NAME, CONFIG_SCHEMA_NAME
+enum
+{
+	CATALOG_SCHEMA_NUM = 0,
+	INTERNAL_SCHEMA_NUM,
+	CACHE_SCHEMA_NUM,
+	CONFIG_SCHEMA_NUM,
+	NUM_TIMESCALEDB_SCHEMAS
 };
 
-#define NUM_TIMESCALEDB_SCHEMAS (sizeof(timescaledb_schema_names) / sizeof(char *))
+static const char *const timescaledb_schema_names[NUM_TIMESCALEDB_SCHEMAS] = {
+	/* if we use the indexes for all the array values clang-format thinks this is an objective-C
+	   file */
+	[CATALOG_SCHEMA_NUM] = CATALOG_SCHEMA_NAME,
+	INTERNAL_SCHEMA_NAME,
+	CACHE_SCHEMA_NAME,
+	CONFIG_SCHEMA_NAME,
+};
 
 #endif /* TIMESCALEDB_EXTENSION_CONSTANTS_H */

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -616,3 +616,25 @@ SELECT * from _timescaledb_catalog.chunk;
 (2 rows)
 
 DROP TABLE my_table;
+-- we cannot change the schemas of catalog tables in our intenal schemas
+-- NOTE pg9.6 requires function args for ALTER FUNCTION
+--      there is a codepath that's only checked without that
+\set ON_ERROR_STOP 0
+ALTER TABLE _timescaledb_catalog.hypertable SET SCHEMA public;
+ERROR:  cannot change the schema of TimescaleDB objects
+ALTER TABLE _timescaledb_config.bgw_job_id_seq SET SCHEMA public;
+ERROR:  cannot change the schema of TimescaleDB objects
+-- TODO this should be disallowed eventually
+-- ALTER TABLE _timescaledb_internal.bgw_job_stat SET SCHEMA public;
+ALTER FUNCTION _timescaledb_internal.insert_blocker() SET SCHEMA public;
+ERROR:  cannot change the schema of TimescaleDB objects
+-- non existent objects are handled gracefully
+ALTER TABLE not_a_real_table SET SCHEMA public;
+ERROR:  relation "not_a_real_table" does not exist
+ALTER TABLE _timescaledb_catalog.not_a_real_table SET SCHEMA public;
+ERROR:  cannot change the schema of TimescaleDB objects
+ALTER FUNCTION not_a_real_function() SET SCHEMA public;
+ERROR:  function not_a_real_function() does not exist
+ALTER FUNCTION _timescaledb_internal.not_a_real_function() SET SCHEMA public;
+ERROR:  function _timescaledb_internal.not_a_real_function() does not exist
+\set ON_ERROR_STOP 1

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -328,3 +328,20 @@ SELECT * from _timescaledb_catalog.hypertable;
 SELECT * from _timescaledb_catalog.chunk;
 
 DROP TABLE my_table;
+
+-- we cannot change the schemas of catalog tables in our intenal schemas
+-- NOTE pg9.6 requires function args for ALTER FUNCTION
+--      there is a codepath that's only checked without that
+\set ON_ERROR_STOP 0
+ALTER TABLE _timescaledb_catalog.hypertable SET SCHEMA public;
+ALTER TABLE _timescaledb_config.bgw_job_id_seq SET SCHEMA public;
+-- TODO this should be disallowed eventually
+-- ALTER TABLE _timescaledb_internal.bgw_job_stat SET SCHEMA public;
+ALTER FUNCTION _timescaledb_internal.insert_blocker() SET SCHEMA public;
+
+-- non existent objects are handled gracefully
+ALTER TABLE not_a_real_table SET SCHEMA public;
+ALTER TABLE _timescaledb_catalog.not_a_real_table SET SCHEMA public;
+ALTER FUNCTION not_a_real_function() SET SCHEMA public;
+ALTER FUNCTION _timescaledb_internal.not_a_real_function() SET SCHEMA public;
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
This was never supposed to be allowed in the first place. Right now we special case  the `_timescaledb_internal` scheme: we want to allow users to move chunks to other schemas, though they are created in `_timescaledb_internal` by default, but we don't want them to move our internal functions.