### PR TITLE
Track hypertables used during process utility hook execution

### DIFF
--- a/sql/ddl_triggers.sql
+++ b/sql/ddl_triggers.sql
@@ -9,7 +9,7 @@ AS '@MODULE_PATHNAME@', 'ts_timescaledb_process_ddl_event' LANGUAGE C;
 
 --EVENT TRIGGER MUST exclude the ALTER EXTENSION tag.
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end
-WHEN TAG IN ('ALTER TABLE','CREATE TRIGGER','CREATE TABLE','CREATE INDEX','ALTER INDEX')
+WHEN TAG IN ('ALTER TABLE','CREATE TRIGGER','CREATE TABLE','CREATE INDEX','ALTER INDEX', 'DROP TABLE', 'DROP INDEX')
 EXECUTE PROCEDURE _timescaledb_internal.process_ddl_event();
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_sql_drop;

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -177,6 +177,9 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.gapfill_timestamptz_time_bucket = error_no_default_fn_pg_community,
 	.alter_job_schedule = error_no_default_fn_pg_enterprise,
 	.reorder_chunk = error_no_default_fn_pg_community,
+	.ddl_command_start = NULL,
+	.ddl_command_end = NULL,
+	.sql_drop = NULL
 };
 
 TSDLLEXPORT CrossModuleFunctions *ts_cm_functions = &ts_cm_functions_default;

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -10,6 +10,7 @@
 #include <c.h>
 #include <postgres.h>
 #include <fmgr.h>
+#include <commands/event_trigger.h>
 
 #include <utils/timestamp.h>
 #include <utils/jsonb.h>
@@ -18,6 +19,7 @@
 
 #include "export.h"
 #include "bgw/job.h"
+#include "process_utility.h"
 
 /*
  * To define a cross-module function add it to this struct, add a default
@@ -51,6 +53,9 @@ typedef struct CrossModuleFunctions
 	PGFunction gapfill_timestamptz_time_bucket;
 	PGFunction alter_job_schedule;
 	PGFunction reorder_chunk;
+	void (*ddl_command_start)(ProcessUtilityArgs *args);
+	void (*ddl_command_end)(EventTriggerData *command);
+	void (*sql_drop)(List *dropped_objects);
 } CrossModuleFunctions;
 
 extern TSDLLEXPORT CrossModuleFunctions *ts_cm_functions;

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -8,6 +8,25 @@
 
 #include <postgres.h>
 #include <nodes/plannodes.h>
+#include <tcop/utility.h>
+#include "hypertable_cache.h"
+#include "compat.h"
+
+typedef struct ProcessUtilityArgs
+{
+	Cache *hcache;
+#if !PG96
+	PlannedStmt *pstmt;
+	QueryEnvironment *queryEnv;
+#endif
+	Node *parsetree;
+	const char *query_string;
+	ProcessUtilityContext context;
+	ParamListInfo params;
+	DestReceiver *dest;
+	List *hypertable_list;
+	char *completion_tag;
+} ProcessUtilityArgs;
 
 extern void ts_process_utility_set_expect_chunk_modification(bool expect);
 

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -452,3 +452,23 @@ SELECT * FROM index_expr_test WHERE meta ->> 'field' = 'value1';
  Fri Jan 20 09:00:01 2017 PST | 17.5 | {"field": "value1"}
 (1 row)
 
+-- Test INDEX DROP error for multiple objects
+CREATE TABLE index_test(time timestamptz, temp float);
+CREATE UNIQUE INDEX index_test_idx ON index_test (time, temp);
+SELECT create_hypertable('index_test', 'time');
+NOTICE:  adding not-null constraint to column "time"
+    create_hypertable    
+-------------------------
+ (6,public,index_test,t)
+(1 row)
+
+CREATE TABLE index_test_2(time timestamptz, temp float);
+CREATE UNIQUE INDEX index_test_2_idx ON index_test_2 (time, temp);
+\set ON_ERROR_STOP 0
+DROP INDEX index_test_idx, index_test_2_idx;
+ERROR:  cannot drop a hypertable index along with other objects
+\set ON_ERROR_STOP 1
+DROP INDEX index_test_idx;
+DROP INDEX index_test_2_idx;
+DROP TABLE index_test;
+DROP TABLE index_test_2;

--- a/test/sql/index.sql
+++ b/test/sql/index.sql
@@ -191,3 +191,20 @@ INSERT INTO index_expr_test VALUES ('2017-01-20T09:00:01', 17.5, '{"field": "val
 EXPLAIN (verbose, costs off)
 SELECT * FROM index_expr_test WHERE meta ->> 'field' = 'value1';
 SELECT * FROM index_expr_test WHERE meta ->> 'field' = 'value1';
+
+-- Test INDEX DROP error for multiple objects
+CREATE TABLE index_test(time timestamptz, temp float);
+CREATE UNIQUE INDEX index_test_idx ON index_test (time, temp);
+SELECT create_hypertable('index_test', 'time');
+
+CREATE TABLE index_test_2(time timestamptz, temp float);
+CREATE UNIQUE INDEX index_test_2_idx ON index_test_2 (time, temp);
+
+\set ON_ERROR_STOP 0
+DROP INDEX index_test_idx, index_test_2_idx;
+\set ON_ERROR_STOP 1
+
+DROP INDEX index_test_idx;
+DROP INDEX index_test_2_idx;
+DROP TABLE index_test;
+DROP TABLE index_test_2;

--- a/tsl/test/expected/ddl_hook.out
+++ b/tsl/test/expected/ddl_hook.out
@@ -1,0 +1,324 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_ddl_command_hook_reg() RETURNS VOID
+AS :TSL_MODULE_PATHNAME, 'ts_test_ddl_command_hook_reg'
+LANGUAGE C VOLATILE STRICT;
+CREATE OR REPLACE FUNCTION ts_test_ddl_command_hook_unreg() RETURNS VOID
+AS :TSL_MODULE_PATHNAME, 'ts_test_ddl_command_hook_unreg'
+LANGUAGE C VOLATILE STRICT;
+SET client_min_messages TO ERROR;
+DROP SCHEMA IF EXISTS htable_schema CASCADE;
+DROP TABLE IF EXISTS htable;
+DROP TABLE IF EXISTS non_htable;
+SET client_min_messages TO NOTICE;
+CREATE SCHEMA htable_schema;
+-- Install test hooks
+SELECT ts_test_ddl_command_hook_reg();
+ ts_test_ddl_command_hook_reg 
+------------------------------
+ 
+(1 row)
+
+CREATE TABLE htable(time timestamptz, device int, color int CONSTRAINT color_check CHECK (color > 0), temp float);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE htable(time timestamptz, device int, color int CONSTRAINT color_check CHECK (color > 0), temp float);
+NOTICE:  test_ddl_command_end: CREATE TABLE
+CREATE UNIQUE INDEX htable_pk ON htable(time);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE UNIQUE INDEX htable_pk ON htable(time);
+NOTICE:  test_ddl_command_end: CREATE INDEX
+-- CREATE TABLE
+SELECT * FROM create_hypertable('htable', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | htable     | t
+(1 row)
+
+SELECT * FROM test.show_columns('htable');
+ Column |           Type           | Nullable 
+--------+--------------------------+----------
+ time   | timestamp with time zone | t
+ device | integer                  | f
+ color  | integer                  | f
+ temp   | double precision         | f
+(4 rows)
+
+SELECT * FROM test.show_constraints('htable');
+ Constraint  | Type | Columns | Index |    Expr     | Deferrable | Deferred | Validated 
+-------------+------+---------+-------+-------------+------------+----------+-----------
+ color_check | c    | {color} | -     | (color > 0) | f          | f        | t
+(1 row)
+
+SELECT * FROM test.show_indexes('htable');
+   Index   | Columns | Expr | Unique | Primary | Exclusion | Tablespace 
+-----------+---------+------+--------+---------+-----------+------------
+ htable_pk | {time}  |      | t      | f       | f         | 
+(1 row)
+
+-- ADD CONSTRAINT
+ALTER TABLE htable ADD CONSTRAINT device_check CHECK (device > 0);
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable ADD CONSTRAINT device_check CHECK (device > 0);
+NOTICE:  test_ddl_command_start: public.htable
+NOTICE:  test_ddl_command_end: ALTER TABLE
+SELECT * FROM test.show_constraints('htable');
+  Constraint  | Type | Columns  | Index |     Expr     | Deferrable | Deferred | Validated 
+--------------+------+----------+-------+--------------+------------+----------+-----------
+ color_check  | c    | {color}  | -     | (color > 0)  | f          | f        | t
+ device_check | c    | {device} | -     | (device > 0) | f          | f        | t
+(2 rows)
+
+-- DROP CONSTRAINT
+ALTER TABLE htable DROP CONSTRAINT device_check;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable DROP CONSTRAINT device_check;
+NOTICE:  test_ddl_command_start: public.htable
+NOTICE:  test_sql_drop: constraint: public.htable.device_check
+NOTICE:  test_ddl_command_end: ALTER TABLE
+SELECT * FROM test.show_constraints('htable');
+ Constraint  | Type | Columns | Index |    Expr     | Deferrable | Deferred | Validated 
+-------------+------+---------+-------+-------------+------------+----------+-----------
+ color_check | c    | {color} | -     | (color > 0) | f          | f        | t
+(1 row)
+
+-- DROP COLUMN
+ALTER TABLE htable DROP COLUMN color;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable DROP COLUMN color;
+NOTICE:  test_ddl_command_start: public.htable
+NOTICE:  test_sql_drop: constraint: public.htable.color_check
+NOTICE:  test_ddl_command_end: ALTER TABLE
+SELECT * FROM test.show_columns('htable');
+ Column |           Type           | Nullable 
+--------+--------------------------+----------
+ time   | timestamp with time zone | t
+ device | integer                  | f
+ temp   | double precision         | f
+(3 rows)
+
+-- ADD COLUMN
+ALTER TABLE htable ADD COLUMN description text;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable ADD COLUMN description text;
+NOTICE:  test_ddl_command_start: public.htable
+NOTICE:  test_ddl_command_end: ALTER TABLE
+SELECT * FROM test.show_columns('htable');
+   Column    |           Type           | Nullable 
+-------------+--------------------------+----------
+ time        | timestamp with time zone | t
+ device      | integer                  | f
+ temp        | double precision         | f
+ description | text                     | f
+(4 rows)
+
+-- CREATE INDEX
+CREATE INDEX htable_description_idx ON htable (description);
+NOTICE:  test_ddl_command_start: 1 hypertables, query: CREATE INDEX htable_description_idx ON htable (description);
+NOTICE:  test_ddl_command_start: public.htable
+SELECT * FROM test.show_indexes('htable');
+         Index          |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
+------------------------+---------------+------+--------+---------+-----------+------------
+ htable_description_idx | {description} |      | f      | f       | f         | 
+ htable_pk              | {time}        |      | t      | f       | f         | 
+(2 rows)
+
+-- CREATE/DROP TRIGGER
+CREATE OR REPLACE FUNCTION test_trigger()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+RETURN OLD;
+END
+$BODY$;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE OR REPLACE FUNCTION test_trigger()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+RETURN OLD;
+END
+$BODY$;
+CREATE TRIGGER htable_trigger_test
+BEFORE INSERT ON htable
+FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+NOTICE:  test_ddl_command_start: 1 hypertables, query: CREATE TRIGGER htable_trigger_test
+BEFORE INSERT ON htable
+FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+NOTICE:  test_ddl_command_start: public.htable
+NOTICE:  test_ddl_command_end: CREATE TRIGGER
+DROP TRIGGER htable_trigger_test on htable;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TRIGGER htable_trigger_test on htable;
+NOTICE:  test_sql_drop: trigger
+DROP FUNCTION test_trigger();
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP FUNCTION test_trigger();
+-- CLUSTER, TRUNCATE, REINDEX, VACUUM (should not call event hooks)
+CREATE TABLE non_htable (id int);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE non_htable (id int);
+NOTICE:  test_ddl_command_end: CREATE TABLE
+CLUSTER htable USING htable_description_idx;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: CLUSTER htable USING htable_description_idx;
+NOTICE:  test_ddl_command_start: public.htable
+TRUNCATE non_htable, htable;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: TRUNCATE non_htable, htable;
+NOTICE:  test_ddl_command_start: public.htable
+REINDEX TABLE htable;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: REINDEX TABLE htable;
+NOTICE:  test_ddl_command_start: public.htable
+VACUUM htable;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: VACUUM htable;
+NOTICE:  test_ddl_command_start: public.htable
+-- ALTER TABLE
+ALTER TABLE htable ADD CONSTRAINT temp_check CHECK (temp > 0.0);
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable ADD CONSTRAINT temp_check CHECK (temp > 0.0);
+NOTICE:  test_ddl_command_start: public.htable
+NOTICE:  test_ddl_command_end: ALTER TABLE
+SELECT * FROM test.show_constraints('htable');
+ Constraint | Type | Columns | Index |               Expr               | Deferrable | Deferred | Validated 
+------------+------+---------+-------+----------------------------------+------------+----------+-----------
+ temp_check | c    | {temp}  | -     | (temp > (0.0)::double precision) | f          | f        | t
+(1 row)
+
+ALTER TABLE htable RENAME CONSTRAINT temp_check TO temp_chk;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable RENAME CONSTRAINT temp_check TO temp_chk;
+NOTICE:  test_ddl_command_start: wait for ddl_command_end
+NOTICE:  test_ddl_command_end: ALTER TABLE
+NOTICE:  test_ddl_command_end: 1 hypertables scheduled
+NOTICE:  test_ddl_command_end: public.htable
+ALTER TABLE htable RENAME COLUMN description TO descr;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable RENAME COLUMN description TO descr;
+NOTICE:  test_ddl_command_start: wait for ddl_command_end
+NOTICE:  test_ddl_command_end: ALTER TABLE
+NOTICE:  test_ddl_command_end: 1 hypertables scheduled
+NOTICE:  test_ddl_command_end: public.htable
+ALTER INDEX htable_description_idx RENAME to htable_descr_idx;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER INDEX htable_description_idx RENAME to htable_descr_idx;
+NOTICE:  test_ddl_command_start: wait for ddl_command_end
+NOTICE:  test_ddl_command_end: ALTER INDEX
+NOTICE:  test_ddl_command_end: 1 hypertables scheduled
+NOTICE:  test_ddl_command_end: public.htable
+ALTER TABLE htable SET SCHEMA htable_schema;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable SET SCHEMA htable_schema;
+NOTICE:  test_ddl_command_start: wait for ddl_command_end
+NOTICE:  test_ddl_command_end: ALTER TABLE
+NOTICE:  test_ddl_command_end: 1 hypertables scheduled
+NOTICE:  test_ddl_command_end: htable_schema.htable
+ALTER TABLE htable_schema.htable SET SCHEMA public;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable_schema.htable SET SCHEMA public;
+NOTICE:  test_ddl_command_start: wait for ddl_command_end
+NOTICE:  test_ddl_command_end: ALTER TABLE
+NOTICE:  test_ddl_command_end: 1 hypertables scheduled
+NOTICE:  test_ddl_command_end: public.htable
+ALTER TABLE public.htable RENAME TO htable2;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE public.htable RENAME TO htable2;
+NOTICE:  test_ddl_command_start: wait for ddl_command_end
+NOTICE:  test_ddl_command_end: ALTER TABLE
+NOTICE:  test_ddl_command_end: 1 hypertables scheduled
+NOTICE:  test_ddl_command_end: public.htable2
+ALTER TABLE htable2 RENAME TO htable;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable2 RENAME TO htable;
+NOTICE:  test_ddl_command_start: wait for ddl_command_end
+NOTICE:  test_ddl_command_end: ALTER TABLE
+NOTICE:  test_ddl_command_end: 1 hypertables scheduled
+NOTICE:  test_ddl_command_end: public.htable
+-- DROP INDEX, TABLE
+\set ON_ERROR_STOP 0
+DROP INDEX htable_description_idx, htable_pk;
+ERROR:  cannot drop a hypertable index along with other objects
+DROP TABLE htable, non_htable;
+ERROR:  cannot drop a hypertable along with other objects
+\set ON_ERROR_STOP 1
+DROP INDEX htable_descr_idx;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP INDEX htable_descr_idx;
+NOTICE:  test_sql_drop: index
+NOTICE:  test_ddl_command_end: DROP INDEX
+DROP TABLE htable;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TABLE htable;
+NOTICE:  test_sql_drop: table: public.htable
+NOTICE:  test_sql_drop: constraint: public.htable.temp_chk
+NOTICE:  test_sql_drop: index
+NOTICE:  test_sql_drop: trigger
+NOTICE:  test_sql_drop: index
+NOTICE:  test_ddl_command_end: DROP TABLE
+DROP TABLE non_htable;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TABLE non_htable;
+NOTICE:  test_sql_drop: table: public.non_htable
+NOTICE:  test_ddl_command_end: DROP TABLE
+-- DROP CASCADE cases
+-- DROP schema
+CREATE TABLE htable_schema.non_htable (id int);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE htable_schema.non_htable (id int);
+NOTICE:  test_ddl_command_end: CREATE TABLE
+CREATE TABLE htable_schema.htable(time timestamptz, device int, color int, temp float);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE htable_schema.htable(time timestamptz, device int, color int, temp float);
+NOTICE:  test_ddl_command_end: CREATE TABLE
+SELECT * FROM create_hypertable('htable_schema.htable', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id |  schema_name  | table_name | created 
+---------------+---------------+------------+---------
+             2 | htable_schema | htable     | t
+(1 row)
+
+DROP SCHEMA htable_schema CASCADE;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP SCHEMA htable_schema CASCADE;
+NOTICE:  drop cascades to 2 other objects
+NOTICE:  test_sql_drop: schema: htable_schema
+NOTICE:  test_sql_drop: table: htable_schema.non_htable
+NOTICE:  test_sql_drop: table: htable_schema.htable
+NOTICE:  test_sql_drop: index
+NOTICE:  test_sql_drop: trigger
+-- DROP column cascades to index drop
+CREATE TABLE htable(time timestamptz, device int, color int, temp float);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE htable(time timestamptz, device int, color int, temp float);
+NOTICE:  test_ddl_command_end: CREATE TABLE
+SELECT * FROM create_hypertable('htable', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | htable     | t
+(1 row)
+
+CREATE INDEX htable_device_idx ON htable (device);
+NOTICE:  test_ddl_command_start: 1 hypertables, query: CREATE INDEX htable_device_idx ON htable (device);
+NOTICE:  test_ddl_command_start: public.htable
+ALTER TABLE htable DROP COLUMN device;
+NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable DROP COLUMN device;
+NOTICE:  test_ddl_command_start: public.htable
+NOTICE:  test_sql_drop: index
+NOTICE:  test_ddl_command_end: ALTER TABLE
+DROP TABLE htable;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TABLE htable;
+NOTICE:  test_sql_drop: table: public.htable
+NOTICE:  test_sql_drop: index
+NOTICE:  test_sql_drop: trigger
+NOTICE:  test_ddl_command_end: DROP TABLE
+-- DROP foreign key
+CREATE TABLE non_htable (id int PRIMARY KEY);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE non_htable (id int PRIMARY KEY);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE non_htable (id int PRIMARY KEY);
+NOTICE:  test_ddl_command_end: CREATE TABLE
+CREATE TABLE htable(time timestamptz, device int REFERENCES non_htable(id));
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE htable(time timestamptz, device int REFERENCES non_htable(id));
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE htable(time timestamptz, device int REFERENCES non_htable(id));
+NOTICE:  test_ddl_command_end: CREATE TABLE
+SELECT * FROM create_hypertable('htable', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             4 | public      | htable     | t
+(1 row)
+
+DROP TABLE non_htable CASCADE;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TABLE non_htable CASCADE;
+NOTICE:  drop cascades to constraint htable_device_fkey on table htable
+NOTICE:  test_sql_drop: table: public.non_htable
+NOTICE:  test_sql_drop: constraint: public.non_htable.non_htable_pkey
+NOTICE:  test_sql_drop: index
+NOTICE:  test_sql_drop: constraint: public.htable.htable_device_fkey
+NOTICE:  test_sql_drop: trigger
+NOTICE:  test_sql_drop: trigger
+NOTICE:  test_sql_drop: trigger
+NOTICE:  test_sql_drop: trigger
+NOTICE:  test_ddl_command_end: DROP TABLE
+-- cleanup
+SELECT ts_test_ddl_command_hook_unreg();
+ ts_test_ddl_command_hook_unreg 
+--------------------------------
+ 
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_FILES
     edition.sql
     gapfill.sql
     reorder.sql
+    ddl_hook.sql
 )
 
 set(TEST_FILES_DEBUG

--- a/tsl/test/sql/ddl_hook.sql
+++ b/tsl/test/sql/ddl_hook.sql
@@ -1,0 +1,122 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE OR REPLACE FUNCTION ts_test_ddl_command_hook_reg() RETURNS VOID
+AS :TSL_MODULE_PATHNAME, 'ts_test_ddl_command_hook_reg'
+LANGUAGE C VOLATILE STRICT;
+
+CREATE OR REPLACE FUNCTION ts_test_ddl_command_hook_unreg() RETURNS VOID
+AS :TSL_MODULE_PATHNAME, 'ts_test_ddl_command_hook_unreg'
+LANGUAGE C VOLATILE STRICT;
+
+SET client_min_messages TO ERROR;
+DROP SCHEMA IF EXISTS htable_schema CASCADE;
+DROP TABLE IF EXISTS htable;
+DROP TABLE IF EXISTS non_htable;
+SET client_min_messages TO NOTICE;
+
+CREATE SCHEMA htable_schema;
+
+-- Install test hooks
+SELECT ts_test_ddl_command_hook_reg();
+
+CREATE TABLE htable(time timestamptz, device int, color int CONSTRAINT color_check CHECK (color > 0), temp float);
+CREATE UNIQUE INDEX htable_pk ON htable(time);
+
+-- CREATE TABLE
+SELECT * FROM create_hypertable('htable', 'time');
+SELECT * FROM test.show_columns('htable');
+SELECT * FROM test.show_constraints('htable');
+SELECT * FROM test.show_indexes('htable');
+
+-- ADD CONSTRAINT
+ALTER TABLE htable ADD CONSTRAINT device_check CHECK (device > 0);
+SELECT * FROM test.show_constraints('htable');
+
+-- DROP CONSTRAINT
+ALTER TABLE htable DROP CONSTRAINT device_check;
+SELECT * FROM test.show_constraints('htable');
+
+-- DROP COLUMN
+ALTER TABLE htable DROP COLUMN color;
+SELECT * FROM test.show_columns('htable');
+
+-- ADD COLUMN
+ALTER TABLE htable ADD COLUMN description text;
+SELECT * FROM test.show_columns('htable');
+
+-- CREATE INDEX
+CREATE INDEX htable_description_idx ON htable (description);
+SELECT * FROM test.show_indexes('htable');
+
+-- CREATE/DROP TRIGGER
+CREATE OR REPLACE FUNCTION test_trigger()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+RETURN OLD;
+END
+$BODY$;
+
+CREATE TRIGGER htable_trigger_test
+BEFORE INSERT ON htable
+FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+
+DROP TRIGGER htable_trigger_test on htable;
+DROP FUNCTION test_trigger();
+
+-- CLUSTER, TRUNCATE, REINDEX, VACUUM (should not call event hooks)
+CREATE TABLE non_htable (id int);
+
+CLUSTER htable USING htable_description_idx;
+TRUNCATE non_htable, htable;
+REINDEX TABLE htable;
+VACUUM htable;
+
+-- ALTER TABLE
+ALTER TABLE htable ADD CONSTRAINT temp_check CHECK (temp > 0.0);
+SELECT * FROM test.show_constraints('htable');
+
+ALTER TABLE htable RENAME CONSTRAINT temp_check TO temp_chk;
+ALTER TABLE htable RENAME COLUMN description TO descr;
+ALTER INDEX htable_description_idx RENAME to htable_descr_idx;
+ALTER TABLE htable SET SCHEMA htable_schema;
+ALTER TABLE htable_schema.htable SET SCHEMA public;
+ALTER TABLE public.htable RENAME TO htable2;
+ALTER TABLE htable2 RENAME TO htable;
+
+-- DROP INDEX, TABLE
+\set ON_ERROR_STOP 0
+DROP INDEX htable_description_idx, htable_pk;
+DROP TABLE htable, non_htable;
+\set ON_ERROR_STOP 1
+DROP INDEX htable_descr_idx;
+DROP TABLE htable;
+DROP TABLE non_htable;
+
+-- DROP CASCADE cases
+
+-- DROP schema
+CREATE TABLE htable_schema.non_htable (id int);
+CREATE TABLE htable_schema.htable(time timestamptz, device int, color int, temp float);
+SELECT * FROM create_hypertable('htable_schema.htable', 'time');
+DROP SCHEMA htable_schema CASCADE;
+
+-- DROP column cascades to index drop
+CREATE TABLE htable(time timestamptz, device int, color int, temp float);
+SELECT * FROM create_hypertable('htable', 'time');
+CREATE INDEX htable_device_idx ON htable (device);
+ALTER TABLE htable DROP COLUMN device;
+DROP TABLE htable;
+
+-- DROP foreign key
+CREATE TABLE non_htable (id int PRIMARY KEY);
+CREATE TABLE htable(time timestamptz, device int REFERENCES non_htable(id));
+SELECT * FROM create_hypertable('htable', 'time');
+DROP TABLE non_htable CASCADE;
+
+-- cleanup
+SELECT ts_test_ddl_command_hook_unreg();

--- a/tsl/test/src/CMakeLists.txt
+++ b/tsl/test/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
   test_auto_policy.c
   test_chunk_stats.c
+  test_ddl_hook.c
 )
 include(${PROJECT_SOURCE_DIR}/tsl/src/build-defs.cmake)
 
@@ -10,3 +11,5 @@ add_library(${TSL_TESTS_LIB_NAME} OBJECT ${SOURCES})
 # module, it needs to be compiled as position-independent code
 # (e.g., the -fPIC compiler flag for GCC)
 set_target_properties(${TSL_TESTS_LIB_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_compile_definitions(${TSL_TESTS_LIB_NAME} PUBLIC TS_SUBMODULE)

--- a/tsl/test/src/test_ddl_hook.c
+++ b/tsl/test/src/test_ddl_hook.c
@@ -1,0 +1,177 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <string.h>
+#include <unistd.h>
+#include <postgres.h>
+#include <fmgr.h>
+
+#include "export.h"
+#include "process_utility.h"
+
+#include "compat.h"
+#include "event_trigger.h"
+#include "cross_module_fn.h"
+
+TS_FUNCTION_INFO_V1(ts_test_ddl_command_hook_reg);
+TS_FUNCTION_INFO_V1(ts_test_ddl_command_hook_unreg);
+
+static List *tsl_delayed_execution_list = NIL;
+
+static void
+test_ddl_command_start(ProcessUtilityArgs *args)
+{
+	Cache *hcache;
+	ListCell *cell;
+	Hypertable *ht;
+
+	elog(NOTICE,
+		 "test_ddl_command_start: %d hypertables, query: %s",
+		 list_length(args->hypertable_list),
+		 args->query_string);
+
+	/*
+	 * Hypertable oid from those commands is available in hypertable_list but
+	 * cannot be resolved here until standard utility hook will synchronize new
+	 * relation name and schema.
+	 *
+	 * Save hypertable list here for command_end execution to avoid statement
+	 * parsing for second time.
+	 */
+	switch (nodeTag(args->parsetree))
+	{
+		case T_AlterObjectSchemaStmt:
+		case T_RenameStmt:
+			elog(NOTICE, "test_ddl_command_start: wait for ddl_command_end");
+			tsl_delayed_execution_list = list_copy(args->hypertable_list);
+			return;
+		default:
+			break;
+	}
+
+	hcache = ts_hypertable_cache_pin();
+
+	foreach (cell, args->hypertable_list)
+	{
+		Oid relid = lfirst_oid(cell);
+
+		ht = ts_hypertable_cache_get_entry(hcache, relid);
+		Assert(ht != NULL);
+
+		elog(NOTICE,
+			 "test_ddl_command_start: %s.%s",
+			 NameStr(ht->fd.schema_name),
+			 NameStr(ht->fd.table_name));
+	}
+
+	ts_cache_release(hcache);
+}
+
+static void
+test_ddl_command_end(EventTriggerData *command)
+{
+	Cache *hcache;
+	ListCell *cell;
+	Hypertable *ht;
+
+	elog(NOTICE, "test_ddl_command_end: %s", command->tag);
+
+	if (tsl_delayed_execution_list == NIL)
+		return;
+
+	elog(NOTICE,
+		 "test_ddl_command_end: %d hypertables scheduled",
+		 list_length(tsl_delayed_execution_list));
+
+	hcache = ts_hypertable_cache_pin();
+
+	foreach (cell, tsl_delayed_execution_list)
+	{
+		Oid relid = lfirst_oid(cell);
+
+		ht = ts_hypertable_cache_get_entry(hcache, relid);
+		Assert(ht != NULL);
+
+		elog(NOTICE,
+			 "test_ddl_command_end: %s.%s",
+			 NameStr(ht->fd.schema_name),
+			 NameStr(ht->fd.table_name));
+	}
+
+	ts_cache_release(hcache);
+
+	pfree(tsl_delayed_execution_list);
+	tsl_delayed_execution_list = NIL;
+}
+
+static void
+test_sql_drop(List *dropped_objects)
+{
+	ListCell *lc;
+
+	foreach (lc, dropped_objects)
+	{
+		EventTriggerDropObject *obj = lfirst(lc);
+
+		switch (obj->type)
+		{
+			case EVENT_TRIGGER_DROP_TABLE_CONSTRAINT:
+			{
+				EventTriggerDropTableConstraint *event = (EventTriggerDropTableConstraint *) obj;
+
+				elog(NOTICE,
+					 "test_sql_drop: constraint: %s.%s.%s",
+					 event->schema,
+					 event->table,
+					 event->constraint_name);
+				break;
+			}
+			case EVENT_TRIGGER_DROP_INDEX:
+			{
+				elog(NOTICE, "test_sql_drop: index");
+				break;
+			}
+			case EVENT_TRIGGER_DROP_TABLE:
+			{
+				EventTriggerDropTable *event = (EventTriggerDropTable *) obj;
+
+				elog(NOTICE, "test_sql_drop: table: %s.%s", event->schema, event->table_name);
+				break;
+			}
+			case EVENT_TRIGGER_DROP_SCHEMA:
+			{
+				EventTriggerDropSchema *event = (EventTriggerDropSchema *) obj;
+
+				elog(NOTICE, "test_sql_drop: schema: %s", event->schema);
+				break;
+			}
+			case EVENT_TRIGGER_DROP_TRIGGER:
+			{
+				elog(NOTICE, "test_sql_drop: trigger");
+				break;
+			}
+		}
+	}
+}
+
+Datum
+ts_test_ddl_command_hook_reg(PG_FUNCTION_ARGS)
+{
+	Assert(ts_cm_functions->ddl_command_start == NULL);
+	ts_cm_functions->ddl_command_start = test_ddl_command_start;
+	ts_cm_functions->ddl_command_end = test_ddl_command_end;
+	ts_cm_functions->sql_drop = test_sql_drop;
+	PG_RETURN_VOID();
+}
+
+Datum
+ts_test_ddl_command_hook_unreg(PG_FUNCTION_ARGS)
+{
+	Assert(ts_cm_functions->ddl_command_start == test_ddl_command_start);
+	ts_cm_functions->ddl_command_start = NULL;
+	ts_cm_functions->ddl_command_end = NULL;
+	ts_cm_functions->sql_drop = NULL;
+	PG_RETURN_VOID();
+}


### PR DESCRIPTION
This patch does refactoring necessary to support execution of DDL commands on remote servers.

Basically it extends cross module api with `ddl_command_start` function and pass `ProcessUtilityArgs` context to it. Additionally it shares hypertables cache pin, which now happens before `process_ddl_command_start` function call and released afterwards.

New variables `hypertables_list`, `subcmd_list` added to `ProcessUtilityArgs`. These fields are used to keep a list of found hypertables during Utility/DDL statement parsing. This information will be used to distinct distributed hypertables and forward DDL commands to any remote servers associated with them.

Added functionaly and test to track DROP INDEX call and ensure it is used against only one hypertable at a time.