### PR TITLE
Fix invalid client_min_messages level in chunk_utils test

### DIFF
--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -203,17 +203,8 @@ SELECT drop_chunks(NULL::interval);
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
 SELECT drop_chunks(NULL::int);
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
--- error messages were refactored in postgres between 9.6 and 10 because of
--- which direct comparison of error messages fails.
--- The change in postgres happened here:
--- https://github.com/postgres/postgres/commit/9a34123bc315e55b33038464422ef1cd2b67dab2
-SET client_min_messages TO FATAL;
--- error message is suppressed for the reason above but this test should still make sure
--- this causes an error. Not returning # rows below can be used as an indication that
--- this did cause an error.
--- should error because not a time type
 SELECT drop_chunks('haha', 'drop_chunk_test3');
-SET client_min_messages TO DEFAULT;
+ERROR:  time constraint arguments of "drop_chunks" should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
 SELECT show_chunks('drop_chunk_test3', 'haha');
 ERROR:  time constraint arguments of "show_chunks" should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
 -- should error because wrong time type
@@ -788,11 +779,8 @@ SELECT show_chunks('drop_chunk_test1');
 
 -- testing drop_chunks when only schema is specified.
 \set ON_ERROR_STOP 0
--- error messages were refactored in postgres between 9.6 and 10 because of
--- which direct comparison of error messages fails.
-SET client_min_messages TO FATAL;
 SELECT drop_chunks(schema_name=>'public');
-SET client_min_messages TO DEFAULT;
+ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
 SELECT drop_chunks(null::bigint, schema_name=>'public');
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
 \set ON_ERROR_STOP 1

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -92,18 +92,7 @@ SELECT drop_chunks();
 SELECT drop_chunks(2);
 SELECT drop_chunks(NULL::interval);
 SELECT drop_chunks(NULL::int);
--- error messages were refactored in postgres between 9.6 and 10 because of
--- which direct comparison of error messages fails.
--- The change in postgres happened here:
--- https://github.com/postgres/postgres/commit/9a34123bc315e55b33038464422ef1cd2b67dab2
-SET client_min_messages TO FATAL;
--- error message is suppressed for the reason above but this test should still make sure
--- this causes an error. Not returning # rows below can be used as an indication that
--- this did cause an error.
--- should error because not a time type
 SELECT drop_chunks('haha', 'drop_chunk_test3');
-SET client_min_messages TO DEFAULT;
-
 SELECT show_chunks('drop_chunk_test3', 'haha');
 
 -- should error because wrong time type
@@ -251,11 +240,7 @@ SELECT show_chunks('drop_chunk_test1');
 
 -- testing drop_chunks when only schema is specified.
 \set ON_ERROR_STOP 0
--- error messages were refactored in postgres between 9.6 and 10 because of
--- which direct comparison of error messages fails.
-SET client_min_messages TO FATAL;
 SELECT drop_chunks(schema_name=>'public');
-SET client_min_messages TO DEFAULT;
 SELECT drop_chunks(null::bigint, schema_name=>'public');
 \set ON_ERROR_STOP 1
 


### PR DESCRIPTION
The chunk_utils test sets `client_min_messages` to `FATAL` in order to
mute some error messages, which differ between PostgreSQL versions and
would otherwise cause test failures on some platforms. However,
according to the PostgreSQL documentation going back to at least 9.6,
this is not a valid log level for this configuration
parameter, although it has been allowed for legacy reasons. However,
starting with PostgreSQL 11.2, `FATAL` is silently turned into `ERROR`
and will cause the test to output the error anyway and thus fail.

This change removes the muting altogether, because the error that is
output is actually a TimescaleDB error and not a PostgreSQL error. The
generated error output probably changed at some point and therefore
this muting is no longer necessary.