### PR TITLE
Fix ordered append optimization for join queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,29 @@ accidentally triggering the load of a previous DB version.**
 ## 1.3.0 (unreleased)
 
 **Minor Features**
-* PR #1062 Make constraint aware append parallel safe
-* PR #1005 Enable creating indexes with one transaction per chunk
-* PR #1007 Remove parent oid from find_children_oids result
-* PR #1038 Infer time_bucket_gapfill arguments from WHERE clause
-* PR #1067 Add treat_null_as_missing option to locf
+* #1062 Make constraint aware append parallel safe
+* #1005 Enable creating indexes with one transaction per chunk
+* #1007 Remove parent oid from find_children_oids result
+* #1038 Infer time_bucket_gapfill arguments from WHERE clause
+* #1067 Add treat_null_as_missing option to locf
+
+**Bugfixes**
+* #1115 Fix ordered append optimization for join queries
+
+**Thanks**
+* @spickman for reporting a segfault with ordered append and JOINs
 
 ## 1.2.2 (2019-03-14)
 
 This release contains bugfixes.
 
 **Bugfixes**
-* PR #1097 Adjust ordered append plan cost
-* PR #1079 Stop background worker on ALTER DATABASE SET TABLESPACE and CREATE DATABASE WITH TEMPLATE
-* PR #1088 Fix ON CONFLICT when using prepared statements and functions
-* PR #1089 Fix compatibility with extensions that define planner_hook
-* PR #1057 Fix chunk exclusion constraint type inference
-* PR #1060 Fix sort_transform optimization
+* #1097 Adjust ordered append plan cost
+* #1079 Stop background worker on ALTER DATABASE SET TABLESPACE and CREATE DATABASE WITH TEMPLATE
+* #1088 Fix ON CONFLICT when using prepared statements and functions
+* #1089 Fix compatibility with extensions that define planner_hook
+* #1057 Fix chunk exclusion constraint type inference
+* #1060 Fix sort_transform optimization
 
 **Thanks**
 * @esatterwhite for reporting a bug when using timescaledb with zombodb

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -15,6 +15,7 @@ SELECT
     ELSE 'EXPLAIN (costs off)'
   END AS "PREFIX"
 \gset
+\set PREFIX_NO_ANALYZE 'EXPLAIN (costs off)'
 \ir include/plan_ordered_append_load.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -28,6 +29,11 @@ BEGIN
     RETURN '2000-01-08T0:00:00+0'::timestamptz;
 END;
 $BODY$;
+CREATE TABLE devices(device_id INT PRIMARY KEY, name TEXT);
+INSERT INTO devices VALUES
+(1,'Device 1'),
+(2,'Device 2'),
+(3,'Device 3');
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');
@@ -52,6 +58,39 @@ SELECT create_hypertable('ordered_append_reverse','time');
 INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+-- table where dimension column is last column
+CREATE TABLE IF NOT EXISTS dimension_last(
+    id INT8 NOT NULL,
+    device_id INT NOT NULL,
+    name TEXT NOT NULL,
+    time timestamptz NOT NULL
+);
+SELECT create_hypertable('dimension_last', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+      create_hypertable      
+-----------------------------
+ (3,public,dimension_last,t)
+(1 row)
+
+-- table with only dimension column
+CREATE TABLE IF NOT EXISTS dimension_only(
+    time timestamptz NOT NULL
+);
+SELECT create_hypertable('dimension_only', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+      create_hypertable      
+-----------------------------
+ (4,public,dimension_only,t)
+(1 row)
+
+INSERT INTO dimension_last VALUES
+(1,1,'Device 1','2000-01-01'),
+(2,1,'Device 1','2000-01-02'),
+(3,1,'Device 1','2000-01-03'),
+(4,1,'Device 1','2000-01-04');
+INSERT INTO dimension_only VALUES
+('2000-01-01'),
+('2000-01-03'),
+('2000-01-05'),
+('2000-01-07');
 \ir include/plan_ordered_append_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -68,15 +107,23 @@ FROM
   INNER JOIN _timescaledb_catalog.dimension d ON ds.dimension_id = d.id
   INNER JOIN _timescaledb_catalog.hypertable ht ON d.hypertable_id = ht.id
 ORDER BY ht.table_name, range_start;
-       hypertable       |      chunk       |   range_start   
-------------------------+------------------+-----------------
- ordered_append         | _hyper_1_1_chunk | 946512000000000
- ordered_append         | _hyper_1_2_chunk | 947116800000000
- ordered_append         | _hyper_1_3_chunk | 947721600000000
- ordered_append_reverse | _hyper_2_6_chunk | 946512000000000
- ordered_append_reverse | _hyper_2_5_chunk | 947116800000000
- ordered_append_reverse | _hyper_2_4_chunk | 947721600000000
-(6 rows)
+       hypertable       |       chunk       |   range_start   
+------------------------+-------------------+-----------------
+ dimension_last         | _hyper_3_7_chunk  | 946684800000000
+ dimension_last         | _hyper_3_8_chunk  | 946771200000000
+ dimension_last         | _hyper_3_9_chunk  | 946857600000000
+ dimension_last         | _hyper_3_10_chunk | 946944000000000
+ dimension_only         | _hyper_4_11_chunk | 946684800000000
+ dimension_only         | _hyper_4_12_chunk | 946857600000000
+ dimension_only         | _hyper_4_13_chunk | 947030400000000
+ dimension_only         | _hyper_4_14_chunk | 947203200000000
+ ordered_append         | _hyper_1_1_chunk  | 946512000000000
+ ordered_append         | _hyper_1_2_chunk  | 947116800000000
+ ordered_append         | _hyper_1_3_chunk  | 947721600000000
+ ordered_append_reverse | _hyper_2_6_chunk  | 946512000000000
+ ordered_append_reverse | _hyper_2_5_chunk  | 947116800000000
+ ordered_append_reverse | _hyper_2_4_chunk  | 947721600000000
+(14 rows)
 
 -- test ASC for ordered chunks
 :PREFIX SELECT
@@ -540,4 +587,91 @@ SELECT * FROM i;
          ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
          ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
 (5 rows)
+
+-- test with table with only dimension column
+:PREFIX SELECT * FROM dimension_only ORDER BY time DESC LIMIT 1;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk (actual rows=1 loops=1)
+               Heap Fetches: 1
+         ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk (never executed)
+               Heap Fetches: 0
+(10 rows)
+
+-- test LEFT JOIN against hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+LEFT JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop Left Join
+         ->  Append
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
+         ->  Append
+               ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+(16 rows)
+
+-- test INNER JOIN against non-hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+INNER JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop
+         ->  Append
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
+         ->  Append
+               ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+(16 rows)
+
+-- test join against non-hypertable
+:PREFIX SELECT *
+FROM dimension_last
+INNER JOIN devices USING(device_id)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=2 loops=1)
+   ->  Nested Loop (actual rows=2 loops=1)
+         ->  Append (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk (never executed)
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk (never executed)
+         ->  Index Scan using devices_pkey on devices (actual rows=1 loops=2)
+               Index Cond: (device_id = _hyper_3_10_chunk.device_id)
+(9 rows)
 

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -15,6 +15,7 @@ SELECT
     ELSE 'EXPLAIN (costs off)'
   END AS "PREFIX"
 \gset
+\set PREFIX_NO_ANALYZE 'EXPLAIN (costs off)'
 \ir include/plan_ordered_append_load.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -28,6 +29,11 @@ BEGIN
     RETURN '2000-01-08T0:00:00+0'::timestamptz;
 END;
 $BODY$;
+CREATE TABLE devices(device_id INT PRIMARY KEY, name TEXT);
+INSERT INTO devices VALUES
+(1,'Device 1'),
+(2,'Device 2'),
+(3,'Device 3');
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');
@@ -52,6 +58,39 @@ SELECT create_hypertable('ordered_append_reverse','time');
 INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+-- table where dimension column is last column
+CREATE TABLE IF NOT EXISTS dimension_last(
+    id INT8 NOT NULL,
+    device_id INT NOT NULL,
+    name TEXT NOT NULL,
+    time timestamptz NOT NULL
+);
+SELECT create_hypertable('dimension_last', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+      create_hypertable      
+-----------------------------
+ (3,public,dimension_last,t)
+(1 row)
+
+-- table with only dimension column
+CREATE TABLE IF NOT EXISTS dimension_only(
+    time timestamptz NOT NULL
+);
+SELECT create_hypertable('dimension_only', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+      create_hypertable      
+-----------------------------
+ (4,public,dimension_only,t)
+(1 row)
+
+INSERT INTO dimension_last VALUES
+(1,1,'Device 1','2000-01-01'),
+(2,1,'Device 1','2000-01-02'),
+(3,1,'Device 1','2000-01-03'),
+(4,1,'Device 1','2000-01-04');
+INSERT INTO dimension_only VALUES
+('2000-01-01'),
+('2000-01-03'),
+('2000-01-05'),
+('2000-01-07');
 \ir include/plan_ordered_append_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -68,15 +107,23 @@ FROM
   INNER JOIN _timescaledb_catalog.dimension d ON ds.dimension_id = d.id
   INNER JOIN _timescaledb_catalog.hypertable ht ON d.hypertable_id = ht.id
 ORDER BY ht.table_name, range_start;
-       hypertable       |      chunk       |   range_start   
-------------------------+------------------+-----------------
- ordered_append         | _hyper_1_1_chunk | 946512000000000
- ordered_append         | _hyper_1_2_chunk | 947116800000000
- ordered_append         | _hyper_1_3_chunk | 947721600000000
- ordered_append_reverse | _hyper_2_6_chunk | 946512000000000
- ordered_append_reverse | _hyper_2_5_chunk | 947116800000000
- ordered_append_reverse | _hyper_2_4_chunk | 947721600000000
-(6 rows)
+       hypertable       |       chunk       |   range_start   
+------------------------+-------------------+-----------------
+ dimension_last         | _hyper_3_7_chunk  | 946684800000000
+ dimension_last         | _hyper_3_8_chunk  | 946771200000000
+ dimension_last         | _hyper_3_9_chunk  | 946857600000000
+ dimension_last         | _hyper_3_10_chunk | 946944000000000
+ dimension_only         | _hyper_4_11_chunk | 946684800000000
+ dimension_only         | _hyper_4_12_chunk | 946857600000000
+ dimension_only         | _hyper_4_13_chunk | 947030400000000
+ dimension_only         | _hyper_4_14_chunk | 947203200000000
+ ordered_append         | _hyper_1_1_chunk  | 946512000000000
+ ordered_append         | _hyper_1_2_chunk  | 947116800000000
+ ordered_append         | _hyper_1_3_chunk  | 947721600000000
+ ordered_append_reverse | _hyper_2_6_chunk  | 946512000000000
+ ordered_append_reverse | _hyper_2_5_chunk  | 947116800000000
+ ordered_append_reverse | _hyper_2_4_chunk  | 947721600000000
+(14 rows)
 
 -- test ASC for ordered chunks
 :PREFIX SELECT
@@ -540,4 +587,88 @@ SELECT * FROM i;
          ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
          ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
 (5 rows)
+
+-- test with table with only dimension column
+:PREFIX SELECT * FROM dimension_only ORDER BY time DESC LIMIT 1;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Append (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk (actual rows=1 loops=1)
+               Heap Fetches: 1
+         ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk (never executed)
+               Heap Fetches: 0
+(10 rows)
+
+-- test LEFT JOIN against hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+LEFT JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop Left Join
+         Join Filter: (_hyper_3_10_chunk."time" = _hyper_4_11_chunk."time")
+         ->  Append
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
+         ->  Materialize
+               ->  Append
+                     ->  Seq Scan on _hyper_4_11_chunk
+                     ->  Seq Scan on _hyper_4_12_chunk
+                     ->  Seq Scan on _hyper_4_13_chunk
+                     ->  Seq Scan on _hyper_4_14_chunk
+(14 rows)
+
+-- test INNER JOIN against non-hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+INNER JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop
+         Join Filter: (_hyper_3_10_chunk."time" = _hyper_4_11_chunk."time")
+         ->  Append
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
+         ->  Materialize
+               ->  Append
+                     ->  Seq Scan on _hyper_4_11_chunk
+                     ->  Seq Scan on _hyper_4_12_chunk
+                     ->  Seq Scan on _hyper_4_13_chunk
+                     ->  Seq Scan on _hyper_4_14_chunk
+(14 rows)
+
+-- test join against non-hypertable
+:PREFIX SELECT *
+FROM dimension_last
+INNER JOIN devices USING(device_id)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=2 loops=1)
+   ->  Nested Loop (actual rows=2 loops=1)
+         Join Filter: (_hyper_3_10_chunk.device_id = devices.device_id)
+         ->  Append (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk (actual rows=1 loops=1)
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk (never executed)
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk (never executed)
+         ->  Materialize (actual rows=1 loops=2)
+               ->  Seq Scan on devices (actual rows=1 loops=1)
+(10 rows)
 

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -15,6 +15,7 @@ SELECT
     ELSE 'EXPLAIN (costs off)'
   END AS "PREFIX"
 \gset
+\set PREFIX_NO_ANALYZE 'EXPLAIN (costs off)'
 \ir include/plan_ordered_append_load.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -28,6 +29,11 @@ BEGIN
     RETURN '2000-01-08T0:00:00+0'::timestamptz;
 END;
 $BODY$;
+CREATE TABLE devices(device_id INT PRIMARY KEY, name TEXT);
+INSERT INTO devices VALUES
+(1,'Device 1'),
+(2,'Device 2'),
+(3,'Device 3');
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');
@@ -52,6 +58,39 @@ SELECT create_hypertable('ordered_append_reverse','time');
 INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+-- table where dimension column is last column
+CREATE TABLE IF NOT EXISTS dimension_last(
+    id INT8 NOT NULL,
+    device_id INT NOT NULL,
+    name TEXT NOT NULL,
+    time timestamptz NOT NULL
+);
+SELECT create_hypertable('dimension_last', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+      create_hypertable      
+-----------------------------
+ (3,public,dimension_last,t)
+(1 row)
+
+-- table with only dimension column
+CREATE TABLE IF NOT EXISTS dimension_only(
+    time timestamptz NOT NULL
+);
+SELECT create_hypertable('dimension_only', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+      create_hypertable      
+-----------------------------
+ (4,public,dimension_only,t)
+(1 row)
+
+INSERT INTO dimension_last VALUES
+(1,1,'Device 1','2000-01-01'),
+(2,1,'Device 1','2000-01-02'),
+(3,1,'Device 1','2000-01-03'),
+(4,1,'Device 1','2000-01-04');
+INSERT INTO dimension_only VALUES
+('2000-01-01'),
+('2000-01-03'),
+('2000-01-05'),
+('2000-01-07');
 \ir include/plan_ordered_append_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -68,15 +107,23 @@ FROM
   INNER JOIN _timescaledb_catalog.dimension d ON ds.dimension_id = d.id
   INNER JOIN _timescaledb_catalog.hypertable ht ON d.hypertable_id = ht.id
 ORDER BY ht.table_name, range_start;
-       hypertable       |      chunk       |   range_start   
-------------------------+------------------+-----------------
- ordered_append         | _hyper_1_1_chunk | 946512000000000
- ordered_append         | _hyper_1_2_chunk | 947116800000000
- ordered_append         | _hyper_1_3_chunk | 947721600000000
- ordered_append_reverse | _hyper_2_6_chunk | 946512000000000
- ordered_append_reverse | _hyper_2_5_chunk | 947116800000000
- ordered_append_reverse | _hyper_2_4_chunk | 947721600000000
-(6 rows)
+       hypertable       |       chunk       |   range_start   
+------------------------+-------------------+-----------------
+ dimension_last         | _hyper_3_7_chunk  | 946684800000000
+ dimension_last         | _hyper_3_8_chunk  | 946771200000000
+ dimension_last         | _hyper_3_9_chunk  | 946857600000000
+ dimension_last         | _hyper_3_10_chunk | 946944000000000
+ dimension_only         | _hyper_4_11_chunk | 946684800000000
+ dimension_only         | _hyper_4_12_chunk | 946857600000000
+ dimension_only         | _hyper_4_13_chunk | 947030400000000
+ dimension_only         | _hyper_4_14_chunk | 947203200000000
+ ordered_append         | _hyper_1_1_chunk  | 946512000000000
+ ordered_append         | _hyper_1_2_chunk  | 947116800000000
+ ordered_append         | _hyper_1_3_chunk  | 947721600000000
+ ordered_append_reverse | _hyper_2_6_chunk  | 946512000000000
+ ordered_append_reverse | _hyper_2_5_chunk  | 947116800000000
+ ordered_append_reverse | _hyper_2_4_chunk  | 947721600000000
+(14 rows)
 
 -- test ASC for ordered chunks
 :PREFIX SELECT
@@ -527,4 +574,87 @@ SELECT * FROM i;
          ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk
          ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
 (5 rows)
+
+-- test with table with only dimension column
+:PREFIX SELECT * FROM dimension_only ORDER BY time DESC LIMIT 1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Limit
+   ->  Append
+         ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk
+         ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk
+         ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk
+         ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk
+(6 rows)
+
+-- test LEFT JOIN against hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+LEFT JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop Left Join
+         ->  Append
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
+         ->  Append
+               ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+(16 rows)
+
+-- test INNER JOIN against non-hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+INNER JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop
+         ->  Append
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
+         ->  Append
+               ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+               ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk
+                     Index Cond: ("time" = _hyper_3_10_chunk."time")
+(16 rows)
+
+-- test join against non-hypertable
+:PREFIX SELECT *
+FROM dimension_last
+INNER JOIN devices USING(device_id)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Limit
+   ->  Nested Loop
+         ->  Append
+               ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+               ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+               ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+               ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
+         ->  Index Scan using devices_pkey on devices
+               Index Cond: (device_id = _hyper_3_10_chunk.device_id)
+(9 rows)
 

--- a/test/sql/include/plan_ordered_append_load.sql
+++ b/test/sql/include/plan_ordered_append_load.sql
@@ -12,6 +12,12 @@ BEGIN
 END;
 $BODY$;
 
+CREATE TABLE devices(device_id INT PRIMARY KEY, name TEXT);
+INSERT INTO devices VALUES
+(1,'Device 1'),
+(2,'Device 2'),
+(3,'Device 3');
+
 -- create a table where we create chunks in order
 CREATE TABLE ordered_append(time timestamptz NOT NULL, device_id INT, value float);
 SELECT create_hypertable('ordered_append','time');
@@ -29,4 +35,33 @@ SELECT create_hypertable('ordered_append_reverse','time');
 INSERT INTO ordered_append_reverse VALUES('2000-01-15',1,1.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-08',1,2.0);
 INSERT INTO ordered_append_reverse VALUES('2000-01-01',1,3.0);
+
+-- table where dimension column is last column
+CREATE TABLE IF NOT EXISTS dimension_last(
+    id INT8 NOT NULL,
+    device_id INT NOT NULL,
+    name TEXT NOT NULL,
+    time timestamptz NOT NULL
+);
+
+SELECT create_hypertable('dimension_last', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+
+-- table with only dimension column
+CREATE TABLE IF NOT EXISTS dimension_only(
+    time timestamptz NOT NULL
+);
+
+SELECT create_hypertable('dimension_only', 'time', chunk_time_interval => interval '1day', if_not_exists => True);
+
+INSERT INTO dimension_last VALUES
+(1,1,'Device 1','2000-01-01'),
+(2,1,'Device 1','2000-01-02'),
+(3,1,'Device 1','2000-01-03'),
+(4,1,'Device 1','2000-01-04');
+
+INSERT INTO dimension_only VALUES
+('2000-01-01'),
+('2000-01-03'),
+('2000-01-05'),
+('2000-01-07');
 

--- a/test/sql/include/plan_ordered_append_query.sql
+++ b/test/sql/include/plan_ordered_append_query.sql
@@ -164,4 +164,27 @@ SELECT * FROM i;
 -- this should use time index
 :PREFIX SELECT * FROM ordered_append ORDER BY time DESC LIMIT 1;
 
+-- test with table with only dimension column
+:PREFIX SELECT * FROM dimension_only ORDER BY time DESC LIMIT 1;
+
+-- test LEFT JOIN against hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+LEFT JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+
+-- test INNER JOIN against non-hypertable
+:PREFIX_NO_ANALYZE SELECT *
+FROM dimension_last
+INNER JOIN dimension_only USING (time)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
+
+-- test join against non-hypertable
+:PREFIX SELECT *
+FROM dimension_last
+INNER JOIN devices USING(device_id)
+ORDER BY dimension_last.time DESC
+LIMIT 2;
 

--- a/test/sql/plan_ordered_append.sql.in
+++ b/test/sql/plan_ordered_append.sql.in
@@ -18,6 +18,8 @@ SELECT
   END AS "PREFIX"
 \gset
 
+\set PREFIX_NO_ANALYZE 'EXPLAIN (costs off)'
+
 \ir include/plan_ordered_append_load.sql
 \ir include/plan_ordered_append_query.sql
 

--- a/test/sql/plan_ordered_append_results_diff.sql
+++ b/test/sql/plan_ordered_append_results_diff.sql
@@ -12,7 +12,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
 
-
 \o /dev/null
 SET client_min_messages = 'error';
 \ir :TEST_LOAD_NAME
@@ -21,9 +20,9 @@ RESET client_min_messages;
 
 --generate the results into two different files
 SET client_min_messages = 'error';
-\set ECHO none
 --make output contain query results
 \set PREFIX ''
+\set PREFIX_NO_ANALYZE ''
 \o :TEST_RESULTS_OPTIMIZED
 SET timescaledb.ordered_append = 'on';
 \ir :TEST_QUERY_NAME


### PR DESCRIPTION
The comparison to check whether the column references
matches the time dimension column assumed that the reference
would be to the hypertable which might not be true for JOINs.
This patch adds a check to make sure the reference in the
ORDER BY is actually a reference to the hypertable before
checking the column is the time dimension.

Fixes #1114