### PR TITLE
Add foreach-style interface to scanner

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES
   planner_import.c
   process_utility.c
   scanner.c
+  scan_iterator.c
   sort_transform.c
   subspace_store.c
   tablespace.c

--- a/src/scan_iterator.c
+++ b/src/scan_iterator.c
@@ -1,0 +1,31 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+
+#include "scan_iterator.h"
+
+void
+ts_scan_iterator_close(ScanIterator *iterator)
+{
+	ts_scanner_end_scan(&iterator->ctx, &iterator->ictx);
+}
+
+void
+ts_scan_iterator_scan_key_init(ScanIterator *iterator, AttrNumber attributeNumber,
+							   StrategyNumber strategy, RegProcedure procedure, Datum argument)
+{
+	Assert(iterator->ctx.scankey == NULL || iterator->ctx.scankey == iterator->scankey);
+	iterator->ctx.scankey = iterator->scankey;
+
+	if (iterator->ctx.nkeys >= EMBEDDED_SCAN_KEY_SIZE)
+		elog(ERROR, "cannot scan more than %d keys", EMBEDDED_SCAN_KEY_SIZE);
+
+	ScanKeyInit(&iterator->scankey[iterator->ctx.nkeys++],
+				attributeNumber,
+				strategy,
+				procedure,
+				argument);
+}

--- a/src/scan_iterator.h
+++ b/src/scan_iterator.h
@@ -1,0 +1,64 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_SCAN_ITERATOR_H
+#define TIMESCALEDB_SCAN_ITERATOR_H
+#include <postgres.h>
+
+#include "scanner.h"
+
+#define EMBEDDED_SCAN_KEY_SIZE 5
+
+typedef struct ScanIterator
+{
+	ScannerCtx ctx;
+	TupleInfo *tinfo;
+	InternalScannerCtx ictx;
+	ScanKeyData scankey[EMBEDDED_SCAN_KEY_SIZE];
+} ScanIterator;
+
+#define ts_scan_iterator_create(catalog_table_id, lock_mode, mctx)                                 \
+	(ScanIterator)                                                                                 \
+	{                                                                                              \
+		.ctx = {                                                                                   \
+			.table = catalog_get_table_id(ts_catalog_get(), catalog_table_id),                     \
+			.nkeys = 0,                                                                            \
+			.scandirection = ForwardScanDirection,                                                 \
+			.lockmode = lock_mode,                                                                 \
+			.result_mctx = mctx,                                                                   \
+		}                                                                                          \
+	}
+
+static inline TupleInfo *
+ts_scan_iterator_tuple_info(ScanIterator *iterator)
+{
+	return iterator->tinfo;
+}
+
+static inline HeapTuple
+ts_scan_iterator_tuple(ScanIterator *iterator)
+{
+	return iterator->tinfo->tuple;
+}
+
+static inline TupleDesc
+ts_scan_iterator_tupledesc(ScanIterator *iterator)
+{
+	return iterator->tinfo->desc;
+}
+
+void ts_scan_iterator_close(ScanIterator *iterator);
+
+void ts_scan_iterator_scan_key_init(ScanIterator *iterator, AttrNumber attributeNumber,
+									StrategyNumber strategy, RegProcedure procedure,
+									Datum argument);
+
+/* You must use `ts_scan_iterator_close` if terminating this loop early */
+#define ts_scanner_foreach(scan_iterator)                                                          \
+	for (ts_scanner_start_scan(&(scan_iterator)->ctx, &(scan_iterator)->ictx);                     \
+		 ((scan_iterator)->tinfo =                                                                 \
+			  ts_scanner_next(&(scan_iterator)->ctx, &(scan_iterator)->ictx)) != NULL;)
+
+#endif /* TIMESCALEDB_SCAN_ITERATOR_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,9 @@
 #define TS_EPOCH_DIFF_MICROSECONDS ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY)
 #define TS_INTERNAL_TIMESTAMP_MIN ((int64) USECS_PER_DAY * (DATETIME_MIN_JULIAN - UNIX_EPOCH_JDATE))
 
+/* find the length of a statically sized array */
+#define TS_ARRAY_LEN(array) (sizeof(array) / sizeof(*array))
+
 extern bool ts_type_is_int8_binary_compatible(Oid sourcetype);
 
 /*

--- a/src/with_clause_parser.h
+++ b/src/with_clause_parser.h
@@ -7,9 +7,7 @@
 #include <c.h>
 
 #include <nodes/parsenodes.h>
-
-/* find the length of a statically sized array */
-#define TS_ARRAY_LEN(array) (sizeof(array) / sizeof(*array))
+#include <utils.h>
 
 typedef struct WithClauseDefinition
 {


### PR DESCRIPTION
This PR adds a foreach-style interface to our catalog scanner code.
It is split into 2 commits
1) Adds the interface to scanner (see commit message for reasons behind adding this interface)
2) Refactors the chunk_constraint code to use the new interface. This commit is meant to showcase best-practices for the usage of the new interface (as well as cleanup that code).

See the detailed info in each of the above commit's messages for more info.

Please review this PR not only for correctness but also for the style of the resulting usage code. Can we simplify it some more?