### PR TITLE
Fix relocate_extension test

### DIFF
--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -109,7 +109,7 @@ SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '
 
 -- testing time_bucket END
 -- testing drop_chunks START
-SELECT "testSchema0".drop_chunks(interval '2 years', 'test_ts');
+SELECT "testSchema0".drop_chunks('2017-03-01'::timestamp, 'test_ts');
  drop_chunks 
 -------------
  

--- a/test/sql/relocate_extension.sql
+++ b/test/sql/relocate_extension.sql
@@ -49,7 +49,7 @@ SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '
 -- testing time_bucket END
 
 -- testing drop_chunks START
-SELECT "testSchema0".drop_chunks(interval '2 years', 'test_ts');
+SELECT "testSchema0".drop_chunks('2017-03-01'::timestamp, 'test_ts');
 SELECT * FROM test_ts ORDER BY time;
 SELECT "testSchema0".drop_chunks(interval '1 minutes', 'test_tz');
 SELECT * FROM test_tz ORDER BY time;


### PR DESCRIPTION
The relocate_extension test used a relative time in the drop_chunks
call which makes the test always fail after a certain time. This
patch changes the test to use absolute time.