### PR TITLE
Fix installcheck IGNORE on grouped parallel tests

### DIFF
--- a/test/pg_isolation_regress.sh
+++ b/test/pg_isolation_regress.sh
@@ -42,9 +42,14 @@ if [[ -z ${TESTS} ]]; then
                 continue
             fi
             t=${t##test: }
-            if ! contains "${IGNORES}" "${t}"; then
-                TESTS="${TESTS} ${t}"
-            fi
+            ## check each individual test in test group to see if it should be ignored
+            ## note that now isolation tests are not grouped together and so the for loop
+            ##   will always run once.
+            for el in ${t[@]}; do
+                if ! contains "${IGNORES}" "${el}"; then
+                    TESTS="${TESTS} ${el}"
+                fi
+            done
         done < ${ISOLATION_TEST_SCHEDULE}
     else
         PG_ISOLATION_REGRESS_OPTS="${PG_ISOLATION_REGRESS_OPTS} --schedule=${ISOLATION_TEST_SCHEDULE}"

--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -20,6 +20,9 @@ contains() {
     return $?
 }
 
+echo "TESTS ${TESTS}"
+echo "IGNORES ${IGNORES}"
+
 if [[ -z ${TESTS} ]]; then
     if [[ -z ${TEST_SCHEDULE} ]]; then
         for t in ${EXE_DIR}/sql/*.sql; do
@@ -39,9 +42,12 @@ if [[ -z ${TESTS} ]]; then
                 continue
             fi
             t=${t##test: }
-            if ! contains "${IGNORES}" "${t}"; then
-                TESTS="${TESTS} ${t}"
-            fi
+            ## check each individual test in test group to see if it should be ignored
+            for el in ${t[@]}; do
+                if ! contains "${IGNORES}" "${el}"; then
+                    TESTS="${TESTS} ${el}"
+                fi
+            done
         done < ${TEST_SCHEDULE}
     else
         PG_REGRESS_OPTS="${PG_REGRESS_OPTS} --schedule=${TEST_SCHEDULE}"


### PR DESCRIPTION
Now TEST_SCHEDULER schedules groups of tests parallelly and sends them
as space separated lists. The PR makes sure this list is traversed
correctly when IGNORE option of installcheck is passed.