### PR TITLE
Fix column handling for columns derived from GROUP BY columns

### DIFF
--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -20,25 +20,21 @@ NOTICE:  adding not-null constraint to column "i"
 
 --has to be big enough to force at least 2 workers below.
 INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE test;
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
-:PREFIX SELECT first(i, j) FROM "test";
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=3 loops=1)
+EXPLAIN (costs off) SELECT first(i, j) FROM "test";
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Append (actual rows=333333 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=166667 loops=3)
-(8 rows)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk
+(7 rows)
 
 SELECT first(i, j) FROM "test";
  first 
@@ -46,18 +42,17 @@ SELECT first(i, j) FROM "test";
      0
 (1 row)
 
-:PREFIX SELECT last(i, j) FROM "test";
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=3 loops=1)
+EXPLAIN (costs off) SELECT last(i, j) FROM "test";
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Append (actual rows=333333 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=166667 loops=3)
-(8 rows)
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk
+(7 rows)
 
 SELECT last(i, j) FROM "test";
   last  

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -20,25 +20,21 @@ NOTICE:  adding not-null constraint to column "i"
 
 --has to be big enough to force at least 2 workers below.
 INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE test;
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
-:PREFIX SELECT first(i, j) FROM "test";
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=3 loops=1)
+EXPLAIN (costs off) SELECT first(i, j) FROM "test";
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Parallel Append (actual rows=333333 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
-(8 rows)
+         ->  Partial Aggregate
+               ->  Parallel Append
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk
+(7 rows)
 
 SELECT first(i, j) FROM "test";
  first 
@@ -46,18 +42,17 @@ SELECT first(i, j) FROM "test";
      0
 (1 row)
 
-:PREFIX SELECT last(i, j) FROM "test";
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=3 loops=1)
+EXPLAIN (costs off) SELECT last(i, j) FROM "test";
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
          Workers Planned: 2
-         Workers Launched: 2
-         ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Parallel Append (actual rows=333333 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
-                     ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
-(8 rows)
+         ->  Partial Aggregate
+               ->  Parallel Append
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk
+(7 rows)
 
 SELECT last(i, j) FROM "test";
   last  

--- a/test/expected/parallel-9.6.out
+++ b/test/expected/parallel-9.6.out
@@ -20,14 +20,11 @@ NOTICE:  adding not-null constraint to column "i"
 
 --has to be big enough to force at least 2 workers below.
 INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE test;
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
-:PREFIX SELECT first(i, j) FROM "test";
+EXPLAIN (costs off) SELECT first(i, j) FROM "test";
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Finalize Aggregate
@@ -45,7 +42,7 @@ SELECT first(i, j) FROM "test";
      0
 (1 row)
 
-:PREFIX SELECT last(i, j) FROM "test";
+EXPLAIN (costs off) SELECT last(i, j) FROM "test";
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Finalize Aggregate

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -18,19 +18,16 @@ SELECT create_hypertable('test','i',chunk_time_interval:=500000);
 --has to be big enough to force at least 2 workers below.
 INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
 
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE test;
 
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
 
-:PREFIX SELECT first(i, j) FROM "test";
+EXPLAIN (costs off) SELECT first(i, j) FROM "test";
 SELECT first(i, j) FROM "test";
 
-:PREFIX SELECT last(i, j) FROM "test";
+EXPLAIN (costs off) SELECT last(i, j) FROM "test";
 SELECT last(i, j) FROM "test";
 
 -- we dont run this with analyze because the sort memory usage is not stable

--- a/tsl/src/gapfill/exec.h
+++ b/tsl/src/gapfill/exec.h
@@ -53,11 +53,20 @@ typedef enum GapFillFetchState
 	FETCHED_LAST,
 } GapFillFetchState;
 
+/*
+ * NULL_COLUMN: column with no special action from gapfill e.g. min(value)
+ * TIME_COLUMN: column with time_bucket_gapfill call
+ * GROUP_COLUMN: any column appearing in GROUP BY clause
+ * DERIVED_COLUMN: column not appearing in GROUP BY but dependent on GROUP BY column
+ * LOCF_COLUMN: column with locf call
+ * INTERPOLATE_COLUMN: column with interpolate call
+ */
 typedef enum GapFillColumnType
 {
 	NULL_COLUMN,
 	TIME_COLUMN,
 	GROUP_COLUMN,
+	DERIVED_COLUMN,
 	LOCF_COLUMN,
 	INTERPOLATE_COLUMN
 } GapFillColumnType;

--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -2447,3 +2447,88 @@ EXECUTE prep_gapfill;
 (6 rows)
 
 DEALLOCATE prep_gapfill;
+-- test column references with TIME_COLUMN last
+SELECT
+  row_number() OVER (PARTITION BY color),
+  locf(min(time)),
+  color,
+  time_bucket_gapfill(1,time,0,5) as time
+FROM (VALUES (1,'blue',1),(2,'red',2)) v(time,color,value)
+GROUP BY 3,4;
+ row_number | locf | color | time 
+------------+------+-------+------
+          1 |      | blue  |    0
+          2 |    1 | blue  |    1
+          3 |    1 | blue  |    2
+          4 |    1 | blue  |    3
+          5 |    1 | blue  |    4
+          1 |      | red   |    0
+          2 |      | red   |    1
+          3 |    2 | red   |    2
+          4 |    2 | red   |    3
+          5 |    2 | red   |    4
+(10 rows)
+
+-- test expressions on GROUP BY columns
+SELECT
+  row_number() OVER (PARTITION BY color),
+  locf(min(time)),
+  color,
+  length(color),
+  time_bucket_gapfill(1,time,0,5) as time
+FROM (VALUES (1,'blue',1),(2,'red',2)) v(time,color,value)
+GROUP BY 3,5;
+ row_number | locf | color | length | time 
+------------+------+-------+--------+------
+          1 |      | blue  |      4 |    0
+          2 |    1 | blue  |      4 |    1
+          3 |    1 | blue  |      4 |    2
+          4 |    1 | blue  |      4 |    3
+          5 |    1 | blue  |      4 |    4
+          1 |      | red   |      3 |    0
+          2 |      | red   |      3 |    1
+          3 |    2 | red   |      3 |    2
+          4 |    2 | red   |      3 |    3
+          5 |    2 | red   |      3 |    4
+(10 rows)
+
+-- test columns derived from GROUP BY columns with cast
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  device_id::text
+FROM (VALUES (1,1),(2,2)) v(time,device_id)
+GROUP BY 1,device_id;
+ time | device_id 
+------+-----------
+    0 | 1
+    1 | 1
+    2 | 1
+    3 | 1
+    4 | 1
+    0 | 2
+    1 | 2
+    2 | 2
+    3 | 2
+    4 | 2
+(10 rows)
+
+-- test columns derived from GROUP BY columns with expression
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  'Device ' || device_id::text
+FROM (VALUES (1,1),(2,2)) v(time,device_id)
+GROUP BY 1,device_id;
+ time | ?column? 
+------+----------
+    0 | Device 1
+    1 | Device 1
+    2 | Device 1
+    3 | Device 1
+    4 | Device 1
+    0 | Device 2
+    1 | Device 2
+    2 | Device 2
+    3 | Device 2
+    4 | Device 2
+(10 rows)
+

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -1338,3 +1338,38 @@ EXECUTE prep_gapfill;
 
 DEALLOCATE prep_gapfill;
 
+-- test column references with TIME_COLUMN last
+SELECT
+  row_number() OVER (PARTITION BY color),
+  locf(min(time)),
+  color,
+  time_bucket_gapfill(1,time,0,5) as time
+FROM (VALUES (1,'blue',1),(2,'red',2)) v(time,color,value)
+GROUP BY 3,4;
+
+-- test expressions on GROUP BY columns
+SELECT
+  row_number() OVER (PARTITION BY color),
+  locf(min(time)),
+  color,
+  length(color),
+  time_bucket_gapfill(1,time,0,5) as time
+FROM (VALUES (1,'blue',1),(2,'red',2)) v(time,color,value)
+GROUP BY 3,5;
+
+-- test columns derived from GROUP BY columns with cast
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  device_id::text
+FROM (VALUES (1,1),(2,2)) v(time,device_id)
+GROUP BY 1,device_id;
+
+-- test columns derived from GROUP BY columns with expression
+SELECT
+  time_bucket_gapfill(1,time,0,5) as time,
+  'Device ' || device_id::text
+FROM (VALUES (1,1),(2,2)) v(time,device_id)
+GROUP BY 1,device_id;
+
+
+


### PR DESCRIPTION
Any column that does not have an aggregation function and is not
an explicit GROUP BY column has to be derived from a GROUP BY
column so we treat those similar to GROUP BY columns for gapfill
purposes.