### PR TITLE
Add interval to internal conversions, and tests for both this and time conversions

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1083,7 +1083,7 @@ chunks_typecheck_and_find_all_in_range_limit(Hyperspace *hs, Dimension *time_dim
 			older_than =
 				ts_interval_from_now_to_internal(older_than_datum, time_dim->fd.column_type);
 		else
-			older_than = ts_time_value_to_internal(older_than_datum, older_than_type, false);
+			older_than = ts_time_value_to_internal(older_than_datum, older_than_type);
 		end_strategy = BTLessStrategyNumber;
 	}
 
@@ -1094,7 +1094,7 @@ chunks_typecheck_and_find_all_in_range_limit(Hyperspace *hs, Dimension *time_dim
 			newer_than =
 				ts_interval_from_now_to_internal(newer_than_datum, time_dim->fd.column_type);
 		else
-			newer_than = ts_time_value_to_internal(newer_than_datum, newer_than_type, false);
+			newer_than = ts_time_value_to_internal(newer_than_datum, newer_than_type);
 		start_strategy = BTGreaterEqualStrategyNumber;
 	}
 

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -467,8 +467,8 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 
 		if (chunk_get_minmax(chunk->table_id, dim->fd.column_type, attno, minmax))
 		{
-			int64 min = ts_time_value_to_internal(minmax[0], dim->fd.column_type, false);
-			int64 max = ts_time_value_to_internal(minmax[1], dim->fd.column_type, false);
+			int64 min = ts_time_value_to_internal(minmax[0], dim->fd.column_type);
+			int64 max = ts_time_value_to_internal(minmax[1], dim->fd.column_type);
 			double interval_fillfactor, size_fillfactor;
 			int64 extrapolated_chunk_size;
 

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -716,7 +716,7 @@ ts_hyperspace_calculate_point(Hyperspace *hs, HeapTuple tuple, TupleDesc tupdesc
 									NameStr(d->fd.column_name)),
 							 errhint("Columns used for time partitioning cannot be NULL")));
 
-				p->coordinates[p->num_coords++] = ts_time_value_to_internal(datum, dimtype, false);
+				p->coordinates[p->num_coords++] = ts_time_value_to_internal(datum, dimtype);
 				break;
 			case DIMENSION_TYPE_CLOSED:
 				p->coordinates[p->num_coords++] = (int64) DatumGetInt32(datum);

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -102,7 +102,7 @@ dimension_restrict_info_open_add(DimensionRestrictInfoOpen *dri, StrategyNumber 
 												   PointerGetDatum(lfirst(item)),
 												   dimvalues->type,
 												   &restype);
-		int64 value = ts_time_value_to_internal(datum, restype, false);
+		int64 value = ts_time_value_to_internal(datum, restype);
 
 		switch (strategy)
 		{

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,13 +13,28 @@
 #include <utils/datetime.h>
 #include <access/htup_details.h>
 
+#include "export.h"
+
+#define TS_EPOCH_DIFF_MICROSECONDS ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY)
+#define TS_INTERNAL_TIMESTAMP_MIN ((int64) USECS_PER_DAY * (DATETIME_MIN_JULIAN - UNIX_EPOCH_JDATE))
+
 extern bool ts_type_is_int8_binary_compatible(Oid sourcetype);
 
 /*
  * Convert a column value into the internal time representation.
+ * cannot store a timestamp earlier than MIN_TIMESTAMP, or greater than
+ *    END_TIMESTAMP - TS_EPOCH_DIFF_MICROSECONDS
+ * nor dates that cannot be translated to timestamps
+ * Will throw an error for that, or other conversion issues.
  */
-extern int64 ts_time_value_to_internal(Datum time_val, Oid type, bool failure_ok);
+extern TSDLLEXPORT int64 ts_time_value_to_internal(Datum time_val, Oid type);
+extern TSDLLEXPORT int64 ts_interval_value_to_internal(Datum time_val, Oid type_oid);
 
+/*
+ * Convert a column from the internal time representation into the specfied type
+ */
+extern TSDLLEXPORT Datum ts_internal_to_time_value(int64 value, Oid type);
+extern TSDLLEXPORT Datum ts_internal_to_interval_value(int64 value, Oid type);
 /*
  * Convert the difference of interval and current timestamp to internal representation
  */

--- a/test/expected/c_unit_tests.out
+++ b/test/expected/c_unit_tests.out
@@ -1,0 +1,21 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_time_to_internal_conversion() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_test_interval_to_internal_conversion() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SELECT ts_test_time_to_internal_conversion();
+ ts_test_time_to_internal_conversion 
+-------------------------------------
+ 
+(1 row)
+
+SELECT ts_test_interval_to_internal_conversion();
+ ts_test_interval_to_internal_conversion 
+-----------------------------------------
+ 
+(1 row)
+

--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -66,17 +66,17 @@ FROM "test"
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Limit
-   ->  Finalize GroupAggregate
-         Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-         ->  Gather Merge
-               Workers Planned: 2
-               ->  Partial GroupAggregate
-                     Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-                     ->  Sort
-                           Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+         ->  Finalize HashAggregate
+               Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+               ->  Gather
+                     Workers Planned: 2
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts)
                            ->  Result
                                  ->  Append
                                        ->  Parallel Seq Scan on _hyper_1_1_chunk
@@ -189,22 +189,23 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 (12 rows)
 
 -- test constraint aware append with parallel aggregation
+SET max_parallel_workers_per_gather = 1;
 :PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=3 loops=1)
-         Workers Planned: 2
-         Workers Launched: 2
-         ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=333333 loops=3)
+   ->  Gather (actual rows=2 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Partial Aggregate (actual rows=1 loops=2)
+               ->  Result (actual rows=500000 loops=2)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=333333 loops=3)
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=500000 loops=2)
                            Hypertable: test
                            Chunks left after exclusion: 2
-                           ->  Append (actual rows=333333 loops=3)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=166667 loops=3)
+                           ->  Append (actual rows=500000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
 (13 rows)
 
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
@@ -213,6 +214,7 @@ SELECT count(*) FROM "test" WHERE length(version()) > 0;
  1000000
 (1 row)
 
+SET max_parallel_workers_per_gather = 4;
 -- now() is not marked parallel safe in PostgreSQL < 12 so using now()
 -- in a query will prevent parallelism but CURRENT_TIMESTAMP and
 -- transaction_timestamp() are marked parallel safe

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -66,22 +66,21 @@ FROM "test"
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Limit
-   ->  Finalize GroupAggregate
-         Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-         ->  Gather Merge
-               Workers Planned: 2
-               ->  Partial GroupAggregate
-                     Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-                     ->  Sort
-                           Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-                           ->  Result
-                                 ->  Parallel Append
-                                       ->  Parallel Seq Scan on _hyper_1_1_chunk
-                                       ->  Parallel Seq Scan on _hyper_1_2_chunk
-(13 rows)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather
+   Workers Planned: 1
+   Single Copy: true
+   ->  Limit
+         ->  Sort
+               Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+               ->  HashAggregate
+                     Group Key: time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts)
+                     ->  Result
+                           ->  Append
+                                 ->  Seq Scan on _hyper_1_1_chunk
+                                 ->  Seq Scan on _hyper_1_2_chunk
+(12 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
@@ -189,22 +188,23 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 (12 rows)
 
 -- test constraint aware append with parallel aggregation
+SET max_parallel_workers_per_gather = 1;
 :PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=3 loops=1)
-         Workers Planned: 2
-         Workers Launched: 2
-         ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=333333 loops=3)
+   ->  Gather (actual rows=2 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Partial Aggregate (actual rows=1 loops=2)
+               ->  Result (actual rows=500000 loops=2)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=333333 loops=3)
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=500000 loops=2)
                            Hypertable: test
                            Chunks left after exclusion: 2
-                           ->  Parallel Append (actual rows=333333 loops=3)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=166667 loops=3)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+                           ->  Parallel Append (actual rows=500000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
 (13 rows)
 
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
@@ -213,6 +213,7 @@ SELECT count(*) FROM "test" WHERE length(version()) > 0;
  1000000
 (1 row)
 
+SET max_parallel_workers_per_gather = 4;
 -- now() is not marked parallel safe in PostgreSQL < 12 so using now()
 -- in a query will prevent parallelism but CURRENT_TIMESTAMP and
 -- transaction_timestamp() are marked parallel safe

--- a/test/expected/parallel-9.6.out
+++ b/test/expected/parallel-9.6.out
@@ -66,21 +66,22 @@ FROM "test"
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Gather
-   Workers Planned: 1
-   Single Copy: true
-   ->  Limit
-         ->  GroupAggregate
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
+         ->  Finalize HashAggregate
                Group Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-               ->  Sort
-                     Sort Key: (time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts))
-                     ->  Result
-                           ->  Append
-                                 ->  Seq Scan on _hyper_1_1_chunk
-                                 ->  Seq Scan on _hyper_1_2_chunk
-(12 rows)
+               ->  Gather
+                     Workers Planned: 2
+                     ->  Partial HashAggregate
+                           Group Key: time_bucket('@ 1 sec'::interval, _hyper_1_1_chunk.ts)
+                           ->  Result
+                                 ->  Append
+                                       ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Parallel Seq Scan on _hyper_1_2_chunk
+(13 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
@@ -187,12 +188,13 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 (11 rows)
 
 -- test constraint aware append with parallel aggregation
+SET max_parallel_workers_per_gather = 1;
 :PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Finalize Aggregate
    ->  Gather
-         Workers Planned: 2
+         Workers Planned: 1
          ->  Partial Aggregate
                ->  Result
                      One-Time Filter: (length(version()) > 0)
@@ -210,6 +212,7 @@ SELECT count(*) FROM "test" WHERE length(version()) > 0;
  1000000
 (1 row)
 
+SET max_parallel_workers_per_gather = 4;
 -- now() is not marked parallel safe in PostgreSQL < 12 so using now()
 -- in a query will prevent parallelism but CURRENT_TIMESTAMP and
 -- transaction_timestamp() are marked parallel safe

--- a/test/sql/.gitignore
+++ b/test/sql/.gitignore
@@ -2,3 +2,8 @@
 /parallel-10.0.sql
 /partitioning-9.6.sql
 /partitioning-10.sql
+/plan_expand_hypertable_optimized-10.sql
+/plan_expand_hypertable_optimized-11.sql
+/plan_hashagg_optimized-10.sql
+/plan_hashagg_optimized-11.sql
+/plan_hashagg_optimized-9.6.sql

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_FILES
   agg_bookends_results_diff.sql
   alter.sql
   append.sql
+  c_unit_tests.sql
   chunk_adaptive.sql
   chunk_utils.sql
   chunks.sql

--- a/test/sql/c_unit_tests.sql
+++ b/test/sql/c_unit_tests.sql
@@ -1,0 +1,15 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_time_to_internal_conversion() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_test_interval_to_internal_conversion() RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SELECT ts_test_time_to_internal_conversion();
+
+SELECT ts_test_interval_to_internal_conversion();

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -60,8 +60,10 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
 
 -- test constraint aware append with parallel aggregation
+SET max_parallel_workers_per_gather = 1;
 :PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
+SET max_parallel_workers_per_gather = 4;
 
 -- now() is not marked parallel safe in PostgreSQL < 12 so using now()
 -- in a query will prevent parallelism but CURRENT_TIMESTAMP and

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
   symbol_conflict.c
+  test_time_to_internal.c
   test_with_clause_parser.c
 )
 

--- a/test/src/test_time_to_internal.c
+++ b/test/src/test_time_to_internal.c
@@ -1,0 +1,285 @@
+#include <postgres.h>
+#include <fmgr.h>
+#include <catalog/pg_type.h>
+#include <utils/date.h>
+
+#include "export.h"
+
+#include "utils.h"
+
+TS_FUNCTION_INFO_V1(ts_test_time_to_internal_conversion);
+TS_FUNCTION_INFO_V1(ts_test_interval_to_internal_conversion);
+
+#define AssertInt64Eq(a, b)                                                                        \
+	do                                                                                             \
+	{                                                                                              \
+		PG_TRY();                                                                                  \
+		{                                                                                          \
+			int64 a_i = (a);                                                                       \
+			int64 b_i = (b);                                                                       \
+			if (a_i != b_i)                                                                        \
+			{                                                                                      \
+				elog(ERROR, "%ld != %ld @ line %d", a_i, b_i, __LINE__);                           \
+			}                                                                                      \
+		}                                                                                          \
+		PG_CATCH();                                                                                \
+		{                                                                                          \
+			elog(WARNING, "error @ line %d", __LINE__);                                            \
+			PG_RE_THROW();                                                                         \
+		}                                                                                          \
+		PG_END_TRY();                                                                              \
+	} while (0)
+
+#define EnsureError(a)                                                                             \
+	do                                                                                             \
+	{                                                                                              \
+		volatile bool this_has_panicked = false;                                                   \
+		PG_TRY();                                                                                  \
+		{                                                                                          \
+			(a);                                                                                   \
+		}                                                                                          \
+		PG_CATCH();                                                                                \
+		{                                                                                          \
+			this_has_panicked = true;                                                              \
+			FlushErrorState();                                                                     \
+		}                                                                                          \
+		PG_END_TRY();                                                                              \
+		if (!this_has_panicked)                                                                    \
+		{                                                                                          \
+			elog(ERROR, "failed to panic @ line %d", __LINE__);                                    \
+		}                                                                                          \
+	} while (0)
+
+Datum
+ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
+{
+	int16 i16;
+	int32 i32;
+	int64 i64;
+
+	/* test integer values */
+
+	/* int16 */
+	for (i16 = -100; i16 < 100; i16++)
+	{
+		AssertInt64Eq(i16, ts_time_value_to_internal(Int16GetDatum(i16), INT2OID));
+		AssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(i16, INT2OID)), i16);
+	}
+
+	AssertInt64Eq(PG_INT16_MAX, ts_time_value_to_internal(Int16GetDatum(PG_INT16_MAX), INT2OID));
+	AssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(PG_INT16_MAX, INT2OID)), PG_INT16_MAX);
+
+	AssertInt64Eq(PG_INT16_MIN, ts_time_value_to_internal(Int16GetDatum(PG_INT16_MIN), INT2OID));
+	AssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(PG_INT16_MIN, INT2OID)), PG_INT16_MIN);
+
+	/* int32 */
+	for (i32 = -100; i32 < 100; i32++)
+	{
+		AssertInt64Eq(i32, ts_time_value_to_internal(Int32GetDatum(i32), INT4OID));
+		AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(i32, INT4OID)), i32);
+	}
+
+	AssertInt64Eq(PG_INT16_MAX, ts_time_value_to_internal(Int32GetDatum(PG_INT16_MAX), INT4OID));
+	AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT16_MAX, INT4OID)), PG_INT16_MAX);
+
+	AssertInt64Eq(PG_INT32_MAX, ts_time_value_to_internal(Int32GetDatum(PG_INT32_MAX), INT4OID));
+	AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT32_MAX, INT4OID)), PG_INT32_MAX);
+
+	AssertInt64Eq(PG_INT32_MIN, ts_time_value_to_internal(Int32GetDatum(PG_INT32_MIN), INT4OID));
+	AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT32_MIN, INT4OID)), PG_INT32_MIN);
+
+	/* int64 */
+	for (i64 = -100; i64 < 100; i64++)
+	{
+		AssertInt64Eq(i64, ts_time_value_to_internal(Int64GetDatum(i64), INT8OID));
+		AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(i64, INT8OID)), i64);
+	}
+
+	AssertInt64Eq(PG_INT16_MIN, ts_time_value_to_internal(Int64GetDatum(PG_INT16_MIN), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT16_MIN, INT8OID)), PG_INT16_MIN);
+
+	AssertInt64Eq(PG_INT32_MAX, ts_time_value_to_internal(Int64GetDatum(PG_INT32_MAX), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT32_MAX, INT8OID)), PG_INT32_MAX);
+
+	AssertInt64Eq(PG_INT64_MAX, ts_time_value_to_internal(Int64GetDatum(PG_INT64_MAX), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, INT8OID)), PG_INT64_MAX);
+
+	AssertInt64Eq(PG_INT64_MIN, ts_time_value_to_internal(Int64GetDatum(PG_INT64_MIN), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT64_MIN, INT8OID)), PG_INT64_MIN);
+
+	/* test time values round trip */
+
+	/* TIMESTAMP */
+	for (i64 = -100; i64 < 100; i64++)
+		AssertInt64Eq(i64,
+					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
+												TIMESTAMPOID));
+
+	for (i64 = -10000000; i64 < 100000000; i64 += 1000000)
+		AssertInt64Eq(i64,
+					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
+												TIMESTAMPOID));
+
+	for (i64 = -1000000000; i64 < 10000000000; i64 += 100000000)
+		AssertInt64Eq(i64,
+					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
+												TIMESTAMPOID));
+
+	EnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPOID));
+	EnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPOID));
+
+	AssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
+				  ts_time_value_to_internal(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN,
+																	  TIMESTAMPOID),
+											TIMESTAMPOID));
+
+	AssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
+				  ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID));
+	EnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID),
+										  TIMESTAMPOID));
+
+	/* TIMESTAMPTZ */
+	for (i64 = -100; i64 < 100; i64++)
+		AssertInt64Eq(i64,
+					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
+												TIMESTAMPTZOID));
+
+	for (i64 = -10000000; i64 < 100000000; i64 += 1000000)
+		AssertInt64Eq(i64,
+					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
+												TIMESTAMPTZOID));
+
+	for (i64 = -1000000000; i64 < 10000000000; i64 += 100000000)
+		AssertInt64Eq(i64,
+					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
+												TIMESTAMPTZOID));
+
+	EnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPTZOID));
+	EnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPTZOID));
+
+	AssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
+				  ts_time_value_to_internal(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN,
+																	  TIMESTAMPTZOID),
+											TIMESTAMPTZOID));
+
+	AssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
+				  ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID));
+	EnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID),
+										  TIMESTAMPTZOID));
+
+	/* DATE */
+	for (i64 = -100 * USECS_PER_DAY; i64 < 100 * USECS_PER_DAY; i64 += USECS_PER_DAY)
+		AssertInt64Eq(i64,
+					  ts_time_value_to_internal(ts_internal_to_time_value(i64, DATEOID), DATEOID));
+
+	EnsureError(ts_internal_to_time_value(PG_INT64_MIN, DATEOID));
+	AssertInt64Eq(106741034, ts_internal_to_time_value(PG_INT64_MAX, DATEOID));
+
+	EnsureError(ts_time_value_to_internal((DATEVAL_NOBEGIN + 1), DATEOID));
+	EnsureError(ts_time_value_to_internal((DATEVAL_NOEND - 1), DATEOID));
+
+	PG_RETURN_VOID();
+};
+
+Datum
+ts_test_interval_to_internal_conversion(PG_FUNCTION_ARGS)
+{
+	int16 i16;
+	int32 i32;
+	int64 i64;
+
+	/* test integer values */
+
+	/* int16 */
+	for (i16 = -100; i16 < 100; i16++)
+	{
+		AssertInt64Eq(i16, ts_interval_value_to_internal(Int16GetDatum(i16), INT2OID));
+		AssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(i16, INT2OID)), i16);
+	}
+
+	AssertInt64Eq(PG_INT16_MAX,
+				  ts_interval_value_to_internal(Int16GetDatum(PG_INT16_MAX), INT2OID));
+	AssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(PG_INT16_MAX, INT2OID)),
+				  PG_INT16_MAX);
+
+	AssertInt64Eq(PG_INT16_MIN,
+				  ts_interval_value_to_internal(Int16GetDatum(PG_INT16_MIN), INT2OID));
+	AssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(PG_INT16_MIN, INT2OID)),
+				  PG_INT16_MIN);
+
+	/* int32 */
+	for (i32 = -100; i32 < 100; i32++)
+	{
+		AssertInt64Eq(i32, ts_interval_value_to_internal(Int32GetDatum(i32), INT4OID));
+		AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(i32, INT4OID)), i32);
+	}
+
+	AssertInt64Eq(PG_INT16_MAX,
+				  ts_interval_value_to_internal(Int32GetDatum(PG_INT16_MAX), INT4OID));
+	AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT16_MAX, INT4OID)),
+				  PG_INT16_MAX);
+
+	AssertInt64Eq(PG_INT32_MAX,
+				  ts_interval_value_to_internal(Int32GetDatum(PG_INT32_MAX), INT4OID));
+	AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT32_MAX, INT4OID)),
+				  PG_INT32_MAX);
+
+	AssertInt64Eq(PG_INT32_MIN,
+				  ts_interval_value_to_internal(Int32GetDatum(PG_INT32_MIN), INT4OID));
+	AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT32_MIN, INT4OID)),
+				  PG_INT32_MIN);
+
+	/* int64 */
+	for (i64 = -100; i64 < 100; i64++)
+	{
+		AssertInt64Eq(i64, ts_interval_value_to_internal(Int64GetDatum(i64), INT8OID));
+		AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(i64, INT8OID)), i64);
+	}
+
+	AssertInt64Eq(PG_INT16_MIN,
+				  ts_interval_value_to_internal(Int64GetDatum(PG_INT16_MIN), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT16_MIN, INT8OID)),
+				  PG_INT16_MIN);
+
+	AssertInt64Eq(PG_INT32_MAX,
+				  ts_interval_value_to_internal(Int64GetDatum(PG_INT32_MAX), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT32_MAX, INT8OID)),
+				  PG_INT32_MAX);
+
+	AssertInt64Eq(PG_INT64_MAX,
+				  ts_interval_value_to_internal(Int64GetDatum(PG_INT64_MAX), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT64_MAX, INT8OID)),
+				  PG_INT64_MAX);
+
+	AssertInt64Eq(PG_INT64_MIN,
+				  ts_interval_value_to_internal(Int64GetDatum(PG_INT64_MIN), INT8OID));
+	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT64_MIN, INT8OID)),
+				  PG_INT64_MIN);
+
+	/* INTERVAL */
+	for (i64 = -100; i64 < 100; i64++)
+		AssertInt64Eq(i64,
+					  ts_interval_value_to_internal(ts_internal_to_interval_value(i64, INTERVALOID),
+													INTERVALOID));
+
+	for (i64 = -10000000; i64 < 100000000; i64 += 1000000)
+		AssertInt64Eq(i64,
+					  ts_interval_value_to_internal(ts_internal_to_interval_value(i64, INTERVALOID),
+													INTERVALOID));
+
+	for (i64 = -1000000000; i64 < 10000000000; i64 += 100000000)
+		AssertInt64Eq(i64,
+					  ts_interval_value_to_internal(ts_internal_to_interval_value(i64, INTERVALOID),
+													INTERVALOID));
+
+	AssertInt64Eq(PG_INT64_MIN,
+				  ts_interval_value_to_internal(ts_internal_to_interval_value(PG_INT64_MIN,
+																			  INTERVALOID),
+												INTERVALOID));
+	AssertInt64Eq(PG_INT64_MAX,
+				  ts_interval_value_to_internal(ts_internal_to_interval_value(PG_INT64_MAX,
+																			  INTERVALOID),
+												INTERVALOID));
+
+	PG_RETURN_VOID();
+}


### PR DESCRIPTION
We find ourselves needing to store intervals (specifically time_bucket widths) in
upcoming PRs, so this commit adds that functionality, along with tests that we
perform the conversion in a sensible, round-trip-able, manner.

The commit adds a single SQL file, c_unit_tests.sql, to be the driver for all such
pure-C unit tests. Since the tests run quickly, and there is very little work to
be done at the SQL level, it does not seem like each group of such tests requires
their own SQL file.

This commit also updates the `test/sql/.gitignore`, as some generated files were
missing.

Going to request @davidkohn88 do the initial review as @cevian is out right, now, so @cevian only needs to do the final review once he gets back.