### PR TITLE
Fix diff tests on BSD / Mac OS X

### DIFF
--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -9,9 +9,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 \set PREFIX 'EXPLAIN (costs OFF)'
 \ir :TEST_LOAD_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
@@ -411,5 +408,3 @@ psql:include/append_query.sql:126: NOTICE:  Stable function now_s() called!
 
 --generate the results into two different files
 \set ECHO errors
-72
-72

--- a/test/expected/plan_expand_hypertable-10.out
+++ b/test/expected/plan_expand_hypertable-10.out
@@ -1230,5 +1230,3 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 :PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL
 \set ECHO errors
-507
-507

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -1232,5 +1232,3 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 :PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL
 \set ECHO errors
-507
-507

--- a/test/expected/plan_expand_hypertable-9.6.out
+++ b/test/expected/plan_expand_hypertable-9.6.out
@@ -1230,5 +1230,3 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 :PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL
 \set ECHO errors
-507
-507

--- a/test/expected/plan_hashagg-10.out
+++ b/test/expected/plan_hashagg-10.out
@@ -370,5 +370,3 @@ ORDER BY MetricMinuteTs DESC;
 \set ECHO none
 psql:include/plan_hashagg_query.sql:60: ERROR:  timestamp units "invalid" not recognized
 psql:include/plan_hashagg_query.sql:60: ERROR:  timestamp units "invalid" not recognized
-99570
-99570

--- a/test/expected/plan_hashagg-11.out
+++ b/test/expected/plan_hashagg-11.out
@@ -342,5 +342,3 @@ ORDER BY MetricMinuteTs DESC;
 \set ECHO none
 psql:include/plan_hashagg_query.sql:60: ERROR:  timestamp units "invalid" not recognized
 psql:include/plan_hashagg_query.sql:60: ERROR:  timestamp units "invalid" not recognized
-99570
-99570

--- a/test/expected/plan_hashagg-9.6.out
+++ b/test/expected/plan_hashagg-9.6.out
@@ -318,5 +318,3 @@ ORDER BY MetricMinuteTs DESC;
 \set ECHO none
 psql:include/plan_hashagg_query.sql:60: ERROR:  timestamp units "invalid" not recognized
 psql:include/plan_hashagg_query.sql:60: ERROR:  timestamp units "invalid" not recognized
-99570
-99570

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -16,9 +16,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -688,5 +685,3 @@ LIMIT 2;
 
 --generate the results into two different files
 \set ECHO errors
-193
-193

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -16,9 +16,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -685,5 +682,3 @@ LIMIT 2;
 
 --generate the results into two different files
 \set ECHO errors
-193
-193

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -16,9 +16,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -671,5 +668,3 @@ LIMIT 2;
 
 --generate the results into two different files
 \set ECHO errors
-193
-193

--- a/test/sql/append.sql
+++ b/test/sql/append.sql
@@ -10,9 +10,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 
 \set PREFIX 'EXPLAIN (costs OFF)'
 \ir :TEST_LOAD_NAME
@@ -33,4 +30,3 @@ SET timescaledb.disable_optimizations = 'on';
 \o
 
 :DIFF_CMD
-:WC_CMD

--- a/test/sql/plan_expand_hypertable.sql.in
+++ b/test/sql/plan_expand_hypertable.sql.in
@@ -17,9 +17,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 
 -- run queries with optimization on and off and diff results
 \set PREFIX ''
@@ -33,4 +30,3 @@ SET timescaledb.disable_optimizations= 'on';
 \o
 
 :DIFF_CMD
-:WC_CMD

--- a/test/sql/plan_hashagg.sql.in
+++ b/test/sql/plan_hashagg.sql.in
@@ -16,9 +16,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 
 SET client_min_messages TO error;
 --generate the results into two different files
@@ -33,4 +30,3 @@ SET timescaledb.disable_optimizations= 'on';
 \o
 
 :DIFF_CMD
-:WC_CMD

--- a/test/sql/plan_ordered_append.sql.in
+++ b/test/sql/plan_ordered_append.sql.in
@@ -18,9 +18,6 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff %s %s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "DIFF_CMD"
 \gset
--- use input redirect here because filenames are absolute and would be different across installations
-SELECT format('\! wc -l <%s; wc -l <%s', :'TEST_RESULTS_OPTIMIZED', :'TEST_RESULTS_UNOPTIMIZED') as "WC_CMD"
-\gset
 
 
 -- look at postgres version to decide whether we run with analyze or without
@@ -51,4 +48,3 @@ SET timescaledb.ordered_append = 'off';
 \o
 
 :DIFF_CMD
-:WC_CMD


### PR DESCRIPTION
A recently introduced change broke some tests on BSD / Mac OS X due
difference in output of the `wc` command, which is used to compare the
number of lines in different output files. The tests that are affected
are those that compare outputs of specific optimizations as they are
turned on and off.

This change removes the `wc` command and output from those tests as it
seems sufficient to rely on `diff`. In other words, if the number of
lines would be different in the output, then diff would also fail.