### PR TITLE
Print regresscheck-t test diff after sanitizer run

### DIFF
--- a/scripts/test_sanitizers.sh
+++ b/scripts/test_sanitizers.sh
@@ -45,7 +45,7 @@ cleanup() {
         docker rm -vf timescaledb-san 2>/dev/null
     else
         # docker logs timescaledb-san
-        docker_exec timescaledb-san "cat /tsdb_build/timescaledb/build/test/regression.diffs"
+        docker_exec timescaledb-san "cat /tsdb_build/timescaledb/build/test/regression.diffs /tsdb_build/timescaledb/build/tsl/test/regression.diffs"
         docker_exec timescaledb-san "cat /tsdb_build/timescaledb/build/test/log/postmaster.log"
     fi
 
@@ -106,4 +106,4 @@ echo "Testing"
 docker exec -u postgres \
     timescaledb-san /bin/bash -c \
     "cd /tsdb_build/timescaledb/build \
-        && PATH=\$PATH make regresscheck regresscheck-t"
+        && PATH=\$PATH make -k regresscheck regresscheck-t"


### PR DESCRIPTION
Change test_sanitizers.sh to always run regresscheck-t even when
regresscheck fails and print regresscheck-t diff on errors.