### PR TITLE
Add support for cross datatype chunk exclusion for time types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ accidentally triggering the load of a previous DB version.**
 ## 1.3.0 (unreleased)
 
 **Minor Features**
+* #1130 Add support for cross datatype chunk exclusion for time types
 * #1112 Add support for window functions to gapfill
 * #1062 Make constraint aware append parallel safe
 * #1005 Enable creating indexes with one transaction per chunk

--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -66,6 +66,33 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+-- create hypertable with DATE time dimension
+CREATE TABLE metrics_date(time DATE NOT NULL);
+SELECT create_hypertable('metrics_date','time');
+     create_hypertable     
+---------------------------
+ (3,public,metrics_date,t)
+(1 row)
+
+INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '1h'::interval);
+-- create hypertable with TIMESTAMP time dimension
+CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
+SELECT create_hypertable('metrics_timestamp','time');
+       create_hypertable        
+--------------------------------
+ (4,public,metrics_timestamp,t)
+(1 row)
+
+INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '1h'::interval);
+-- create hypertable with TIMESTAMPTZ time dimension
+CREATE TABLE metrics_timestamptz(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('metrics_timestamptz','time');
+        create_hypertable         
+----------------------------------
+ (5,public,metrics_timestamptz,t)
+(1 row)
+
+INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '1h'::interval);
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -405,6 +432,474 @@ psql:include/append_query.sql:126: NOTICE:  Stable function now_s() called!
                ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1
                      Index Cond: ("time" > (now_s() - '@ 3 hours'::interval))
 (14 rows)
+
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_material;
+-- test constraint_exclusion with date time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::date ORDER BY time;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_3_10_chunk."time"
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_3_10_chunk."time"
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_date
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_3_9_chunk."time"
+         ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(11 rows)
+
+-- test Const OP Var
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::date < time ORDER BY time;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_3_10_chunk."time"
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_3_10_chunk."time"
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_date
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_3_9_chunk."time"
+         ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(11 rows)
+
+-- test 2 constraints
+-- the queries should all have 2 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_3_10_chunk."time"
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+(6 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_3_10_chunk."time"
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+(6 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_date
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_3_9_chunk."time"
+         ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+               Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+               Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+(9 rows)
+
+-- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::date ORDER BY time;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_4_14_chunk."time"
+   ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_4_14_chunk."time"
+   ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamp
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_4_14_chunk."time"
+         ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(11 rows)
+
+-- test Const OP Var
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::date < time ORDER BY time;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_4_14_chunk."time"
+   ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+   ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_4_14_chunk."time"
+   ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+   ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(8 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamp
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_4_14_chunk."time"
+         ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(11 rows)
+
+-- test 2 constraints
+-- the queries should all have 2 chunks
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_4_14_chunk."time"
+   ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+         Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+   ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+         Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+(6 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_4_14_chunk."time"
+   ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+   ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+(6 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamp
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_4_14_chunk."time"
+         ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
+               Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
+               Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+(9 rows)
+
+-- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::date ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_5_19_chunk."time"
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+               Index Cond: ("time" > '01-15-2000'::date)
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+               Index Cond: ("time" > '01-15-2000'::date)
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+               Index Cond: ("time" > '01-15-2000'::date)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_5_19_chunk."time"
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_5_19_chunk."time"
+   ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+-- test Const OP Var
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::date < time ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_5_19_chunk."time"
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+               Index Cond: ("time" > '01-15-2000'::date)
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+               Index Cond: ("time" > '01-15-2000'::date)
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+               Index Cond: ("time" > '01-15-2000'::date)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 3
+   ->  Merge Append
+         Sort Key: _hyper_5_19_chunk."time"
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+               Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
+(11 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_5_19_chunk."time"
+   ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(8 rows)
+
+-- test 2 constraints
+-- the queries should all have 2 chunks
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_5_19_chunk."time"
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+               Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+               Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+(9 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_5_19_chunk."time"
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+               Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+               Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+(9 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_5_19_chunk."time"
+   ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
+(6 rows)
+
+-- test CURRENT_DATE
+-- should be 0 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > CURRENT_DATE ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_date
+   Chunks left after exclusion: 0
+(3 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > CURRENT_DATE ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamp
+   Chunks left after exclusion: 0
+(3 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > CURRENT_DATE ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 0
+(3 rows)
+
+-- test CURRENT_TIMESTAMP
+-- should be 0 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > CURRENT_TIMESTAMP ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_date
+   Chunks left after exclusion: 0
+(3 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > CURRENT_TIMESTAMP ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamp
+   Chunks left after exclusion: 0
+(3 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > CURRENT_TIMESTAMP ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 0
+(3 rows)
+
+-- test now()
+-- should be 0 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > now() ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_date
+   Chunks left after exclusion: 0
+(3 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > now() ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamp
+   Chunks left after exclusion: 0
+(3 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > now() ORDER BY time;
+             QUERY PLAN              
+-------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 0
+(3 rows)
 
 --generate the results into two different files
 \set ECHO errors

--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -190,23 +190,22 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 
 -- test constraint aware append with parallel aggregation
 SET max_parallel_workers_per_gather = 1;
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=2 loops=1)
+EXPLAIN (costs off) SELECT count(*) FROM "test" WHERE length(version()) > 0;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
          Workers Planned: 1
-         Workers Launched: 1
-         ->  Partial Aggregate (actual rows=1 loops=2)
-               ->  Result (actual rows=500000 loops=2)
+         ->  Partial Aggregate
+               ->  Result
                      One-Time Filter: (length(version()) > 0)
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=500000 loops=2)
+                     ->  Custom Scan (ConstraintAwareAppend)
                            Hypertable: test
                            Chunks left after exclusion: 2
-                           ->  Append (actual rows=500000 loops=2)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
-(13 rows)
+                           ->  Append
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk
+(12 rows)
 
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
   count  

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -189,23 +189,22 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 
 -- test constraint aware append with parallel aggregation
 SET max_parallel_workers_per_gather = 1;
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=2 loops=1)
+EXPLAIN (costs off) SELECT count(*) FROM "test" WHERE length(version()) > 0;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
          Workers Planned: 1
-         Workers Launched: 1
-         ->  Partial Aggregate (actual rows=1 loops=2)
-               ->  Result (actual rows=500000 loops=2)
+         ->  Partial Aggregate
+               ->  Result
                      One-Time Filter: (length(version()) > 0)
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=500000 loops=2)
+                     ->  Custom Scan (ConstraintAwareAppend)
                            Hypertable: test
                            Chunks left after exclusion: 2
-                           ->  Parallel Append (actual rows=500000 loops=2)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
-(13 rows)
+                           ->  Parallel Append
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk
+(12 rows)
 
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
   count  

--- a/test/expected/parallel-9.6.out
+++ b/test/expected/parallel-9.6.out
@@ -189,7 +189,7 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 
 -- test constraint aware append with parallel aggregation
 SET max_parallel_workers_per_gather = 1;
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
+EXPLAIN (costs off) SELECT count(*) FROM "test" WHERE length(version()) > 0;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Finalize Aggregate

--- a/test/expected/plan_expand_hypertable-10.out
+++ b/test/expected/plan_expand_hypertable-10.out
@@ -28,7 +28,7 @@ ALTER TABLE hyper_w_space
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper_w_space', 'time', 'device_id', 4, chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:28: NOTICE:  adding not-null constraint to column "time"
+psql:include/plan_expand_hypertable_load.sql:26: NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (2,public,hyper_w_space,t)
@@ -43,7 +43,7 @@ ALTER TABLE hyper_ts
 DROP COLUMN time_broken,
 ADD COLUMN time TIMESTAMPTZ;
 SELECT create_hypertable('hyper_ts', 'time', 'device_id', 2, chunk_time_interval => '10 seconds'::interval);
-psql:include/plan_expand_hypertable_load.sql:43: NOTICE:  adding not-null constraint to column "time"
+psql:include/plan_expand_hypertable_load.sql:41: NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (3,public,hyper_ts,t)
@@ -61,16 +61,18 @@ $BODY$
 $BODY$;
 CREATE TABLE hyper_timefunc ("time" float8 NOT NULL, "device_id" text, "value" integer);
 SELECT create_hypertable('hyper_timefunc', 'time', 'device_id', 4, chunk_time_interval => 10, time_partitioning_func => 'unix_to_timestamp');
-psql:include/plan_expand_hypertable_load.sql:59: WARNING:  unexpected interval: smaller than one second
+psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: smaller than one second
       create_hypertable      
 -----------------------------
  (4,public,hyper_timefunc,t)
 (1 row)
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
-SET client_min_messages = 'error';
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper;
+ANALYZE hyper_w_space;
+ANALYZE tag;
+ANALYZE hyper_ts;
+ANALYZE hyper_timefunc;
 \ir include/plan_expand_hypertable_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -28,7 +28,7 @@ ALTER TABLE hyper_w_space
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper_w_space', 'time', 'device_id', 4, chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:28: NOTICE:  adding not-null constraint to column "time"
+psql:include/plan_expand_hypertable_load.sql:26: NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (2,public,hyper_w_space,t)
@@ -43,7 +43,7 @@ ALTER TABLE hyper_ts
 DROP COLUMN time_broken,
 ADD COLUMN time TIMESTAMPTZ;
 SELECT create_hypertable('hyper_ts', 'time', 'device_id', 2, chunk_time_interval => '10 seconds'::interval);
-psql:include/plan_expand_hypertable_load.sql:43: NOTICE:  adding not-null constraint to column "time"
+psql:include/plan_expand_hypertable_load.sql:41: NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (3,public,hyper_ts,t)
@@ -61,16 +61,18 @@ $BODY$
 $BODY$;
 CREATE TABLE hyper_timefunc ("time" float8 NOT NULL, "device_id" text, "value" integer);
 SELECT create_hypertable('hyper_timefunc', 'time', 'device_id', 4, chunk_time_interval => 10, time_partitioning_func => 'unix_to_timestamp');
-psql:include/plan_expand_hypertable_load.sql:59: WARNING:  unexpected interval: smaller than one second
+psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: smaller than one second
       create_hypertable      
 -----------------------------
  (4,public,hyper_timefunc,t)
 (1 row)
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
-SET client_min_messages = 'error';
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper;
+ANALYZE hyper_w_space;
+ANALYZE tag;
+ANALYZE hyper_ts;
+ANALYZE hyper_timefunc;
 \ir include/plan_expand_hypertable_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/plan_expand_hypertable-9.6.out
+++ b/test/expected/plan_expand_hypertable-9.6.out
@@ -28,7 +28,7 @@ ALTER TABLE hyper_w_space
 DROP COLUMN time_broken,
 ADD COLUMN time BIGINT;
 SELECT create_hypertable('hyper_w_space', 'time', 'device_id', 4, chunk_time_interval => 10);
-psql:include/plan_expand_hypertable_load.sql:28: NOTICE:  adding not-null constraint to column "time"
+psql:include/plan_expand_hypertable_load.sql:26: NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
  (2,public,hyper_w_space,t)
@@ -43,7 +43,7 @@ ALTER TABLE hyper_ts
 DROP COLUMN time_broken,
 ADD COLUMN time TIMESTAMPTZ;
 SELECT create_hypertable('hyper_ts', 'time', 'device_id', 2, chunk_time_interval => '10 seconds'::interval);
-psql:include/plan_expand_hypertable_load.sql:43: NOTICE:  adding not-null constraint to column "time"
+psql:include/plan_expand_hypertable_load.sql:41: NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------
  (3,public,hyper_ts,t)
@@ -61,16 +61,18 @@ $BODY$
 $BODY$;
 CREATE TABLE hyper_timefunc ("time" float8 NOT NULL, "device_id" text, "value" integer);
 SELECT create_hypertable('hyper_timefunc', 'time', 'device_id', 4, chunk_time_interval => 10, time_partitioning_func => 'unix_to_timestamp');
-psql:include/plan_expand_hypertable_load.sql:59: WARNING:  unexpected interval: smaller than one second
+psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: smaller than one second
       create_hypertable      
 -----------------------------
  (4,public,hyper_timefunc,t)
 (1 row)
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
-SET client_min_messages = 'error';
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper;
+ANALYZE hyper_w_space;
+ANALYZE tag;
+ANALYZE hyper_ts;
+ANALYZE hyper_timefunc;
 \ir include/plan_expand_hypertable_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/sql/include/append_load.sql
+++ b/test/sql/include/append_load.sql
@@ -49,3 +49,18 @@ INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
 
+-- create hypertable with DATE time dimension
+CREATE TABLE metrics_date(time DATE NOT NULL);
+SELECT create_hypertable('metrics_date','time');
+INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '1h'::interval);
+
+-- create hypertable with TIMESTAMP time dimension
+CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
+SELECT create_hypertable('metrics_timestamp','time');
+INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '1h'::interval);
+
+-- create hypertable with TIMESTAMPTZ time dimension
+CREATE TABLE metrics_timestamptz(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('metrics_timestamptz','time');
+INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::date, '2000-02-01'::date, '1h'::interval);
+

--- a/test/sql/include/append_query.sql
+++ b/test/sql/include/append_query.sql
@@ -125,3 +125,79 @@ set enable_material = 'off';
 SELECT * FROM append_test a INNER JOIN join_test j ON (a.colorid = j.colorid)
 WHERE a.time > now_s() - interval '3 hours' AND j.time > now_s() - interval '3 hours';
 
+reset enable_hashjoin;
+reset enable_mergejoin;
+reset enable_material;
+
+-- test constraint_exclusion with date time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::date ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
+
+-- test Const OP Var
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::date < time ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
+
+-- test 2 constraints
+-- the queries should all have 2 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
+
+-- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::date ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
+
+-- test Const OP Var
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::date < time ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
+
+-- test 2 constraints
+-- the queries should all have 2 chunks
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
+
+-- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::date ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
+
+-- test Const OP Var
+-- the queries should all have 3 chunks
+:PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::date < time ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
+
+-- test 2 constraints
+-- the queries should all have 2 chunks
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
+
+-- test CURRENT_DATE
+-- should be 0 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > CURRENT_DATE ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > CURRENT_DATE ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > CURRENT_DATE ORDER BY time;
+
+-- test CURRENT_TIMESTAMP
+-- should be 0 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > CURRENT_TIMESTAMP ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > CURRENT_TIMESTAMP ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > CURRENT_TIMESTAMP ORDER BY time;
+
+-- test now()
+-- should be 0 chunks
+:PREFIX SELECT * FROM metrics_date WHERE time > now() ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time > now() ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time > now() ORDER BY time;
+

--- a/test/sql/include/plan_expand_hypertable_load.sql
+++ b/test/sql/include/plan_expand_hypertable_load.sql
@@ -16,8 +16,6 @@ INSERT INTO hyper SELECT g, g FROM generate_series(0,1000) g;
 --insert a point with INT_MAX_64
 INSERT INTO hyper (time, value) SELECT 9223372036854775807::bigint, 0;
 
-
-
 --time and space
 CREATE TABLE hyper_w_space ("time_broken" bigint NOT NULL, "device_id" text, "value" integer);
 
@@ -60,6 +58,8 @@ SELECT create_hypertable('hyper_timefunc', 'time', 'device_id', 4, chunk_time_in
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
 
-SET client_min_messages = 'error';
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper;
+ANALYZE hyper_w_space;
+ANALYZE tag;
+ANALYZE hyper_ts;
+ANALYZE hyper_timefunc;

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -145,3 +145,4 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM hyper_timefunc WHERE time < 4 ORDER BY value;
 --excluding based on time expression is currently unoptimized
 :PREFIX SELECT * FROM hyper_timefunc WHERE unix_to_timestamp(time) < 'Wed Dec 31 16:00:04 1969 PST' ORDER BY value;
+

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -61,7 +61,7 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 
 -- test constraint aware append with parallel aggregation
 SET max_parallel_workers_per_gather = 1;
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
+EXPLAIN (costs off) SELECT count(*) FROM "test" WHERE length(version()) > 0;
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
 SET max_parallel_workers_per_gather = 4;
 


### PR DESCRIPTION
Cross datatype comparisons between DATE/TIMESTAMP/TIMESTAMPTZ
are not immutable which prevents their usage for chunk exclusion.
Unfortunately estimate_expression_value will not estimate those
expressions which makes them unusable for execution time chunk
exclusion with constraint aware append.
To circumvent this we inject casts and use an operator
with the same datatype on both sides when building the
restrictinfo. This will allows estimate_expression_value
to evaluate those expressions and makes them accessible for
execution chunk exclusion with constraint aware append.

The following transformations are done:
TIMESTAMP OP TIMESTAMPTZ => TIMESTAMP OP (TIMESTAMPTZ::TIMESTAMP)
TIMESTAMPTZ OP DATE => TIMESTAMPTZ OP (DATE::TIMESTAMPTZ)

No transformation is required for TIMESTAMP OP DATE because
those operators are marked immutable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/timescale/timescaledb/1130)
<!-- Reviewable:end -->
