### PR TITLE
Add array_unnest to alignment supressions it looks like trigger lookup triggers it

### DIFF
--- a/scripts/suppressions/suppr_ub.txt
+++ b/scripts/suppressions/suppr_ub.txt
@@ -2,6 +2,7 @@ alignment:pg_comp_crc32c_sse42
 alignment:array_cmp
 alignment:array_iter_setup
 alignment:array_out
+alignment:array_unnest
 alignment:array_eq
 alignment:AllocSetCheck
 nonnull-attribute:TransactionIdSetPageStatus


### PR DESCRIPTION
See https://api.travis-ci.org/v3/job/513807308/log.txt for an example failure.