### PR TITLE
Remove unspecific ANALYZE from sql_query_results test

### DIFF
--- a/test/expected/sql_query_results_optimized.out
+++ b/test/expected/sql_query_results_optimized.out
@@ -98,10 +98,12 @@ SELECT * FROM create_hypertable('"public"."hyper_timefunc"'::regclass, 'time'::n
 
 INSERT INTO hyper_timefunc SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
 INSERT INTO hyper_timefunc SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE plain_table;
+ANALYZE hyper_timefunc;
+ANALYZE hyper_1;
+ANALYZE hyper_1_tz;
+ANALYZE hyper_1_int;
+ANALYZE hyper_1_date;
 --non-aggregates use MergeAppend in both optimized and non-optimized
 EXPLAIN (costs off) SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
                                   QUERY PLAN                                  
@@ -260,10 +262,7 @@ LIMIT 2;
 --test that still works with an expression index on data_trunc.
 DROP INDEX "time_plain";
 CREATE INDEX "time_trunc" ON PUBLIC.hyper_1 (date_trunc('minute', time));
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper_1;
 EXPLAIN (costs off) SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
@@ -285,10 +284,7 @@ SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
 
 --test that works with both indexes
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper_1;
 EXPLAIN (costs off) SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------

--- a/test/expected/sql_query_results_unoptimized.out
+++ b/test/expected/sql_query_results_unoptimized.out
@@ -99,10 +99,12 @@ SELECT * FROM create_hypertable('"public"."hyper_timefunc"'::regclass, 'time'::n
 
 INSERT INTO hyper_timefunc SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(0,10000) ser;
 INSERT INTO hyper_timefunc SELECT ser, ser, ser+10000, sqrt(ser::numeric) FROM generate_series(10001,20000) ser;
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE plain_table;
+ANALYZE hyper_timefunc;
+ANALYZE hyper_1;
+ANALYZE hyper_1_tz;
+ANALYZE hyper_1_int;
+ANALYZE hyper_1_date;
 --non-aggregates use MergeAppend in both optimized and non-optimized
 EXPLAIN (costs off) SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
                                   QUERY PLAN                                  
@@ -271,10 +273,7 @@ LIMIT 2;
 --test that still works with an expression index on data_trunc.
 DROP INDEX "time_plain";
 CREATE INDEX "time_trunc" ON PUBLIC.hyper_1 (date_trunc('minute', time));
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper_1;
 EXPLAIN (costs off) SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
@@ -297,10 +296,7 @@ SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2)
 
 --test that works with both indexes
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
-SET client_min_messages = 'error';
---avoid warning polluting output
-ANALYZE;
-RESET client_min_messages;
+ANALYZE hyper_1;
 EXPLAIN (costs off) SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------

--- a/test/expected/sql_query_results_x_diff.out
+++ b/test/expected/sql_query_results_x_diff.out
@@ -8,32 +8,32 @@
 ---
 > SET timescaledb.disable_optimizations= 'on';
 > SET max_parallel_workers_per_gather = 0; -- Disable parallel for this test
-110c111,113
+112c113,115
 <    ->  Append
 ---
 >    ->  Merge Append
 >          Sort Key: hyper_1."time" DESC
 >          ->  Index Scan using time_plain on hyper_1
-112c115
+114c117
 < (3 rows)
 ---
 > (5 rows)
-126c129,130
+128c131,132
 <          Sort Key: (to_timestamp(_hyper_5_19_chunk."time")) DESC
 ---
 >          Sort Key: (to_timestamp(hyper_timefunc."time")) DESC
 >          ->  Index Scan using time_plain_timefunc on hyper_timefunc
-128c132
+130c134
 < (4 rows)
 ---
 > (5 rows)
-139,140c143,144
+141,142c145,146
 <                                         QUERY PLAN                                        
 < ------------------------------------------------------------------------------------------
 ---
 >                                 QUERY PLAN                                 
 > ---------------------------------------------------------------------------
-143,148c147,154
+145,150c149,156
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 <          ->  Result
 <                ->  Merge Append
@@ -49,13 +49,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-152,153c158,159
+154,155c160,161
 <                                                       QUERY PLAN                                                      
 < ----------------------------------------------------------------------------------------------------------------------
 ---
 >                                               QUERY PLAN                                              
 > ------------------------------------------------------------------------------------------------------
-155,173c161,181
+157,175c163,183
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, (_hyper_4_6_chunk."time")::timestamp with time zone))
 <          ->  Result
@@ -97,13 +97,13 @@
 >                            ->  Seq Scan on _hyper_4_17_chunk
 >                            ->  Seq Scan on _hyper_4_18_chunk
 > (21 rows)
-198,199c206,207
+200,201c208,209
 <                                                 QUERY PLAN                                                 
 < -----------------------------------------------------------------------------------------------------------
 ---
 >                                                    QUERY PLAN                                                    
 > -----------------------------------------------------------------------------------------------------------------
-201,210c209,219
+203,212c211,221
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, hyper_1."time"))
 <          ->  Custom Scan (ConstraintAwareAppend)
@@ -126,54 +126,54 @@
 >                            ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
 >                                  Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (11 rows)
-239c248
+241c250
 <          Sort Key: (date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time"))) DESC
 ---
 >          Sort Key: (date_trunc('minute'::text, to_timestamp(hyper_timefunc."time"))) DESC
-241c250
+243c252
 <                Group Key: date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time"))
 ---
 >                Group Key: date_trunc('minute'::text, to_timestamp(hyper_timefunc."time"))
-243a253,254
+245a255,256
 >                            ->  Seq Scan on hyper_timefunc
 >                                  Filter: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-246c257
+248c259
 < (9 rows)
 ---
 > (11 rows)
-272c283
+271c282
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 ---
 >          Group Key: (date_trunc('minute'::text, hyper_1."time"))
-275c286,287
+274c285,286
 <                      Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
 ---
 >                      Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
 >                      ->  Index Scan Backward using time_trunc on hyper_1
-277c289
+276c288
 < (7 rows)
 ---
 > (8 rows)
-297c309
+293c305
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 ---
 >          Group Key: (date_trunc('minute'::text, hyper_1."time"))
-300c312,313
+296c308,309
 <                      Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
 ---
 >                      Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
 >                      ->  Index Scan Backward using time_trunc on hyper_1
-302c315
+298c311
 < (7 rows)
 ---
 > (8 rows)
-313,314c326,327
+309,310c322,323
 <                                            QUERY PLAN                                           
 < ------------------------------------------------------------------------------------------------
 ---
 >                                    QUERY PLAN                                    
 > ---------------------------------------------------------------------------------
-317,322c330,337
+313,318c326,333
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
 <          ->  Result
 <                ->  Merge Append
@@ -189,13 +189,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-334,335c349,350
+330,331c345,346
 <                                                                      QUERY PLAN                                                                     
 < ----------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-338,343c353,360
+334,339c349,356
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
 <                ->  Merge Append
@@ -211,13 +211,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-355,356c372,373
+351,352c368,369
 <                                                         QUERY PLAN                                                        
 < --------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-359,364c376,383
+355,360c372,379
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
 <          ->  Result
 <                ->  Merge Append
@@ -233,13 +233,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-376,377c395,396
+372,373c391,392
 <                                                                      QUERY PLAN                                                                     
 < ----------------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-380,385c399,406
+376,381c395,402
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Result
 <                ->  Merge Append
@@ -255,13 +255,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-397,398c418,419
+393,394c414,415
 <                                            QUERY PLAN                                           
 < ------------------------------------------------------------------------------------------------
 ---
 >                                      QUERY PLAN                                     
 > ------------------------------------------------------------------------------------
-401,406c422,429
+397,402c418,425
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
 <          ->  Result
 <                ->  Merge Append
@@ -277,13 +277,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-418,419c441,442
+414,415c437,438
 <                                                           QUERY PLAN                                                           
 < -------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                     QUERY PLAN                                                     
 > -------------------------------------------------------------------------------------------------------------------
-422,427c445,452
+418,423c441,448
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_2_2_chunk."time")::timestamp without time zone))
 <          ->  Result
 <                ->  Merge Append
@@ -299,13 +299,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-439,440c464,465
+435,436c460,461
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                              QUERY PLAN                             
 > --------------------------------------------------------------------
-443,450c468,477
+439,446c464,473
 <          Group Key: (time_bucket(10, _hyper_3_3_chunk."time"))
 <          ->  Result
 <                ->  Merge Append
@@ -325,13 +325,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-462,463c489,490
+458,459c485,486
 <                                           QUERY PLAN                                          
 < ----------------------------------------------------------------------------------------------
 ---
 >                               QUERY PLAN                               
 > -----------------------------------------------------------------------
-466,473c493,502
+462,469c489,498
 <          Group Key: (time_bucket(10, _hyper_3_3_chunk."time", 2))
 <          ->  Result
 <                ->  Merge Append
@@ -351,13 +351,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-524,525c553,554
+520,521c549,550
 <                                           QUERY PLAN                                           
 < -----------------------------------------------------------------------------------------------
 ---
 >                                              QUERY PLAN                                              
 > -----------------------------------------------------------------------------------------------------
-527,531c556,562
+523,527c552,558
 <    ->  GroupAggregate
 <          Group Key: date_trunc('minute'::text, "time")
 <          ->  Index Scan using time_plain_plain_table on plain_table
@@ -371,5 +371,5 @@
 >                ->  Index Scan using time_plain_plain_table on plain_table
 >                      Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (7 rows)
-545a577
+541a573
 > RESET max_parallel_workers_per_gather;


### PR DESCRIPTION
Using ANALYZE without a specific table will generate a warning
in the postgres log for every table the user does not have
permissions for. This leads to a lot of unnecessary noise
in the travis logs. This patch removes ANALYZE without table
and replaces it with calls that target the specific tables
used in this test case.