### PR TITLE
Refactor collecting RestrictInfo

### DIFF
--- a/test/expected/plan_expand_hypertable-10.out
+++ b/test/expected/plan_expand_hypertable-10.out
@@ -1166,6 +1166,22 @@ SET constraint_exclusion = 'off';
                      ->  Seq Scan on _hyper_2_105_chunk h1_1
 (11 rows)
 
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) ORDER BY h1.value;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Sort
+   Sort Key: h1.value
+   ->  Hash Join
+         Hash Cond: (h2.device_id = h1.device_id)
+         ->  Append
+               ->  Seq Scan on _hyper_3_116_chunk h2
+               ->  Seq Scan on _hyper_3_117_chunk h2_1
+         ->  Hash
+               ->  Append
+                     ->  Seq Scan on _hyper_2_104_chunk h1
+                     ->  Seq Scan on _hyper_2_105_chunk h1_1
+(11 rows)
+
 :PREFIX SELECT * FROM hyper h1, hyper h2 WHERE _timescaledb_internal.chunks_in(h1, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(h2, ARRAY[2,3]);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1203,32 +1219,32 @@ SET enable_seqscan=false;
 (7 rows)
 
 \set ON_ERROR_STOP 0
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:24: ERROR:  only one chunks_in call is allowed per hypertable
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:25: ERROR:  function _timescaledb_internal.chunks_in(integer, integer[]) does not exist at character 48
-SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:26: ERROR:  illegal invocation of chunks_in function
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  function _timescaledb_internal.chunks_in(integer, integer[]) does not exist at character 27
+SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:28: ERROR:  illegal invocation of chunks_in function
 SELECT _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) FROM hyper;
-psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  illegal invocation of chunks_in function
+psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  illegal invocation of chunks_in function
 -- non existing chunk id
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  chunk id 123456789 not found
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 123456789 not found
 -- chunk that belongs to another hypertable
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 104 does not belong to hypertable "hyper"
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  chunk id 104 does not belong to hypertable "hyper"
 -- passing wrong row ref
 SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(ROW(1,2), ARRAY[104]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  illegal invocation of chunks_in function
+psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  illegal invocation of chunks_in function
 -- passing func as chunk id
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
-psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  second argument to chunk_in should contain only integer consts
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+psql:include/plan_expand_hypertable_chunks_in_query.sql:37: ERROR:  second argument to chunk_in should contain only integer consts
 -- chunks_in is STRICT function and for NULL arguments a null result is returned
 SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
  value | time 
 -------+------
 (0 rows)
 
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:40: ERROR:  chunk id can't be NULL
 \set ECHO errors

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -1168,6 +1168,22 @@ SET constraint_exclusion = 'off';
                      ->  Seq Scan on _hyper_2_105_chunk h1_1
 (11 rows)
 
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) ORDER BY h1.value;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Sort
+   Sort Key: h1.value
+   ->  Hash Join
+         Hash Cond: (h2.device_id = h1.device_id)
+         ->  Append
+               ->  Seq Scan on _hyper_3_116_chunk h2
+               ->  Seq Scan on _hyper_3_117_chunk h2_1
+         ->  Hash
+               ->  Append
+                     ->  Seq Scan on _hyper_2_104_chunk h1
+                     ->  Seq Scan on _hyper_2_105_chunk h1_1
+(11 rows)
+
 :PREFIX SELECT * FROM hyper h1, hyper h2 WHERE _timescaledb_internal.chunks_in(h1, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(h2, ARRAY[2,3]);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1205,32 +1221,32 @@ SET enable_seqscan=false;
 (7 rows)
 
 \set ON_ERROR_STOP 0
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:24: ERROR:  only one chunks_in call is allowed per hypertable
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:25: ERROR:  function _timescaledb_internal.chunks_in(integer, integer[]) does not exist at character 48
-SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:26: ERROR:  illegal invocation of chunks_in function
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  function _timescaledb_internal.chunks_in(integer, integer[]) does not exist at character 27
+SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:28: ERROR:  illegal invocation of chunks_in function
 SELECT _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) FROM hyper;
-psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  illegal invocation of chunks_in function
+psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  illegal invocation of chunks_in function
 -- non existing chunk id
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  chunk id 123456789 not found
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 123456789 not found
 -- chunk that belongs to another hypertable
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 104 does not belong to hypertable "hyper"
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  chunk id 104 does not belong to hypertable "hyper"
 -- passing wrong row ref
 SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(ROW(1,2), ARRAY[104]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  illegal invocation of chunks_in function
+psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  illegal invocation of chunks_in function
 -- passing func as chunk id
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
-psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  second argument to chunk_in should contain only integer consts
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+psql:include/plan_expand_hypertable_chunks_in_query.sql:37: ERROR:  second argument to chunk_in should contain only integer consts
 -- chunks_in is STRICT function and for NULL arguments a null result is returned
 SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
  value | time 
 -------+------
 (0 rows)
 
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:40: ERROR:  chunk id can't be NULL
 \set ECHO errors

--- a/test/expected/plan_expand_hypertable-9.6.out
+++ b/test/expected/plan_expand_hypertable-9.6.out
@@ -1166,6 +1166,22 @@ SET constraint_exclusion = 'off';
                      ->  Seq Scan on _hyper_2_105_chunk h1_1
 (11 rows)
 
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) ORDER BY h1.value;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Sort
+   Sort Key: h1.value
+   ->  Hash Join
+         Hash Cond: (h2.device_id = h1.device_id)
+         ->  Append
+               ->  Seq Scan on _hyper_3_116_chunk h2
+               ->  Seq Scan on _hyper_3_117_chunk h2_1
+         ->  Hash
+               ->  Append
+                     ->  Seq Scan on _hyper_2_104_chunk h1
+                     ->  Seq Scan on _hyper_2_105_chunk h1_1
+(11 rows)
+
 :PREFIX SELECT * FROM hyper h1, hyper h2 WHERE _timescaledb_internal.chunks_in(h1, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(h2, ARRAY[2,3]);
                      QUERY PLAN                      
 -----------------------------------------------------
@@ -1203,32 +1219,32 @@ SET enable_seqscan=false;
 (7 rows)
 
 \set ON_ERROR_STOP 0
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:24: ERROR:  only one chunks_in call is allowed per hypertable
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:25: ERROR:  function _timescaledb_internal.chunks_in(integer, integer[]) does not exist at character 48
-SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:26: ERROR:  illegal invocation of chunks_in function
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  function _timescaledb_internal.chunks_in(integer, integer[]) does not exist at character 27
+SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:28: ERROR:  illegal invocation of chunks_in function
 SELECT _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) FROM hyper;
-psql:include/plan_expand_hypertable_chunks_in_query.sql:27: ERROR:  illegal invocation of chunks_in function
+psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  illegal invocation of chunks_in function
 -- non existing chunk id
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:29: ERROR:  chunk id 123456789 not found
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 123456789 not found
 -- chunk that belongs to another hypertable
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:31: ERROR:  chunk id 104 does not belong to hypertable "hyper"
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  chunk id 104 does not belong to hypertable "hyper"
 -- passing wrong row ref
 SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(ROW(1,2), ARRAY[104]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:33: ERROR:  illegal invocation of chunks_in function
+psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  illegal invocation of chunks_in function
 -- passing func as chunk id
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
-psql:include/plan_expand_hypertable_chunks_in_query.sql:35: ERROR:  second argument to chunk_in should contain only integer consts
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+psql:include/plan_expand_hypertable_chunks_in_query.sql:37: ERROR:  second argument to chunk_in should contain only integer consts
 -- chunks_in is STRICT function and for NULL arguments a null result is returned
 SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
  value | time 
 -------+------
 (0 rows)
 
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
-psql:include/plan_expand_hypertable_chunks_in_query.sql:38: ERROR:  chunk id can't be NULL
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
+psql:include/plan_expand_hypertable_chunks_in_query.sql:40: ERROR:  chunk id can't be NULL
 \set ECHO errors

--- a/test/sql/include/plan_expand_hypertable_chunks_in_query.sql
+++ b/test/sql/include/plan_expand_hypertable_chunks_in_query.sql
@@ -14,25 +14,27 @@ SET constraint_exclusion = 'off';
 :PREFIX SELECT * FROM hyper_ts WHERE device_id = 'dev1' AND time < to_timestamp(10) AND _timescaledb_internal.chunks_in(hyper_ts, ARRAY[116]) ORDER BY value;
 :PREFIX SELECT * FROM hyper_ts h JOIN tag on (h.tag_id = tag.id ) WHERE _timescaledb_internal.chunks_in(h, ARRAY[116]) AND time < to_timestamp(10) AND device_id = 'dev1' ORDER BY value;
 :PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) ORDER BY h1.value;
+:PREFIX SELECT * FROM hyper_w_space h1 JOIN hyper_ts h2 ON h1.device_id=h2.device_id AND _timescaledb_internal.chunks_in(h2, ARRAY[116,117]) WHERE _timescaledb_internal.chunks_in(h1, ARRAY[104,105]) ORDER BY h1.value;
 :PREFIX SELECT * FROM hyper h1, hyper h2 WHERE _timescaledb_internal.chunks_in(h1, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(h2, ARRAY[2,3]);
 SET enable_seqscan=false;
 -- Should perform index-only scan. Since we pass whole row into the function it might block planner from using index-only scan.
 -- But since we'll remove the function from the query tree before planner decision it shouldn't affect index-only decision.
 :PREFIX SELECT time FROM hyper WHERE time=0 AND _timescaledb_internal.chunks_in(hyper, ARRAY[1]);
 :PREFIX SELECT first(value, time) FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[1]);
+
 \set ON_ERROR_STOP 0
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) AND _timescaledb_internal.chunks_in(hyper, ARRAY[2,3]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(2, ARRAY[1]);
 SELECT * FROM hyper WHERE time < 10 OR _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]);
 SELECT _timescaledb_internal.chunks_in(hyper, ARRAY[1,2]) FROM hyper;
 -- non existing chunk id
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[123456789]);
 -- chunk that belongs to another hypertable
-:PREFIX SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
+SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(hyper, ARRAY[104]);
 -- passing wrong row ref
 SELECT * FROM hyper WHERE _timescaledb_internal.chunks_in(ROW(1,2), ARRAY[104]);
 -- passing func as chunk id
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, array_append(ARRAY[1],current_setting('server_version_num')::int));
 -- chunks_in is STRICT function and for NULL arguments a null result is returned
 SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
-:PREFIX SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
+SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);


### PR DESCRIPTION
Building RestrictInfo for plan time chunk exclusion only collected
expressions in WHERE clause but not constraints present in ON clause
of JOINs. This patch adds support for collecting constraints from
JOIN conditions.

This patch also changes the expression_tree_mutator to an
expression_tree_walker because the modifications we do do not require
using a mutator.