### PR TITLE
Stop processing commit message on scissors line

### DIFF
--- a/scripts/githooks/commit_msg.py
+++ b/scripts/githooks/commit_msg.py
@@ -23,6 +23,8 @@ class GitCommitMessage:
         if filename != None:
             with open(filename, 'r') as f:
                 for line in f:
+                    if line.startswith('# ------------------------ >8 ------------------------')
+                        break
                     if not line.startswith('#'):
                         lines.append(line)
 


### PR DESCRIPTION
The commit message template may include the actual diff to be
committed separated with a special scissors. This patch adds
support for the scissors line to the commit hook otherwise
the diff content may trigger any of the rules.