### PR TITLE
Add time_bucket support to chunk exclusion

### DIFF
--- a/src/constraint_aware_append.c
+++ b/src/constraint_aware_append.c
@@ -96,53 +96,6 @@ can_exclude_chunk(PlannerInfo *root, Scan *scan, EState *estate, Index rt_index,
 		   excluded_by_constraint(root, rte, rt_index, restrictinfos);
 }
 
-/*
- * get_operator
- *
- *    finds an operator given an exact specification (name, namespace,
- *    left and right type IDs).
- */
-static Oid
-get_operator(const char *name, Oid namespace, Oid left, Oid right)
-{
-	HeapTuple tup;
-	Oid opoid = InvalidOid;
-
-	tup = SearchSysCache4(OPERNAMENSP,
-						  PointerGetDatum(name),
-						  ObjectIdGetDatum(left),
-						  ObjectIdGetDatum(right),
-						  ObjectIdGetDatum(namespace));
-	if (HeapTupleIsValid(tup))
-	{
-		opoid = HeapTupleGetOid(tup);
-		ReleaseSysCache(tup);
-	}
-
-	return opoid;
-}
-
-/*
- * lookup cast func oid in pg_cast
- */
-static Oid
-get_cast_func(Oid source, Oid target)
-{
-	Oid result = InvalidOid;
-	HeapTuple casttup;
-
-	casttup = SearchSysCache2(CASTSOURCETARGET, ObjectIdGetDatum(source), ObjectIdGetDatum(target));
-	if (HeapTupleIsValid(casttup))
-	{
-		Form_pg_cast castform = (Form_pg_cast) GETSTRUCT(casttup);
-
-		result = castform->castfunc;
-		ReleaseSysCache(casttup);
-	}
-
-	return result;
-}
-
 #define DATATYPE_PAIR(left, right, type1, type2)                                                   \
 	((left == type1 && right == type2) || (left == type2 && right == type1))
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -61,6 +61,10 @@ extern bool ts_function_types_equal(Oid left[], Oid right[], int nargs);
 
 extern Oid get_function_oid(char *name, char *schema_name, int nargs, Oid arg_types[]);
 
+extern Oid get_operator(const char *name, Oid namespace, Oid left, Oid right);
+
+extern Oid get_cast_func(Oid source, Oid target);
+
 extern void *ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size,
 										 size_t copy_size);
 

--- a/test/expected/plan_expand_hypertable-10.out
+++ b/test/expected/plan_expand_hypertable-10.out
@@ -68,6 +68,33 @@ psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: 
 (1 row)
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
+CREATE TABLE metrics_timestamp(time timestamp);
+SELECT create_hypertable('metrics_timestamp','time');
+psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
+       create_hypertable        
+--------------------------------
+ (5,public,metrics_timestamp,t)
+(1 row)
+
+INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1d'::interval);
+CREATE TABLE metrics_timestamptz(time timestamptz);
+SELECT create_hypertable('metrics_timestamptz','time');
+psql:include/plan_expand_hypertable_load.sql:66: NOTICE:  adding not-null constraint to column "time"
+        create_hypertable         
+----------------------------------
+ (6,public,metrics_timestamptz,t)
+(1 row)
+
+INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval);
+CREATE TABLE metrics_date(time date);
+SELECT create_hypertable('metrics_date','time');
+psql:include/plan_expand_hypertable_load.sql:70: NOTICE:  adding not-null constraint to column "time"
+     create_hypertable     
+---------------------------
+ (7,public,metrics_date,t)
+(1 row)
+
+INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date,'2000-02-01'::date,'1d'::interval);
 ANALYZE hyper;
 ANALYZE hyper_w_space;
 ANALYZE tag;
@@ -881,6 +908,237 @@ SELECT * FROM cte ORDER BY value;
                      Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
          ->  Seq Scan on tag
                Filter: (name = 'tag1'::text)
+(9 rows)
+
+-- time_bucket exclusion
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 10::bigint ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '10'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '10'::bigint)
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 11::bigint ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) <= 10::bigint ORDER BY time;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time) ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ('10'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ('10'::bigint > time_bucket('10'::bigint, "time"))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time) ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_8_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_8_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_10_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_11_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_4_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_6_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_5_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_9_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_7_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+(23 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
+(5 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+(7 rows)
+
+-- time_bucket exclusion with date
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_7_165_chunk."time"
+   ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < '01-03-2000'::date)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_7_166_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_7_166_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+         ->  Seq Scan on _hyper_7_165_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+(7 rows)
+
+-- time_bucket exclusion with timestamp
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_5_155_chunk."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000'::timestamp without time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_5_156_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_5_156_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+         ->  Seq Scan on _hyper_5_155_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+(7 rows)
+
+-- time_bucket exclusion with timestamptz
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 6 hours'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+-- time_bucket exclusion with timestamptz and day interval
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('7d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_162_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_162_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
 (9 rows)
 
 --exclude chunks based on time column with partitioning function. This

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -68,6 +68,33 @@ psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: 
 (1 row)
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
+CREATE TABLE metrics_timestamp(time timestamp);
+SELECT create_hypertable('metrics_timestamp','time');
+psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
+       create_hypertable        
+--------------------------------
+ (5,public,metrics_timestamp,t)
+(1 row)
+
+INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1d'::interval);
+CREATE TABLE metrics_timestamptz(time timestamptz);
+SELECT create_hypertable('metrics_timestamptz','time');
+psql:include/plan_expand_hypertable_load.sql:66: NOTICE:  adding not-null constraint to column "time"
+        create_hypertable         
+----------------------------------
+ (6,public,metrics_timestamptz,t)
+(1 row)
+
+INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval);
+CREATE TABLE metrics_date(time date);
+SELECT create_hypertable('metrics_date','time');
+psql:include/plan_expand_hypertable_load.sql:70: NOTICE:  adding not-null constraint to column "time"
+     create_hypertable     
+---------------------------
+ (7,public,metrics_date,t)
+(1 row)
+
+INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date,'2000-02-01'::date,'1d'::interval);
 ANALYZE hyper;
 ANALYZE hyper_w_space;
 ANALYZE tag;
@@ -882,6 +909,237 @@ SELECT * FROM cte ORDER BY value;
                      Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
          ->  Seq Scan on tag
                Filter: (name = 'tag1'::text)
+(9 rows)
+
+-- time_bucket exclusion
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 10::bigint ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '10'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '10'::bigint)
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 11::bigint ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) <= 10::bigint ORDER BY time;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time) ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ('10'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ('10'::bigint > time_bucket('10'::bigint, "time"))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time) ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_8_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_8_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_10_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_11_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_4_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_6_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_5_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_9_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_7_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+(23 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
+(5 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+(7 rows)
+
+-- time_bucket exclusion with date
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_7_165_chunk."time"
+   ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < '01-03-2000'::date)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_7_166_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_7_166_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+         ->  Seq Scan on _hyper_7_165_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+(7 rows)
+
+-- time_bucket exclusion with timestamp
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_5_155_chunk."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000'::timestamp without time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_5_156_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_5_156_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+         ->  Seq Scan on _hyper_5_155_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+(7 rows)
+
+-- time_bucket exclusion with timestamptz
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 6 hours'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+-- time_bucket exclusion with timestamptz and day interval
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('7d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_162_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_162_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
 (9 rows)
 
 --exclude chunks based on time column with partitioning function. This

--- a/test/expected/plan_expand_hypertable-9.6.out
+++ b/test/expected/plan_expand_hypertable-9.6.out
@@ -68,6 +68,33 @@ psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: 
 (1 row)
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
+CREATE TABLE metrics_timestamp(time timestamp);
+SELECT create_hypertable('metrics_timestamp','time');
+psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
+       create_hypertable        
+--------------------------------
+ (5,public,metrics_timestamp,t)
+(1 row)
+
+INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1d'::interval);
+CREATE TABLE metrics_timestamptz(time timestamptz);
+SELECT create_hypertable('metrics_timestamptz','time');
+psql:include/plan_expand_hypertable_load.sql:66: NOTICE:  adding not-null constraint to column "time"
+        create_hypertable         
+----------------------------------
+ (6,public,metrics_timestamptz,t)
+(1 row)
+
+INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval);
+CREATE TABLE metrics_date(time date);
+SELECT create_hypertable('metrics_date','time');
+psql:include/plan_expand_hypertable_load.sql:70: NOTICE:  adding not-null constraint to column "time"
+     create_hypertable     
+---------------------------
+ (7,public,metrics_date,t)
+(1 row)
+
+INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date,'2000-02-01'::date,'1d'::interval);
 ANALYZE hyper;
 ANALYZE hyper_w_space;
 ANALYZE tag;
@@ -881,6 +908,237 @@ SELECT * FROM cte ORDER BY value;
                      Filter: (("time" < 'Wed Dec 31 16:00:10 1969 PST'::timestamp with time zone) AND (device_id = 'dev1'::text))
          ->  Seq Scan on tag
                Filter: (name = 'tag1'::text)
+(9 rows)
+
+-- time_bucket exclusion
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 10::bigint ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '10'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '10'::bigint)
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 11::bigint ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (time_bucket('10'::bigint, "time") < '11'::bigint)
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) <= 10::bigint ORDER BY time;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: (time_bucket('10'::bigint, "time") <= '10'::bigint)
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time) ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ('10'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ('10'::bigint > time_bucket('10'::bigint, "time"))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time) ORDER BY time;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_1_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ('11'::bigint > time_bucket('10'::bigint, "time"))
+(9 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_8_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_8_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_10_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_11_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_4_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_6_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_5_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_9_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_7_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+(23 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 20))
+(7 rows)
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((time_bucket('1'::bigint, "time") > 11) AND (time_bucket('1'::bigint, "time") < 19))
+(5 rows)
+
+:PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_1_2_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_1_2_chunk
+               Filter: ((10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+         ->  Seq Scan on _hyper_1_3_chunk
+               Filter: ((10 < time_bucket('10'::bigint, "time")) AND (20 > time_bucket('10'::bigint, "time")))
+(7 rows)
+
+-- time_bucket exclusion with date
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_7_165_chunk."time"
+   ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < '01-03-2000'::date)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_7_166_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_7_166_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+         ->  Seq Scan on _hyper_7_165_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+(7 rows)
+
+-- time_bucket exclusion with timestamp
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_5_155_chunk."time"
+   ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000'::timestamp without time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_5_156_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_5_156_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+         ->  Seq Scan on _hyper_5_155_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+(7 rows)
+
+-- time_bucket exclusion with timestamptz
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 6 hours'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                  QUERY PLAN                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+-- time_bucket exclusion with timestamptz and day interval
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Merge Append
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(4 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                QUERY PLAN                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_160_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('7d',time) <= '2000-01-10' ORDER BY time;
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_6_162_chunk."time"
+   ->  Append
+         ->  Seq Scan on _hyper_6_162_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_160_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Seq Scan on _hyper_6_161_chunk
+               Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
 (9 rows)
 
 --exclude chunks based on time column with partitioning function. This

--- a/test/sql/include/plan_expand_hypertable_load.sql
+++ b/test/sql/include/plan_expand_hypertable_load.sql
@@ -58,6 +58,18 @@ SELECT create_hypertable('hyper_timefunc', 'time', 'device_id', 4, chunk_time_in
 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
 
+CREATE TABLE metrics_timestamp(time timestamp);
+SELECT create_hypertable('metrics_timestamp','time');
+INSERT INTO metrics_timestamp SELECT generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1d'::interval);
+
+CREATE TABLE metrics_timestamptz(time timestamptz);
+SELECT create_hypertable('metrics_timestamptz','time');
+INSERT INTO metrics_timestamptz SELECT generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval);
+
+CREATE TABLE metrics_date(time date);
+SELECT create_hypertable('metrics_date','time');
+INSERT INTO metrics_date SELECT generate_series('2000-01-01'::date,'2000-02-01'::date,'1d'::interval);
+
 ANALYZE hyper;
 ANALYZE hyper_w_space;
 ANALYZE tag;

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -139,6 +139,35 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 :PREFIX SELECT * FROM hyper_ts JOIN tag on (hyper_ts.tag_id = tag.id ) WHERE tag.name = 'tag1' and time < to_timestamp(10) and device_id = 'dev1' ORDER BY value;
 
+-- time_bucket exclusion
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 10::bigint ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) < 11::bigint ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) <= 10::bigint ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE 10::bigint > time_bucket(10, time) ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time) ORDER BY time;
+
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE time_bucket(1, time) > 11 AND time_bucket(1, time) < 19 ORDER BY time;
+:PREFIX SELECT * FROM hyper WHERE 10 < time_bucket(10, time) AND 20 > time_bucket(10,time) ORDER BY time;
+
+-- time_bucket exclusion with date
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+:PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+
+-- time_bucket exclusion with timestamp
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+
+-- time_bucket exclusion with timestamptz
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
+
+-- time_bucket exclusion with timestamptz and day interval
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
+:PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('7d',time) <= '2000-01-10' ORDER BY time;
+
 --exclude chunks based on time column with partitioning function. This
 --transparently applies the time partitioning function on the time
 --value to be able to exclude chunks (similar to a closed dimension).


### PR DESCRIPTION
This patch adds support for chunk exclusion for time_bucket
expressions in the WHERE clause. The following transformation
is done when building RestrictInfo:

Transform time_bucket calls of the following form in WHERE clause:

time_bucket(width, column) OP value

Since time_bucket always returns the lower bound of the bucket
for lower bound comparisons the width is not relevant and the
following transformation can be applied:

time_bucket(width, column) > value
column > value

Example with values:

time_bucket(10, column) > 109
column > 109

For upper bound comparisons width needs to be taken into account
and we need to extend the upper bound by width to capture all
possible values.

time_bucket(width, column) < value
column < value + width

Example with values:

time_bucket(10, column) < 100
column < 100 + 10

This allows chunk exclusions to work for views with aggregations.