### PR TITLE
Ignore .psqlrc start-up file when running tests

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -6,6 +6,7 @@ CURRENT_DIR=$(dirname $0)
 EXE_DIR=${EXE_DIR:-${CURRENT_DIR}}
 PG_REGRESS_PSQL=$1
 PSQL=${PSQL:-$PG_REGRESS_PSQL}
+PSQL="${PSQL} -X" # Prevent any .psqlrc files from being executed during the tests
 TEST_PGUSER=${TEST_PGUSER:-postgres}
 TEST_INPUT_DIR=${TEST_INPUT_DIR:-${EXE_DIR}}
 TEST_OUTPUT_DIR=${TEST_OUTPUT_DIR:-${EXE_DIR}}


### PR DESCRIPTION
Any output or side-effects that a (private) .psqlrc generates should not
cause test failures. By excluding the start-up file we make sure we get
consistent output for everyone.