### PR TITLE
Add content of installation_metadata to telemetry

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,6 +79,8 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned_version='0.0.1'"
 
+    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb_telemetry.cloud='ci'"
+
     # TODO removing the following line causes a stack overflow on appveyor
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.telemetry_level='off'"

--- a/src/guc.c
+++ b/src/guc.c
@@ -46,6 +46,7 @@ int ts_guc_telemetry_level = TELEMETRY_BASIC;
 TSDLLEXPORT char *ts_guc_license_key = TS_DEFAULT_LICENSE;
 char *ts_last_tune_time = NULL;
 char *ts_last_tune_version = NULL;
+char *ts_telemetry_cloud = NULL;
 
 #ifdef TS_DEBUG
 bool ts_shutdown_bgw = false;
@@ -205,6 +206,18 @@ _guc_init(void)
 							   /* check_hook= */ NULL,
 							   /* assign_hook= */ NULL,
 							   /* show_hook= */ NULL);
+
+	DefineCustomStringVariable(/* name= */ "timescaledb_telemetry.cloud",
+							   /* short_dec= */ "cloud provider",
+							   /* long_dec= */ "cloud provider used for this instance",
+							   /* valueAddr= */ &ts_telemetry_cloud,
+							   /* bootValue= */ NULL,
+							   /* context= */ PGC_SIGHUP,
+							   /* flags= */ 0,
+							   /* check_hook= */ NULL,
+							   /* assign_hook= */ NULL,
+							   /* show_hook= */ NULL);
+
 #ifdef TS_DEBUG
 	DefineCustomBoolVariable(/* name= */ "timescaledb.shutdown_bgw_scheduler",
 							 /* short_dec= */ "immediately shutdown the bgw scheduler",

--- a/src/guc.h
+++ b/src/guc.h
@@ -23,6 +23,7 @@ extern int ts_guc_telemetry_level;
 extern TSDLLEXPORT char *ts_guc_license_key;
 extern char *ts_last_tune_time;
 extern char *ts_last_tune_version;
+extern char *ts_telemetry_cloud;
 
 #ifdef TS_DEBUG
 extern bool ts_shutdown_bgw;

--- a/src/telemetry/metadata.h
+++ b/src/telemetry/metadata.h
@@ -7,7 +7,9 @@
 #define TIMESCALEDB_TELEMETRY_METADATA_H
 
 #include <postgres.h>
+#include <utils/jsonb.h>
 
+extern void ts_metadata_add_values(JsonbParseState *state);
 extern Datum ts_metadata_get_uuid(void);
 extern Datum ts_metadata_get_exported_uuid(void);
 extern Datum ts_metadata_get_install_timestamp(void);

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -48,11 +48,14 @@
 #define REQ_DATA_VOLUME "data_volume"
 #define REQ_NUM_HYPERTABLES "num_hypertables"
 #define REQ_RELATED_EXTENSIONS "related_extensions"
+#define REQ_INSTALLATION_METADATA "db_metadata"
 #define REQ_LICENSE_INFO "license"
 #define REQ_LICENSE_EDITION "edition"
 #define REQ_LICENSE_EDITION_APACHE "apache_only"
 #define REQ_TS_LAST_TUNE_TIME "last_tuned_time"
 #define REQ_TS_LAST_TUNE_VERSION "last_tuned_version"
+#define REQ_INSTANCE_METADATA "instance_metadata"
+#define REQ_TS_TELEMETRY_CLOUD "cloud"
 
 #define PG_PROMETHEUS "pg_prometheus"
 #define POSTGIS "postgis"
@@ -270,6 +273,28 @@ build_version_body(void)
 
 	if (ts_last_tune_version != NULL)
 		ts_jsonb_add_str(parseState, REQ_TS_LAST_TUNE_VERSION, ts_last_tune_version);
+
+	/* add cloud to telemetry when set */
+	if (ts_telemetry_cloud != NULL)
+	{
+		ext_key.type = jbvString;
+		ext_key.val.string.val = REQ_INSTANCE_METADATA;
+		ext_key.val.string.len = strlen(REQ_INSTANCE_METADATA);
+		pushJsonbValue(&parseState, WJB_KEY, &ext_key);
+
+		pushJsonbValue(&parseState, WJB_BEGIN_OBJECT, NULL);
+		ts_jsonb_add_str(parseState, REQ_TS_TELEMETRY_CLOUD, ts_telemetry_cloud);
+		pushJsonbValue(&parseState, WJB_END_OBJECT, NULL);
+	}
+
+	/* Add additional content from installation_metadata */
+	ext_key.type = jbvString;
+	ext_key.val.string.val = REQ_INSTALLATION_METADATA;
+	ext_key.val.string.len = strlen(REQ_INSTALLATION_METADATA);
+	pushJsonbValue(&parseState, WJB_KEY, &ext_key);
+	pushJsonbValue(&parseState, WJB_BEGIN_OBJECT, NULL);
+	ts_metadata_add_values(parseState);
+	pushJsonbValue(&parseState, WJB_END_OBJECT, NULL);
 
 	/* end of telemetry object */
 	result = pushJsonbValue(&parseState, WJB_END_OBJECT, NULL);

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -14,6 +14,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_validate_server_version(re
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_main_conn(text, text)
 RETURNS BOOLEAN AS :MODULE_PATHNAME, 'ts_test_telemetry_main_conn' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry(host text = NULL, servname text = NULL, port int = NULL) RETURNS JSONB AS :MODULE_PATHNAME, 'ts_test_telemetry' LANGUAGE C IMMUTABLE PARALLEL SAFE;
+INSERT INTO _timescaledb_catalog.installation_metadata VALUES ('foo','bar');
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT _timescaledb_internal.test_status_ssl(200);
  test_status_ssl 
@@ -292,6 +293,7 @@ WHERE key != 'os_name_pretty';
  os_release
  os_version
  data_volume
+ db_metadata
  build_os_name
  install_method
  installed_time
@@ -299,9 +301,24 @@ WHERE key != 'os_name_pretty';
  num_hypertables
  build_os_version
  exported_db_uuid
+ instance_metadata
  last_tuned_version
  postgresql_version
  related_extensions
  timescaledb_version
-(17 rows)
+(19 rows)
+
+-- check telemetry picks up content from installation_metadata
+SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
+ json_object_field 
+-------------------
+ {"foo": "bar"}
+(1 row)
+
+-- check timescaledb_telemetry.cloud
+SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
+ json_object_field 
+-------------------
+ {"cloud": "ci"}
+(1 row)
 

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -4,3 +4,4 @@ random_page_cost=1.0
 timescaledb.telemetry_level=off
 timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'
 timescaledb.last_tuned_version='0.0.1'
+timescaledb_telemetry.cloud='ci'

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -16,6 +16,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry_main_conn(text, 
 RETURNS BOOLEAN AS :MODULE_PATHNAME, 'ts_test_telemetry_main_conn' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.test_telemetry(host text = NULL, servname text = NULL, port int = NULL) RETURNS JSONB AS :MODULE_PATHNAME, 'ts_test_telemetry' LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+INSERT INTO _timescaledb_catalog.installation_metadata VALUES ('foo','bar');
+
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT _timescaledb_internal.test_status_ssl(200);
 SELECT _timescaledb_internal.test_status_ssl(201);
@@ -123,3 +125,11 @@ SET timescaledb.telemetry_level=off;
 
 SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
 WHERE key != 'os_name_pretty';
+
+-- check telemetry picks up content from installation_metadata
+SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
+
+-- check timescaledb_telemetry.cloud
+SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
+
+


### PR DESCRIPTION
Add all entries from _timescaledb_catalog.installation_metadata
to the telemetry report under the key `meta`.