### PR TITLE
Fix postgres.conf ApacheOnly license

### DIFF
--- a/src/license_guc.c
+++ b/src/license_guc.c
@@ -105,7 +105,7 @@ ts_license_enable_module_loading(void)
 							   false);
 
 	if (result <= 0)
-		elog(ERROR, "invalid value for timescaledb.license_key");
+		elog(ERROR, "invalid value for timescaledb.license_key '%s'", ts_guc_license_key);
 }
 
 /*
@@ -116,6 +116,7 @@ bool
 ts_license_update_check(char **newval, void **extra, GucSource source)
 {
 	Datum module_can_start;
+	bool try_to_load_tsl = true;
 
 	if (*newval == NULL)
 		return false;
@@ -129,12 +130,14 @@ ts_license_update_check(char **newval, void **extra, GucSource source)
 	 */
 	if (TS_LICENSE_IS_APACHE_ONLY(*newval))
 	{
-		if (current_license_can_downgrade_to_apache())
-			return true;
+		if (!current_license_can_downgrade_to_apache())
+		{
+			GUC_check_errdetail("Cannot downgrade a running session to Apache Only.");
+			GUC_check_errhint("change the license in the configuration file");
+			return false;
+		}
 
-		GUC_check_errdetail("Cannot downgrade a running session to Apache Only.");
-		GUC_check_errhint("change the license in the configure file");
-		return false;
+		try_to_load_tsl = false;
 	}
 
 	if (!can_load)
@@ -142,6 +145,9 @@ ts_license_update_check(char **newval, void **extra, GucSource source)
 		load_source = source;
 		return true;
 	}
+
+	if (!try_to_load_tsl)
+		return true;
 
 	if (!load_tsl())
 	{

--- a/test/expected/edition.out
+++ b/test/expected/edition.out
@@ -20,6 +20,10 @@ SELECT _timescaledb_internal.enterprise_enabled();
 (1 row)
 
 \unset ECHO
+SET timescaledb.license_key='ApacheOnly';
+ERROR:  invalid value for parameter "timescaledb.license_key": "ApacheOnly"
+DETAIL:  Cannot downgrade a running session to Apache Only.
+HINT:  change the license in the configuration file
 SELECT allow_downgrade_to_apache();
  allow_downgrade_to_apache 
 ---------------------------

--- a/test/sql/edition.sql
+++ b/test/sql/edition.sql
@@ -15,6 +15,10 @@ SELECT _timescaledb_internal.enterprise_enabled();
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+\set ON_ERROR_STOP 0
+SET timescaledb.license_key='ApacheOnly';
+\set ON_ERROR_STOP 1
+
 SELECT allow_downgrade_to_apache();
 SET timescaledb.license_key='ApacheOnly';
 select * from timescaledb_information.license;


### PR DESCRIPTION
Right now the only way to enable an ApacheOnly license is the hardcoded
default in the ApacheOnly binary. This commit allows users to specify
said license in the postgres.conf when running an ApacheOnly binary.
While this doesn't add any new capabilities, users who wish to be sure
they only use the ApacheOnly binary can specify the license in the conf
and be sure that of they accidentally run another binary they will get
an error.