### PR TITLE
Check for window agg context in finalize_agg

### DIFF
--- a/tsl/test/expected/partialize_finalize.out
+++ b/tsl/test/expected/partialize_finalize.out
@@ -304,6 +304,8 @@ ERROR:  invalid input type: public.int4
 with cte as (SELECT  _timescaledb_internal.partialize_agg(aggregate_to_test_ffunc_extra(8, 'name'::text)) as part)
 select _timescaledb_internal.finalize_agg( 'aggregate_to_test_ffunc_extra(int, anyelement)', null, null, array[array['pg_catalog'::name, 'int4'::name], array['pg_catalog', 'text'], array['pg_catalog', 'text']], part, null::text) from cte;
 ERROR:  invalid number of input types
+select _timescaledb_internal.finalize_agg(NULL::text,NULL::name,NULL::name,NULL::_name,NULL::bytea,a) over () from foo;
+ERROR:  finalize_agg_sfunc called in non-aggregate context
 \set ON_ERROR_STOP 1
 --make sure right type in warning and is null returns true
 with cte as (SELECT  _timescaledb_internal.partialize_agg(aggregate_to_test_ffunc_extra(8, 'name'::text)) as part)

--- a/tsl/test/sql/partialize_finalize.sql
+++ b/tsl/test/sql/partialize_finalize.sql
@@ -240,6 +240,8 @@ select _timescaledb_internal.finalize_agg( 'aggregate_to_test_ffunc_extra(int, a
 
 with cte as (SELECT  _timescaledb_internal.partialize_agg(aggregate_to_test_ffunc_extra(8, 'name'::text)) as part)
 select _timescaledb_internal.finalize_agg( 'aggregate_to_test_ffunc_extra(int, anyelement)', null, null, array[array['pg_catalog'::name, 'int4'::name], array['pg_catalog', 'text'], array['pg_catalog', 'text']], part, null::text) from cte;
+
+select _timescaledb_internal.finalize_agg(NULL::text,NULL::name,NULL::name,NULL::_name,NULL::bytea,a) over () from foo;
 \set ON_ERROR_STOP 1
 
 --make sure right type in warning and is null returns true


### PR DESCRIPTION
When finalize_agg is called as a window function AggCheckCallContext
will return true but the context will not be an AggState but a
WindowAggState, this patch checks for AggState explicitly and errors
when the function is called in window function context.