### PR TITLE
Fix ordered append for PG11

### DIFF
--- a/src/plan_ordered_append.c
+++ b/src/plan_ordered_append.c
@@ -158,7 +158,7 @@ ts_ordered_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht
 								0,
 								false,
 								merge->partitioned_rels,
-								root->limit_tuples);
+								rows);
 #endif
 
 	append->path.pathkeys = merge->path.pathkeys;
@@ -166,6 +166,7 @@ ts_ordered_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht
 	append->path.parallel_safe = false;
 	append->path.startup_cost = ((Path *) linitial(merge->subpaths))->startup_cost;
 	append->path.total_cost = total_cost;
+	append->path.rows = rows;
 
 	return (Path *) append;
 }

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -140,12 +140,11 @@ ORDER BY time ASC LIMIT 1;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_1_chunk."time"
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-(6 rows)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(5 rows)
 
 -- test DESC for ordered chunks
 :PREFIX SELECT
@@ -155,12 +154,11 @@ ORDER BY time DESC LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_3_chunk."time" DESC
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-(6 rows)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (never executed)
+(5 rows)
 
 -- test ASC for reverse ordered chunks
 :PREFIX SELECT
@@ -170,12 +168,11 @@ ORDER BY time ASC LIMIT 1;
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_2_6_chunk."time"
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk (actual rows=1 loops=1)
-(6 rows)
+         ->  Index Scan Backward using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (never executed)
+         ->  Index Scan Backward using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk (never executed)
+(5 rows)
 
 -- test DESC for reverse ordered chunks
 :PREFIX SELECT
@@ -185,12 +182,11 @@ ORDER BY time DESC LIMIT 1;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_2_4_chunk."time" DESC
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan using _hyper_2_4_chunk_ordered_append_reverse_time_idx on _hyper_2_4_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk (actual rows=1 loops=1)
-(6 rows)
+         ->  Index Scan using _hyper_2_5_chunk_ordered_append_reverse_time_idx on _hyper_2_5_chunk (never executed)
+         ->  Index Scan using _hyper_2_6_chunk_ordered_append_reverse_time_idx on _hyper_2_6_chunk (never executed)
+(5 rows)
 
 -- test query with ORDER BY column not in targetlist
 :PREFIX SELECT
@@ -200,12 +196,11 @@ ORDER BY time ASC LIMIT 1;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_1_chunk."time"
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-(6 rows)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(5 rows)
 
 -- ORDER BY may include other columns after time column
 :PREFIX SELECT
@@ -215,12 +210,11 @@ ORDER BY time DESC, device_id LIMIT 1;
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device_id
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-(6 rows)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
+(5 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
 :PREFIX SELECT
@@ -291,13 +285,12 @@ ORDER BY time ASC LIMIT 1;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_2_chunk."time"
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-(7 rows)
+(6 rows)
 
 :PREFIX SELECT
   time, device_id, value
@@ -307,13 +300,12 @@ ORDER BY time DESC LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_3_chunk."time" DESC
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
                Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-(7 rows)
+(6 rows)
 
 -- test interaction with constraint aware append
 :PREFIX SELECT
@@ -468,14 +460,14 @@ ORDER BY time ASC LIMIT 1;
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY time ASC LIMIT 1;
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_1_chunk."time"
-         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+   ->  Result (actual rows=1 loops=1)
+         ->  Append (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
 (6 rows)
 
 -- test query with order by time_bucket (should not use ordered append)
@@ -568,12 +560,11 @@ SELECT * FROM i;
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
    ->  Materialize (actual rows=2 loops=2)
          ->  Limit (actual rows=2 loops=1)
-               ->  Merge Append (actual rows=2 loops=1)
-                     Sort Key: _hyper_1_3_chunk."time" DESC
+               ->  Append (actual rows=2 loops=1)
                      ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=2 loops=1)
-                     ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-                     ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-(9 rows)
+                     ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+                     ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (never executed)
+(8 rows)
 
 -- test plan with best index is chosen
 -- this should use device_id, time index
@@ -581,15 +572,14 @@ SELECT * FROM i;
                                                          QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_3_chunk."time" DESC
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan using _hyper_1_3_chunk_ordered_append_device_id_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
                Index Cond: (device_id = 1)
-         ->  Index Scan using _hyper_1_2_chunk_ordered_append_device_id_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_device_id_time_idx on _hyper_1_2_chunk (never executed)
                Index Cond: (device_id = 1)
-         ->  Index Scan using _hyper_1_1_chunk_ordered_append_device_id_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_device_id_time_idx on _hyper_1_1_chunk (never executed)
                Index Cond: (device_id = 1)
-(9 rows)
+(8 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -597,12 +587,11 @@ SELECT * FROM i;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Merge Append (actual rows=1 loops=1)
-         Sort Key: _hyper_1_3_chunk."time" DESC
+   ->  Append (actual rows=1 loops=1)
          ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-(6 rows)
+         ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (never executed)
+(5 rows)
 
 -- test with table with only dimension column
 :PREFIX SELECT * FROM dimension_only ORDER BY time DESC LIMIT 1;
@@ -654,21 +643,22 @@ LIMIT 2;
 --------------------------------------------------------------------------------------------------------
  Limit
    ->  Nested Loop
+         ->  Merge Append
+               Sort Key: _hyper_4_11_chunk."time" DESC
+               ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk
+               ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk
+               ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk
+               ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk
          ->  Append
                ->  Index Scan using _hyper_3_10_chunk_dimension_last_time_idx on _hyper_3_10_chunk
+                     Index Cond: ("time" = _hyper_4_11_chunk."time")
                ->  Index Scan using _hyper_3_9_chunk_dimension_last_time_idx on _hyper_3_9_chunk
+                     Index Cond: ("time" = _hyper_4_11_chunk."time")
                ->  Index Scan using _hyper_3_8_chunk_dimension_last_time_idx on _hyper_3_8_chunk
+                     Index Cond: ("time" = _hyper_4_11_chunk."time")
                ->  Index Scan using _hyper_3_7_chunk_dimension_last_time_idx on _hyper_3_7_chunk
-         ->  Append
-               ->  Index Only Scan using _hyper_4_11_chunk_dimension_only_time_idx on _hyper_4_11_chunk
-                     Index Cond: ("time" = _hyper_3_10_chunk."time")
-               ->  Index Only Scan using _hyper_4_12_chunk_dimension_only_time_idx on _hyper_4_12_chunk
-                     Index Cond: ("time" = _hyper_3_10_chunk."time")
-               ->  Index Only Scan using _hyper_4_13_chunk_dimension_only_time_idx on _hyper_4_13_chunk
-                     Index Cond: ("time" = _hyper_3_10_chunk."time")
-               ->  Index Only Scan using _hyper_4_14_chunk_dimension_only_time_idx on _hyper_4_14_chunk
-                     Index Cond: ("time" = _hyper_3_10_chunk."time")
-(16 rows)
+                     Index Cond: ("time" = _hyper_4_11_chunk."time")
+(17 rows)
 
 -- test join against non-hypertable
 :PREFIX SELECT *

--- a/test/expected/sql_query_results_optimized-11.out
+++ b/test/expected/sql_query_results_optimized-11.out
@@ -109,10 +109,9 @@ EXPLAIN (costs off) SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Limit
-   ->  Merge Append
-         Sort Key: _hyper_1_1_chunk."time" DESC
+   ->  Append
          ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(4 rows)
+(3 rows)
 
 SELECT * FROM hyper_1 ORDER BY "time" DESC limit 2;
            time           | series_0 | series_1 |     series_2     

--- a/test/expected/sql_query_results_x_diff-11.out
+++ b/test/expected/sql_query_results_x_diff-11.out
@@ -8,31 +8,32 @@
 ---
 > SET timescaledb.disable_optimizations= 'on';
 > SET max_parallel_workers_per_gather = 0; -- Disable parallel for this test
-113c114,115
-<          Sort Key: _hyper_1_1_chunk."time" DESC
+112c113,115
+<    ->  Append
 ---
+>    ->  Merge Append
 >          Sort Key: hyper_1."time" DESC
 >          ->  Index Scan using time_plain on hyper_1
-115c117
-< (4 rows)
+114c117
+< (3 rows)
 ---
 > (5 rows)
-129c131,132
+128c131,132
 <          Sort Key: (to_timestamp(_hyper_5_19_chunk."time")) DESC
 ---
 >          Sort Key: (to_timestamp(hyper_timefunc."time")) DESC
 >          ->  Index Scan using time_plain_timefunc on hyper_timefunc
-131c134
+130c134
 < (4 rows)
 ---
 > (5 rows)
-142,143c145,146
+141,142c145,146
 <                                      QUERY PLAN                                     
 < ------------------------------------------------------------------------------------
 ---
 >                                 QUERY PLAN                                 
 > ---------------------------------------------------------------------------
-146,150c149,156
+145,149c149,156
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 <          ->  Merge Append
 <                Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
@@ -47,13 +48,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-154,155c160,161
+153,154c160,161
 <                                                    QUERY PLAN                                                   
 < ----------------------------------------------------------------------------------------------------------------
 ---
 >                                               QUERY PLAN                                              
 > ------------------------------------------------------------------------------------------------------
-157,174c163,183
+156,173c163,183
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, (_hyper_4_6_chunk."time")::timestamp with time zone))
 <          ->  Merge Append
@@ -94,13 +95,13 @@
 >                            ->  Seq Scan on _hyper_4_17_chunk
 >                            ->  Seq Scan on _hyper_4_18_chunk
 > (21 rows)
-199,200c208,209
+198,199c208,209
 <                                                 QUERY PLAN                                                 
 < -----------------------------------------------------------------------------------------------------------
 ---
 >                                                    QUERY PLAN                                                    
 > -----------------------------------------------------------------------------------------------------------------
-202,211c211,221
+201,210c211,221
 <    ->  GroupAggregate
 <          Group Key: (date_trunc('minute'::text, hyper_1."time"))
 <          ->  Custom Scan (ConstraintAwareAppend)
@@ -123,17 +124,17 @@
 >                            ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
 >                                  Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (11 rows)
-236,237c246,247
+235,236c246,247
 <                                                        QUERY PLAN                                                        
 < -------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                           QUERY PLAN                                                           
 > -------------------------------------------------------------------------------------------------------------------------------
-240c250
+239c250
 <          Sort Key: (date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time"))) DESC
 ---
 >          Sort Key: (date_trunc('minute'::text, to_timestamp(hyper_timefunc."time"))) DESC
-242,246c252,259
+241,245c252,259
 <                Group Key: (date_trunc('minute'::text, to_timestamp(_hyper_5_19_chunk."time")))
 <                ->  Append
 <                      ->  Index Scan using _hyper_5_19_chunk_time_plain_timefunc on _hyper_5_19_chunk
@@ -148,13 +149,13 @@
 >                            ->  Index Scan using _hyper_5_19_chunk_time_plain_timefunc on _hyper_5_19_chunk
 >                                  Index Cond: (to_timestamp("time") < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (11 rows)
-265,266c278,279
+264,265c278,279
 <                                          QUERY PLAN                                          
 < ---------------------------------------------------------------------------------------------
 ---
 >                                             QUERY PLAN                                             
 > ---------------------------------------------------------------------------------------------------
-269,273c282,288
+268,272c282,288
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 <          ->  Merge Append
 <                Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
@@ -168,13 +169,13 @@
 >                      ->  Index Scan Backward using time_trunc on hyper_1
 >                      ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
 > (8 rows)
-286,287c301,302
+285,286c301,302
 <                                          QUERY PLAN                                          
 < ---------------------------------------------------------------------------------------------
 ---
 >                                             QUERY PLAN                                             
 > ---------------------------------------------------------------------------------------------------
-290,294c305,311
+289,293c305,311
 <          Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
 <          ->  Merge Append
 <                Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
@@ -188,13 +189,13 @@
 >                      ->  Index Scan Backward using time_trunc on hyper_1
 >                      ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
 > (8 rows)
-305,306c322,323
+304,305c322,323
 <                                         QUERY PLAN                                        
 < ------------------------------------------------------------------------------------------
 ---
 >                                    QUERY PLAN                                    
 > ---------------------------------------------------------------------------------
-309,313c326,333
+308,312c326,333
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
 <          ->  Merge Append
 <                Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
@@ -209,13 +210,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-325,326c345,346
+324,325c345,346
 <                                                                   QUERY PLAN                                                                  
 < ----------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-329,333c349,356
+328,332c349,356
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Merge Append
 <                Sort Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
@@ -230,13 +231,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-345,346c368,369
+344,345c368,369
 <                                                      QUERY PLAN                                                     
 < --------------------------------------------------------------------------------------------------------------------
 ---
 >                                                 QUERY PLAN                                                 
 > -----------------------------------------------------------------------------------------------------------
-349,353c372,379
+348,352c372,379
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
 <          ->  Merge Append
 <                Sort Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval))) DESC
@@ -251,13 +252,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-365,366c391,392
+364,365c391,392
 <                                                                   QUERY PLAN                                                                  
 < ----------------------------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                              QUERY PLAN                                                              
 > -------------------------------------------------------------------------------------------------------------------------------------
-369,373c395,402
+368,372c395,402
 <          Group Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval))
 <          ->  Merge Append
 <                Sort Key: ((time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)) + '@ 30 secs'::interval)) DESC
@@ -272,13 +273,13 @@
 >                            ->  Seq Scan on hyper_1
 >                            ->  Seq Scan on _hyper_1_1_chunk
 > (9 rows)
-385,386c414,415
+384,385c414,415
 <                                         QUERY PLAN                                        
 < ------------------------------------------------------------------------------------------
 ---
 >                                      QUERY PLAN                                     
 > ------------------------------------------------------------------------------------
-389,393c418,425
+388,392c418,425
 <          Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
 <          ->  Merge Append
 <                Sort Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time")) DESC
@@ -293,13 +294,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-405,406c437,438
+404,405c437,438
 <                                                        QUERY PLAN                                                        
 < -------------------------------------------------------------------------------------------------------------------------
 ---
 >                                                     QUERY PLAN                                                     
 > -------------------------------------------------------------------------------------------------------------------
-409,413c441,448
+408,412c441,448
 <          Group Key: (time_bucket('@ 1 min'::interval, (_hyper_2_2_chunk."time")::timestamp without time zone))
 <          ->  Merge Append
 <                Sort Key: (time_bucket('@ 1 min'::interval, (_hyper_2_2_chunk."time")::timestamp without time zone)) DESC
@@ -314,13 +315,13 @@
 >                            ->  Seq Scan on hyper_1_tz
 >                            ->  Seq Scan on _hyper_2_2_chunk
 > (9 rows)
-425,426c460,461
+424,425c460,461
 <                                        QUERY PLAN                                       
 < ----------------------------------------------------------------------------------------
 ---
 >                              QUERY PLAN                             
 > --------------------------------------------------------------------
-429,435c464,473
+428,434c464,473
 <          Group Key: (time_bucket(10, _hyper_3_3_chunk."time"))
 <          ->  Merge Append
 <                Sort Key: (time_bucket(10, _hyper_3_3_chunk."time")) DESC
@@ -339,13 +340,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-447,448c485,486
+446,447c485,486
 <                                        QUERY PLAN                                       
 < ----------------------------------------------------------------------------------------
 ---
 >                               QUERY PLAN                               
 > -----------------------------------------------------------------------
-451,457c489,498
+450,456c489,498
 <          Group Key: (time_bucket(10, _hyper_3_3_chunk."time", 2))
 <          ->  Merge Append
 <                Sort Key: (time_bucket(10, _hyper_3_3_chunk."time", 2)) DESC
@@ -364,13 +365,13 @@
 >                            ->  Seq Scan on _hyper_3_4_chunk
 >                            ->  Seq Scan on _hyper_3_5_chunk
 > (11 rows)
-508,509c549,550
+507,508c549,550
 <                                           QUERY PLAN                                           
 < -----------------------------------------------------------------------------------------------
 ---
 >                                              QUERY PLAN                                              
 > -----------------------------------------------------------------------------------------------------
-511,515c552,558
+510,514c552,558
 <    ->  GroupAggregate
 <          Group Key: date_trunc('minute'::text, "time")
 <          ->  Index Scan using time_plain_plain_table on plain_table
@@ -384,5 +385,5 @@
 >                ->  Index Scan using time_plain_plain_table on plain_table
 >                      Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
 > (7 rows)
-529a573
+528a573
 > RESET max_parallel_workers_per_gather;


### PR DESCRIPTION
Merging the partitionwise aggregation patch broke ordered append
for PG11, this patch fixes ordered append for PG11.
We report the number of rows of the included chunks in the path
because the limit cost calculation will factor this into its cost
calculation.