### PR TITLE
Remove LIMIT clause restriction from ordered append

### DIFF
--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -409,10 +409,9 @@ should_order_append(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, bool *re
 
 	/*
 	 * only do this optimization for hypertables with 1 dimension and queries
-	 * with an ORDER BY and LIMIT clause
+	 * with an ORDER BY clause
 	 */
-	if (ht->space->num_dimensions != 1 || root->parse->sortClause == NIL ||
-		root->limit_tuples == -1.0)
+	if (ht->space->num_dimensions != 1 || root->parse->sortClause == NIL)
 		return false;
 
 	return ts_ordered_append_should_optimize(root, rel, ht, reverse);

--- a/test/expected/agg_bookends_optimized-10.out
+++ b/test/expected/agg_bookends_optimized-10.out
@@ -25,10 +25,9 @@ INSERT INTO "btest" VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_1_1_chunk."time"
+ Append
    ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk
-(3 rows)
+(2 rows)
 
 :PREFIX SELECT last(temp, time) FROM "btest";
                                         QUERY PLAN                                        

--- a/test/expected/agg_bookends_optimized-11.out
+++ b/test/expected/agg_bookends_optimized-11.out
@@ -25,10 +25,9 @@ INSERT INTO "btest" VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_1_1_chunk."time"
+ Append
    ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk
-(3 rows)
+(2 rows)
 
 :PREFIX SELECT last(temp, time) FROM "btest";
                                         QUERY PLAN                                        

--- a/test/expected/agg_bookends_optimized-9.6.out
+++ b/test/expected/agg_bookends_optimized-9.6.out
@@ -25,10 +25,9 @@ INSERT INTO "btest" VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1
 :PREFIX SELECT time, gp, temp FROM btest ORDER BY time;
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_1_1_chunk."time"
+ Append
    ->  Index Scan Backward using _hyper_1_1_chunk_btest_time_idx on _hyper_1_1_chunk
-(3 rows)
+(2 rows)
 
 :PREFIX SELECT last(temp, time) FROM "btest";
                                         QUERY PLAN                                        

--- a/test/expected/append.out
+++ b/test/expected/append.out
@@ -188,11 +188,10 @@ psql:include/append_query.sql:33: NOTICE:  Immutable function now_i() called!
  Custom Scan (ConstraintAwareAppend)
    Hypertable: append_test
    Chunks left after exclusion: 1
-   ->  Merge Append
-         Sort Key: _hyper_1_3_chunk."time"
+   ->  Append
          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                Index Cond: ("time" > ('Tue Aug 22 10:00:00 2017 PDT'::timestamp with time zone - '@ 2 mons'::interval))
-(7 rows)
+(6 rows)
 
 -- currently, we cannot distinguish between stable and volatile
 -- functions as far as applying our modified plan. However, volatile
@@ -206,15 +205,14 @@ ORDER BY time;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: append_test
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_1_1_chunk."time"
+   ->  Append
          ->  Index Scan Backward using _hyper_1_1_chunk_append_test_time_idx on _hyper_1_1_chunk
                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
          ->  Index Scan Backward using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                Filter: ("time" > (now_v() - '@ 2 mons'::interval))
-(11 rows)
+(10 rows)
 
 -- prepared statement output should be the same regardless of
 -- optimizations
@@ -233,11 +231,10 @@ psql:include/append_query.sql:49: NOTICE:  Stable function now_s() called!
  Custom Scan (ConstraintAwareAppend)
    Hypertable: append_test
    Chunks left after exclusion: 1
-   ->  Merge Append
-         Sort Key: _hyper_1_3_chunk."time"
+   ->  Append
          ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
                Index Cond: ("time" > (now_s() - '@ 2 mons'::interval))
-(7 rows)
+(6 rows)
 
 DEALLOCATE query_opt;
 -- aggregates should produce same output
@@ -298,11 +295,10 @@ EXECUTE query_param(now_s() - interval '2 months');
 psql:include/append_query.sql:78: NOTICE:  Stable function now_s() called!
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_1_3_chunk."time"
+ Append
    ->  Index Scan Backward using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
          Index Cond: ("time" > 'Thu Jun 22 10:00:00 2017 PDT'::timestamp with time zone)
-(4 rows)
+(3 rows)
 
 DEALLOCATE query_param;
 --test with cte
@@ -441,28 +437,26 @@ reset enable_material;
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::date ORDER BY time;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_3_10_chunk."time"
+ Append
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
          Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
          Index Cond: ("time" > '01-15-2000'::date)
-   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
-         Index Cond: ("time" > '01-15-2000'::date)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp ORDER BY time;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_3_10_chunk."time"
+ Append
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
-         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz ORDER BY time;
                                                QUERY PLAN                                                
@@ -470,43 +464,40 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_date
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_3_9_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-(11 rows)
+(10 rows)
 
 -- test Const OP Var
 -- the queries should all have 3 chunks
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::date < time ORDER BY time;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_3_10_chunk."time"
+ Append
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
          Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
          Index Cond: ("time" > '01-15-2000'::date)
-   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
-         Index Cond: ("time" > '01-15-2000'::date)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamp < time ORDER BY time;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_3_10_chunk."time"
+ Append
+   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-   ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
-         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE '2000-01-15'::timestamptz < time ORDER BY time;
                                                QUERY PLAN                                                
@@ -514,39 +505,36 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_date
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_3_9_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_3_11_chunk_metrics_date_time_idx on _hyper_3_11_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-(11 rows)
+(10 rows)
 
 -- test 2 constraints
 -- the queries should all have 2 chunks
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_3_10_chunk."time"
-   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
-         Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+ Append
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-(6 rows)
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
+(5 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_3_10_chunk."time"
-   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
-         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+ Append
    ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-(6 rows)
+   ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
+         Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
+(5 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
                                                                                QUERY PLAN                                                                                
@@ -554,41 +542,38 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_date
    Chunks left after exclusion: 2
-   ->  Merge Append
-         Sort Key: _hyper_3_9_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_3_9_chunk_metrics_date_time_idx on _hyper_3_9_chunk
                Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
          ->  Index Only Scan Backward using _hyper_3_10_chunk_metrics_date_time_idx on _hyper_3_10_chunk
                Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-(9 rows)
+(8 rows)
 
 -- test constraint_exclusion with timestamp time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
 -- the queries should all have 3 chunks
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::date ORDER BY time;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_4_14_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
          Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
          Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
          Index Cond: ("time" > '01-15-2000'::date)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp ORDER BY time;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_4_14_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz ORDER BY time;
                                                   QUERY PLAN                                                  
@@ -596,43 +581,40 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamp
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_4_14_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-(11 rows)
+(10 rows)
 
 -- test Const OP Var
 -- the queries should all have 3 chunks
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::date < time ORDER BY time;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_4_14_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
          Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
          Index Cond: ("time" > '01-15-2000'::date)
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
          Index Cond: ("time" > '01-15-2000'::date)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamp < time ORDER BY time;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_4_14_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
    ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE '2000-01-15'::timestamptz < time ORDER BY time;
                                                   QUERY PLAN                                                  
@@ -640,39 +622,36 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamp
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_4_14_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_4_16_chunk_metrics_timestamp_time_idx on _hyper_4_16_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-(11 rows)
+(10 rows)
 
 -- test 2 constraints
 -- the queries should all have 2 chunks
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::date AND time < '2000-01-21'::date ORDER BY time;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_4_14_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
          Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_4_14_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
    ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-(6 rows)
+(5 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
                                                                                QUERY PLAN                                                                                
@@ -680,13 +659,12 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamp
    Chunks left after exclusion: 2
-   ->  Merge Append
-         Sort Key: _hyper_4_14_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_4_14_chunk_metrics_timestamp_time_idx on _hyper_4_14_chunk
                Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
          ->  Index Only Scan Backward using _hyper_4_15_chunk_metrics_timestamp_time_idx on _hyper_4_15_chunk
                Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-(9 rows)
+(8 rows)
 
 -- test constraint_exclusion with timestamptz time dimension and DATE/TIMESTAMP/TIMESTAMPTZ constraints
 -- the queries should all have 3 chunks
@@ -696,15 +674,14 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamptz
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_5_19_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
                Index Cond: ("time" > '01-15-2000'::date)
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
                Index Cond: ("time" > '01-15-2000'::date)
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
                Index Cond: ("time" > '01-15-2000'::date)
-(11 rows)
+(10 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp ORDER BY time;
                                                    QUERY PLAN                                                   
@@ -712,28 +689,26 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamptz
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_5_19_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-(11 rows)
+(10 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz ORDER BY time;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_19_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
-         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(7 rows)
 
 -- test Const OP Var
 -- the queries should all have 3 chunks
@@ -743,15 +718,14 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamptz
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_5_19_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
                Index Cond: ("time" > '01-15-2000'::date)
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
                Index Cond: ("time" > '01-15-2000'::date)
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
                Index Cond: ("time" > '01-15-2000'::date)
-(11 rows)
+(10 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::timestamp < time ORDER BY time;
                                                    QUERY PLAN                                                   
@@ -759,28 +733,26 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamptz
    Chunks left after exclusion: 3
-   ->  Merge Append
-         Sort Key: _hyper_5_19_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
          ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
                Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone)
-(11 rows)
+(10 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE '2000-01-15'::timestamptz < time ORDER BY time;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_19_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
-         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
          Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+         Index Cond: ("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone)
+(7 rows)
 
 -- test 2 constraints
 -- the queries should all have 2 chunks
@@ -790,13 +762,12 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamptz
    Chunks left after exclusion: 2
-   ->  Merge Append
-         Sort Key: _hyper_5_19_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
                Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
                Index Cond: (("time" > '01-15-2000'::date) AND ("time" < '01-21-2000'::date))
-(9 rows)
+(8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamp AND time < '2000-01-21'::timestamp ORDER BY time;
                                                                               QUERY PLAN                                                                               
@@ -804,24 +775,22 @@ reset enable_material;
  Custom Scan (ConstraintAwareAppend)
    Hypertable: metrics_timestamptz
    Chunks left after exclusion: 2
-   ->  Merge Append
-         Sort Key: _hyper_5_19_chunk."time"
+   ->  Append
          ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
                Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
          ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
                Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000'::timestamp without time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000'::timestamp without time zone))
-(9 rows)
+(8 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time > '2000-01-15'::timestamptz AND time < '2000-01-21'::timestamptz ORDER BY time;
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_19_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
          Index Cond: (("time" > 'Sat Jan 15 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Fri Jan 21 00:00:00 2000 PST'::timestamp with time zone))
-(6 rows)
+(5 rows)
 
 -- test CURRENT_DATE
 -- should be 0 chunks

--- a/test/expected/plan_expand_hypertable-10.out
+++ b/test/expected/plan_expand_hypertable-10.out
@@ -982,27 +982,27 @@ SELECT * FROM cte ORDER BY value;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_1_8_chunk."time"
+   Sort Key: _hyper_1_2_chunk."time"
    ->  Append
-         ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_10_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_11_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_4_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_6_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_2_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_3_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_4_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_5_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_6_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_7_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_8_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_9_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_7_chunk
+         ->  Seq Scan on _hyper_1_10_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_11_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
 (23 rows)
 
@@ -1044,113 +1044,104 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_7_165_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
          Index Cond: ("time" < '01-04-2000'::date)
          Filter: (time_bucket('@ 1 day'::interval, "time") < '01-03-2000'::date)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                        QUERY PLAN                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_7_166_chunk."time"
-   ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_date_time_idx on _hyper_7_166_chunk
-         Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+ Append
    ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
          Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_date_time_idx on _hyper_7_166_chunk
+         Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+(7 rows)
 
 -- time_bucket exclusion with timestamp
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_155_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
          Index Cond: ("time" < 'Tue Jan 04 00:00:00 2000'::timestamp without time zone)
          Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000'::timestamp without time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                                                             QUERY PLAN                                                                                                             
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_156_chunk."time"
-   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
-         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+ Append
    ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+(7 rows)
 
 -- time_bucket exclusion with timestamptz
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
                                                        QUERY PLAN                                                        
 -------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
          Filter: (time_bucket('@ 6 hours'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
                                                                                                                QUERY PLAN                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(8 rows)
+(7 rows)
 
 -- time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: ("time" < 'Tue Jan 04 00:00:00 2000 PST'::timestamp with time zone)
          Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                                                              QUERY PLAN                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('7d',time) <= '2000-01-10' ORDER BY time;
                                                                                                               QUERY PLAN                                                                                                              
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_162_chunk."time"
-   ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
-         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(11 rows)
+   ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(10 rows)
 
 --exclude chunks based on time column with partitioning function. This
 --transparently applies the time partitioning function on the time

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -982,27 +982,27 @@ SELECT * FROM cte ORDER BY value;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_1_8_chunk."time"
+   Sort Key: _hyper_1_2_chunk."time"
    ->  Append
-         ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_10_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_11_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_4_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_6_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_2_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_3_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_4_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_5_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_6_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_7_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_8_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_9_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_7_chunk
+         ->  Seq Scan on _hyper_1_10_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_11_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
 (23 rows)
 
@@ -1044,113 +1044,104 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_7_165_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
          Index Cond: ("time" < '01-04-2000'::date)
          Filter: (time_bucket('@ 1 day'::interval, "time") < '01-03-2000'::date)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                        QUERY PLAN                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_7_166_chunk."time"
-   ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_date_time_idx on _hyper_7_166_chunk
-         Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+ Append
    ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
          Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_date_time_idx on _hyper_7_166_chunk
+         Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+(7 rows)
 
 -- time_bucket exclusion with timestamp
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_155_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
          Index Cond: ("time" < 'Tue Jan 04 00:00:00 2000'::timestamp without time zone)
          Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000'::timestamp without time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                                                             QUERY PLAN                                                                                                             
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_156_chunk."time"
-   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
-         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+ Append
    ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+(7 rows)
 
 -- time_bucket exclusion with timestamptz
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
                                                        QUERY PLAN                                                        
 -------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
          Filter: (time_bucket('@ 6 hours'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
                                                                                                                QUERY PLAN                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(8 rows)
+(7 rows)
 
 -- time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: ("time" < 'Tue Jan 04 00:00:00 2000 PST'::timestamp with time zone)
          Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                                                              QUERY PLAN                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('7d',time) <= '2000-01-10' ORDER BY time;
                                                                                                               QUERY PLAN                                                                                                              
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_162_chunk."time"
-   ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
-         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(11 rows)
+   ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(10 rows)
 
 --exclude chunks based on time column with partitioning function. This
 --transparently applies the time partitioning function on the time

--- a/test/expected/plan_expand_hypertable-9.6.out
+++ b/test/expected/plan_expand_hypertable-9.6.out
@@ -982,27 +982,27 @@ SELECT * FROM cte ORDER BY value;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: _hyper_1_8_chunk."time"
+   Sort Key: _hyper_1_2_chunk."time"
    ->  Append
-         ->  Seq Scan on _hyper_1_8_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_10_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_11_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_4_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_6_chunk
-               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_2_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_3_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_4_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_5_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_6_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_7_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_8_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
          ->  Seq Scan on _hyper_1_9_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
-         ->  Seq Scan on _hyper_1_7_chunk
+         ->  Seq Scan on _hyper_1_10_chunk
+               Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
+         ->  Seq Scan on _hyper_1_11_chunk
                Filter: (("time" > 10) AND ("time" < '110'::bigint) AND (time_bucket('10'::bigint, "time") > 10) AND (time_bucket('10'::bigint, "time") < 100))
 (23 rows)
 
@@ -1044,113 +1044,104 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_7_165_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
          Index Cond: ("time" < '01-04-2000'::date)
          Filter: (time_bucket('@ 1 day'::interval, "time") < '01-03-2000'::date)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_date WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                        QUERY PLAN                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_7_166_chunk."time"
-   ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_date_time_idx on _hyper_7_166_chunk
-         Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+ Append
    ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_date_time_idx on _hyper_7_165_chunk
          Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_date_time_idx on _hyper_7_166_chunk
+         Index Cond: (("time" >= '01-03-2000'::date) AND ("time" <= '01-11-2000'::date))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= '01-03-2000'::date) AND (time_bucket('@ 1 day'::interval, "time") <= '01-10-2000'::date))
+(7 rows)
 
 -- time_bucket exclusion with timestamp
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_155_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
          Index Cond: ("time" < 'Tue Jan 04 00:00:00 2000'::timestamp without time zone)
          Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000'::timestamp without time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                                                             QUERY PLAN                                                                                                             
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_5_156_chunk."time"
-   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
-         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+ Append
    ->  Index Only Scan Backward using _hyper_5_155_chunk_metrics_timestamp_time_idx on _hyper_5_155_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
-(8 rows)
+   ->  Index Only Scan Backward using _hyper_5_156_chunk_metrics_timestamp_time_idx on _hyper_5_156_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000'::timestamp without time zone))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000'::timestamp without time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000'::timestamp without time zone))
+(7 rows)
 
 -- time_bucket exclusion with timestamptz
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
                                                        QUERY PLAN                                                        
 -------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
          Filter: (time_bucket('@ 6 hours'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
                                                                                                                QUERY PLAN                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(8 rows)
+(7 rows)
 
 -- time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: ("time" < 'Tue Jan 04 00:00:00 2000 PST'::timestamp with time zone)
          Filter: (time_bucket('@ 1 day'::interval, "time") < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
-(5 rows)
+(4 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;
                                                                                                              QUERY PLAN                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_160_chunk."time"
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Tue Jan 11 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 1 day'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(8 rows)
+(7 rows)
 
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('7d',time) <= '2000-01-10' ORDER BY time;
                                                                                                               QUERY PLAN                                                                                                              
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_6_162_chunk."time"
-   ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
-         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
-         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+ Append
    ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
    ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
          Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
          Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(11 rows)
+   ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 17 00:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 1 day'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 7 days'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(10 rows)
 
 --exclude chunks based on time column with partitioning function. This
 --transparently applies the time partitioning function on the time

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -255,12 +255,11 @@ FROM ordered_append
 ORDER BY time ASC;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=73443 loops=1)
-   Sort Key: _hyper_1_1_chunk."time"
+ Append (actual rows=73443 loops=1)
    ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=20160 loops=1)
    ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=30240 loops=1)
    ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=23043 loops=1)
-(5 rows)
+(4 rows)
 
 -- queries without ORDER BY shouldnt use ordered append (still uses append though)
 :PREFIX SELECT

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -255,12 +255,11 @@ FROM ordered_append
 ORDER BY time ASC;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=73443 loops=1)
-   Sort Key: _hyper_1_1_chunk."time"
+ Append (actual rows=73443 loops=1)
    ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=20160 loops=1)
    ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=30240 loops=1)
    ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=23043 loops=1)
-(5 rows)
+(4 rows)
 
 -- queries without ORDER BY shouldnt use ordered append (still uses append though)
 :PREFIX SELECT

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -254,12 +254,11 @@ FROM ordered_append
 ORDER BY time ASC;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
- Merge Append
-   Sort Key: _hyper_1_1_chunk."time"
+ Append
    ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
    ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
    ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
-(5 rows)
+(4 rows)
 
 -- queries without ORDER BY shouldnt use ordered append (still uses append though)
 :PREFIX SELECT


### PR DESCRIPTION
This patch removes the restrictions for the ordered append
optimization to require a LIMIT clause. The other restrictions are
still in place, namely the ORDER BY clause needs to reference
the time dimension and the hypertable can only have a single
dimension.
The ordered append plans are preferable to the merge append plans
that would be used otherwise in this situation because they dont
need to resort data from individual chunks.