### PR TITLE
Enable optimizing SELECTs within INSERTs

### DIFF
--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -102,7 +102,7 @@ dimension_restrict_info_open_add(DimensionRestrictInfoOpen *dri, StrategyNumber 
 												   PointerGetDatum(lfirst(item)),
 												   dimvalues->type,
 												   &restype);
-		int64 value = ts_time_value_to_internal(datum, restype);
+		int64 value = ts_time_value_to_internal_or_infinite(datum, restype, NULL);
 
 		switch (strategy)
 		{

--- a/src/planner.c
+++ b/src/planner.c
@@ -129,7 +129,8 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 	ListCell *lc;
 
 	if (ts_extension_is_loaded() && !ts_guc_disable_optimizations &&
-		ts_guc_enable_constraint_exclusion && parse->resultRelation == 0)
+		ts_guc_enable_constraint_exclusion &&
+		(parse->commandType == CMD_INSERT || parse->commandType == CMD_SELECT))
 	{
 		Cache *hc = ts_hypertable_cache_pin();
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,6 +23,13 @@
 
 extern bool ts_type_is_int8_binary_compatible(Oid sourcetype);
 
+typedef enum TimevalInfinity
+{
+	TimevalFinite = 0,
+	TimevalNegInfinity = -1,
+	TimevalPosInfinity = 1,
+} TimevalInfinity;
+
 /*
  * Convert a column value into the internal time representation.
  * cannot store a timestamp earlier than MIN_TIMESTAMP, or greater than
@@ -31,6 +38,8 @@ extern bool ts_type_is_int8_binary_compatible(Oid sourcetype);
  * Will throw an error for that, or other conversion issues.
  */
 extern TSDLLEXPORT int64 ts_time_value_to_internal(Datum time_val, Oid type);
+extern int64 ts_time_value_to_internal_or_infinite(Datum time_val, Oid type_oid,
+												   TimevalInfinity *is_infinite_out);
 extern TSDLLEXPORT int64 ts_interval_value_to_internal(Datum time_val, Oid type_oid);
 
 /*

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -238,40 +238,12 @@ SELECT * FROM tick_character;
  GBPJPY    | 142.639 |    5.8 | Mon Mar 20 09:18:22.3 2017 PDT
 (1 row)
 
-CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
-SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
-NOTICE:  adding not-null constraint to column "time"
-         create_hypertable         
------------------------------------
- (4,public,many_partitions_test,t)
-(1 row)
-
---NOTE: how much slower the first two queries are -- they are creating chunks
-INSERT INTO many_partitions_test
-    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(1,100) ser;
-INSERT INTO many_partitions_test
-    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(101,200) ser;
-INSERT INTO many_partitions_test
-    SELECT to_timestamp(ser), ser, (ser-201)::text FROM generate_series(201,300) ser;
-SELECT * FROM  many_partitions_test ORDER BY time DESC LIMIT 2;
-           time           | temp | device 
---------------------------+------+--------
- Wed Dec 31 16:05:00 1969 |  300 | 99
- Wed Dec 31 16:04:59 1969 |  299 | 98
-(2 rows)
-
-SELECT count(*) FROM  many_partitions_test;
- count 
--------
-   300
-(1 row)
-
 CREATE TABLE  date_col_test(time date, temp float8, device text NOT NULL);
 SELECT create_hypertable('date_col_test', 'time', 'device', 1000, chunk_time_interval => INTERVAL '1 Day');
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
- (5,public,date_col_test,t)
+ (4,public,date_col_test,t)
 (1 row)
 
 INSERT INTO date_col_test
@@ -284,395 +256,6 @@ SELECT * FROM date_col_test WHERE time > '2001-01-01';
  02-01-2001 |   98 | dev1
 (2 rows)
 
-CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
-SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
-NOTICE:  adding not-null constraint to column "time"
-          create_hypertable           
---------------------------------------
- (6,public,many_partitions_test_1m,t)
-(1 row)
-
-EXPLAIN (verbose on, costs off)
-INSERT INTO many_partitions_test_1m(time, temp, device)
-SELECT time_bucket('1 minute', time) AS period, avg(temp), device
-FROM many_partitions_test
-GROUP BY period, device;
-                                                                        QUERY PLAN                                                                        
-----------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
-   ->  Insert on public.many_partitions_test_1m
-         ->  Custom Scan (ChunkDispatch)
-               Output: "*SELECT*".period, "*SELECT*".avg, "*SELECT*".device
-               ->  HashAggregate
-                     Output: (time_bucket('@ 1 min'::interval, many_partitions_test."time")), avg(many_partitions_test.temp), many_partitions_test.device
-                     Group Key: time_bucket('@ 1 min'::interval, many_partitions_test."time"), many_partitions_test.device
-                     ->  Result
-                           Output: time_bucket('@ 1 min'::interval, many_partitions_test."time"), many_partitions_test.device, many_partitions_test.temp
-                           ->  Append
-                                 ->  Seq Scan on public.many_partitions_test
-                                       Output: many_partitions_test."time", many_partitions_test.temp, many_partitions_test.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_9_chunk
-                                       Output: _hyper_4_9_chunk."time", _hyper_4_9_chunk.temp, _hyper_4_9_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_10_chunk
-                                       Output: _hyper_4_10_chunk."time", _hyper_4_10_chunk.temp, _hyper_4_10_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_11_chunk
-                                       Output: _hyper_4_11_chunk."time", _hyper_4_11_chunk.temp, _hyper_4_11_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_12_chunk
-                                       Output: _hyper_4_12_chunk."time", _hyper_4_12_chunk.temp, _hyper_4_12_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_13_chunk
-                                       Output: _hyper_4_13_chunk."time", _hyper_4_13_chunk.temp, _hyper_4_13_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_14_chunk
-                                       Output: _hyper_4_14_chunk."time", _hyper_4_14_chunk.temp, _hyper_4_14_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_15_chunk
-                                       Output: _hyper_4_15_chunk."time", _hyper_4_15_chunk.temp, _hyper_4_15_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_16_chunk
-                                       Output: _hyper_4_16_chunk."time", _hyper_4_16_chunk.temp, _hyper_4_16_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_17_chunk
-                                       Output: _hyper_4_17_chunk."time", _hyper_4_17_chunk.temp, _hyper_4_17_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_18_chunk
-                                       Output: _hyper_4_18_chunk."time", _hyper_4_18_chunk.temp, _hyper_4_18_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_19_chunk
-                                       Output: _hyper_4_19_chunk."time", _hyper_4_19_chunk.temp, _hyper_4_19_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_20_chunk
-                                       Output: _hyper_4_20_chunk."time", _hyper_4_20_chunk.temp, _hyper_4_20_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_21_chunk
-                                       Output: _hyper_4_21_chunk."time", _hyper_4_21_chunk.temp, _hyper_4_21_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_22_chunk
-                                       Output: _hyper_4_22_chunk."time", _hyper_4_22_chunk.temp, _hyper_4_22_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_23_chunk
-                                       Output: _hyper_4_23_chunk."time", _hyper_4_23_chunk.temp, _hyper_4_23_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_24_chunk
-                                       Output: _hyper_4_24_chunk."time", _hyper_4_24_chunk.temp, _hyper_4_24_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_25_chunk
-                                       Output: _hyper_4_25_chunk."time", _hyper_4_25_chunk.temp, _hyper_4_25_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_26_chunk
-                                       Output: _hyper_4_26_chunk."time", _hyper_4_26_chunk.temp, _hyper_4_26_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_27_chunk
-                                       Output: _hyper_4_27_chunk."time", _hyper_4_27_chunk.temp, _hyper_4_27_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_28_chunk
-                                       Output: _hyper_4_28_chunk."time", _hyper_4_28_chunk.temp, _hyper_4_28_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_29_chunk
-                                       Output: _hyper_4_29_chunk."time", _hyper_4_29_chunk.temp, _hyper_4_29_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_30_chunk
-                                       Output: _hyper_4_30_chunk."time", _hyper_4_30_chunk.temp, _hyper_4_30_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_31_chunk
-                                       Output: _hyper_4_31_chunk."time", _hyper_4_31_chunk.temp, _hyper_4_31_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_32_chunk
-                                       Output: _hyper_4_32_chunk."time", _hyper_4_32_chunk.temp, _hyper_4_32_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_33_chunk
-                                       Output: _hyper_4_33_chunk."time", _hyper_4_33_chunk.temp, _hyper_4_33_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_34_chunk
-                                       Output: _hyper_4_34_chunk."time", _hyper_4_34_chunk.temp, _hyper_4_34_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_35_chunk
-                                       Output: _hyper_4_35_chunk."time", _hyper_4_35_chunk.temp, _hyper_4_35_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_36_chunk
-                                       Output: _hyper_4_36_chunk."time", _hyper_4_36_chunk.temp, _hyper_4_36_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_37_chunk
-                                       Output: _hyper_4_37_chunk."time", _hyper_4_37_chunk.temp, _hyper_4_37_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_38_chunk
-                                       Output: _hyper_4_38_chunk."time", _hyper_4_38_chunk.temp, _hyper_4_38_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_39_chunk
-                                       Output: _hyper_4_39_chunk."time", _hyper_4_39_chunk.temp, _hyper_4_39_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_40_chunk
-                                       Output: _hyper_4_40_chunk."time", _hyper_4_40_chunk.temp, _hyper_4_40_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_41_chunk
-                                       Output: _hyper_4_41_chunk."time", _hyper_4_41_chunk.temp, _hyper_4_41_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_42_chunk
-                                       Output: _hyper_4_42_chunk."time", _hyper_4_42_chunk.temp, _hyper_4_42_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_43_chunk
-                                       Output: _hyper_4_43_chunk."time", _hyper_4_43_chunk.temp, _hyper_4_43_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_44_chunk
-                                       Output: _hyper_4_44_chunk."time", _hyper_4_44_chunk.temp, _hyper_4_44_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_45_chunk
-                                       Output: _hyper_4_45_chunk."time", _hyper_4_45_chunk.temp, _hyper_4_45_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_46_chunk
-                                       Output: _hyper_4_46_chunk."time", _hyper_4_46_chunk.temp, _hyper_4_46_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_47_chunk
-                                       Output: _hyper_4_47_chunk."time", _hyper_4_47_chunk.temp, _hyper_4_47_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_48_chunk
-                                       Output: _hyper_4_48_chunk."time", _hyper_4_48_chunk.temp, _hyper_4_48_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_49_chunk
-                                       Output: _hyper_4_49_chunk."time", _hyper_4_49_chunk.temp, _hyper_4_49_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_50_chunk
-                                       Output: _hyper_4_50_chunk."time", _hyper_4_50_chunk.temp, _hyper_4_50_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_51_chunk
-                                       Output: _hyper_4_51_chunk."time", _hyper_4_51_chunk.temp, _hyper_4_51_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_52_chunk
-                                       Output: _hyper_4_52_chunk."time", _hyper_4_52_chunk.temp, _hyper_4_52_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_53_chunk
-                                       Output: _hyper_4_53_chunk."time", _hyper_4_53_chunk.temp, _hyper_4_53_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_54_chunk
-                                       Output: _hyper_4_54_chunk."time", _hyper_4_54_chunk.temp, _hyper_4_54_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_55_chunk
-                                       Output: _hyper_4_55_chunk."time", _hyper_4_55_chunk.temp, _hyper_4_55_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_56_chunk
-                                       Output: _hyper_4_56_chunk."time", _hyper_4_56_chunk.temp, _hyper_4_56_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_57_chunk
-                                       Output: _hyper_4_57_chunk."time", _hyper_4_57_chunk.temp, _hyper_4_57_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_58_chunk
-                                       Output: _hyper_4_58_chunk."time", _hyper_4_58_chunk.temp, _hyper_4_58_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_59_chunk
-                                       Output: _hyper_4_59_chunk."time", _hyper_4_59_chunk.temp, _hyper_4_59_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_60_chunk
-                                       Output: _hyper_4_60_chunk."time", _hyper_4_60_chunk.temp, _hyper_4_60_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_61_chunk
-                                       Output: _hyper_4_61_chunk."time", _hyper_4_61_chunk.temp, _hyper_4_61_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_62_chunk
-                                       Output: _hyper_4_62_chunk."time", _hyper_4_62_chunk.temp, _hyper_4_62_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_63_chunk
-                                       Output: _hyper_4_63_chunk."time", _hyper_4_63_chunk.temp, _hyper_4_63_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_64_chunk
-                                       Output: _hyper_4_64_chunk."time", _hyper_4_64_chunk.temp, _hyper_4_64_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_65_chunk
-                                       Output: _hyper_4_65_chunk."time", _hyper_4_65_chunk.temp, _hyper_4_65_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_66_chunk
-                                       Output: _hyper_4_66_chunk."time", _hyper_4_66_chunk.temp, _hyper_4_66_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_67_chunk
-                                       Output: _hyper_4_67_chunk."time", _hyper_4_67_chunk.temp, _hyper_4_67_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_68_chunk
-                                       Output: _hyper_4_68_chunk."time", _hyper_4_68_chunk.temp, _hyper_4_68_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_69_chunk
-                                       Output: _hyper_4_69_chunk."time", _hyper_4_69_chunk.temp, _hyper_4_69_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_70_chunk
-                                       Output: _hyper_4_70_chunk."time", _hyper_4_70_chunk.temp, _hyper_4_70_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_71_chunk
-                                       Output: _hyper_4_71_chunk."time", _hyper_4_71_chunk.temp, _hyper_4_71_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_72_chunk
-                                       Output: _hyper_4_72_chunk."time", _hyper_4_72_chunk.temp, _hyper_4_72_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_73_chunk
-                                       Output: _hyper_4_73_chunk."time", _hyper_4_73_chunk.temp, _hyper_4_73_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_74_chunk
-                                       Output: _hyper_4_74_chunk."time", _hyper_4_74_chunk.temp, _hyper_4_74_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_75_chunk
-                                       Output: _hyper_4_75_chunk."time", _hyper_4_75_chunk.temp, _hyper_4_75_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_76_chunk
-                                       Output: _hyper_4_76_chunk."time", _hyper_4_76_chunk.temp, _hyper_4_76_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_77_chunk
-                                       Output: _hyper_4_77_chunk."time", _hyper_4_77_chunk.temp, _hyper_4_77_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_78_chunk
-                                       Output: _hyper_4_78_chunk."time", _hyper_4_78_chunk.temp, _hyper_4_78_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_79_chunk
-                                       Output: _hyper_4_79_chunk."time", _hyper_4_79_chunk.temp, _hyper_4_79_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_80_chunk
-                                       Output: _hyper_4_80_chunk."time", _hyper_4_80_chunk.temp, _hyper_4_80_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_81_chunk
-                                       Output: _hyper_4_81_chunk."time", _hyper_4_81_chunk.temp, _hyper_4_81_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_82_chunk
-                                       Output: _hyper_4_82_chunk."time", _hyper_4_82_chunk.temp, _hyper_4_82_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_83_chunk
-                                       Output: _hyper_4_83_chunk."time", _hyper_4_83_chunk.temp, _hyper_4_83_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_84_chunk
-                                       Output: _hyper_4_84_chunk."time", _hyper_4_84_chunk.temp, _hyper_4_84_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_85_chunk
-                                       Output: _hyper_4_85_chunk."time", _hyper_4_85_chunk.temp, _hyper_4_85_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_86_chunk
-                                       Output: _hyper_4_86_chunk."time", _hyper_4_86_chunk.temp, _hyper_4_86_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_87_chunk
-                                       Output: _hyper_4_87_chunk."time", _hyper_4_87_chunk.temp, _hyper_4_87_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_88_chunk
-                                       Output: _hyper_4_88_chunk."time", _hyper_4_88_chunk.temp, _hyper_4_88_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_89_chunk
-                                       Output: _hyper_4_89_chunk."time", _hyper_4_89_chunk.temp, _hyper_4_89_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_90_chunk
-                                       Output: _hyper_4_90_chunk."time", _hyper_4_90_chunk.temp, _hyper_4_90_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_91_chunk
-                                       Output: _hyper_4_91_chunk."time", _hyper_4_91_chunk.temp, _hyper_4_91_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_92_chunk
-                                       Output: _hyper_4_92_chunk."time", _hyper_4_92_chunk.temp, _hyper_4_92_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_93_chunk
-                                       Output: _hyper_4_93_chunk."time", _hyper_4_93_chunk.temp, _hyper_4_93_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_94_chunk
-                                       Output: _hyper_4_94_chunk."time", _hyper_4_94_chunk.temp, _hyper_4_94_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_95_chunk
-                                       Output: _hyper_4_95_chunk."time", _hyper_4_95_chunk.temp, _hyper_4_95_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_96_chunk
-                                       Output: _hyper_4_96_chunk."time", _hyper_4_96_chunk.temp, _hyper_4_96_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_97_chunk
-                                       Output: _hyper_4_97_chunk."time", _hyper_4_97_chunk.temp, _hyper_4_97_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_98_chunk
-                                       Output: _hyper_4_98_chunk."time", _hyper_4_98_chunk.temp, _hyper_4_98_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_99_chunk
-                                       Output: _hyper_4_99_chunk."time", _hyper_4_99_chunk.temp, _hyper_4_99_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_100_chunk
-                                       Output: _hyper_4_100_chunk."time", _hyper_4_100_chunk.temp, _hyper_4_100_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_101_chunk
-                                       Output: _hyper_4_101_chunk."time", _hyper_4_101_chunk.temp, _hyper_4_101_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_102_chunk
-                                       Output: _hyper_4_102_chunk."time", _hyper_4_102_chunk.temp, _hyper_4_102_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_103_chunk
-                                       Output: _hyper_4_103_chunk."time", _hyper_4_103_chunk.temp, _hyper_4_103_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_104_chunk
-                                       Output: _hyper_4_104_chunk."time", _hyper_4_104_chunk.temp, _hyper_4_104_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_105_chunk
-                                       Output: _hyper_4_105_chunk."time", _hyper_4_105_chunk.temp, _hyper_4_105_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_106_chunk
-                                       Output: _hyper_4_106_chunk."time", _hyper_4_106_chunk.temp, _hyper_4_106_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_107_chunk
-                                       Output: _hyper_4_107_chunk."time", _hyper_4_107_chunk.temp, _hyper_4_107_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_108_chunk
-                                       Output: _hyper_4_108_chunk."time", _hyper_4_108_chunk.temp, _hyper_4_108_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_109_chunk
-                                       Output: _hyper_4_109_chunk."time", _hyper_4_109_chunk.temp, _hyper_4_109_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_110_chunk
-                                       Output: _hyper_4_110_chunk."time", _hyper_4_110_chunk.temp, _hyper_4_110_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_111_chunk
-                                       Output: _hyper_4_111_chunk."time", _hyper_4_111_chunk.temp, _hyper_4_111_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_112_chunk
-                                       Output: _hyper_4_112_chunk."time", _hyper_4_112_chunk.temp, _hyper_4_112_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_113_chunk
-                                       Output: _hyper_4_113_chunk."time", _hyper_4_113_chunk.temp, _hyper_4_113_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_114_chunk
-                                       Output: _hyper_4_114_chunk."time", _hyper_4_114_chunk.temp, _hyper_4_114_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_115_chunk
-                                       Output: _hyper_4_115_chunk."time", _hyper_4_115_chunk.temp, _hyper_4_115_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_116_chunk
-                                       Output: _hyper_4_116_chunk."time", _hyper_4_116_chunk.temp, _hyper_4_116_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_117_chunk
-                                       Output: _hyper_4_117_chunk."time", _hyper_4_117_chunk.temp, _hyper_4_117_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_118_chunk
-                                       Output: _hyper_4_118_chunk."time", _hyper_4_118_chunk.temp, _hyper_4_118_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_119_chunk
-                                       Output: _hyper_4_119_chunk."time", _hyper_4_119_chunk.temp, _hyper_4_119_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_120_chunk
-                                       Output: _hyper_4_120_chunk."time", _hyper_4_120_chunk.temp, _hyper_4_120_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_121_chunk
-                                       Output: _hyper_4_121_chunk."time", _hyper_4_121_chunk.temp, _hyper_4_121_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_122_chunk
-                                       Output: _hyper_4_122_chunk."time", _hyper_4_122_chunk.temp, _hyper_4_122_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_123_chunk
-                                       Output: _hyper_4_123_chunk."time", _hyper_4_123_chunk.temp, _hyper_4_123_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_124_chunk
-                                       Output: _hyper_4_124_chunk."time", _hyper_4_124_chunk.temp, _hyper_4_124_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_125_chunk
-                                       Output: _hyper_4_125_chunk."time", _hyper_4_125_chunk.temp, _hyper_4_125_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_126_chunk
-                                       Output: _hyper_4_126_chunk."time", _hyper_4_126_chunk.temp, _hyper_4_126_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_127_chunk
-                                       Output: _hyper_4_127_chunk."time", _hyper_4_127_chunk.temp, _hyper_4_127_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_128_chunk
-                                       Output: _hyper_4_128_chunk."time", _hyper_4_128_chunk.temp, _hyper_4_128_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_129_chunk
-                                       Output: _hyper_4_129_chunk."time", _hyper_4_129_chunk.temp, _hyper_4_129_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_130_chunk
-                                       Output: _hyper_4_130_chunk."time", _hyper_4_130_chunk.temp, _hyper_4_130_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_131_chunk
-                                       Output: _hyper_4_131_chunk."time", _hyper_4_131_chunk.temp, _hyper_4_131_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_132_chunk
-                                       Output: _hyper_4_132_chunk."time", _hyper_4_132_chunk.temp, _hyper_4_132_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_133_chunk
-                                       Output: _hyper_4_133_chunk."time", _hyper_4_133_chunk.temp, _hyper_4_133_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_134_chunk
-                                       Output: _hyper_4_134_chunk."time", _hyper_4_134_chunk.temp, _hyper_4_134_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_135_chunk
-                                       Output: _hyper_4_135_chunk."time", _hyper_4_135_chunk.temp, _hyper_4_135_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_136_chunk
-                                       Output: _hyper_4_136_chunk."time", _hyper_4_136_chunk.temp, _hyper_4_136_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_137_chunk
-                                       Output: _hyper_4_137_chunk."time", _hyper_4_137_chunk.temp, _hyper_4_137_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_138_chunk
-                                       Output: _hyper_4_138_chunk."time", _hyper_4_138_chunk.temp, _hyper_4_138_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_139_chunk
-                                       Output: _hyper_4_139_chunk."time", _hyper_4_139_chunk.temp, _hyper_4_139_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_140_chunk
-                                       Output: _hyper_4_140_chunk."time", _hyper_4_140_chunk.temp, _hyper_4_140_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_141_chunk
-                                       Output: _hyper_4_141_chunk."time", _hyper_4_141_chunk.temp, _hyper_4_141_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_142_chunk
-                                       Output: _hyper_4_142_chunk."time", _hyper_4_142_chunk.temp, _hyper_4_142_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_143_chunk
-                                       Output: _hyper_4_143_chunk."time", _hyper_4_143_chunk.temp, _hyper_4_143_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_144_chunk
-                                       Output: _hyper_4_144_chunk."time", _hyper_4_144_chunk.temp, _hyper_4_144_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_145_chunk
-                                       Output: _hyper_4_145_chunk."time", _hyper_4_145_chunk.temp, _hyper_4_145_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_146_chunk
-                                       Output: _hyper_4_146_chunk."time", _hyper_4_146_chunk.temp, _hyper_4_146_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_147_chunk
-                                       Output: _hyper_4_147_chunk."time", _hyper_4_147_chunk.temp, _hyper_4_147_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_148_chunk
-                                       Output: _hyper_4_148_chunk."time", _hyper_4_148_chunk.temp, _hyper_4_148_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_149_chunk
-                                       Output: _hyper_4_149_chunk."time", _hyper_4_149_chunk.temp, _hyper_4_149_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_150_chunk
-                                       Output: _hyper_4_150_chunk."time", _hyper_4_150_chunk.temp, _hyper_4_150_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_151_chunk
-                                       Output: _hyper_4_151_chunk."time", _hyper_4_151_chunk.temp, _hyper_4_151_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_152_chunk
-                                       Output: _hyper_4_152_chunk."time", _hyper_4_152_chunk.temp, _hyper_4_152_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_153_chunk
-                                       Output: _hyper_4_153_chunk."time", _hyper_4_153_chunk.temp, _hyper_4_153_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_154_chunk
-                                       Output: _hyper_4_154_chunk."time", _hyper_4_154_chunk.temp, _hyper_4_154_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_155_chunk
-                                       Output: _hyper_4_155_chunk."time", _hyper_4_155_chunk.temp, _hyper_4_155_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_156_chunk
-                                       Output: _hyper_4_156_chunk."time", _hyper_4_156_chunk.temp, _hyper_4_156_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_157_chunk
-                                       Output: _hyper_4_157_chunk."time", _hyper_4_157_chunk.temp, _hyper_4_157_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_158_chunk
-                                       Output: _hyper_4_158_chunk."time", _hyper_4_158_chunk.temp, _hyper_4_158_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_159_chunk
-                                       Output: _hyper_4_159_chunk."time", _hyper_4_159_chunk.temp, _hyper_4_159_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_160_chunk
-                                       Output: _hyper_4_160_chunk."time", _hyper_4_160_chunk.temp, _hyper_4_160_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_161_chunk
-                                       Output: _hyper_4_161_chunk."time", _hyper_4_161_chunk.temp, _hyper_4_161_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_162_chunk
-                                       Output: _hyper_4_162_chunk."time", _hyper_4_162_chunk.temp, _hyper_4_162_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_163_chunk
-                                       Output: _hyper_4_163_chunk."time", _hyper_4_163_chunk.temp, _hyper_4_163_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_164_chunk
-                                       Output: _hyper_4_164_chunk."time", _hyper_4_164_chunk.temp, _hyper_4_164_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_165_chunk
-                                       Output: _hyper_4_165_chunk."time", _hyper_4_165_chunk.temp, _hyper_4_165_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_166_chunk
-                                       Output: _hyper_4_166_chunk."time", _hyper_4_166_chunk.temp, _hyper_4_166_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_167_chunk
-                                       Output: _hyper_4_167_chunk."time", _hyper_4_167_chunk.temp, _hyper_4_167_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_168_chunk
-                                       Output: _hyper_4_168_chunk."time", _hyper_4_168_chunk.temp, _hyper_4_168_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_169_chunk
-                                       Output: _hyper_4_169_chunk."time", _hyper_4_169_chunk.temp, _hyper_4_169_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_170_chunk
-                                       Output: _hyper_4_170_chunk."time", _hyper_4_170_chunk.temp, _hyper_4_170_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_171_chunk
-                                       Output: _hyper_4_171_chunk."time", _hyper_4_171_chunk.temp, _hyper_4_171_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_172_chunk
-                                       Output: _hyper_4_172_chunk."time", _hyper_4_172_chunk.temp, _hyper_4_172_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_173_chunk
-                                       Output: _hyper_4_173_chunk."time", _hyper_4_173_chunk.temp, _hyper_4_173_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_174_chunk
-                                       Output: _hyper_4_174_chunk."time", _hyper_4_174_chunk.temp, _hyper_4_174_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_175_chunk
-                                       Output: _hyper_4_175_chunk."time", _hyper_4_175_chunk.temp, _hyper_4_175_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_176_chunk
-                                       Output: _hyper_4_176_chunk."time", _hyper_4_176_chunk.temp, _hyper_4_176_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_177_chunk
-                                       Output: _hyper_4_177_chunk."time", _hyper_4_177_chunk.temp, _hyper_4_177_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_178_chunk
-                                       Output: _hyper_4_178_chunk."time", _hyper_4_178_chunk.temp, _hyper_4_178_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_179_chunk
-                                       Output: _hyper_4_179_chunk."time", _hyper_4_179_chunk.temp, _hyper_4_179_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_180_chunk
-                                       Output: _hyper_4_180_chunk."time", _hyper_4_180_chunk.temp, _hyper_4_180_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_181_chunk
-                                       Output: _hyper_4_181_chunk."time", _hyper_4_181_chunk.temp, _hyper_4_181_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_182_chunk
-                                       Output: _hyper_4_182_chunk."time", _hyper_4_182_chunk.temp, _hyper_4_182_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_183_chunk
-                                       Output: _hyper_4_183_chunk."time", _hyper_4_183_chunk.temp, _hyper_4_183_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_184_chunk
-                                       Output: _hyper_4_184_chunk."time", _hyper_4_184_chunk.temp, _hyper_4_184_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_185_chunk
-                                       Output: _hyper_4_185_chunk."time", _hyper_4_185_chunk.temp, _hyper_4_185_chunk.device
-                                 ->  Seq Scan on _timescaledb_internal._hyper_4_186_chunk
-                                       Output: _hyper_4_186_chunk."time", _hyper_4_186_chunk.temp, _hyper_4_186_chunk.device
-(368 rows)
-
-INSERT INTO many_partitions_test_1m(time, temp, device)
-SELECT time_bucket('1 minute', time) AS period, avg(temp), device
-FROM many_partitions_test
-GROUP BY period, device;
 -- Out-of-order insertion regression test.
 -- this used to trip an assert in subspace_store.c checking that
 -- max_open_chunks_per_insert was obeyed
@@ -682,7 +265,7 @@ SELECT create_hypertable('chunk_assert_fail', 'i', 'j', 1000, chunk_time_interva
 NOTICE:  adding not-null constraint to column "i"
        create_hypertable        
 --------------------------------
- (7,public,chunk_assert_fail,t)
+ (5,public,chunk_assert_fail,t)
 (1 row)
 
 insert into chunk_assert_fail values (1, 1), (1, 2), (2,1);
@@ -694,28 +277,12 @@ select * from chunk_assert_fail;
  2 | 1
 (3 rows)
 
-set timescaledb.max_open_chunks_per_insert=default;
-SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
-           time           | temp | device 
---------------------------+------+--------
- Wed Dec 31 16:00:00 1969 |    1 | 1
- Wed Dec 31 16:00:00 1969 |   10 | 10
- Wed Dec 31 16:00:00 1969 |   11 | 11
- Wed Dec 31 16:00:00 1969 |   12 | 12
- Wed Dec 31 16:00:00 1969 |   13 | 13
- Wed Dec 31 16:00:00 1969 |   14 | 14
- Wed Dec 31 16:00:00 1969 |   15 | 15
- Wed Dec 31 16:00:00 1969 |   16 | 16
- Wed Dec 31 16:00:00 1969 |   17 | 17
- Wed Dec 31 16:00:00 1969 |   18 | 18
-(10 rows)
-
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
- (8,public,one_space_test,t)
+ (6,public,one_space_test,t)
 (1 row)
 
 INSERT INTO one_space_test VALUES
@@ -754,4 +321,232 @@ SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
                  ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
                        ->  Result (actual rows=1 loops=1)
 (8 rows)
+
+-- INSERTs can exclude chunks based on constraints
+EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on chunk_assert_fail
+         ->  Custom Scan (ChunkDispatch)
+               ->  Append
+                     ->  Seq Scan on _hyper_5_11_chunk
+                     ->  Seq Scan on _hyper_5_12_chunk
+                     ->  Seq Scan on _hyper_5_13_chunk
+(7 rows)
+
+EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i < 1;
+                 QUERY PLAN                 
+--------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on chunk_assert_fail
+         ->  Custom Scan (ChunkDispatch)
+               ->  Result
+                     One-Time Filter: false
+(5 rows)
+
+EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i = 1;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on chunk_assert_fail
+         ->  Custom Scan (ChunkDispatch)
+               ->  Append
+                     ->  Index Scan using _hyper_5_12_chunk_chunk_assert_fail_i_idx on _hyper_5_12_chunk
+                           Index Cond: (i = 1)
+                     ->  Index Scan using _hyper_5_11_chunk_chunk_assert_fail_i_idx on _hyper_5_11_chunk
+                           Index Cond: (i = 1)
+(8 rows)
+
+EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on chunk_assert_fail
+         ->  Custom Scan (ChunkDispatch)
+               ->  Append
+                     ->  Index Scan using _hyper_5_13_chunk_chunk_assert_fail_i_idx on _hyper_5_13_chunk
+                           Index Cond: (i > 1)
+(6 rows)
+
+INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
+EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time < 'infinity' LIMIT 1;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on one_space_test
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Append
+                           ->  Index Scan using _hyper_6_14_chunk_one_space_test_time_idx on _hyper_6_14_chunk
+                                 Index Cond: ("time" < 'infinity'::timestamp without time zone)
+                           ->  Index Scan using _hyper_6_15_chunk_one_space_test_time_idx on _hyper_6_15_chunk
+                                 Index Cond: ("time" < 'infinity'::timestamp without time zone)
+(9 rows)
+
+EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time >= 'infinity' LIMIT 1;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on one_space_test
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Result
+                           One-Time Filter: false
+(6 rows)
+
+EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity' LIMIT 1;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on one_space_test
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Result
+                           One-Time Filter: false
+(6 rows)
+
+EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on one_space_test
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Append
+                           ->  Index Scan using _hyper_6_14_chunk_one_space_test_time_idx on _hyper_6_14_chunk
+                                 Index Cond: ("time" > '-infinity'::timestamp without time zone)
+                           ->  Index Scan using _hyper_6_15_chunk_one_space_test_time_idx on _hyper_6_15_chunk
+                                 Index Cond: ("time" > '-infinity'::timestamp without time zone)
+(9 rows)
+
+INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time < 'infinity' LIMIT 1;
+INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time >= 'infinity' LIMIT 1;
+INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity' LIMIT 1;
+INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
+CREATE TABLE timestamp_inf(time TIMESTAMP);
+SELECT create_hypertable('timestamp_inf', 'time');
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (7,public,timestamp_inf,t)
+(1 row)
+
+INSERT INTO timestamp_inf VALUES ('2018/01/02'), ('2019/01/02');
+EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
+    WHERE time < 'infinity' LIMIT 1;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on timestamp_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Append
+                           ->  Index Only Scan using _hyper_7_17_chunk_timestamp_inf_time_idx on _hyper_7_17_chunk
+                                 Index Cond: ("time" < 'infinity'::timestamp without time zone)
+                           ->  Index Only Scan using _hyper_7_16_chunk_timestamp_inf_time_idx on _hyper_7_16_chunk
+                                 Index Cond: ("time" < 'infinity'::timestamp without time zone)
+(9 rows)
+
+EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
+    WHERE time >= 'infinity' LIMIT 1;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on timestamp_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Result
+                           One-Time Filter: false
+(6 rows)
+
+EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
+    WHERE time <= '-infinity' LIMIT 1;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on timestamp_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Result
+                           One-Time Filter: false
+(6 rows)
+
+EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
+    WHERE time > '-infinity' LIMIT 1;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on timestamp_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Append
+                           ->  Index Only Scan using _hyper_7_17_chunk_timestamp_inf_time_idx on _hyper_7_17_chunk
+                                 Index Cond: ("time" > '-infinity'::timestamp without time zone)
+                           ->  Index Only Scan using _hyper_7_16_chunk_timestamp_inf_time_idx on _hyper_7_16_chunk
+                                 Index Cond: ("time" > '-infinity'::timestamp without time zone)
+(9 rows)
+
+CREATE TABLE date_inf(time DATE);
+SELECT create_hypertable('date_inf', 'time');
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable   
+-----------------------
+ (8,public,date_inf,t)
+(1 row)
+
+INSERT INTO date_inf VALUES ('2018/01/02'), ('2019/01/02');
+EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
+    WHERE time < 'infinity' LIMIT 1;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on date_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Append
+                           ->  Index Only Scan using _hyper_8_18_chunk_date_inf_time_idx on _hyper_8_18_chunk
+                                 Index Cond: ("time" < 'infinity'::date)
+                           ->  Index Only Scan using _hyper_8_19_chunk_date_inf_time_idx on _hyper_8_19_chunk
+                                 Index Cond: ("time" < 'infinity'::date)
+(9 rows)
+
+EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
+    WHERE time >= 'infinity' LIMIT 1;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on date_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Result
+                           One-Time Filter: false
+(6 rows)
+
+EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
+    WHERE time <= '-infinity' LIMIT 1;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on date_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Result
+                           One-Time Filter: false
+(6 rows)
+
+EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
+    WHERE time > '-infinity' LIMIT 1;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on date_inf
+         ->  Custom Scan (ChunkDispatch)
+               ->  Limit
+                     ->  Append
+                           ->  Index Only Scan using _hyper_8_18_chunk_date_inf_time_idx on _hyper_8_18_chunk
+                                 Index Cond: ("time" > '-infinity'::date)
+                           ->  Index Only Scan using _hyper_8_19_chunk_date_inf_time_idx on _hyper_8_19_chunk
+                                 Index Cond: ("time" > '-infinity'::date)
+(9 rows)
 

--- a/test/expected/insert_many-10.out
+++ b/test/expected/insert_many-10.out
@@ -1,0 +1,433 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
+NOTICE:  adding not-null constraint to column "time"
+         create_hypertable         
+-----------------------------------
+ (1,public,many_partitions_test,t)
+(1 row)
+
+--NOTE: how much slower the first two queries are -- they are creating chunks
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(1,100) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(101,200) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, (ser-201)::text FROM generate_series(201,300) ser;
+SELECT * FROM  many_partitions_test ORDER BY time DESC LIMIT 2;
+           time           | temp | device 
+--------------------------+------+--------
+ Wed Dec 31 16:05:00 1969 |  300 | 99
+ Wed Dec 31 16:04:59 1969 |  299 | 98
+(2 rows)
+
+SELECT count(*) FROM  many_partitions_test;
+ count 
+-------
+   300
+(1 row)
+
+CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
+NOTICE:  adding not-null constraint to column "time"
+          create_hypertable           
+--------------------------------------
+ (2,public,many_partitions_test_1m,t)
+(1 row)
+
+EXPLAIN (verbose on, costs off)
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on public.many_partitions_test_1m
+         ->  Custom Scan (ChunkDispatch)
+               Output: "*SELECT*".period, "*SELECT*".avg, "*SELECT*".device
+               ->  HashAggregate
+                     Output: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")), avg(_hyper_1_1_chunk.temp), _hyper_1_1_chunk.device
+                     Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.device
+                     ->  Result
+                           Output: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.device, _hyper_1_1_chunk.temp
+                           ->  Append
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                                       Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.temp, _hyper_1_1_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.temp, _hyper_1_2_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_3_chunk
+                                       Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.temp, _hyper_1_3_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                                       Output: _hyper_1_4_chunk."time", _hyper_1_4_chunk.temp, _hyper_1_4_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                                       Output: _hyper_1_5_chunk."time", _hyper_1_5_chunk.temp, _hyper_1_5_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                                       Output: _hyper_1_6_chunk."time", _hyper_1_6_chunk.temp, _hyper_1_6_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                                       Output: _hyper_1_7_chunk."time", _hyper_1_7_chunk.temp, _hyper_1_7_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                                       Output: _hyper_1_8_chunk."time", _hyper_1_8_chunk.temp, _hyper_1_8_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                                       Output: _hyper_1_9_chunk."time", _hyper_1_9_chunk.temp, _hyper_1_9_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                                       Output: _hyper_1_10_chunk."time", _hyper_1_10_chunk.temp, _hyper_1_10_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_11_chunk
+                                       Output: _hyper_1_11_chunk."time", _hyper_1_11_chunk.temp, _hyper_1_11_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_12_chunk
+                                       Output: _hyper_1_12_chunk."time", _hyper_1_12_chunk.temp, _hyper_1_12_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_13_chunk
+                                       Output: _hyper_1_13_chunk."time", _hyper_1_13_chunk.temp, _hyper_1_13_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_14_chunk
+                                       Output: _hyper_1_14_chunk."time", _hyper_1_14_chunk.temp, _hyper_1_14_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_15_chunk
+                                       Output: _hyper_1_15_chunk."time", _hyper_1_15_chunk.temp, _hyper_1_15_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_16_chunk
+                                       Output: _hyper_1_16_chunk."time", _hyper_1_16_chunk.temp, _hyper_1_16_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk
+                                       Output: _hyper_1_17_chunk."time", _hyper_1_17_chunk.temp, _hyper_1_17_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_18_chunk
+                                       Output: _hyper_1_18_chunk."time", _hyper_1_18_chunk.temp, _hyper_1_18_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_19_chunk
+                                       Output: _hyper_1_19_chunk."time", _hyper_1_19_chunk.temp, _hyper_1_19_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_20_chunk
+                                       Output: _hyper_1_20_chunk."time", _hyper_1_20_chunk.temp, _hyper_1_20_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_21_chunk
+                                       Output: _hyper_1_21_chunk."time", _hyper_1_21_chunk.temp, _hyper_1_21_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_22_chunk
+                                       Output: _hyper_1_22_chunk."time", _hyper_1_22_chunk.temp, _hyper_1_22_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_23_chunk
+                                       Output: _hyper_1_23_chunk."time", _hyper_1_23_chunk.temp, _hyper_1_23_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_24_chunk
+                                       Output: _hyper_1_24_chunk."time", _hyper_1_24_chunk.temp, _hyper_1_24_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk
+                                       Output: _hyper_1_25_chunk."time", _hyper_1_25_chunk.temp, _hyper_1_25_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_26_chunk
+                                       Output: _hyper_1_26_chunk."time", _hyper_1_26_chunk.temp, _hyper_1_26_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_27_chunk
+                                       Output: _hyper_1_27_chunk."time", _hyper_1_27_chunk.temp, _hyper_1_27_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_28_chunk
+                                       Output: _hyper_1_28_chunk."time", _hyper_1_28_chunk.temp, _hyper_1_28_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_29_chunk
+                                       Output: _hyper_1_29_chunk."time", _hyper_1_29_chunk.temp, _hyper_1_29_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_30_chunk
+                                       Output: _hyper_1_30_chunk."time", _hyper_1_30_chunk.temp, _hyper_1_30_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_31_chunk
+                                       Output: _hyper_1_31_chunk."time", _hyper_1_31_chunk.temp, _hyper_1_31_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_32_chunk
+                                       Output: _hyper_1_32_chunk."time", _hyper_1_32_chunk.temp, _hyper_1_32_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_33_chunk
+                                       Output: _hyper_1_33_chunk."time", _hyper_1_33_chunk.temp, _hyper_1_33_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_34_chunk
+                                       Output: _hyper_1_34_chunk."time", _hyper_1_34_chunk.temp, _hyper_1_34_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_35_chunk
+                                       Output: _hyper_1_35_chunk."time", _hyper_1_35_chunk.temp, _hyper_1_35_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_36_chunk
+                                       Output: _hyper_1_36_chunk."time", _hyper_1_36_chunk.temp, _hyper_1_36_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_37_chunk
+                                       Output: _hyper_1_37_chunk."time", _hyper_1_37_chunk.temp, _hyper_1_37_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_38_chunk
+                                       Output: _hyper_1_38_chunk."time", _hyper_1_38_chunk.temp, _hyper_1_38_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_39_chunk
+                                       Output: _hyper_1_39_chunk."time", _hyper_1_39_chunk.temp, _hyper_1_39_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_40_chunk
+                                       Output: _hyper_1_40_chunk."time", _hyper_1_40_chunk.temp, _hyper_1_40_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_41_chunk
+                                       Output: _hyper_1_41_chunk."time", _hyper_1_41_chunk.temp, _hyper_1_41_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_42_chunk
+                                       Output: _hyper_1_42_chunk."time", _hyper_1_42_chunk.temp, _hyper_1_42_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_43_chunk
+                                       Output: _hyper_1_43_chunk."time", _hyper_1_43_chunk.temp, _hyper_1_43_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_44_chunk
+                                       Output: _hyper_1_44_chunk."time", _hyper_1_44_chunk.temp, _hyper_1_44_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_45_chunk
+                                       Output: _hyper_1_45_chunk."time", _hyper_1_45_chunk.temp, _hyper_1_45_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_46_chunk
+                                       Output: _hyper_1_46_chunk."time", _hyper_1_46_chunk.temp, _hyper_1_46_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_47_chunk
+                                       Output: _hyper_1_47_chunk."time", _hyper_1_47_chunk.temp, _hyper_1_47_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_48_chunk
+                                       Output: _hyper_1_48_chunk."time", _hyper_1_48_chunk.temp, _hyper_1_48_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_49_chunk
+                                       Output: _hyper_1_49_chunk."time", _hyper_1_49_chunk.temp, _hyper_1_49_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_50_chunk
+                                       Output: _hyper_1_50_chunk."time", _hyper_1_50_chunk.temp, _hyper_1_50_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_51_chunk
+                                       Output: _hyper_1_51_chunk."time", _hyper_1_51_chunk.temp, _hyper_1_51_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_52_chunk
+                                       Output: _hyper_1_52_chunk."time", _hyper_1_52_chunk.temp, _hyper_1_52_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_53_chunk
+                                       Output: _hyper_1_53_chunk."time", _hyper_1_53_chunk.temp, _hyper_1_53_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_54_chunk
+                                       Output: _hyper_1_54_chunk."time", _hyper_1_54_chunk.temp, _hyper_1_54_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_55_chunk
+                                       Output: _hyper_1_55_chunk."time", _hyper_1_55_chunk.temp, _hyper_1_55_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_56_chunk
+                                       Output: _hyper_1_56_chunk."time", _hyper_1_56_chunk.temp, _hyper_1_56_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_57_chunk
+                                       Output: _hyper_1_57_chunk."time", _hyper_1_57_chunk.temp, _hyper_1_57_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_58_chunk
+                                       Output: _hyper_1_58_chunk."time", _hyper_1_58_chunk.temp, _hyper_1_58_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_59_chunk
+                                       Output: _hyper_1_59_chunk."time", _hyper_1_59_chunk.temp, _hyper_1_59_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_60_chunk
+                                       Output: _hyper_1_60_chunk."time", _hyper_1_60_chunk.temp, _hyper_1_60_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_61_chunk
+                                       Output: _hyper_1_61_chunk."time", _hyper_1_61_chunk.temp, _hyper_1_61_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_62_chunk
+                                       Output: _hyper_1_62_chunk."time", _hyper_1_62_chunk.temp, _hyper_1_62_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_63_chunk
+                                       Output: _hyper_1_63_chunk."time", _hyper_1_63_chunk.temp, _hyper_1_63_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_64_chunk
+                                       Output: _hyper_1_64_chunk."time", _hyper_1_64_chunk.temp, _hyper_1_64_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_65_chunk
+                                       Output: _hyper_1_65_chunk."time", _hyper_1_65_chunk.temp, _hyper_1_65_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_66_chunk
+                                       Output: _hyper_1_66_chunk."time", _hyper_1_66_chunk.temp, _hyper_1_66_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_67_chunk
+                                       Output: _hyper_1_67_chunk."time", _hyper_1_67_chunk.temp, _hyper_1_67_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_68_chunk
+                                       Output: _hyper_1_68_chunk."time", _hyper_1_68_chunk.temp, _hyper_1_68_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_69_chunk
+                                       Output: _hyper_1_69_chunk."time", _hyper_1_69_chunk.temp, _hyper_1_69_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_70_chunk
+                                       Output: _hyper_1_70_chunk."time", _hyper_1_70_chunk.temp, _hyper_1_70_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_71_chunk
+                                       Output: _hyper_1_71_chunk."time", _hyper_1_71_chunk.temp, _hyper_1_71_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_72_chunk
+                                       Output: _hyper_1_72_chunk."time", _hyper_1_72_chunk.temp, _hyper_1_72_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_73_chunk
+                                       Output: _hyper_1_73_chunk."time", _hyper_1_73_chunk.temp, _hyper_1_73_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_74_chunk
+                                       Output: _hyper_1_74_chunk."time", _hyper_1_74_chunk.temp, _hyper_1_74_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_75_chunk
+                                       Output: _hyper_1_75_chunk."time", _hyper_1_75_chunk.temp, _hyper_1_75_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_76_chunk
+                                       Output: _hyper_1_76_chunk."time", _hyper_1_76_chunk.temp, _hyper_1_76_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_77_chunk
+                                       Output: _hyper_1_77_chunk."time", _hyper_1_77_chunk.temp, _hyper_1_77_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_78_chunk
+                                       Output: _hyper_1_78_chunk."time", _hyper_1_78_chunk.temp, _hyper_1_78_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_79_chunk
+                                       Output: _hyper_1_79_chunk."time", _hyper_1_79_chunk.temp, _hyper_1_79_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_80_chunk
+                                       Output: _hyper_1_80_chunk."time", _hyper_1_80_chunk.temp, _hyper_1_80_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_81_chunk
+                                       Output: _hyper_1_81_chunk."time", _hyper_1_81_chunk.temp, _hyper_1_81_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_82_chunk
+                                       Output: _hyper_1_82_chunk."time", _hyper_1_82_chunk.temp, _hyper_1_82_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_83_chunk
+                                       Output: _hyper_1_83_chunk."time", _hyper_1_83_chunk.temp, _hyper_1_83_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_84_chunk
+                                       Output: _hyper_1_84_chunk."time", _hyper_1_84_chunk.temp, _hyper_1_84_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_85_chunk
+                                       Output: _hyper_1_85_chunk."time", _hyper_1_85_chunk.temp, _hyper_1_85_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_86_chunk
+                                       Output: _hyper_1_86_chunk."time", _hyper_1_86_chunk.temp, _hyper_1_86_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_87_chunk
+                                       Output: _hyper_1_87_chunk."time", _hyper_1_87_chunk.temp, _hyper_1_87_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_88_chunk
+                                       Output: _hyper_1_88_chunk."time", _hyper_1_88_chunk.temp, _hyper_1_88_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_89_chunk
+                                       Output: _hyper_1_89_chunk."time", _hyper_1_89_chunk.temp, _hyper_1_89_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_90_chunk
+                                       Output: _hyper_1_90_chunk."time", _hyper_1_90_chunk.temp, _hyper_1_90_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_91_chunk
+                                       Output: _hyper_1_91_chunk."time", _hyper_1_91_chunk.temp, _hyper_1_91_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_92_chunk
+                                       Output: _hyper_1_92_chunk."time", _hyper_1_92_chunk.temp, _hyper_1_92_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_93_chunk
+                                       Output: _hyper_1_93_chunk."time", _hyper_1_93_chunk.temp, _hyper_1_93_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_94_chunk
+                                       Output: _hyper_1_94_chunk."time", _hyper_1_94_chunk.temp, _hyper_1_94_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_95_chunk
+                                       Output: _hyper_1_95_chunk."time", _hyper_1_95_chunk.temp, _hyper_1_95_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_96_chunk
+                                       Output: _hyper_1_96_chunk."time", _hyper_1_96_chunk.temp, _hyper_1_96_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_97_chunk
+                                       Output: _hyper_1_97_chunk."time", _hyper_1_97_chunk.temp, _hyper_1_97_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_98_chunk
+                                       Output: _hyper_1_98_chunk."time", _hyper_1_98_chunk.temp, _hyper_1_98_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_99_chunk
+                                       Output: _hyper_1_99_chunk."time", _hyper_1_99_chunk.temp, _hyper_1_99_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_100_chunk
+                                       Output: _hyper_1_100_chunk."time", _hyper_1_100_chunk.temp, _hyper_1_100_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_101_chunk
+                                       Output: _hyper_1_101_chunk."time", _hyper_1_101_chunk.temp, _hyper_1_101_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_102_chunk
+                                       Output: _hyper_1_102_chunk."time", _hyper_1_102_chunk.temp, _hyper_1_102_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_103_chunk
+                                       Output: _hyper_1_103_chunk."time", _hyper_1_103_chunk.temp, _hyper_1_103_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_104_chunk
+                                       Output: _hyper_1_104_chunk."time", _hyper_1_104_chunk.temp, _hyper_1_104_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_105_chunk
+                                       Output: _hyper_1_105_chunk."time", _hyper_1_105_chunk.temp, _hyper_1_105_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_106_chunk
+                                       Output: _hyper_1_106_chunk."time", _hyper_1_106_chunk.temp, _hyper_1_106_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_107_chunk
+                                       Output: _hyper_1_107_chunk."time", _hyper_1_107_chunk.temp, _hyper_1_107_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_108_chunk
+                                       Output: _hyper_1_108_chunk."time", _hyper_1_108_chunk.temp, _hyper_1_108_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_109_chunk
+                                       Output: _hyper_1_109_chunk."time", _hyper_1_109_chunk.temp, _hyper_1_109_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_110_chunk
+                                       Output: _hyper_1_110_chunk."time", _hyper_1_110_chunk.temp, _hyper_1_110_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_111_chunk
+                                       Output: _hyper_1_111_chunk."time", _hyper_1_111_chunk.temp, _hyper_1_111_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_112_chunk
+                                       Output: _hyper_1_112_chunk."time", _hyper_1_112_chunk.temp, _hyper_1_112_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_113_chunk
+                                       Output: _hyper_1_113_chunk."time", _hyper_1_113_chunk.temp, _hyper_1_113_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_114_chunk
+                                       Output: _hyper_1_114_chunk."time", _hyper_1_114_chunk.temp, _hyper_1_114_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_115_chunk
+                                       Output: _hyper_1_115_chunk."time", _hyper_1_115_chunk.temp, _hyper_1_115_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_116_chunk
+                                       Output: _hyper_1_116_chunk."time", _hyper_1_116_chunk.temp, _hyper_1_116_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_117_chunk
+                                       Output: _hyper_1_117_chunk."time", _hyper_1_117_chunk.temp, _hyper_1_117_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_118_chunk
+                                       Output: _hyper_1_118_chunk."time", _hyper_1_118_chunk.temp, _hyper_1_118_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_119_chunk
+                                       Output: _hyper_1_119_chunk."time", _hyper_1_119_chunk.temp, _hyper_1_119_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_120_chunk
+                                       Output: _hyper_1_120_chunk."time", _hyper_1_120_chunk.temp, _hyper_1_120_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_121_chunk
+                                       Output: _hyper_1_121_chunk."time", _hyper_1_121_chunk.temp, _hyper_1_121_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_122_chunk
+                                       Output: _hyper_1_122_chunk."time", _hyper_1_122_chunk.temp, _hyper_1_122_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_123_chunk
+                                       Output: _hyper_1_123_chunk."time", _hyper_1_123_chunk.temp, _hyper_1_123_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_124_chunk
+                                       Output: _hyper_1_124_chunk."time", _hyper_1_124_chunk.temp, _hyper_1_124_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_125_chunk
+                                       Output: _hyper_1_125_chunk."time", _hyper_1_125_chunk.temp, _hyper_1_125_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_126_chunk
+                                       Output: _hyper_1_126_chunk."time", _hyper_1_126_chunk.temp, _hyper_1_126_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_127_chunk
+                                       Output: _hyper_1_127_chunk."time", _hyper_1_127_chunk.temp, _hyper_1_127_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_128_chunk
+                                       Output: _hyper_1_128_chunk."time", _hyper_1_128_chunk.temp, _hyper_1_128_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_129_chunk
+                                       Output: _hyper_1_129_chunk."time", _hyper_1_129_chunk.temp, _hyper_1_129_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_130_chunk
+                                       Output: _hyper_1_130_chunk."time", _hyper_1_130_chunk.temp, _hyper_1_130_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_131_chunk
+                                       Output: _hyper_1_131_chunk."time", _hyper_1_131_chunk.temp, _hyper_1_131_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_132_chunk
+                                       Output: _hyper_1_132_chunk."time", _hyper_1_132_chunk.temp, _hyper_1_132_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_133_chunk
+                                       Output: _hyper_1_133_chunk."time", _hyper_1_133_chunk.temp, _hyper_1_133_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_134_chunk
+                                       Output: _hyper_1_134_chunk."time", _hyper_1_134_chunk.temp, _hyper_1_134_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_135_chunk
+                                       Output: _hyper_1_135_chunk."time", _hyper_1_135_chunk.temp, _hyper_1_135_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_136_chunk
+                                       Output: _hyper_1_136_chunk."time", _hyper_1_136_chunk.temp, _hyper_1_136_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_137_chunk
+                                       Output: _hyper_1_137_chunk."time", _hyper_1_137_chunk.temp, _hyper_1_137_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_138_chunk
+                                       Output: _hyper_1_138_chunk."time", _hyper_1_138_chunk.temp, _hyper_1_138_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_139_chunk
+                                       Output: _hyper_1_139_chunk."time", _hyper_1_139_chunk.temp, _hyper_1_139_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_140_chunk
+                                       Output: _hyper_1_140_chunk."time", _hyper_1_140_chunk.temp, _hyper_1_140_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_141_chunk
+                                       Output: _hyper_1_141_chunk."time", _hyper_1_141_chunk.temp, _hyper_1_141_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_142_chunk
+                                       Output: _hyper_1_142_chunk."time", _hyper_1_142_chunk.temp, _hyper_1_142_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_143_chunk
+                                       Output: _hyper_1_143_chunk."time", _hyper_1_143_chunk.temp, _hyper_1_143_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_144_chunk
+                                       Output: _hyper_1_144_chunk."time", _hyper_1_144_chunk.temp, _hyper_1_144_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_145_chunk
+                                       Output: _hyper_1_145_chunk."time", _hyper_1_145_chunk.temp, _hyper_1_145_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_146_chunk
+                                       Output: _hyper_1_146_chunk."time", _hyper_1_146_chunk.temp, _hyper_1_146_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_147_chunk
+                                       Output: _hyper_1_147_chunk."time", _hyper_1_147_chunk.temp, _hyper_1_147_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_148_chunk
+                                       Output: _hyper_1_148_chunk."time", _hyper_1_148_chunk.temp, _hyper_1_148_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_149_chunk
+                                       Output: _hyper_1_149_chunk."time", _hyper_1_149_chunk.temp, _hyper_1_149_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_150_chunk
+                                       Output: _hyper_1_150_chunk."time", _hyper_1_150_chunk.temp, _hyper_1_150_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_151_chunk
+                                       Output: _hyper_1_151_chunk."time", _hyper_1_151_chunk.temp, _hyper_1_151_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_152_chunk
+                                       Output: _hyper_1_152_chunk."time", _hyper_1_152_chunk.temp, _hyper_1_152_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_153_chunk
+                                       Output: _hyper_1_153_chunk."time", _hyper_1_153_chunk.temp, _hyper_1_153_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_154_chunk
+                                       Output: _hyper_1_154_chunk."time", _hyper_1_154_chunk.temp, _hyper_1_154_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_155_chunk
+                                       Output: _hyper_1_155_chunk."time", _hyper_1_155_chunk.temp, _hyper_1_155_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_156_chunk
+                                       Output: _hyper_1_156_chunk."time", _hyper_1_156_chunk.temp, _hyper_1_156_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_157_chunk
+                                       Output: _hyper_1_157_chunk."time", _hyper_1_157_chunk.temp, _hyper_1_157_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_158_chunk
+                                       Output: _hyper_1_158_chunk."time", _hyper_1_158_chunk.temp, _hyper_1_158_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_159_chunk
+                                       Output: _hyper_1_159_chunk."time", _hyper_1_159_chunk.temp, _hyper_1_159_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_160_chunk
+                                       Output: _hyper_1_160_chunk."time", _hyper_1_160_chunk.temp, _hyper_1_160_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_161_chunk
+                                       Output: _hyper_1_161_chunk."time", _hyper_1_161_chunk.temp, _hyper_1_161_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_162_chunk
+                                       Output: _hyper_1_162_chunk."time", _hyper_1_162_chunk.temp, _hyper_1_162_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_163_chunk
+                                       Output: _hyper_1_163_chunk."time", _hyper_1_163_chunk.temp, _hyper_1_163_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_164_chunk
+                                       Output: _hyper_1_164_chunk."time", _hyper_1_164_chunk.temp, _hyper_1_164_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_165_chunk
+                                       Output: _hyper_1_165_chunk."time", _hyper_1_165_chunk.temp, _hyper_1_165_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_166_chunk
+                                       Output: _hyper_1_166_chunk."time", _hyper_1_166_chunk.temp, _hyper_1_166_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_167_chunk
+                                       Output: _hyper_1_167_chunk."time", _hyper_1_167_chunk.temp, _hyper_1_167_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_168_chunk
+                                       Output: _hyper_1_168_chunk."time", _hyper_1_168_chunk.temp, _hyper_1_168_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_169_chunk
+                                       Output: _hyper_1_169_chunk."time", _hyper_1_169_chunk.temp, _hyper_1_169_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_170_chunk
+                                       Output: _hyper_1_170_chunk."time", _hyper_1_170_chunk.temp, _hyper_1_170_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_171_chunk
+                                       Output: _hyper_1_171_chunk."time", _hyper_1_171_chunk.temp, _hyper_1_171_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_172_chunk
+                                       Output: _hyper_1_172_chunk."time", _hyper_1_172_chunk.temp, _hyper_1_172_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_173_chunk
+                                       Output: _hyper_1_173_chunk."time", _hyper_1_173_chunk.temp, _hyper_1_173_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_174_chunk
+                                       Output: _hyper_1_174_chunk."time", _hyper_1_174_chunk.temp, _hyper_1_174_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_175_chunk
+                                       Output: _hyper_1_175_chunk."time", _hyper_1_175_chunk.temp, _hyper_1_175_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_176_chunk
+                                       Output: _hyper_1_176_chunk."time", _hyper_1_176_chunk.temp, _hyper_1_176_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_177_chunk
+                                       Output: _hyper_1_177_chunk."time", _hyper_1_177_chunk.temp, _hyper_1_177_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_178_chunk
+                                       Output: _hyper_1_178_chunk."time", _hyper_1_178_chunk.temp, _hyper_1_178_chunk.device
+(366 rows)
+
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
+           time           | temp | device 
+--------------------------+------+--------
+ Wed Dec 31 16:00:00 1969 |    1 | 1
+ Wed Dec 31 16:00:00 1969 |   10 | 10
+ Wed Dec 31 16:00:00 1969 |   11 | 11
+ Wed Dec 31 16:00:00 1969 |   12 | 12
+ Wed Dec 31 16:00:00 1969 |   13 | 13
+ Wed Dec 31 16:00:00 1969 |   14 | 14
+ Wed Dec 31 16:00:00 1969 |   15 | 15
+ Wed Dec 31 16:00:00 1969 |   16 | 16
+ Wed Dec 31 16:00:00 1969 |   17 | 17
+ Wed Dec 31 16:00:00 1969 |   18 | 18
+(10 rows)
+

--- a/test/expected/insert_many-11.out
+++ b/test/expected/insert_many-11.out
@@ -1,0 +1,431 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
+NOTICE:  adding not-null constraint to column "time"
+         create_hypertable         
+-----------------------------------
+ (1,public,many_partitions_test,t)
+(1 row)
+
+--NOTE: how much slower the first two queries are -- they are creating chunks
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(1,100) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(101,200) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, (ser-201)::text FROM generate_series(201,300) ser;
+SELECT * FROM  many_partitions_test ORDER BY time DESC LIMIT 2;
+           time           | temp | device 
+--------------------------+------+--------
+ Wed Dec 31 16:05:00 1969 |  300 | 99
+ Wed Dec 31 16:04:59 1969 |  299 | 98
+(2 rows)
+
+SELECT count(*) FROM  many_partitions_test;
+ count 
+-------
+   300
+(1 row)
+
+CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
+NOTICE:  adding not-null constraint to column "time"
+          create_hypertable           
+--------------------------------------
+ (2,public,many_partitions_test_1m,t)
+(1 row)
+
+EXPLAIN (verbose on, costs off)
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on public.many_partitions_test_1m
+         ->  Custom Scan (ChunkDispatch)
+               Output: "*SELECT*".period, "*SELECT*".avg, "*SELECT*".device
+               ->  HashAggregate
+                     Output: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")), avg(_hyper_1_1_chunk.temp), _hyper_1_1_chunk.device
+                     Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")), _hyper_1_1_chunk.device
+                     ->  Append
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.device, _hyper_1_1_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_2_chunk."time"), _hyper_1_2_chunk.device, _hyper_1_2_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_3_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_3_chunk."time"), _hyper_1_3_chunk.device, _hyper_1_3_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_4_chunk."time"), _hyper_1_4_chunk.device, _hyper_1_4_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_5_chunk."time"), _hyper_1_5_chunk.device, _hyper_1_5_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_6_chunk."time"), _hyper_1_6_chunk.device, _hyper_1_6_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_7_chunk."time"), _hyper_1_7_chunk.device, _hyper_1_7_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_8_chunk."time"), _hyper_1_8_chunk.device, _hyper_1_8_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_9_chunk."time"), _hyper_1_9_chunk.device, _hyper_1_9_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_10_chunk."time"), _hyper_1_10_chunk.device, _hyper_1_10_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_11_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_11_chunk."time"), _hyper_1_11_chunk.device, _hyper_1_11_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_12_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_12_chunk."time"), _hyper_1_12_chunk.device, _hyper_1_12_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_13_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_13_chunk."time"), _hyper_1_13_chunk.device, _hyper_1_13_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_14_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_14_chunk."time"), _hyper_1_14_chunk.device, _hyper_1_14_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_15_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_15_chunk."time"), _hyper_1_15_chunk.device, _hyper_1_15_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_16_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_16_chunk."time"), _hyper_1_16_chunk.device, _hyper_1_16_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_17_chunk."time"), _hyper_1_17_chunk.device, _hyper_1_17_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_18_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_18_chunk."time"), _hyper_1_18_chunk.device, _hyper_1_18_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_19_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_19_chunk."time"), _hyper_1_19_chunk.device, _hyper_1_19_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_20_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_20_chunk."time"), _hyper_1_20_chunk.device, _hyper_1_20_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_21_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_21_chunk."time"), _hyper_1_21_chunk.device, _hyper_1_21_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_22_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_22_chunk."time"), _hyper_1_22_chunk.device, _hyper_1_22_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_23_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_23_chunk."time"), _hyper_1_23_chunk.device, _hyper_1_23_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_24_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_24_chunk."time"), _hyper_1_24_chunk.device, _hyper_1_24_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_25_chunk."time"), _hyper_1_25_chunk.device, _hyper_1_25_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_26_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_26_chunk."time"), _hyper_1_26_chunk.device, _hyper_1_26_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_27_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_27_chunk."time"), _hyper_1_27_chunk.device, _hyper_1_27_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_28_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_28_chunk."time"), _hyper_1_28_chunk.device, _hyper_1_28_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_29_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_29_chunk."time"), _hyper_1_29_chunk.device, _hyper_1_29_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_30_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_30_chunk."time"), _hyper_1_30_chunk.device, _hyper_1_30_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_31_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_31_chunk."time"), _hyper_1_31_chunk.device, _hyper_1_31_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_32_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_32_chunk."time"), _hyper_1_32_chunk.device, _hyper_1_32_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_33_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_33_chunk."time"), _hyper_1_33_chunk.device, _hyper_1_33_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_34_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_34_chunk."time"), _hyper_1_34_chunk.device, _hyper_1_34_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_35_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_35_chunk."time"), _hyper_1_35_chunk.device, _hyper_1_35_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_36_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_36_chunk."time"), _hyper_1_36_chunk.device, _hyper_1_36_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_37_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_37_chunk."time"), _hyper_1_37_chunk.device, _hyper_1_37_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_38_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_38_chunk."time"), _hyper_1_38_chunk.device, _hyper_1_38_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_39_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_39_chunk."time"), _hyper_1_39_chunk.device, _hyper_1_39_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_40_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_40_chunk."time"), _hyper_1_40_chunk.device, _hyper_1_40_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_41_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_41_chunk."time"), _hyper_1_41_chunk.device, _hyper_1_41_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_42_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_42_chunk."time"), _hyper_1_42_chunk.device, _hyper_1_42_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_43_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_43_chunk."time"), _hyper_1_43_chunk.device, _hyper_1_43_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_44_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_44_chunk."time"), _hyper_1_44_chunk.device, _hyper_1_44_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_45_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_45_chunk."time"), _hyper_1_45_chunk.device, _hyper_1_45_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_46_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_46_chunk."time"), _hyper_1_46_chunk.device, _hyper_1_46_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_47_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_47_chunk."time"), _hyper_1_47_chunk.device, _hyper_1_47_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_48_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_48_chunk."time"), _hyper_1_48_chunk.device, _hyper_1_48_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_49_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_49_chunk."time"), _hyper_1_49_chunk.device, _hyper_1_49_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_50_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_50_chunk."time"), _hyper_1_50_chunk.device, _hyper_1_50_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_51_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_51_chunk."time"), _hyper_1_51_chunk.device, _hyper_1_51_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_52_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_52_chunk."time"), _hyper_1_52_chunk.device, _hyper_1_52_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_53_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_53_chunk."time"), _hyper_1_53_chunk.device, _hyper_1_53_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_54_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_54_chunk."time"), _hyper_1_54_chunk.device, _hyper_1_54_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_55_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_55_chunk."time"), _hyper_1_55_chunk.device, _hyper_1_55_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_56_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_56_chunk."time"), _hyper_1_56_chunk.device, _hyper_1_56_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_57_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_57_chunk."time"), _hyper_1_57_chunk.device, _hyper_1_57_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_58_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_58_chunk."time"), _hyper_1_58_chunk.device, _hyper_1_58_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_59_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_59_chunk."time"), _hyper_1_59_chunk.device, _hyper_1_59_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_60_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_60_chunk."time"), _hyper_1_60_chunk.device, _hyper_1_60_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_61_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_61_chunk."time"), _hyper_1_61_chunk.device, _hyper_1_61_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_62_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_62_chunk."time"), _hyper_1_62_chunk.device, _hyper_1_62_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_63_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_63_chunk."time"), _hyper_1_63_chunk.device, _hyper_1_63_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_64_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_64_chunk."time"), _hyper_1_64_chunk.device, _hyper_1_64_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_65_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_65_chunk."time"), _hyper_1_65_chunk.device, _hyper_1_65_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_66_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_66_chunk."time"), _hyper_1_66_chunk.device, _hyper_1_66_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_67_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_67_chunk."time"), _hyper_1_67_chunk.device, _hyper_1_67_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_68_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_68_chunk."time"), _hyper_1_68_chunk.device, _hyper_1_68_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_69_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_69_chunk."time"), _hyper_1_69_chunk.device, _hyper_1_69_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_70_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_70_chunk."time"), _hyper_1_70_chunk.device, _hyper_1_70_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_71_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_71_chunk."time"), _hyper_1_71_chunk.device, _hyper_1_71_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_72_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_72_chunk."time"), _hyper_1_72_chunk.device, _hyper_1_72_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_73_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_73_chunk."time"), _hyper_1_73_chunk.device, _hyper_1_73_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_74_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_74_chunk."time"), _hyper_1_74_chunk.device, _hyper_1_74_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_75_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_75_chunk."time"), _hyper_1_75_chunk.device, _hyper_1_75_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_76_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_76_chunk."time"), _hyper_1_76_chunk.device, _hyper_1_76_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_77_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_77_chunk."time"), _hyper_1_77_chunk.device, _hyper_1_77_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_78_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_78_chunk."time"), _hyper_1_78_chunk.device, _hyper_1_78_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_79_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_79_chunk."time"), _hyper_1_79_chunk.device, _hyper_1_79_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_80_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_80_chunk."time"), _hyper_1_80_chunk.device, _hyper_1_80_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_81_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_81_chunk."time"), _hyper_1_81_chunk.device, _hyper_1_81_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_82_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_82_chunk."time"), _hyper_1_82_chunk.device, _hyper_1_82_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_83_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_83_chunk."time"), _hyper_1_83_chunk.device, _hyper_1_83_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_84_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_84_chunk."time"), _hyper_1_84_chunk.device, _hyper_1_84_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_85_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_85_chunk."time"), _hyper_1_85_chunk.device, _hyper_1_85_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_86_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_86_chunk."time"), _hyper_1_86_chunk.device, _hyper_1_86_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_87_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_87_chunk."time"), _hyper_1_87_chunk.device, _hyper_1_87_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_88_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_88_chunk."time"), _hyper_1_88_chunk.device, _hyper_1_88_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_89_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_89_chunk."time"), _hyper_1_89_chunk.device, _hyper_1_89_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_90_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_90_chunk."time"), _hyper_1_90_chunk.device, _hyper_1_90_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_91_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_91_chunk."time"), _hyper_1_91_chunk.device, _hyper_1_91_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_92_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_92_chunk."time"), _hyper_1_92_chunk.device, _hyper_1_92_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_93_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_93_chunk."time"), _hyper_1_93_chunk.device, _hyper_1_93_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_94_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_94_chunk."time"), _hyper_1_94_chunk.device, _hyper_1_94_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_95_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_95_chunk."time"), _hyper_1_95_chunk.device, _hyper_1_95_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_96_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_96_chunk."time"), _hyper_1_96_chunk.device, _hyper_1_96_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_97_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_97_chunk."time"), _hyper_1_97_chunk.device, _hyper_1_97_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_98_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_98_chunk."time"), _hyper_1_98_chunk.device, _hyper_1_98_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_99_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_99_chunk."time"), _hyper_1_99_chunk.device, _hyper_1_99_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_100_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_100_chunk."time"), _hyper_1_100_chunk.device, _hyper_1_100_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_101_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_101_chunk."time"), _hyper_1_101_chunk.device, _hyper_1_101_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_102_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_102_chunk."time"), _hyper_1_102_chunk.device, _hyper_1_102_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_103_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_103_chunk."time"), _hyper_1_103_chunk.device, _hyper_1_103_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_104_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_104_chunk."time"), _hyper_1_104_chunk.device, _hyper_1_104_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_105_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_105_chunk."time"), _hyper_1_105_chunk.device, _hyper_1_105_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_106_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_106_chunk."time"), _hyper_1_106_chunk.device, _hyper_1_106_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_107_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_107_chunk."time"), _hyper_1_107_chunk.device, _hyper_1_107_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_108_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_108_chunk."time"), _hyper_1_108_chunk.device, _hyper_1_108_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_109_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_109_chunk."time"), _hyper_1_109_chunk.device, _hyper_1_109_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_110_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_110_chunk."time"), _hyper_1_110_chunk.device, _hyper_1_110_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_111_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_111_chunk."time"), _hyper_1_111_chunk.device, _hyper_1_111_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_112_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_112_chunk."time"), _hyper_1_112_chunk.device, _hyper_1_112_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_113_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_113_chunk."time"), _hyper_1_113_chunk.device, _hyper_1_113_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_114_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_114_chunk."time"), _hyper_1_114_chunk.device, _hyper_1_114_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_115_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_115_chunk."time"), _hyper_1_115_chunk.device, _hyper_1_115_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_116_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_116_chunk."time"), _hyper_1_116_chunk.device, _hyper_1_116_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_117_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_117_chunk."time"), _hyper_1_117_chunk.device, _hyper_1_117_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_118_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_118_chunk."time"), _hyper_1_118_chunk.device, _hyper_1_118_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_119_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_119_chunk."time"), _hyper_1_119_chunk.device, _hyper_1_119_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_120_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_120_chunk."time"), _hyper_1_120_chunk.device, _hyper_1_120_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_121_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_121_chunk."time"), _hyper_1_121_chunk.device, _hyper_1_121_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_122_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_122_chunk."time"), _hyper_1_122_chunk.device, _hyper_1_122_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_123_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_123_chunk."time"), _hyper_1_123_chunk.device, _hyper_1_123_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_124_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_124_chunk."time"), _hyper_1_124_chunk.device, _hyper_1_124_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_125_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_125_chunk."time"), _hyper_1_125_chunk.device, _hyper_1_125_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_126_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_126_chunk."time"), _hyper_1_126_chunk.device, _hyper_1_126_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_127_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_127_chunk."time"), _hyper_1_127_chunk.device, _hyper_1_127_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_128_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_128_chunk."time"), _hyper_1_128_chunk.device, _hyper_1_128_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_129_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_129_chunk."time"), _hyper_1_129_chunk.device, _hyper_1_129_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_130_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_130_chunk."time"), _hyper_1_130_chunk.device, _hyper_1_130_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_131_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_131_chunk."time"), _hyper_1_131_chunk.device, _hyper_1_131_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_132_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_132_chunk."time"), _hyper_1_132_chunk.device, _hyper_1_132_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_133_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_133_chunk."time"), _hyper_1_133_chunk.device, _hyper_1_133_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_134_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_134_chunk."time"), _hyper_1_134_chunk.device, _hyper_1_134_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_135_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_135_chunk."time"), _hyper_1_135_chunk.device, _hyper_1_135_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_136_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_136_chunk."time"), _hyper_1_136_chunk.device, _hyper_1_136_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_137_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_137_chunk."time"), _hyper_1_137_chunk.device, _hyper_1_137_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_138_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_138_chunk."time"), _hyper_1_138_chunk.device, _hyper_1_138_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_139_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_139_chunk."time"), _hyper_1_139_chunk.device, _hyper_1_139_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_140_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_140_chunk."time"), _hyper_1_140_chunk.device, _hyper_1_140_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_141_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_141_chunk."time"), _hyper_1_141_chunk.device, _hyper_1_141_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_142_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_142_chunk."time"), _hyper_1_142_chunk.device, _hyper_1_142_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_143_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_143_chunk."time"), _hyper_1_143_chunk.device, _hyper_1_143_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_144_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_144_chunk."time"), _hyper_1_144_chunk.device, _hyper_1_144_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_145_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_145_chunk."time"), _hyper_1_145_chunk.device, _hyper_1_145_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_146_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_146_chunk."time"), _hyper_1_146_chunk.device, _hyper_1_146_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_147_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_147_chunk."time"), _hyper_1_147_chunk.device, _hyper_1_147_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_148_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_148_chunk."time"), _hyper_1_148_chunk.device, _hyper_1_148_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_149_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_149_chunk."time"), _hyper_1_149_chunk.device, _hyper_1_149_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_150_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_150_chunk."time"), _hyper_1_150_chunk.device, _hyper_1_150_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_151_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_151_chunk."time"), _hyper_1_151_chunk.device, _hyper_1_151_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_152_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_152_chunk."time"), _hyper_1_152_chunk.device, _hyper_1_152_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_153_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_153_chunk."time"), _hyper_1_153_chunk.device, _hyper_1_153_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_154_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_154_chunk."time"), _hyper_1_154_chunk.device, _hyper_1_154_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_155_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_155_chunk."time"), _hyper_1_155_chunk.device, _hyper_1_155_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_156_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_156_chunk."time"), _hyper_1_156_chunk.device, _hyper_1_156_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_157_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_157_chunk."time"), _hyper_1_157_chunk.device, _hyper_1_157_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_158_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_158_chunk."time"), _hyper_1_158_chunk.device, _hyper_1_158_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_159_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_159_chunk."time"), _hyper_1_159_chunk.device, _hyper_1_159_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_160_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_160_chunk."time"), _hyper_1_160_chunk.device, _hyper_1_160_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_161_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_161_chunk."time"), _hyper_1_161_chunk.device, _hyper_1_161_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_162_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_162_chunk."time"), _hyper_1_162_chunk.device, _hyper_1_162_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_163_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_163_chunk."time"), _hyper_1_163_chunk.device, _hyper_1_163_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_164_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_164_chunk."time"), _hyper_1_164_chunk.device, _hyper_1_164_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_165_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_165_chunk."time"), _hyper_1_165_chunk.device, _hyper_1_165_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_166_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_166_chunk."time"), _hyper_1_166_chunk.device, _hyper_1_166_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_167_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_167_chunk."time"), _hyper_1_167_chunk.device, _hyper_1_167_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_168_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_168_chunk."time"), _hyper_1_168_chunk.device, _hyper_1_168_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_169_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_169_chunk."time"), _hyper_1_169_chunk.device, _hyper_1_169_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_170_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_170_chunk."time"), _hyper_1_170_chunk.device, _hyper_1_170_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_171_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_171_chunk."time"), _hyper_1_171_chunk.device, _hyper_1_171_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_172_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_172_chunk."time"), _hyper_1_172_chunk.device, _hyper_1_172_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_173_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_173_chunk."time"), _hyper_1_173_chunk.device, _hyper_1_173_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_174_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_174_chunk."time"), _hyper_1_174_chunk.device, _hyper_1_174_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_175_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_175_chunk."time"), _hyper_1_175_chunk.device, _hyper_1_175_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_176_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_176_chunk."time"), _hyper_1_176_chunk.device, _hyper_1_176_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_177_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_177_chunk."time"), _hyper_1_177_chunk.device, _hyper_1_177_chunk.temp
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_178_chunk
+                                 Output: time_bucket('@ 1 min'::interval, _hyper_1_178_chunk."time"), _hyper_1_178_chunk.device, _hyper_1_178_chunk.temp
+(364 rows)
+
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
+           time           | temp | device 
+--------------------------+------+--------
+ Wed Dec 31 16:00:00 1969 |    1 | 1
+ Wed Dec 31 16:00:00 1969 |   10 | 10
+ Wed Dec 31 16:00:00 1969 |   11 | 11
+ Wed Dec 31 16:00:00 1969 |   12 | 12
+ Wed Dec 31 16:00:00 1969 |   13 | 13
+ Wed Dec 31 16:00:00 1969 |   14 | 14
+ Wed Dec 31 16:00:00 1969 |   15 | 15
+ Wed Dec 31 16:00:00 1969 |   16 | 16
+ Wed Dec 31 16:00:00 1969 |   17 | 17
+ Wed Dec 31 16:00:00 1969 |   18 | 18
+(10 rows)
+

--- a/test/expected/insert_many-9.6.out
+++ b/test/expected/insert_many-9.6.out
@@ -1,0 +1,433 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
+NOTICE:  adding not-null constraint to column "time"
+         create_hypertable         
+-----------------------------------
+ (1,public,many_partitions_test,t)
+(1 row)
+
+--NOTE: how much slower the first two queries are -- they are creating chunks
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(1,100) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(101,200) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, (ser-201)::text FROM generate_series(201,300) ser;
+SELECT * FROM  many_partitions_test ORDER BY time DESC LIMIT 2;
+           time           | temp | device 
+--------------------------+------+--------
+ Wed Dec 31 16:05:00 1969 |  300 | 99
+ Wed Dec 31 16:04:59 1969 |  299 | 98
+(2 rows)
+
+SELECT count(*) FROM  many_partitions_test;
+ count 
+-------
+   300
+(1 row)
+
+CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
+NOTICE:  adding not-null constraint to column "time"
+          create_hypertable           
+--------------------------------------
+ (2,public,many_partitions_test_1m,t)
+(1 row)
+
+EXPLAIN (verbose on, costs off)
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on public.many_partitions_test_1m
+         ->  Custom Scan (ChunkDispatch)
+               Output: "*SELECT*".period, "*SELECT*".avg, "*SELECT*".device
+               ->  HashAggregate
+                     Output: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")), avg(_hyper_1_1_chunk.temp), _hyper_1_1_chunk.device
+                     Group Key: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.device
+                     ->  Result
+                           Output: time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"), _hyper_1_1_chunk.device, _hyper_1_1_chunk.temp
+                           ->  Append
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk
+                                       Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.temp, _hyper_1_1_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.temp, _hyper_1_2_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_3_chunk
+                                       Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.temp, _hyper_1_3_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_4_chunk
+                                       Output: _hyper_1_4_chunk."time", _hyper_1_4_chunk.temp, _hyper_1_4_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_5_chunk
+                                       Output: _hyper_1_5_chunk."time", _hyper_1_5_chunk.temp, _hyper_1_5_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_6_chunk
+                                       Output: _hyper_1_6_chunk."time", _hyper_1_6_chunk.temp, _hyper_1_6_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_7_chunk
+                                       Output: _hyper_1_7_chunk."time", _hyper_1_7_chunk.temp, _hyper_1_7_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_8_chunk
+                                       Output: _hyper_1_8_chunk."time", _hyper_1_8_chunk.temp, _hyper_1_8_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_9_chunk
+                                       Output: _hyper_1_9_chunk."time", _hyper_1_9_chunk.temp, _hyper_1_9_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_10_chunk
+                                       Output: _hyper_1_10_chunk."time", _hyper_1_10_chunk.temp, _hyper_1_10_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_11_chunk
+                                       Output: _hyper_1_11_chunk."time", _hyper_1_11_chunk.temp, _hyper_1_11_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_12_chunk
+                                       Output: _hyper_1_12_chunk."time", _hyper_1_12_chunk.temp, _hyper_1_12_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_13_chunk
+                                       Output: _hyper_1_13_chunk."time", _hyper_1_13_chunk.temp, _hyper_1_13_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_14_chunk
+                                       Output: _hyper_1_14_chunk."time", _hyper_1_14_chunk.temp, _hyper_1_14_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_15_chunk
+                                       Output: _hyper_1_15_chunk."time", _hyper_1_15_chunk.temp, _hyper_1_15_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_16_chunk
+                                       Output: _hyper_1_16_chunk."time", _hyper_1_16_chunk.temp, _hyper_1_16_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_17_chunk
+                                       Output: _hyper_1_17_chunk."time", _hyper_1_17_chunk.temp, _hyper_1_17_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_18_chunk
+                                       Output: _hyper_1_18_chunk."time", _hyper_1_18_chunk.temp, _hyper_1_18_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_19_chunk
+                                       Output: _hyper_1_19_chunk."time", _hyper_1_19_chunk.temp, _hyper_1_19_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_20_chunk
+                                       Output: _hyper_1_20_chunk."time", _hyper_1_20_chunk.temp, _hyper_1_20_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_21_chunk
+                                       Output: _hyper_1_21_chunk."time", _hyper_1_21_chunk.temp, _hyper_1_21_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_22_chunk
+                                       Output: _hyper_1_22_chunk."time", _hyper_1_22_chunk.temp, _hyper_1_22_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_23_chunk
+                                       Output: _hyper_1_23_chunk."time", _hyper_1_23_chunk.temp, _hyper_1_23_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_24_chunk
+                                       Output: _hyper_1_24_chunk."time", _hyper_1_24_chunk.temp, _hyper_1_24_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_25_chunk
+                                       Output: _hyper_1_25_chunk."time", _hyper_1_25_chunk.temp, _hyper_1_25_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_26_chunk
+                                       Output: _hyper_1_26_chunk."time", _hyper_1_26_chunk.temp, _hyper_1_26_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_27_chunk
+                                       Output: _hyper_1_27_chunk."time", _hyper_1_27_chunk.temp, _hyper_1_27_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_28_chunk
+                                       Output: _hyper_1_28_chunk."time", _hyper_1_28_chunk.temp, _hyper_1_28_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_29_chunk
+                                       Output: _hyper_1_29_chunk."time", _hyper_1_29_chunk.temp, _hyper_1_29_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_30_chunk
+                                       Output: _hyper_1_30_chunk."time", _hyper_1_30_chunk.temp, _hyper_1_30_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_31_chunk
+                                       Output: _hyper_1_31_chunk."time", _hyper_1_31_chunk.temp, _hyper_1_31_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_32_chunk
+                                       Output: _hyper_1_32_chunk."time", _hyper_1_32_chunk.temp, _hyper_1_32_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_33_chunk
+                                       Output: _hyper_1_33_chunk."time", _hyper_1_33_chunk.temp, _hyper_1_33_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_34_chunk
+                                       Output: _hyper_1_34_chunk."time", _hyper_1_34_chunk.temp, _hyper_1_34_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_35_chunk
+                                       Output: _hyper_1_35_chunk."time", _hyper_1_35_chunk.temp, _hyper_1_35_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_36_chunk
+                                       Output: _hyper_1_36_chunk."time", _hyper_1_36_chunk.temp, _hyper_1_36_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_37_chunk
+                                       Output: _hyper_1_37_chunk."time", _hyper_1_37_chunk.temp, _hyper_1_37_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_38_chunk
+                                       Output: _hyper_1_38_chunk."time", _hyper_1_38_chunk.temp, _hyper_1_38_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_39_chunk
+                                       Output: _hyper_1_39_chunk."time", _hyper_1_39_chunk.temp, _hyper_1_39_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_40_chunk
+                                       Output: _hyper_1_40_chunk."time", _hyper_1_40_chunk.temp, _hyper_1_40_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_41_chunk
+                                       Output: _hyper_1_41_chunk."time", _hyper_1_41_chunk.temp, _hyper_1_41_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_42_chunk
+                                       Output: _hyper_1_42_chunk."time", _hyper_1_42_chunk.temp, _hyper_1_42_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_43_chunk
+                                       Output: _hyper_1_43_chunk."time", _hyper_1_43_chunk.temp, _hyper_1_43_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_44_chunk
+                                       Output: _hyper_1_44_chunk."time", _hyper_1_44_chunk.temp, _hyper_1_44_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_45_chunk
+                                       Output: _hyper_1_45_chunk."time", _hyper_1_45_chunk.temp, _hyper_1_45_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_46_chunk
+                                       Output: _hyper_1_46_chunk."time", _hyper_1_46_chunk.temp, _hyper_1_46_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_47_chunk
+                                       Output: _hyper_1_47_chunk."time", _hyper_1_47_chunk.temp, _hyper_1_47_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_48_chunk
+                                       Output: _hyper_1_48_chunk."time", _hyper_1_48_chunk.temp, _hyper_1_48_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_49_chunk
+                                       Output: _hyper_1_49_chunk."time", _hyper_1_49_chunk.temp, _hyper_1_49_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_50_chunk
+                                       Output: _hyper_1_50_chunk."time", _hyper_1_50_chunk.temp, _hyper_1_50_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_51_chunk
+                                       Output: _hyper_1_51_chunk."time", _hyper_1_51_chunk.temp, _hyper_1_51_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_52_chunk
+                                       Output: _hyper_1_52_chunk."time", _hyper_1_52_chunk.temp, _hyper_1_52_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_53_chunk
+                                       Output: _hyper_1_53_chunk."time", _hyper_1_53_chunk.temp, _hyper_1_53_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_54_chunk
+                                       Output: _hyper_1_54_chunk."time", _hyper_1_54_chunk.temp, _hyper_1_54_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_55_chunk
+                                       Output: _hyper_1_55_chunk."time", _hyper_1_55_chunk.temp, _hyper_1_55_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_56_chunk
+                                       Output: _hyper_1_56_chunk."time", _hyper_1_56_chunk.temp, _hyper_1_56_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_57_chunk
+                                       Output: _hyper_1_57_chunk."time", _hyper_1_57_chunk.temp, _hyper_1_57_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_58_chunk
+                                       Output: _hyper_1_58_chunk."time", _hyper_1_58_chunk.temp, _hyper_1_58_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_59_chunk
+                                       Output: _hyper_1_59_chunk."time", _hyper_1_59_chunk.temp, _hyper_1_59_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_60_chunk
+                                       Output: _hyper_1_60_chunk."time", _hyper_1_60_chunk.temp, _hyper_1_60_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_61_chunk
+                                       Output: _hyper_1_61_chunk."time", _hyper_1_61_chunk.temp, _hyper_1_61_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_62_chunk
+                                       Output: _hyper_1_62_chunk."time", _hyper_1_62_chunk.temp, _hyper_1_62_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_63_chunk
+                                       Output: _hyper_1_63_chunk."time", _hyper_1_63_chunk.temp, _hyper_1_63_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_64_chunk
+                                       Output: _hyper_1_64_chunk."time", _hyper_1_64_chunk.temp, _hyper_1_64_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_65_chunk
+                                       Output: _hyper_1_65_chunk."time", _hyper_1_65_chunk.temp, _hyper_1_65_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_66_chunk
+                                       Output: _hyper_1_66_chunk."time", _hyper_1_66_chunk.temp, _hyper_1_66_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_67_chunk
+                                       Output: _hyper_1_67_chunk."time", _hyper_1_67_chunk.temp, _hyper_1_67_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_68_chunk
+                                       Output: _hyper_1_68_chunk."time", _hyper_1_68_chunk.temp, _hyper_1_68_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_69_chunk
+                                       Output: _hyper_1_69_chunk."time", _hyper_1_69_chunk.temp, _hyper_1_69_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_70_chunk
+                                       Output: _hyper_1_70_chunk."time", _hyper_1_70_chunk.temp, _hyper_1_70_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_71_chunk
+                                       Output: _hyper_1_71_chunk."time", _hyper_1_71_chunk.temp, _hyper_1_71_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_72_chunk
+                                       Output: _hyper_1_72_chunk."time", _hyper_1_72_chunk.temp, _hyper_1_72_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_73_chunk
+                                       Output: _hyper_1_73_chunk."time", _hyper_1_73_chunk.temp, _hyper_1_73_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_74_chunk
+                                       Output: _hyper_1_74_chunk."time", _hyper_1_74_chunk.temp, _hyper_1_74_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_75_chunk
+                                       Output: _hyper_1_75_chunk."time", _hyper_1_75_chunk.temp, _hyper_1_75_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_76_chunk
+                                       Output: _hyper_1_76_chunk."time", _hyper_1_76_chunk.temp, _hyper_1_76_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_77_chunk
+                                       Output: _hyper_1_77_chunk."time", _hyper_1_77_chunk.temp, _hyper_1_77_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_78_chunk
+                                       Output: _hyper_1_78_chunk."time", _hyper_1_78_chunk.temp, _hyper_1_78_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_79_chunk
+                                       Output: _hyper_1_79_chunk."time", _hyper_1_79_chunk.temp, _hyper_1_79_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_80_chunk
+                                       Output: _hyper_1_80_chunk."time", _hyper_1_80_chunk.temp, _hyper_1_80_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_81_chunk
+                                       Output: _hyper_1_81_chunk."time", _hyper_1_81_chunk.temp, _hyper_1_81_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_82_chunk
+                                       Output: _hyper_1_82_chunk."time", _hyper_1_82_chunk.temp, _hyper_1_82_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_83_chunk
+                                       Output: _hyper_1_83_chunk."time", _hyper_1_83_chunk.temp, _hyper_1_83_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_84_chunk
+                                       Output: _hyper_1_84_chunk."time", _hyper_1_84_chunk.temp, _hyper_1_84_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_85_chunk
+                                       Output: _hyper_1_85_chunk."time", _hyper_1_85_chunk.temp, _hyper_1_85_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_86_chunk
+                                       Output: _hyper_1_86_chunk."time", _hyper_1_86_chunk.temp, _hyper_1_86_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_87_chunk
+                                       Output: _hyper_1_87_chunk."time", _hyper_1_87_chunk.temp, _hyper_1_87_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_88_chunk
+                                       Output: _hyper_1_88_chunk."time", _hyper_1_88_chunk.temp, _hyper_1_88_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_89_chunk
+                                       Output: _hyper_1_89_chunk."time", _hyper_1_89_chunk.temp, _hyper_1_89_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_90_chunk
+                                       Output: _hyper_1_90_chunk."time", _hyper_1_90_chunk.temp, _hyper_1_90_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_91_chunk
+                                       Output: _hyper_1_91_chunk."time", _hyper_1_91_chunk.temp, _hyper_1_91_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_92_chunk
+                                       Output: _hyper_1_92_chunk."time", _hyper_1_92_chunk.temp, _hyper_1_92_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_93_chunk
+                                       Output: _hyper_1_93_chunk."time", _hyper_1_93_chunk.temp, _hyper_1_93_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_94_chunk
+                                       Output: _hyper_1_94_chunk."time", _hyper_1_94_chunk.temp, _hyper_1_94_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_95_chunk
+                                       Output: _hyper_1_95_chunk."time", _hyper_1_95_chunk.temp, _hyper_1_95_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_96_chunk
+                                       Output: _hyper_1_96_chunk."time", _hyper_1_96_chunk.temp, _hyper_1_96_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_97_chunk
+                                       Output: _hyper_1_97_chunk."time", _hyper_1_97_chunk.temp, _hyper_1_97_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_98_chunk
+                                       Output: _hyper_1_98_chunk."time", _hyper_1_98_chunk.temp, _hyper_1_98_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_99_chunk
+                                       Output: _hyper_1_99_chunk."time", _hyper_1_99_chunk.temp, _hyper_1_99_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_100_chunk
+                                       Output: _hyper_1_100_chunk."time", _hyper_1_100_chunk.temp, _hyper_1_100_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_101_chunk
+                                       Output: _hyper_1_101_chunk."time", _hyper_1_101_chunk.temp, _hyper_1_101_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_102_chunk
+                                       Output: _hyper_1_102_chunk."time", _hyper_1_102_chunk.temp, _hyper_1_102_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_103_chunk
+                                       Output: _hyper_1_103_chunk."time", _hyper_1_103_chunk.temp, _hyper_1_103_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_104_chunk
+                                       Output: _hyper_1_104_chunk."time", _hyper_1_104_chunk.temp, _hyper_1_104_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_105_chunk
+                                       Output: _hyper_1_105_chunk."time", _hyper_1_105_chunk.temp, _hyper_1_105_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_106_chunk
+                                       Output: _hyper_1_106_chunk."time", _hyper_1_106_chunk.temp, _hyper_1_106_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_107_chunk
+                                       Output: _hyper_1_107_chunk."time", _hyper_1_107_chunk.temp, _hyper_1_107_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_108_chunk
+                                       Output: _hyper_1_108_chunk."time", _hyper_1_108_chunk.temp, _hyper_1_108_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_109_chunk
+                                       Output: _hyper_1_109_chunk."time", _hyper_1_109_chunk.temp, _hyper_1_109_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_110_chunk
+                                       Output: _hyper_1_110_chunk."time", _hyper_1_110_chunk.temp, _hyper_1_110_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_111_chunk
+                                       Output: _hyper_1_111_chunk."time", _hyper_1_111_chunk.temp, _hyper_1_111_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_112_chunk
+                                       Output: _hyper_1_112_chunk."time", _hyper_1_112_chunk.temp, _hyper_1_112_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_113_chunk
+                                       Output: _hyper_1_113_chunk."time", _hyper_1_113_chunk.temp, _hyper_1_113_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_114_chunk
+                                       Output: _hyper_1_114_chunk."time", _hyper_1_114_chunk.temp, _hyper_1_114_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_115_chunk
+                                       Output: _hyper_1_115_chunk."time", _hyper_1_115_chunk.temp, _hyper_1_115_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_116_chunk
+                                       Output: _hyper_1_116_chunk."time", _hyper_1_116_chunk.temp, _hyper_1_116_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_117_chunk
+                                       Output: _hyper_1_117_chunk."time", _hyper_1_117_chunk.temp, _hyper_1_117_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_118_chunk
+                                       Output: _hyper_1_118_chunk."time", _hyper_1_118_chunk.temp, _hyper_1_118_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_119_chunk
+                                       Output: _hyper_1_119_chunk."time", _hyper_1_119_chunk.temp, _hyper_1_119_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_120_chunk
+                                       Output: _hyper_1_120_chunk."time", _hyper_1_120_chunk.temp, _hyper_1_120_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_121_chunk
+                                       Output: _hyper_1_121_chunk."time", _hyper_1_121_chunk.temp, _hyper_1_121_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_122_chunk
+                                       Output: _hyper_1_122_chunk."time", _hyper_1_122_chunk.temp, _hyper_1_122_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_123_chunk
+                                       Output: _hyper_1_123_chunk."time", _hyper_1_123_chunk.temp, _hyper_1_123_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_124_chunk
+                                       Output: _hyper_1_124_chunk."time", _hyper_1_124_chunk.temp, _hyper_1_124_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_125_chunk
+                                       Output: _hyper_1_125_chunk."time", _hyper_1_125_chunk.temp, _hyper_1_125_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_126_chunk
+                                       Output: _hyper_1_126_chunk."time", _hyper_1_126_chunk.temp, _hyper_1_126_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_127_chunk
+                                       Output: _hyper_1_127_chunk."time", _hyper_1_127_chunk.temp, _hyper_1_127_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_128_chunk
+                                       Output: _hyper_1_128_chunk."time", _hyper_1_128_chunk.temp, _hyper_1_128_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_129_chunk
+                                       Output: _hyper_1_129_chunk."time", _hyper_1_129_chunk.temp, _hyper_1_129_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_130_chunk
+                                       Output: _hyper_1_130_chunk."time", _hyper_1_130_chunk.temp, _hyper_1_130_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_131_chunk
+                                       Output: _hyper_1_131_chunk."time", _hyper_1_131_chunk.temp, _hyper_1_131_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_132_chunk
+                                       Output: _hyper_1_132_chunk."time", _hyper_1_132_chunk.temp, _hyper_1_132_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_133_chunk
+                                       Output: _hyper_1_133_chunk."time", _hyper_1_133_chunk.temp, _hyper_1_133_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_134_chunk
+                                       Output: _hyper_1_134_chunk."time", _hyper_1_134_chunk.temp, _hyper_1_134_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_135_chunk
+                                       Output: _hyper_1_135_chunk."time", _hyper_1_135_chunk.temp, _hyper_1_135_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_136_chunk
+                                       Output: _hyper_1_136_chunk."time", _hyper_1_136_chunk.temp, _hyper_1_136_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_137_chunk
+                                       Output: _hyper_1_137_chunk."time", _hyper_1_137_chunk.temp, _hyper_1_137_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_138_chunk
+                                       Output: _hyper_1_138_chunk."time", _hyper_1_138_chunk.temp, _hyper_1_138_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_139_chunk
+                                       Output: _hyper_1_139_chunk."time", _hyper_1_139_chunk.temp, _hyper_1_139_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_140_chunk
+                                       Output: _hyper_1_140_chunk."time", _hyper_1_140_chunk.temp, _hyper_1_140_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_141_chunk
+                                       Output: _hyper_1_141_chunk."time", _hyper_1_141_chunk.temp, _hyper_1_141_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_142_chunk
+                                       Output: _hyper_1_142_chunk."time", _hyper_1_142_chunk.temp, _hyper_1_142_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_143_chunk
+                                       Output: _hyper_1_143_chunk."time", _hyper_1_143_chunk.temp, _hyper_1_143_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_144_chunk
+                                       Output: _hyper_1_144_chunk."time", _hyper_1_144_chunk.temp, _hyper_1_144_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_145_chunk
+                                       Output: _hyper_1_145_chunk."time", _hyper_1_145_chunk.temp, _hyper_1_145_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_146_chunk
+                                       Output: _hyper_1_146_chunk."time", _hyper_1_146_chunk.temp, _hyper_1_146_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_147_chunk
+                                       Output: _hyper_1_147_chunk."time", _hyper_1_147_chunk.temp, _hyper_1_147_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_148_chunk
+                                       Output: _hyper_1_148_chunk."time", _hyper_1_148_chunk.temp, _hyper_1_148_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_149_chunk
+                                       Output: _hyper_1_149_chunk."time", _hyper_1_149_chunk.temp, _hyper_1_149_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_150_chunk
+                                       Output: _hyper_1_150_chunk."time", _hyper_1_150_chunk.temp, _hyper_1_150_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_151_chunk
+                                       Output: _hyper_1_151_chunk."time", _hyper_1_151_chunk.temp, _hyper_1_151_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_152_chunk
+                                       Output: _hyper_1_152_chunk."time", _hyper_1_152_chunk.temp, _hyper_1_152_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_153_chunk
+                                       Output: _hyper_1_153_chunk."time", _hyper_1_153_chunk.temp, _hyper_1_153_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_154_chunk
+                                       Output: _hyper_1_154_chunk."time", _hyper_1_154_chunk.temp, _hyper_1_154_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_155_chunk
+                                       Output: _hyper_1_155_chunk."time", _hyper_1_155_chunk.temp, _hyper_1_155_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_156_chunk
+                                       Output: _hyper_1_156_chunk."time", _hyper_1_156_chunk.temp, _hyper_1_156_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_157_chunk
+                                       Output: _hyper_1_157_chunk."time", _hyper_1_157_chunk.temp, _hyper_1_157_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_158_chunk
+                                       Output: _hyper_1_158_chunk."time", _hyper_1_158_chunk.temp, _hyper_1_158_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_159_chunk
+                                       Output: _hyper_1_159_chunk."time", _hyper_1_159_chunk.temp, _hyper_1_159_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_160_chunk
+                                       Output: _hyper_1_160_chunk."time", _hyper_1_160_chunk.temp, _hyper_1_160_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_161_chunk
+                                       Output: _hyper_1_161_chunk."time", _hyper_1_161_chunk.temp, _hyper_1_161_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_162_chunk
+                                       Output: _hyper_1_162_chunk."time", _hyper_1_162_chunk.temp, _hyper_1_162_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_163_chunk
+                                       Output: _hyper_1_163_chunk."time", _hyper_1_163_chunk.temp, _hyper_1_163_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_164_chunk
+                                       Output: _hyper_1_164_chunk."time", _hyper_1_164_chunk.temp, _hyper_1_164_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_165_chunk
+                                       Output: _hyper_1_165_chunk."time", _hyper_1_165_chunk.temp, _hyper_1_165_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_166_chunk
+                                       Output: _hyper_1_166_chunk."time", _hyper_1_166_chunk.temp, _hyper_1_166_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_167_chunk
+                                       Output: _hyper_1_167_chunk."time", _hyper_1_167_chunk.temp, _hyper_1_167_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_168_chunk
+                                       Output: _hyper_1_168_chunk."time", _hyper_1_168_chunk.temp, _hyper_1_168_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_169_chunk
+                                       Output: _hyper_1_169_chunk."time", _hyper_1_169_chunk.temp, _hyper_1_169_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_170_chunk
+                                       Output: _hyper_1_170_chunk."time", _hyper_1_170_chunk.temp, _hyper_1_170_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_171_chunk
+                                       Output: _hyper_1_171_chunk."time", _hyper_1_171_chunk.temp, _hyper_1_171_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_172_chunk
+                                       Output: _hyper_1_172_chunk."time", _hyper_1_172_chunk.temp, _hyper_1_172_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_173_chunk
+                                       Output: _hyper_1_173_chunk."time", _hyper_1_173_chunk.temp, _hyper_1_173_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_174_chunk
+                                       Output: _hyper_1_174_chunk."time", _hyper_1_174_chunk.temp, _hyper_1_174_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_175_chunk
+                                       Output: _hyper_1_175_chunk."time", _hyper_1_175_chunk.temp, _hyper_1_175_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_176_chunk
+                                       Output: _hyper_1_176_chunk."time", _hyper_1_176_chunk.temp, _hyper_1_176_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_177_chunk
+                                       Output: _hyper_1_177_chunk."time", _hyper_1_177_chunk.temp, _hyper_1_177_chunk.device
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_178_chunk
+                                       Output: _hyper_1_178_chunk."time", _hyper_1_178_chunk.temp, _hyper_1_178_chunk.device
+(366 rows)
+
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;
+           time           | temp | device 
+--------------------------+------+--------
+ Wed Dec 31 16:00:00 1969 |    1 | 1
+ Wed Dec 31 16:00:00 1969 |   10 | 10
+ Wed Dec 31 16:00:00 1969 |   11 | 11
+ Wed Dec 31 16:00:00 1969 |   12 | 12
+ Wed Dec 31 16:00:00 1969 |   13 | 13
+ Wed Dec 31 16:00:00 1969 |   14 | 14
+ Wed Dec 31 16:00:00 1969 |   15 | 15
+ Wed Dec 31 16:00:00 1969 |   16 | 16
+ Wed Dec 31 16:00:00 1969 |   17 | 17
+ Wed Dec 31 16:00:00 1969 |   18 | 18
+(10 rows)
+

--- a/test/expected/rowsecurity-10.out
+++ b/test/expected/rowsecurity-10.out
@@ -3601,8 +3601,6 @@ EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
    ->  Insert on t2
          ->  Custom Scan (ChunkDispatch)
                ->  Append
-                     ->  Seq Scan on t1 t1_1
-                           Filter: ((a % 2) = 0)
                      ->  Seq Scan on _hyper_15_69_chunk
                            Filter: ((a % 2) = 0)
                      ->  Seq Scan on _hyper_15_70_chunk
@@ -3625,7 +3623,7 @@ EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
                            Filter: ((a % 2) = 0)
                      ->  Seq Scan on _hyper_15_79_chunk
                            Filter: ((a % 2) = 0)
-(28 rows)
+(26 rows)
 
 SELECT * FROM t2;
  a  |                b                 

--- a/test/expected/rowsecurity-9.6.out
+++ b/test/expected/rowsecurity-9.6.out
@@ -3598,8 +3598,6 @@ EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
    ->  Insert on t2
          ->  Custom Scan (ChunkDispatch)
                ->  Append
-                     ->  Seq Scan on t1 t1_1
-                           Filter: ((a % 2) = 0)
                      ->  Seq Scan on _hyper_15_66_chunk
                            Filter: ((a % 2) = 0)
                      ->  Seq Scan on _hyper_15_67_chunk
@@ -3622,7 +3620,7 @@ EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
                            Filter: ((a % 2) = 0)
                      ->  Seq Scan on _hyper_15_76_chunk
                            Filter: ((a % 2) = 0)
-(28 rows)
+(26 rows)
 
 SELECT * FROM t2;
  a  |                b                 

--- a/test/sql/.gitignore
+++ b/test/sql/.gitignore
@@ -1,3 +1,6 @@
+/insert_many-9.6.sql
+/insert_many-10.sql
+/insert_many-11.sql
 /parallel-9.6.sql
 /parallel-10.0.sql
 /partitioning-9.6.sql

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -127,6 +127,7 @@ set(TEST_TEMPLATES
   #some error messages changed in PG11 from "relation" to "table" so alternate_users has different output
   agg_bookends_optimized.sql.in
   alternate_users.sql.in
+  insert_many.sql.in
   parallel.sql.in
   partitioning.sql.in
   plan_expand_hypertable.sql.in

--- a/test/sql/insert_many.sql.in
+++ b/test/sql/insert_many.sql.in
@@ -1,0 +1,32 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
+--NOTE: how much slower the first two queries are -- they are creating chunks
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(1,100) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, ser::text FROM generate_series(101,200) ser;
+INSERT INTO many_partitions_test
+    SELECT to_timestamp(ser), ser, (ser-201)::text FROM generate_series(201,300) ser;
+
+SELECT * FROM  many_partitions_test ORDER BY time DESC LIMIT 2;
+SELECT count(*) FROM  many_partitions_test;
+
+CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
+SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
+
+EXPLAIN (verbose on, costs off)
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+
+INSERT INTO many_partitions_test_1m(time, temp, device)
+SELECT time_bucket('1 minute', time) AS period, avg(temp), device
+FROM many_partitions_test
+GROUP BY period, device;
+
+SELECT * FROM many_partitions_test_1m ORDER BY time, device LIMIT 10;


### PR DESCRIPTION
Before this PR only SELECTs would be optimized to exclude unneeded
chunks by our planner. This PR enables such optimizations on SELECTs
found within an INSERT as well. This should speed up commands of the
form

    INSERT INTO <hypertable> (SELECT ... FROM <hyepertable> WHERE ...)

We would like to enable this for all commands, but currently DELETE and
UPDATE can not handle them, and cause errors when the optimizations are
enabled.

This commit also fixes an issue that would occur if we tried to exclude
chunks based off of infinite time values.