### PR TITLE
Handle NULL in a check constraint name

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1141,6 +1141,9 @@ validate_hypertable_constraint(Hypertable *ht, Oid chunk_relid, void *arg)
 	chunk_cmd->name =
 		ts_chunk_constraint_get_name_from_hypertable_constraint(chunk_relid, cmd->name);
 
+	if (chunk_cmd->name == NULL)
+		return;
+
 	/* do not pass down the VALIDATE RECURSE subtype */
 	chunk_cmd->subtype = AT_ValidateConstraint;
 	AlterTableInternal(chunk_relid, list_make1(chunk_cmd), false);

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -783,3 +783,19 @@ SELECT * FROM create_hypertable('hyper_unique', 'time', chunk_time_interval => 1
 INSERT INTO hyper_unique(time, device_id,sensor_1) VALUES (1257987700000000000, 'dev2', 11);
 ALTER SCHEMA my_associated_schema RENAME TO new_associated_schema;
 ALTER TABLE hyper_unique DROP CONSTRAINT hyper_unique_time_key;
+-- test for constraint validation crash, see #1183
+CREATE TABLE test_validate(time timestamp NOT NULL, a TEXT, b TEXT);
+SELECT * FROM create_hypertable('test_validate', 'time');
+ hypertable_id | schema_name |  table_name   | created 
+---------------+-------------+---------------+---------
+            14 | public      | test_validate | t
+(1 row)
+
+INSERT INTO test_validate values(now(), 'a', 'b');
+ALTER TABLE test_validate
+ADD COLUMN c TEXT,
+ADD CONSTRAINT c_not_null CHECK (c IS NOT NULL) NOT VALID;
+UPDATE test_validate SET c = '';
+ALTER TABLE test_validate
+VALIDATE CONSTRAINT c_not_null;
+DROP TABLE test_validate;

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -581,3 +581,19 @@ INSERT INTO hyper_unique(time, device_id,sensor_1) VALUES (1257987700000000000, 
 ALTER SCHEMA my_associated_schema RENAME TO new_associated_schema;
 
 ALTER TABLE hyper_unique DROP CONSTRAINT hyper_unique_time_key;
+
+-- test for constraint validation crash, see #1183
+CREATE TABLE test_validate(time timestamp NOT NULL, a TEXT, b TEXT);
+SELECT * FROM create_hypertable('test_validate', 'time');
+INSERT INTO test_validate values(now(), 'a', 'b');
+
+ALTER TABLE test_validate
+ADD COLUMN c TEXT,
+ADD CONSTRAINT c_not_null CHECK (c IS NOT NULL) NOT VALID;
+
+UPDATE test_validate SET c = '';
+
+ALTER TABLE test_validate
+VALIDATE CONSTRAINT c_not_null;
+
+DROP TABLE test_validate;


### PR DESCRIPTION
Hi,

I've got a strange situation. When I perform a DDL on a hypertable with adding
a column and an invalid check constraing, at the validation time it crashes. My
investigation resulted in this small change.

Check constraints are propagated to child chunks by default, but they're
missing from _timescaledb_catalog.chunk_constraint table. It can lead to a
situation, when such a constraint will be added as not valid, and then at
validation time validate_hypertable_constraint will construct a chunk_cmd with
a NULL name (since it was not there and
ts_chunk_constraint_get_name_from_hypertable_constraint returns NULL), what
eventually leads to a crash.

I haven't fixed any tests tests (looks like they're broken just because more
constraints are registered), because I would like to get a confirmation first
that my conclusions are correct or I'm missing something. Also I see two tests
from constraint.sql for constraint validation, but they're only for the
negative path.