### PR TITLE
Add default index for continuous aggregates

### DIFF
--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -50,6 +50,11 @@ static const WithClauseDefinition continuous_aggregate_with_clause_def[] = {
 			.arg_name = "max_interval_per_job",
 			.type_id = TEXTOID,
 		},
+		[ContinuousViewOptionCreateGroupIndex] = {
+			.arg_name = "create_group_indexes",
+			.type_id = BOOLOID,
+			.default_val = BoolGetDatum(true),
+		},
 };
 
 WithClauseResult *

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -22,6 +22,7 @@ typedef enum ContinuousAggViewOption
 	ContinuousViewOptionRefreshLag,
 	ContinuousViewOptionRefreshInterval,
 	ContinuousViewOptionMaxIntervalPerRun,
+	ContinuousViewOptionCreateGroupIndex,
 } ContinuousAggViewOption;
 
 typedef enum ContinuousAggViewType

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -198,4 +198,8 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 			*DatumGetIntervalP(with_clause_options[ContinuousViewOptionRefreshInterval].parsed);
 		ts_bgw_job_update_by_id(agg->data.job_id, job);
 	}
+	if (!with_clause_options[ContinuousViewOptionCreateGroupIndex].is_default)
+	{
+		elog(ERROR, "cannot alter create_group_indexes option for continuous aggregates");
+	}
 }

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -49,6 +49,7 @@ select a, count(b)
 from foo
 group by time_bucket(1, a), a;
 NOTICE:  adding not-null constraint to column "time_partition_col"
+NOTICE:  adding index _materialized_hypertable_2_a_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(a, time_partition_col)
 SELECT * FROM _timescaledb_config.bgw_job;
   id  |          application_name           |       job_type       | schedule_interval | max_runtime | max_retries | retry_period 
 ------+-------------------------------------+----------------------+-------------------+-------------+-------------+--------------
@@ -514,6 +515,7 @@ SELECT
 \set ECHO errors
 psql:include/cont_agg_equal.sql:8: NOTICE:  drop cascades to 2 other objects
 psql:include/cont_agg_equal.sql:13: NOTICE:  adding not-null constraint to column "time_partition_col"
+psql:include/cont_agg_equal.sql:13: NOTICE:  adding index _materialized_hypertable_13_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_13 USING BTREE(location, time_partition_col)
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
  Number of rows different between view and original (expect 0) |     0
@@ -756,8 +758,11 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec), location, humidity, temperature;
 NOTICE:  adding not-null constraint to column "time_partition_col"
+NOTICE:  adding index _materialized_hypertable_17_grp_5_5_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING BTREE(grp_5_5, time_partition_col)
+NOTICE:  adding index _materialized_hypertable_17_grp_6_6_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING BTREE(grp_6_6, time_partition_col)
+NOTICE:  adding index _materialized_hypertable_17_grp_7_7_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING BTREE(grp_7_7, time_partition_col)
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
  schedule_interval 
 -------------------
@@ -781,6 +786,39 @@ SELECT schedule_interval FROM _timescaledb_config.bgw_job;
  schedule_interval 
 -------------------
  @ 2 hours
+(1 row)
+
+select indexname, indexdef from pg_indexes where tablename = 
+(SELECT h.table_name
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'mat_with_test')
+order by indexname;
+                         indexname                          |                                                                                  indexdef                                                                                   
+------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _materialized_hypertable_17_grp_5_5_time_partition_col_idx | CREATE INDEX _materialized_hypertable_17_grp_5_5_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING btree (grp_5_5, time_partition_col DESC)
+ _materialized_hypertable_17_grp_6_6_time_partition_col_idx | CREATE INDEX _materialized_hypertable_17_grp_6_6_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING btree (grp_6_6, time_partition_col DESC)
+ _materialized_hypertable_17_grp_7_7_time_partition_col_idx | CREATE INDEX _materialized_hypertable_17_grp_7_7_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING btree (grp_7_7, time_partition_col DESC)
+ _materialized_hypertable_17_time_partition_col_idx         | CREATE INDEX _materialized_hypertable_17_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING btree (time_partition_col DESC)
+(4 rows)
+
+drop view mat_with_test cascade;
+--no additional indexes
+create or replace view mat_with_test( timec, minl, sumt , sumh)
+WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h', timescaledb.create_group_indexes=false)
+as
+select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket('1day', timec), location, humidity, temperature;
+NOTICE:  adding not-null constraint to column "time_partition_col"
+select indexname, indexdef from pg_indexes where tablename = 
+(SELECT h.table_name
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'mat_with_test');
+                     indexname                      |                                                                          indexdef                                                                          
+----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _materialized_hypertable_18_time_partition_col_idx | CREATE INDEX _materialized_hypertable_18_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_18 USING btree (time_partition_col DESC)
 (1 row)
 
 DROP TABLE conditions CASCADE;
@@ -903,7 +941,7 @@ WARNING:  type integer text
 (3 rows)
 
 DROP view mat_ffunc_test cascade;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_21_61_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_22_61_chunk
 create or replace view mat_ffunc_test
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -99,6 +99,7 @@ CREATE VIEW mat_before
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_BEFORE;
 NOTICE:  adding not-null constraint to column "time_partition_col"
+NOTICE:  adding index _materialized_hypertable_3_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, time_partition_col)
 --materialize this VIEW after dump this tests
 --that the partialize VIEW and refresh mechanics
 --survives the dump intact
@@ -106,6 +107,7 @@ CREATE VIEW mat_after
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_AFTER;
 NOTICE:  adding not-null constraint to column "time_partition_col"
+NOTICE:  adding index _materialized_hypertable_4_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(location, time_partition_col)
 --materialize mat_before
 REFRESH MATERIALIZED VIEW mat_before;
 INFO:  new materialization range for public.conditions_before (time column timec) (1548633600000000)

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -370,6 +370,10 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_with_test'
 \gset
 \set ON_ERROR_STOP 0
+ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
+ERROR:  cannot alter create_group_indexes option for continuous aggregates
+ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
+ERROR:  cannot alter create_group_indexes option for continuous aggregates
 ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1 joule');
 ERROR:  invalid input syntax for type interval: "1 joule"
 ALTER VIEW mat_with_test RESET(timescaledb.refresh_lag);

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -40,6 +40,7 @@ FROM
   device_readings
 GROUP BY bucket, device_id; --We have to group by the bucket column, but can also add other group-by columns
 NOTICE:  adding not-null constraint to column "time_partition_col"
+NOTICE:  adding index _materialized_hypertable_2_device_id_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(device_id, time_partition_col)
 --Next, insert some data into the raw hypertable
 INSERT INTO device_readings
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
@@ -237,6 +238,7 @@ FROM
   device_readings
 GROUP BY bucket, device_id;
 NOTICE:  adding not-null constraint to column "time_partition_col"
+NOTICE:  adding index _materialized_hypertable_3_device_id_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device_id, time_partition_col)
 DROP VIEW device_summary CASCADE;
 -- Option 2: Keep things as TIMESTAMPTZ in the view and convert to local time when
 -- querying from the view
@@ -255,6 +257,7 @@ FROM
   device_readings
 GROUP BY bucket, device_id;
 NOTICE:  adding not-null constraint to column "time_partition_col"
+NOTICE:  adding index _materialized_hypertable_4_device_id_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, time_partition_col)
 REFRESH MATERIALIZED VIEW device_summary;
 INFO:  new materialization range for public.device_readings larger than allowed in one run, truncating (time column observation_time) (1546236000000000)
 INFO:  new materialization range for public.device_readings (time column observation_time) (1543723200000000)

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -367,6 +367,8 @@ WHERE user_view_name = 'mat_with_test'
 \gset
 
 \set ON_ERROR_STOP 0
+ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
+ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
 ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1 joule');
 ALTER VIEW mat_with_test RESET(timescaledb.refresh_lag);
 ALTER VIEW mat_with_test ALTER timec DROP default;


### PR DESCRIPTION
Add indexes for materialization table created by continuous aggregates.
This behavior can be turned on/off by using timescaledb.create_groupcol_index parameter
of the WITH clause when the continuous agg is created.