### PR TITLE
Refactor time_bucket chunk exclusion

### DIFF
--- a/test/expected/plan_expand_hypertable-10.out
+++ b/test/expected/plan_expand_hypertable-10.out
@@ -979,7 +979,6 @@ SELECT * FROM cte ORDER BY value;
 (9 rows)
 
 -- test overflow behaviour of time_bucket exclusion
-SET client_min_messages TO error;
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
@@ -1007,7 +1006,7 @@ SET client_min_messages TO error;
 -- our supported range of values for time is smaller then postgres
 \set ON_ERROR_STOP 0
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:156: ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
 -- transformation would be out of range
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1000d',time) < '294276-01-01'::timestamp ORDER BY time;
@@ -1031,7 +1030,7 @@ psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of rang
 -- our supported range of values for time is smaller then postgres
 \set ON_ERROR_STOP 0
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:165: ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
 -- transformation would be out of range
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1000d',time) < '294276-01-01'::timestamptz ORDER BY time;
@@ -1050,7 +1049,6 @@ psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of rang
          Filter: (time_bucket('@ 1000 days'::interval, "time") < 'Sat Jan 01 00:00:00 294276 PST'::timestamp with time zone)
 (11 rows)
 
-RESET client_min_messages;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1581,10 +1579,10 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:40: ERROR:  chunk id can't be NULL
 \set ECHO errors
-psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of range
-psql:include/plan_expand_hypertable_query.sql:157: STATEMENT:  SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of range
-psql:include/plan_expand_hypertable_query.sql:166: STATEMENT:  SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
+psql:include/plan_expand_hypertable_query.sql:156: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:156: STATEMENT:  SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
+psql:include/plan_expand_hypertable_query.sql:165: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:165: STATEMENT:  SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
 682a683,754
 >            time           
 > --------------------------

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -979,7 +979,6 @@ SELECT * FROM cte ORDER BY value;
 (9 rows)
 
 -- test overflow behaviour of time_bucket exclusion
-SET client_min_messages TO error;
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
@@ -1007,7 +1006,7 @@ SET client_min_messages TO error;
 -- our supported range of values for time is smaller then postgres
 \set ON_ERROR_STOP 0
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:156: ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
 -- transformation would be out of range
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1000d',time) < '294276-01-01'::timestamp ORDER BY time;
@@ -1031,7 +1030,7 @@ psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of rang
 -- our supported range of values for time is smaller then postgres
 \set ON_ERROR_STOP 0
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:165: ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
 -- transformation would be out of range
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1000d',time) < '294276-01-01'::timestamptz ORDER BY time;
@@ -1050,7 +1049,6 @@ psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of rang
          Filter: (time_bucket('@ 1000 days'::interval, "time") < 'Sat Jan 01 00:00:00 294276 PST'::timestamp with time zone)
 (11 rows)
 
-RESET client_min_messages;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1582,10 +1580,10 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:40: ERROR:  chunk id can't be NULL
 \set ECHO errors
-psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of range
-psql:include/plan_expand_hypertable_query.sql:157: STATEMENT:  SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of range
-psql:include/plan_expand_hypertable_query.sql:166: STATEMENT:  SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
+psql:include/plan_expand_hypertable_query.sql:156: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:156: STATEMENT:  SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
+psql:include/plan_expand_hypertable_query.sql:165: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:165: STATEMENT:  SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
 682a683,754
 >            time           
 > --------------------------

--- a/test/expected/plan_expand_hypertable-9.6.out
+++ b/test/expected/plan_expand_hypertable-9.6.out
@@ -979,7 +979,6 @@ SELECT * FROM cte ORDER BY value;
 (9 rows)
 
 -- test overflow behaviour of time_bucket exclusion
-SET client_min_messages TO error;
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
@@ -1007,7 +1006,7 @@ SET client_min_messages TO error;
 -- our supported range of values for time is smaller then postgres
 \set ON_ERROR_STOP 0
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:156: ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
 -- transformation would be out of range
 :PREFIX SELECT * FROM metrics_timestamp WHERE time_bucket('1000d',time) < '294276-01-01'::timestamp ORDER BY time;
@@ -1031,7 +1030,7 @@ psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of rang
 -- our supported range of values for time is smaller then postgres
 \set ON_ERROR_STOP 0
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:165: ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
 -- transformation would be out of range
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1000d',time) < '294276-01-01'::timestamptz ORDER BY time;
@@ -1050,7 +1049,6 @@ psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of rang
          Filter: (time_bucket('@ 1000 days'::interval, "time") < 'Sat Jan 01 00:00:00 294276 PST'::timestamp with time zone)
 (11 rows)
 
-RESET client_min_messages;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1581,10 +1579,10 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, ARRAY[NULL::int]);
 psql:include/plan_expand_hypertable_chunks_in_query.sql:40: ERROR:  chunk id can't be NULL
 \set ECHO errors
-psql:include/plan_expand_hypertable_query.sql:157: ERROR:  timestamp out of range
-psql:include/plan_expand_hypertable_query.sql:157: STATEMENT:  SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
-psql:include/plan_expand_hypertable_query.sql:166: ERROR:  timestamp out of range
-psql:include/plan_expand_hypertable_query.sql:166: STATEMENT:  SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
+psql:include/plan_expand_hypertable_query.sql:156: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:156: STATEMENT:  SELECT * FROM metrics_timestamp WHERE time_bucket('1d',time) < '294276-01-01'::timestamp ORDER BY time;
+psql:include/plan_expand_hypertable_query.sql:165: ERROR:  timestamp out of range
+psql:include/plan_expand_hypertable_query.sql:165: STATEMENT:  SELECT * FROM metrics_timestamptz WHERE time_bucket('1d',time) < '294276-01-01'::timestamptz ORDER BY time;
 682a683,754
 >            time           
 > --------------------------

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -147,7 +147,6 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT * FROM hyper WHERE 11::bigint > time_bucket(10, time) ORDER BY time;
 
 -- test overflow behaviour of time_bucket exclusion
-SET client_min_messages TO error;
 :PREFIX SELECT * FROM hyper WHERE time > 950 AND time_bucket(10, time) < '9223372036854775807'::bigint ORDER BY time;
 
 -- test timestamp upper boundary
@@ -167,8 +166,6 @@ SET client_min_messages TO error;
 \set ON_ERROR_STOP 1
 -- transformation would be out of range
 :PREFIX SELECT * FROM metrics_timestamptz WHERE time_bucket('1000d',time) < '294276-01-01'::timestamptz ORDER BY time;
-
-RESET client_min_messages;
 
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 100 ORDER BY time;
 :PREFIX SELECT * FROM hyper WHERE time_bucket(10, time) > 10 AND time_bucket(10, time) < 20 ORDER BY time;


### PR DESCRIPTION
Change the time_bucket chunk exclusion to not use expressions
to construct the upper boundary but instead generate a Const
with the upper boundary. The previous approach with using expressions
made it harder to check cleanly for the existance of overflows
cause even though we could catch the error we would have a
catalog cache leak in the error path.