### PR TITLE
Fix release build warning

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2588,7 +2588,7 @@ process_create_trigger_start(ProcessUtilityArgs *args)
 	CreateTrigStmt *stmt = (CreateTrigStmt *) args->parsetree;
 	Cache *hcache;
 	Hypertable *ht;
-	ObjectAddress address;
+	ObjectAddress PG_USED_FOR_ASSERTS_ONLY address;
 
 	if (!stmt->row)
 		return false;


### PR DESCRIPTION
The address variable in process_create_trigger_start is only used
in an assert in debug builds so compiler will warn about this
variable in non-debug builds. This patch sets the unused attribute
for the variable to silence the warning.