### PR TITLE
Optimize getting the chunk_id in continuous aggs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ accidentally triggering the load of a previous DB version.**
 ## 1.3.0 (unreleased)
 
 **Minor Features**
+* #1193 Optimize getting the chunk_id in continuous aggs
 * #1130 Add support for cross datatype chunk exclusion for time types
 * #1112 Add support for window functions to gapfill
 * #1062 Make constraint aware append parallel safe

--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -46,7 +46,6 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.calculate_chunk_interval(
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunks_in(record RECORD, chunks INTEGER[]) RETURNS BOOL
 AS '@MODULE_PATHNAME@', 'ts_chunks_in' LANGUAGE C VOLATILE STRICT;
 
--- returns the chunk id for the chunk that would contain a given tuple, or NULL if no such chunk
--- currently exists in the hypertable. tuple must be of the hypertable's row type.
-CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_for_tuple(hypertable_id INTEGER, tuple ANYELEMENT) RETURNS INTEGER
-AS '@MODULE_PATHNAME@', 'ts_chunk_for_tuple' LANGUAGE C STABLE STRICT PARALLEL SAFE;
+--given a chunk's relid, return the id. Error out if not a chunk relid.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_id_from_relid(relid OID) RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_chunk_id_from_relid' LANGUAGE C STABLE STRICT PARALLEL SAFE;

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1098,51 +1098,38 @@ BEGIN;
 (0 rows)
 
 ROLLBACK;
-CREATE TABLE chunk_for_tuple_test(time bigint, temp float8, device_id int);
-SELECT hypertable_id FROM create_hypertable('chunk_for_tuple_test', 'time', chunk_time_interval => 10) \gset
+CREATE TABLE chunk_id_from_relid_test(time bigint, temp float8, device_id int);
+SELECT hypertable_id FROM create_hypertable('chunk_id_from_relid_test', 'time', chunk_time_interval => 10) \gset
 NOTICE:  adding not-null constraint to column "time"
-INSERT INTO chunk_for_tuple_test VALUES (0, 1.1, 0), (0, 1.3, 11), (12, 2.0, 0), (12, 0.1, 11);
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, chunk_for_tuple_test.*) FROM chunk_for_tuple_test;
- chunk_for_tuple 
------------------
-              24
-              24
-              25
-              25
+INSERT INTO chunk_id_from_relid_test VALUES (0, 1.1, 0), (0, 1.3, 11), (12, 2.0, 0), (12, 0.1, 11);
+SELECT _timescaledb_internal.chunk_id_from_relid(tableoid) FROM chunk_id_from_relid_test;
+ chunk_id_from_relid 
+---------------------
+                  24
+                  24
+                  25
+                  25
 (4 rows)
 
-DROP TABLE chunk_for_tuple_test;
-CREATE TABLE chunk_for_tuple_test(time bigint, temp float8, device_id int);
-SELECT hypertable_id FROM  create_hypertable('chunk_for_tuple_test',
+DROP TABLE chunk_id_from_relid_test;
+CREATE TABLE chunk_id_from_relid_test(time bigint, temp float8, device_id int);
+SELECT hypertable_id FROM  create_hypertable('chunk_id_from_relid_test',
     'time', chunk_time_interval => 10,
     partitioning_column => 'device_id',
     number_partitions => 3) \gset
 NOTICE:  adding not-null constraint to column "time"
-INSERT INTO chunk_for_tuple_test VALUES (0, 1.1, 2), (0, 1.3, 11), (12, 2.0, 2), (12, 0.1, 11);
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, chunk_for_tuple_test.*) FROM chunk_for_tuple_test;
- chunk_for_tuple 
------------------
-              26
-              27
-              28
-              29
+INSERT INTO chunk_id_from_relid_test VALUES (0, 1.1, 2), (0, 1.3, 11), (12, 2.0, 2), (12, 0.1, 11);
+SELECT _timescaledb_internal.chunk_id_from_relid(tableoid) FROM chunk_id_from_relid_test;
+ chunk_id_from_relid 
+---------------------
+                  26
+                  27
+                  28
+                  29
 (4 rows)
 
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, _timescaledb_internal._hyper_8_28_chunk.*::chunk_for_tuple_test) FROM _timescaledb_internal._hyper_8_28_chunk;
- chunk_for_tuple 
------------------
-              28
-(1 row)
-
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, (33, 50.0, 3)::chunk_for_tuple_test);
-ERROR:  could not find chunk for tuple
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, 1) FROM chunk_for_tuple_test;
-ERROR:  input must be of the row type of the hypertable 'chunk_for_tuple_test'
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, _timescaledb_internal._hyper_8_28_chunk.*) FROM _timescaledb_internal._hyper_8_28_chunk;
-ERROR:  input must be of the row type of the hypertable 'chunk_for_tuple_test'
-SELECT _timescaledb_internal.chunk_for_tuple(-1, chunk_for_tuple_test.*) FROM chunk_for_tuple_test;
-ERROR:  hypertable -1 does not exist
-SELECT _timescaledb_internal.chunk_for_tuple(-1, _timescaledb_internal._hyper_8_28_chunk.*) FROM _timescaledb_internal._hyper_8_28_chunk;
-ERROR:  hypertable -1 does not exist
-\set ON_ERROR_STOP 1
+SELECT _timescaledb_internal.chunk_id_from_relid('pg_type'::regclass);
+ERROR:  chunk not found
+SELECT _timescaledb_internal.chunk_id_from_relid('chunk_id_from_relid_test'::regclass);
+ERROR:  chunk not found

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -347,31 +347,25 @@ BEGIN;
     SELECT * FROM test.show_subtables('drop_chunk_test_date');
 ROLLBACK;
 
-CREATE TABLE chunk_for_tuple_test(time bigint, temp float8, device_id int);
-SELECT hypertable_id FROM create_hypertable('chunk_for_tuple_test', 'time', chunk_time_interval => 10) \gset
+CREATE TABLE chunk_id_from_relid_test(time bigint, temp float8, device_id int);
+SELECT hypertable_id FROM create_hypertable('chunk_id_from_relid_test', 'time', chunk_time_interval => 10) \gset
 
-INSERT INTO chunk_for_tuple_test VALUES (0, 1.1, 0), (0, 1.3, 11), (12, 2.0, 0), (12, 0.1, 11);
+INSERT INTO chunk_id_from_relid_test VALUES (0, 1.1, 0), (0, 1.3, 11), (12, 2.0, 0), (12, 0.1, 11);
 
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, chunk_for_tuple_test.*) FROM chunk_for_tuple_test;
+SELECT _timescaledb_internal.chunk_id_from_relid(tableoid) FROM chunk_id_from_relid_test;
 
-DROP TABLE chunk_for_tuple_test;
+DROP TABLE chunk_id_from_relid_test;
 
-CREATE TABLE chunk_for_tuple_test(time bigint, temp float8, device_id int);
-SELECT hypertable_id FROM  create_hypertable('chunk_for_tuple_test',
+CREATE TABLE chunk_id_from_relid_test(time bigint, temp float8, device_id int);
+SELECT hypertable_id FROM  create_hypertable('chunk_id_from_relid_test',
     'time', chunk_time_interval => 10,
     partitioning_column => 'device_id',
     number_partitions => 3) \gset
 
-INSERT INTO chunk_for_tuple_test VALUES (0, 1.1, 2), (0, 1.3, 11), (12, 2.0, 2), (12, 0.1, 11);
+INSERT INTO chunk_id_from_relid_test VALUES (0, 1.1, 2), (0, 1.3, 11), (12, 2.0, 2), (12, 0.1, 11);
 
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, chunk_for_tuple_test.*) FROM chunk_for_tuple_test;
-
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, _timescaledb_internal._hyper_8_28_chunk.*::chunk_for_tuple_test) FROM _timescaledb_internal._hyper_8_28_chunk;
+SELECT _timescaledb_internal.chunk_id_from_relid(tableoid) FROM chunk_id_from_relid_test;
 
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, (33, 50.0, 3)::chunk_for_tuple_test);
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, 1) FROM chunk_for_tuple_test;
-SELECT _timescaledb_internal.chunk_for_tuple(:hypertable_id, _timescaledb_internal._hyper_8_28_chunk.*) FROM _timescaledb_internal._hyper_8_28_chunk;
-SELECT _timescaledb_internal.chunk_for_tuple(-1, chunk_for_tuple_test.*) FROM chunk_for_tuple_test;
-SELECT _timescaledb_internal.chunk_for_tuple(-1, _timescaledb_internal._hyper_8_28_chunk.*) FROM _timescaledb_internal._hyper_8_28_chunk;
-\set ON_ERROR_STOP 1
+SELECT _timescaledb_internal.chunk_id_from_relid('pg_type'::regclass);
+SELECT _timescaledb_internal.chunk_id_from_relid('chunk_id_from_relid_test'::regclass);


### PR DESCRIPTION
We replace chunk_for_tuple with chunk_id_from_relid for getting
chunk id fields when materializing continuous aggs. The old
function required passing in the entire row. This was very slow
because a lot of data was passed around at execution time.

The new function just uses the internal `tableoid` attribute to
convert the table relid to a chunk_id. This is much more efficient.
We also add memoization to the new function because it is most often
called consecutively for the same chunk.