### PR TITLE
Fix sanitizer and release tests [Merge into 1.3.x]

### DIFF
--- a/scripts/test_sanitizers.sh
+++ b/scripts/test_sanitizers.sh
@@ -90,11 +90,10 @@ docker exec timescaledb-san /bin/bash -c "mkdir /tsdb_build && chown postgres /t
 docker exec -u postgres timescaledb-san /bin/bash -c "cp -R /timescaledb tsdb_build"
 
 docker exec -u postgres \
-    -e CFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
-    -e CMAKE_BUILD_TYPE="Debug" \
+    -e CFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -O2" \
     -e PG_SOURCE_DIR="/usr/src/postgresql/" \
     timescaledb-san /bin/bash -c \
-    "cd /tsdb_build/timescaledb && BUILD_FORCE_REMOVE=true ./bootstrap -DTEST_GROUP_SIZE=1 && cd build && make"
+    "cd /tsdb_build/timescaledb && BUILD_FORCE_REMOVE=true ./bootstrap -DCMAKE_BUILD_TYPE='Debug' -DTEST_GROUP_SIZE=1 && cd build && make"
 
 wait_for_pg timescaledb-san
 
@@ -107,4 +106,5 @@ echo "Testing"
 docker exec -u postgres \
     timescaledb-san /bin/bash -c \
     "cd /tsdb_build/timescaledb/build \
-        && PATH=\$PATH make -k regresscheck regresscheck-t"
+        && PATH=\$PATH make -k regresscheck regresscheck-t \
+            IGNORES='bgw_db_scheduler bgw_launcher continuous_aggs_ddl-11'"

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -1,21 +1,20 @@
 set(TEST_FILES
-    continuous_aggs_materialize.sql
+    continuous_aggs_dump.sql
+    continuous_aggs_errors.sql
+    continuous_aggs_usage.sql
     continuous_aggs_watermark.sql
     edition.sql
     gapfill.sql
     reorder.sql
     partialize_finalize.sql
-    ddl_hook.sql
-    continuous_aggs.sql
-    continuous_aggs_errors.sql
-    continuous_aggs_dump.sql
-    continuous_aggs_usage.sql
 )
 
 set(TEST_FILES_DEBUG
-    continuous_aggs_bgw
     bgw_policy.sql
     bgw_reorder_drop_chunks.sql
+    continuous_aggs.sql
+    continuous_aggs_bgw.sql
+    continuous_aggs_materialize.sql
     ddl_hook.sql
     tsl_tables.sql
 )


### PR DESCRIPTION
We were not building timescaledb with debug enabled in the sanitizer
tests, causing tests which needed debug symbols to fail. This commit
changes the sanitizer tests to include such symbols. We still enable
optimizations, as that results in more realistic build environment for
memory tests.
This commit also ensures some tests which should only be run in debug
builds are in fact only run in debug builds.