### PR TITLE
 Fix cascade in scheduled drop chunks, and allow scheduled drop_chunks to cascade to aggs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #1115 Fix ordered append optimization for join queries
 * #1132 Adjust ordered append path cost
+* #1195 Fix cascade in scheduled drop chunks
 
 **Thanks**
 * @spickman for reporting a segfault with ordered append and JOINs

--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -21,7 +21,8 @@ INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedul
 (1, 'Telemetry Reporter', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h')
 ON CONFLICT (id) DO NOTHING;
 
-CREATE OR REPLACE FUNCTION add_drop_chunks_policy(hypertable REGCLASS, older_than INTERVAL, cascade BOOL = FALSE, if_not_exists BOOL = false) RETURNS INTEGER
+CREATE OR REPLACE FUNCTION add_drop_chunks_policy(hypertable REGCLASS, older_than INTERVAL, cascade BOOL = FALSE, if_not_exists BOOL = false, cascade_to_materializations BOOL = false)
+RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_add_drop_chunks_policy'
 LANGUAGE C VOLATILE STRICT;
 

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -198,7 +198,8 @@ CREATE TABLE IF NOT EXISTS _timescaledb_config.bgw_policy_drop_chunks (
     job_id          		INTEGER     PRIMARY KEY REFERENCES _timescaledb_config.bgw_job(id) ON DELETE CASCADE,
     hypertable_id   		INTEGER     UNIQUE NOT NULL REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE,
 	older_than				INTERVAL    NOT NULL,
-	cascade					BOOLEAN
+	cascade					BOOLEAN,
+    cascade_to_materializations BOOLEAN
 );
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_policy_drop_chunks', '');
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -99,3 +99,11 @@ LANGUAGE C STABLE PARALLEL SAFE;
 ALTER TABLE  _timescaledb_config.bgw_job
 DROP CONSTRAINT valid_job_type,
 ADD CONSTRAINT valid_job_type CHECK (job_type IN ('telemetry_and_version_check_if_enabled', 'reorder', 'drop_chunks', 'continuous_aggregate'));
+
+ALTER TABLE _timescaledb_config.bgw_policy_drop_chunks
+  ADD COLUMN cascade_to_materializations BOOLEAN;
+DROP FUNCTION IF EXISTS add_drop_chunks_policy(REGCLASS, INTERVAL, BOOL, BOOL);
+CREATE OR REPLACE FUNCTION add_drop_chunks_policy(hypertable REGCLASS, older_than INTERVAL, cascade BOOL = FALSE, if_not_exists BOOL = false, cascade_to_materializations BOOL = false)
+RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_add_drop_chunks_policy'
+LANGUAGE C VOLATILE STRICT;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -31,7 +31,7 @@ CREATE OR REPLACE VIEW timescaledb_information.license AS
 
 CREATE OR REPLACE VIEW timescaledb_information.drop_chunks_policies as
   SELECT format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as hypertable, p.older_than, p.cascade, p.job_id, j.schedule_interval,
-    j.max_runtime, j.max_retries, j.retry_period
+    j.max_runtime, j.max_retries, j.retry_period, p.cascade_to_materializations
   FROM _timescaledb_config.bgw_policy_drop_chunks p
     INNER JOIN _timescaledb_catalog.hypertable ht ON p.hypertable_id = ht.id
     INNER JOIN _timescaledb_config.bgw_job j ON p.job_id = j.id;

--- a/src/bgw_policy/drop_chunks.c
+++ b/src/bgw_policy/drop_chunks.c
@@ -122,7 +122,7 @@ ts_bgw_policy_drop_chunks_insert_with_relation(Relation rel, BgwPolicyDropChunks
 	values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_older_than)] =
 		IntervalPGetDatum(&policy->fd.older_than);
 	values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade)] =
-		BoolGetDatum(&policy->fd.cascade);
+		BoolGetDatum(policy->fd.cascade);
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_insert_values(rel, tupdesc, values, nulls);

--- a/src/bgw_policy/drop_chunks.c
+++ b/src/bgw_policy/drop_chunks.c
@@ -42,13 +42,13 @@ ts_bgw_policy_drop_chunks_delete_row_only_by_job_id(int32 job_id)
 	ScanKeyData scankey[1];
 
 	ScanKeyInit(&scankey[0],
-				Anum_bgw_policy_drop_chunks_pkey_idx_job_id,
+				Anum_bgw_policy_drop_chunks_pkey_job_id,
 				BTEqualStrategyNumber,
 				F_INT4EQ,
 				Int32GetDatum(job_id));
 
 	return ts_catalog_scan_one(BGW_POLICY_DROP_CHUNKS,
-							   BGW_POLICY_DROP_CHUNKS_PKEY_IDX,
+							   BGW_POLICY_DROP_CHUNKS_PKEY,
 							   scankey,
 							   1,
 							   ts_bgw_policy_delete_row_only_tuple_found,
@@ -64,13 +64,13 @@ ts_bgw_policy_drop_chunks_find_by_job(int32 job_id)
 	BgwPolicyDropChunks *ret = NULL;
 
 	ScanKeyInit(&scankey[0],
-				Anum_bgw_policy_drop_chunks_pkey_idx_job_id,
+				Anum_bgw_policy_drop_chunks_pkey_job_id,
 				BTEqualStrategyNumber,
 				F_INT4EQ,
 				Int32GetDatum(job_id));
 
 	ts_catalog_scan_one(BGW_POLICY_DROP_CHUNKS,
-						BGW_POLICY_DROP_CHUNKS_PKEY_IDX,
+						BGW_POLICY_DROP_CHUNKS_PKEY,
 						scankey,
 						1,
 						bgw_policy_drop_chunks_tuple_found,
@@ -88,13 +88,13 @@ ts_bgw_policy_drop_chunks_find_by_hypertable(int32 hypertable_id)
 	BgwPolicyDropChunks *ret = NULL;
 
 	ScanKeyInit(&scankey[0],
-				Anum_bgw_policy_drop_chunks_hypertable_id_idx_hypertable_id,
+				Anum_bgw_policy_drop_chunks_hypertable_id_key_hypertable_id,
 				BTEqualStrategyNumber,
 				F_INT4EQ,
 				Int32GetDatum(hypertable_id));
 
 	ts_catalog_scan_one(BGW_POLICY_DROP_CHUNKS,
-						BGW_POLICY_DROP_CHUNKS_HYPERTABLE_ID_IDX,
+						BGW_POLICY_DROP_CHUNKS_HYPERTABLE_ID_KEY,
 						scankey,
 						1,
 						bgw_policy_drop_chunks_tuple_found,
@@ -123,6 +123,8 @@ ts_bgw_policy_drop_chunks_insert_with_relation(Relation rel, BgwPolicyDropChunks
 		IntervalPGetDatum(&policy->fd.older_than);
 	values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade)] =
 		BoolGetDatum(policy->fd.cascade);
+	values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade_to_materializations)] =
+		BoolGetDatum(policy->fd.cascade_to_materializations);
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_insert_values(rel, tupdesc, values, nulls);

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -179,8 +179,8 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 	[BGW_POLICY_DROP_CHUNKS] = {
 		.length = _MAX_BGW_POLICY_DROP_CHUNKS_INDEX,
 		.names = (char *[]) {
-			[BGW_POLICY_DROP_CHUNKS_PKEY_IDX] = "bgw_policy_drop_chunks_pkey",
-			[BGW_POLICY_DROP_CHUNKS_HYPERTABLE_ID_IDX] = "bgw_policy_drop_chunks_hypertable_id_key",
+			[BGW_POLICY_DROP_CHUNKS_PKEY] = "bgw_policy_drop_chunks_pkey",
+			[BGW_POLICY_DROP_CHUNKS_HYPERTABLE_ID_KEY] = "bgw_policy_drop_chunks_hypertable_id_key",
 		},
 	},
 	[BGW_POLICY_CHUNK_STATS] = {

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -683,17 +683,21 @@ typedef struct FormData_bgw_policy_reorder_hypertable_id_idx
 	int32 hypertable_id;
 } FormData_bgw_policy_reorder_hypertable_id_idx;
 
-/****** BGW_POLICY_DROP_CHUNKS TABLE definitions */
+/******************************************
+ *
+ * bgw_policy_drop_chunks table definitions
+ *
+ ******************************************/
 #define BGW_POLICY_DROP_CHUNKS_TABLE_NAME "bgw_policy_drop_chunks"
-
-enum Anum_bgw_policy_drop_chunks
+typedef enum Anum_bgw_policy_drop_chunks
 {
 	Anum_bgw_policy_drop_chunks_job_id = 1,
 	Anum_bgw_policy_drop_chunks_hypertable_id,
 	Anum_bgw_policy_drop_chunks_older_than,
 	Anum_bgw_policy_drop_chunks_cascade,
+	Anum_bgw_policy_drop_chunks_cascade_to_materializations,
 	_Anum_bgw_policy_drop_chunks_max,
-};
+} Anum_bgw_policy_drop_chunks;
 
 #define Natts_bgw_policy_drop_chunks (_Anum_bgw_policy_drop_chunks_max - 1)
 
@@ -703,38 +707,33 @@ typedef struct FormData_bgw_policy_drop_chunks
 	int32 hypertable_id;
 	Interval older_than;
 	bool cascade;
+	bool cascade_to_materializations;
 } FormData_bgw_policy_drop_chunks;
 
 typedef FormData_bgw_policy_drop_chunks *Form_bgw_policy_drop_chunks;
 
 enum
 {
-	BGW_POLICY_DROP_CHUNKS_PKEY_IDX = 0,
-	BGW_POLICY_DROP_CHUNKS_HYPERTABLE_ID_IDX,
+	BGW_POLICY_DROP_CHUNKS_HYPERTABLE_ID_KEY = 0,
+	BGW_POLICY_DROP_CHUNKS_PKEY,
 	_MAX_BGW_POLICY_DROP_CHUNKS_INDEX,
 };
-
-enum Anum_bgw_policy_drop_chunks_pkey_idx
+typedef enum Anum_bgw_policy_drop_chunks_hypertable_id_key
 {
-	Anum_bgw_policy_drop_chunks_pkey_idx_job_id = 1,
-	_Anum_bgw_policy_drop_chunks_pkey_idx_max,
-};
+	Anum_bgw_policy_drop_chunks_hypertable_id_key_hypertable_id = 1,
+	_Anum_bgw_policy_drop_chunks_hypertable_id_key_max,
+} Anum_bgw_policy_drop_chunks_hypertable_id_key;
 
-typedef struct FormData_bgw_policy_drop_chunks_pkey_idx
-{
-	int32 job_id;
-} FormData_bgw_policy_drop_chunks_pkey_idx;
+#define Natts_bgw_policy_drop_chunks_hypertable_id_key                                             \
+	(_Anum_bgw_policy_drop_chunks_hypertable_id_key_max - 1)
 
-enum Anum_bgw_policy_drop_chunks_hypertable_id_idx
+typedef enum Anum_bgw_policy_drop_chunks_pkey
 {
-	Anum_bgw_policy_drop_chunks_hypertable_id_idx_hypertable_id = 1,
-	_Anum_bgw_policy_drop_chunks_hypertable_id_idx_max,
-};
+	Anum_bgw_policy_drop_chunks_pkey_job_id = 1,
+	_Anum_bgw_policy_drop_chunks_pkey_max,
+} Anum_bgw_policy_drop_chunks_pkey;
 
-typedef struct FormData_bgw_policy_drop_chunks_hypertable_id_idx
-{
-	int32 hypertable_id;
-} FormData_bgw_policy_drop_chunks_hypertable_id_idx;
+#define Natts_bgw_policy_drop_chunks_pkey (_Anum_bgw_policy_drop_chunks_pkey_max - 1)
 
 /****** BGW_POLICY_CHUNK_STATS TABLE definitions */
 #define BGW_POLICY_CHUNK_STATS_TABLE_NAME "bgw_policy_chunk_stats"

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -67,11 +67,13 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	Interval *older_than = PG_GETARG_INTERVAL_P(1);
 	bool cascade = PG_GETARG_BOOL(2);
 	bool if_not_exists = PG_GETARG_BOOL(3);
+	bool cascade_to_materializations = PG_GETARG_BOOL(4);
 
 	BgwPolicyDropChunks policy = { .fd = {
 									   .hypertable_id = ts_hypertable_relid_to_id(ht_oid),
 									   .older_than = *older_than,
 									   .cascade = cascade,
+									   .cascade_to_materializations = cascade_to_materializations,
 								   } };
 
 	license_enforce_enterprise_enabled();
@@ -103,7 +105,8 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 		if (!DatumGetBool(DirectFunctionCall2(interval_eq,
 											  IntervalPGetDatum(&existing->fd.older_than),
 											  IntervalPGetDatum(older_than))) ||
-			(existing->fd.cascade != cascade))
+			(existing->fd.cascade != cascade) ||
+			(existing->fd.cascade_to_materializations != cascade_to_materializations))
 		{
 			elog(WARNING,
 				 "could not add drop_chunks policy due to existing policy on hypertable with "

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -172,7 +172,7 @@ execute_drop_chunks_policy(int32 job_id)
 							INTERVALOID,
 							InvalidOid,
 							args->fd.cascade,
-							false,
+							args->fd.cascade_to_materializations,
 							LOG);
 	elog(LOG, "completed dropping chunks");
 

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -60,8 +60,8 @@ SELECT * FROM _timescaledb_config.bgw_job;
 (0 rows)
 
 SELECT * FROM timescaledb_information.drop_chunks_policies;
- hypertable | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period 
-------------+------------+---------+--------+-------------------+-------------+-------------+--------------
+ hypertable | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
+------------+------------+---------+--------+-------------------+-------------+-------------+--------------+-----------------------------
 (0 rows)
 
 SELECT * FROM timescaledb_information.reorder_policies;
@@ -297,7 +297,7 @@ SELECT indexrelid::regclass, indisclustered
  _timescaledb_internal._hyper_1_3_chunk_test_reorder_table_time_idx | t
 (3 rows)
 
---check that views work correctly 
+--check that views work correctly
 SELECT * FROM timescaledb_information.reorder_policies;
      hypertable     |    hypertable_index_name    | job_id | schedule_interval | max_runtime | max_retries | retry_period 
 --------------------+-----------------------------+--------+-------------------+-------------+-------------+--------------
@@ -422,9 +422,9 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
-   1001 |             2 | @ 4 mons   | f
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+   1001 |             2 | @ 4 mons   | f       | f
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
@@ -582,9 +582,9 @@ SELECT show_chunks('test_drop_chunks_table');
 
 --test that views work
 SELECT * FROM timescaledb_information.drop_chunks_policies;
-       hypertable       | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period 
-------------------------+------------+---------+--------+-------------------+-------------+-------------+--------------
- test_drop_chunks_table | @ 4 mons   | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+       hypertable       | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
+------------------------+------------+---------+--------+-------------------+-------------+-------------+--------------+-----------------------------
+ test_drop_chunks_table | @ 4 mons   | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours   | f
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;
@@ -592,4 +592,65 @@ SELECT * FROM timescaledb_information.policy_stats;
 ------------------------+--------+-------------+------------------+------------------------------+------------------------------+------------------------------+------------+----------------
  test_drop_chunks_table |   1001 | drop_chunks | t                | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:02 1999 PST |          2 |              0
 (1 row)
+
+-- continuous aggregate blocks drop_chunks
+INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '12 months', 0);
+CREATE VIEW tdc_view
+  WITH (timescaledb.continuous)
+  AS SELECT time_bucket('1 hour', time), count(drop_order)
+     FROM test_drop_chunks_table
+     GROUP BY 1;
+NOTICE:  adding not-null constraint to column "time_partition_col"
+SELECT show_chunks('test_drop_chunks_table');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(4 rows)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(10000, 10000);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                        msg                         
+--------+-----------+------------------+----------------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
+      0 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
+      0 |     50000 | DB Scheduler     | [TESTING] Wait until 1000000, started at 50000
+      1 |   1000000 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |   1000000 | DB Scheduler     | [TESTING] Wait until 10050000, started at 1000000
+      0 |  10050000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |  10050000 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |  10050000 | DB Scheduler     | [TESTING] Wait until 20050000, started at 10050000
+(9 rows)
+
+SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
+  id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
+------+----------------------------+-------------+-------------------+-------------+-------------+--------------
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+(1 row)
+
+-- should now have a failure
+SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+    FROM _timescaledb_internal.bgw_job_stat
+    where job_id=:drop_chunks_job_id;
+ job_id |           next_start            |           until_next            | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+---------------------------------+---------------------------------+------------------+------------+-----------------+----------------+---------------
+   1001 | Fri Dec 31 16:00:15.05 1999 PST | Fri Dec 31 16:00:10.05 1999 PST | f                |          3 |               2 |              1 |             0
+(1 row)
+
+SELECT show_chunks('test_drop_chunks_table');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(4 rows)
 

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -424,7 +424,7 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
  job_id | hypertable_id | older_than | cascade 
 --------+---------------+------------+---------
-   1001 |             2 | @ 4 mons   | t
+   1001 |             2 | @ 4 mons   | f
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
@@ -584,7 +584,7 @@ SELECT show_chunks('test_drop_chunks_table');
 SELECT * FROM timescaledb_information.drop_chunks_policies;
        hypertable       | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period 
 ------------------------+------------+---------+--------+-------------------+-------------+-------------+--------------
- test_drop_chunks_table | @ 4 mons   | t       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+ test_drop_chunks_table | @ 4 mons   | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -168,6 +168,12 @@ WARNING:  could not add drop_chunks policy due to existing policy on hypertable 
                      -1
 (1 row)
 
+select * from _timescaledb_config.bgw_policy_drop_chunks;
+ job_id | hypertable_id | older_than | cascade 
+--------+---------------+------------+---------
+   1002 |             1 | @ 3 mons   | t
+(1 row)
+
 \set ON_ERROR_STOP 0
 select add_drop_chunks_policy('test_table', INTERVAL '3 month', false);
 ERROR:  drop chunks policy already exists for hypertable "test_table"
@@ -231,7 +237,7 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 month');
 select * from _timescaledb_config.bgw_policy_drop_chunks;
  job_id | hypertable_id | older_than | cascade 
 --------+---------------+------------+---------
-   1003 |             1 | @ 3 mons   | t
+   1003 |             1 | @ 3 mons   | f
 (1 row)
 
 select remove_drop_chunks_policy('test_table');
@@ -470,8 +476,8 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 select * from _timescaledb_config.bgw_policy_drop_chunks;
  job_id | hypertable_id | older_than | cascade 
 --------+---------------+------------+---------
-   1008 |             3 | @ 2 days   | t
-   1009 |             4 | @ 1 day    | t
+   1008 |             3 | @ 2 days   | f
+   1009 |             4 | @ 1 day    | f
 (2 rows)
 
 DROP TABLE test_table;
@@ -484,7 +490,7 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 select * from _timescaledb_config.bgw_policy_drop_chunks;
  job_id | hypertable_id | older_than | cascade 
 --------+---------------+------------+---------
-   1009 |             4 | @ 1 day    | t
+   1009 |             4 | @ 1 day    | f
 (1 row)
 
 DROP TABLE test_table2;

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -17,8 +17,8 @@ AS :TSL_MODULE_PATHNAME, 'ts_test_bgw_job_delete_by_id'
 LANGUAGE C VOLATILE STRICT;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
 (0 rows)
 
 select * from _timescaledb_config.bgw_policy_reorder;
@@ -168,10 +168,17 @@ WARNING:  could not add drop_chunks policy due to existing policy on hypertable 
                      -1
 (1 row)
 
+select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true, cascade_to_materializations => true);
+WARNING:  could not add drop_chunks policy due to existing policy on hypertable with different arguments
+ add_drop_chunks_policy 
+------------------------
+                     -1
+(1 row)
+
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
-   1002 |             1 | @ 3 mons   | t
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+   1002 |             1 | @ 3 mons   | t       | f
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -183,11 +190,13 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 days');
 ERROR:  drop chunks policy already exists for hypertable "test_table"
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', true);
 ERROR:  drop chunks policy already exists for hypertable "test_table"
+select add_drop_chunks_policy('test_table', INTERVAL '3 days', cascade_to_materializations => true);
+ERROR:  drop chunks policy already exists for hypertable "test_table"
 \set ON_ERROR_STOP 1
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
-   1002 |             1 | @ 3 mons   | t
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+   1002 |             1 | @ 3 mons   | t       | f
 (1 row)
 
 select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
@@ -203,8 +212,8 @@ select remove_drop_chunks_policy('test_table');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
 (0 rows)
 
 select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
@@ -235,9 +244,9 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 month');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
-   1003 |             1 | @ 3 mons   | f
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+   1003 |             1 | @ 3 mons   | f       | f
 (1 row)
 
 select remove_drop_chunks_policy('test_table');
@@ -247,8 +256,8 @@ select remove_drop_chunks_policy('test_table');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
 (0 rows)
 
 -- Make sure remove works when there's nothing to remove
@@ -474,10 +483,10 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
-   1008 |             3 | @ 2 days   | f
-   1009 |             4 | @ 1 day    | f
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+   1008 |             3 | @ 2 days   | f       | f
+   1009 |             4 | @ 1 day    | f       | f
 (2 rows)
 
 DROP TABLE test_table;
@@ -488,9 +497,9 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
-   1009 |             4 | @ 1 day    | f
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+   1009 |             4 | @ 1 day    | f       | f
 (1 row)
 
 DROP TABLE test_table2;
@@ -500,8 +509,8 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (0 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
 (0 rows)
 
 -- Now test chunk_stat insertion

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -73,6 +73,8 @@ select add_drop_chunks_policy('test_table', INTERVAL '1 year', if_not_exists => 
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true);
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', true, if_not_exists => true);
 
+select * from _timescaledb_config.bgw_policy_drop_chunks;
+
 \set ON_ERROR_STOP 0
 select add_drop_chunks_policy('test_table', INTERVAL '3 month', false);
 select add_drop_chunks_policy('test_table', INTERVAL '1 year');

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -72,6 +72,7 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 month', false, true);
 select add_drop_chunks_policy('test_table', INTERVAL '1 year', if_not_exists => true);
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true);
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', true, if_not_exists => true);
+select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true, cascade_to_materializations => true);
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
 
@@ -80,6 +81,7 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 month', false);
 select add_drop_chunks_policy('test_table', INTERVAL '1 year');
 select add_drop_chunks_policy('test_table', INTERVAL '3 days');
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', true);
+select add_drop_chunks_policy('test_table', INTERVAL '3 days', cascade_to_materializations => true);
 \set ON_ERROR_STOP 1
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;


### PR DESCRIPTION
Before this PR, cascade was unconditionally set to true, as stored if the pointer to the inputted form data was non-null instead of the value stored within it. This PR changes that, so the intended setting for cascade is stored instead.

This PR also adds a `cascade_to_materializations` flag to the scheduled version of drop_chunks that behaves much like the one from manual `drop_chunks`: if a hypertable that has a continuous aggregate tries to drop chunks, and this flag is not set, the chunks will not be dropped