### PR TITLE
Fix UPSERT with prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ accidentally triggering the load of a previous DB version.**
 * #1115 Fix ordered append optimization for join queries
 * #1132 Adjust ordered append path cost
 * #1195 Fix cascade in scheduled drop chunks
+* #1196 Fix UPSERT with prepared statements
 
 **Thanks**
 * @spickman for reporting a segfault with ordered append and JOINs
 * @comicfans for reporting a performance regression with ordered append
+* @Specter-Y for reporting a segfault with UPSERT and prepared statements
 
 ## 1.2.2 (2019-03-14)
 

--- a/src/chunk_dispatch_state.c
+++ b/src/chunk_dispatch_state.c
@@ -158,17 +158,6 @@ chunk_dispatch_end(CustomScanState *node)
 	ExecEndNode(substate);
 	ts_chunk_dispatch_destroy(state->dispatch);
 	ts_cache_release(state->hypertable_cache);
-
-	/*
-	 * we need to restore arbiterIndexes list to it's original value
-	 * in case this gets turned into generic plan and skips the plan
-	 * creation for the next execution
-	 */
-#if PG96 || PG10
-	state->parent->mt_arbiterindexes = state->dispatch->arbiter_indexes;
-#else
-	((ModifyTable *) state->parent->ps.plan)->arbiterIndexes = state->dispatch->arbiter_indexes;
-#endif
 }
 
 static void
@@ -251,14 +240,6 @@ ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *
 	state->dispatch->returning_lists = mt_plan->returningLists;
 	state->dispatch->on_conflict = mt_plan->onConflictAction;
 	state->dispatch->on_conflict_set = mt_plan->onConflictSet;
-
-	/*
-	 * Save arbiterIndexes from the ModifyTable plan node because we
-	 * replace the list during execution with our modified version.
-	 * We restore it to it's original value after execution in
-	 * chunk_dispatch_end, this is required should this plan be
-	 * turned into a generic plan.
-	 */
 	state->dispatch->arbiter_indexes = mt_plan->arbiterIndexes;
 
 	Assert(mt_plan->onConflictWhere == NULL || IsA(mt_plan->onConflictWhere, List));

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -438,13 +438,40 @@ select * from cte;
 (2 rows)
 
 -- test ON CONFLICT with prepared statements
-CREATE TABLE prepared_test(time timestamptz PRIMARY KEY, value float);
+CREATE TABLE prepared_test(time timestamptz PRIMARY KEY, value float CHECK(value > 0));
 SELECT create_hypertable('prepared_test','time');
      create_hypertable      
 ----------------------------
  (7,public,prepared_test,t)
 (1 row)
 
+CREATE TABLE source_data(time timestamptz PRIMARY KEY, value float);
+INSERT INTO source_data VALUES('2000-01-01',0.5), ('2001-01-01',0.5);
+-- at some point PostgreSQL will turn the plan into a generic plan
+-- so we execute the prepared statement 10 times
+-- check that an error in the prepared statement does not lead to the plan becoming unusable
+PREPARE prep_insert_select AS INSERT INTO prepared_test select * from source_data ON CONFLICT (time) DO UPDATE SET value = EXCLUDED.value;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+EXECUTE prep_insert_select;
+--this insert will create an invalid tuple in source_data
+--so that future calls to prep_insert_select will fail
+INSERT INTO source_data VALUES('2000-01-02',-0.5);
+\set ON_ERROR_STOP 0
+EXECUTE prep_insert_select;
+ERROR:  new row for relation "_hyper_7_11_chunk" violates check constraint "prepared_test_value_check"
+EXECUTE prep_insert_select;
+ERROR:  new row for relation "_hyper_7_11_chunk" violates check constraint "prepared_test_value_check"
+\set ON_ERROR_STOP 1
+DELETE FROM source_data WHERE value <= 0;
+EXECUTE prep_insert_select;
 PREPARE prep_insert AS INSERT INTO prepared_test VALUES('2000-01-01',0.5) ON CONFLICT (time) DO UPDATE SET value = EXCLUDED.value;
 -- at some point PostgreSQL will turn the plan into a generic plan
 -- so we execute the prepared statement 10 times
@@ -462,7 +489,8 @@ SELECT * FROM prepared_test;
              time             | value 
 ------------------------------+-------
  Sat Jan 01 00:00:00 2000 PST |   0.5
-(1 row)
+ Mon Jan 01 00:00:00 2001 PST |   0.5
+(2 rows)
 
 DELETE FROM prepared_test;
 -- test ON CONFLICT with functions


### PR DESCRIPTION
When doing upsert with prepared statement the code to restore
arbiter_indexes would not trigger when an error occurred on the
INSERT leading to a segfault on the next EXECUTE of the prepared
statement.

Fixes #1165 