### PR TITLE
Suppress not-null notice when creating cont aggs

### DIFF
--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -347,7 +347,6 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
  json_object_field 
 -------------------

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1141,6 +1141,8 @@ mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input, int original_q
 			coltypmod = exprTypmod((Node *) tle->expr);
 			colcollation = exprCollation((Node *) tle->expr);
 			col = makeColumnDef(colname, coltype, coltypmod, colcollation);
+			if (timebkt_chk)
+				col->is_not_null = true;
 			part_te = (TargetEntry *) copyObject(input);
 		}
 		break;

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -600,7 +600,6 @@ CREATE VIEW tdc_view
   AS SELECT time_bucket('1 hour', time), count(drop_order)
      FROM test_drop_chunks_table
      GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT show_chunks('test_drop_chunks_table');
                show_chunks               
 -----------------------------------------

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -48,7 +48,6 @@ as
 select a, count(b)
 from foo
 group by time_bucket(1, a), a;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 NOTICE:  adding index _materialized_hypertable_2_a_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(a, time_partition_col)
 SELECT * FROM _timescaledb_config.bgw_job;
   id  |          application_name           |       job_type       | schedule_interval | max_runtime | max_retries | retry_period 
@@ -123,7 +122,6 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -198,7 +196,6 @@ select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by time_bucket('1week', timec) ;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -255,7 +252,6 @@ from conditions
 where location = 'NYC'
 group by time_bucket('1week', timec)
 ;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -309,7 +305,6 @@ min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by time_bucket('1week', timec)
 having stddev(humidity) is not null;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 ;
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -385,7 +380,6 @@ from conditions
 group by  time_bucket('1week', timec)
 having min(location) >= 'NYC' and avg(temperature) > 20
 ;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -498,7 +492,6 @@ SELECT
 \gset
 \set ECHO errors
 psql:include/cont_agg_equal.sql:8: NOTICE:  view "mat_test" does not exist, skipping
-psql:include/cont_agg_equal.sql:13: NOTICE:  adding not-null constraint to column "time_partition_col"
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
  Number of rows different between view and original (expect 0) |     0
@@ -514,7 +507,6 @@ SELECT
 \gset
 \set ECHO errors
 psql:include/cont_agg_equal.sql:8: NOTICE:  drop cascades to 2 other objects
-psql:include/cont_agg_equal.sql:13: NOTICE:  adding not-null constraint to column "time_partition_col"
 psql:include/cont_agg_equal.sql:13: NOTICE:  adding index _materialized_hypertable_13_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_13 USING BTREE(location, time_partition_col)
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
@@ -637,7 +629,6 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 \set ON_ERROR_STOP 0
 DROP TABLE conditions;
 ERROR:  cannot drop table conditions because other objects depend on it
@@ -759,7 +750,6 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec), location, humidity, temperature;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 NOTICE:  adding index _materialized_hypertable_17_grp_5_5_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING BTREE(grp_5_5, time_partition_col)
 NOTICE:  adding index _materialized_hypertable_17_grp_6_6_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING BTREE(grp_6_6, time_partition_col)
 NOTICE:  adding index _materialized_hypertable_17_grp_7_7_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_17 USING BTREE(grp_7_7, time_partition_col)
@@ -810,7 +800,6 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec), location, humidity, temperature;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 select indexname, indexdef from pg_indexes where tablename =
 (SELECT h.table_name
 FROM _timescaledb_catalog.continuous_agg ca
@@ -845,7 +834,6 @@ as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
  schedule_interval 
 -------------------
@@ -898,7 +886,6 @@ WITH (timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.refres
 AS SELECT time_bucket('4', time), COUNT(data)
    FROM space_table
    GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 INSERT INTO space_table VALUES
   (0, 1, 1), (0, 2, 1), (1, 1, 1), (1, 2, 1),
   (10, 1, 1), (10, 2, 1), (11, 1, 1), (11, 2, 1);
@@ -1024,7 +1011,6 @@ as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test'::text)
 from conditions
 group by time_bucket(100, timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 INFO:  new materialization range for public.conditions (time column timec) (400)
 INFO:  materializing continuous aggregate public.mat_ffunc_test: new range up to 400
@@ -1047,7 +1033,6 @@ as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigint '123')
 from conditions
 group by time_bucket(100, timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 INFO:  new materialization range for public.conditions (time column timec) (400)
 INFO:  materializing continuous aggregate public.mat_ffunc_test: new range up to 400

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -85,7 +85,6 @@ CREATE VIEW test_continuous_agg_view
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 -- even before running, stats shows something
 SELECT view_name, completed_threshold, invalidation_threshold, job_status, last_run_duration
     FROM timescaledb_information.continuous_aggregate_stats;
@@ -182,7 +181,6 @@ CREATE VIEW test_continuous_agg_view
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT job_id FROM _timescaledb_catalog.continuous_agg \gset
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
  ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -24,7 +24,6 @@ AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 GRANT select on mat_m1 to :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 select count(*) from mat_m1;
@@ -54,7 +53,6 @@ CREATE VIEW rename_test WITH ( timescaledb.continuous)
 AS SELECT time_bucket('1week', time), COUNT(data)
     FROM foo
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name |  partial_view_schema  | partial_view_name 
@@ -214,7 +212,6 @@ CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
@@ -359,7 +356,6 @@ CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_u_name

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -24,7 +24,6 @@ AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 GRANT select on mat_m1 to :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 select count(*) from mat_m1;
@@ -54,7 +53,6 @@ CREATE VIEW rename_test WITH ( timescaledb.continuous)
 AS SELECT time_bucket('1week', time), COUNT(data)
     FROM foo
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name |  partial_view_schema  | partial_view_name 
@@ -214,7 +212,6 @@ CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
@@ -359,7 +356,6 @@ CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_u_name

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -24,7 +24,6 @@ AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 GRANT select on mat_m1 to :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 select count(*) from mat_m1;
@@ -54,7 +53,6 @@ CREATE VIEW rename_test WITH ( timescaledb.continuous)
 AS SELECT time_bucket('1week', time), COUNT(data)
     FROM foo
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name |  partial_view_schema  | partial_view_name 
@@ -214,7 +212,6 @@ CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
@@ -359,7 +356,6 @@ CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
     GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_u_name

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -98,7 +98,6 @@ NOTICE:  view "mat_test" does not exist, skipping
 CREATE VIEW mat_before
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_BEFORE;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 NOTICE:  adding index _materialized_hypertable_3_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, time_partition_col)
 --materialize this VIEW after dump this tests
 --that the partialize VIEW and refresh mechanics
@@ -106,7 +105,6 @@ NOTICE:  adding index _materialized_hypertable_3_location_time_partition_col_idx
 CREATE VIEW mat_after
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_AFTER;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 NOTICE:  adding index _materialized_hypertable_4_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(location, time_partition_col)
 --materialize mat_before
 REFRESH MATERIALIZED VIEW mat_before;

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -360,7 +360,6 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT  h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
        partial_view_name as "PART_VIEW_NAME",
@@ -439,7 +438,6 @@ as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
-NOTICE:  adding not-null constraint to column "time_partition_col"
 \set ON_ERROR_STOP 0
 ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1h');
 ERROR:  parameter timescaledb.refresh_lag must be an integer for hypertables with integer time values
@@ -456,7 +454,6 @@ as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 -- custom time partition functions are not supported with invalidations
 CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
     AS $$ SELECT length($1)::BIGINT $$

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -624,7 +624,6 @@ CREATE VIEW test_t_mat_view
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_test_t
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT mat_hypertable_id, raw_hypertable_id, user_view_schema, user_view_name,
        partial_view_schema, partial_view_name,
        _timescaledb_internal.to_timestamp(bucket_width), _timescaledb_internal.to_interval(refresh_lag),
@@ -840,7 +839,6 @@ CREATE VIEW extreme_view
     AS SELECT time_bucket('1', time), SUM(data) as value
         FROM continuous_agg_extreme
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 --TODO this should be created as part of CREATE VIEW
 SELECT id as raw_table_id FROM _timescaledb_catalog.hypertable WHERE table_name='continuous_agg_extreme' \gset
 CREATE TRIGGER continuous_agg_insert_trigger
@@ -984,7 +982,6 @@ CREATE VIEW negative_view_5
     AS SELECT time_bucket('5', time), COUNT(data) as value
         FROM continuous_agg_negative
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 -- two chunks, 4 buckets
 INSERT INTO continuous_agg_negative
     SELECT i, i FROM generate_series(0, 11) AS i;
@@ -1076,7 +1073,6 @@ CREATE VIEW max_mat_view
     AS SELECT time_bucket('2', time), COUNT(data) as value
         FROM continuous_agg_max_mat
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 10) AS i;
 -- first run create two materializations
 REFRESH MATERIALIZED VIEW max_mat_view;
@@ -1148,7 +1144,6 @@ CREATE VIEW max_mat_view_t
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_max_mat_t
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 INSERT INTO continuous_agg_max_mat_t
     SELECT i, i FROM
         generate_series('2019-09-09 1:00'::TIMESTAMPTZ, '2019-09-09 10:00', '1 hour') AS i;
@@ -1221,7 +1216,6 @@ CREATE VIEW max_mat_view_timestamp
     AS SELECT time_bucket('2 hours', time)
         FROM continuous_agg_max_mat_timestamp
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 INSERT INTO continuous_agg_max_mat_timestamp
     SELECT generate_series('2019-09-09 1:00'::TIMESTAMPTZ, '2019-09-09 10:00', '1 hour');
 -- first materializes everything
@@ -1253,7 +1247,6 @@ CREATE VIEW max_mat_view_date
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 INSERT INTO continuous_agg_max_mat_date
     SELECT generate_series('2019-09-01'::DATE, '2019-09-010 10:00', '1 day');
 -- first materializes everything

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -39,7 +39,6 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket, device_id; --We have to group by the bucket column, but can also add other group-by columns
-NOTICE:  adding not-null constraint to column "time_partition_col"
 NOTICE:  adding index _materialized_hypertable_2_device_id_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(device_id, time_partition_col)
 --Next, insert some data into the raw hypertable
 INSERT INTO device_readings
@@ -237,7 +236,6 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket, device_id;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 NOTICE:  adding index _materialized_hypertable_3_device_id_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device_id, time_partition_col)
 DROP VIEW device_summary CASCADE;
 -- Option 2: Keep things as TIMESTAMPTZ in the view and convert to local time when
@@ -256,7 +254,6 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket, device_id;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 NOTICE:  adding index _materialized_hypertable_4_device_id_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, time_partition_col)
 REFRESH MATERIALIZED VIEW device_summary;
 INFO:  new materialization range for public.device_readings larger than allowed in one run, truncating (time column observation_time) (1546236000000000)

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -211,7 +211,6 @@ CREATE VIEW cit_view
     AS SELECT time_bucket('5', time), COUNT(time)
         FROM ca_inval_test
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 INSERT INTO ca_inval_test SELECT generate_series(0, 5);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
@@ -301,7 +300,6 @@ CREATE VIEW continuous_view
     AS SELECT time_bucket('5', time), COUNT(location)
         FROM ts_continuous_test
         GROUP BY 1;
-NOTICE:  adding not-null constraint to column "time_partition_col"
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
 ---------------+-----------


### PR DESCRIPTION
Add a not-null constraint to the time column on the materialization
table automatically. This suppresses the superfluous notices which
happens when creating continuous aggregates (and don't tell you much).