### PR TITLE
Add telemetry for policies: drop_chunk & reorder

### DIFF
--- a/src/bgw_policy/drop_chunks.c
+++ b/src/bgw_policy/drop_chunks.c
@@ -17,6 +17,7 @@
 #include "utils.h"
 #include "hypertable.h"
 #include "bgw/job.h"
+#include "scan_iterator.h"
 
 static ScanTupleResult
 bgw_policy_drop_chunks_tuple_found(TupleInfo *ti, void *const data)
@@ -140,4 +141,15 @@ ts_bgw_policy_drop_chunks_insert(BgwPolicyDropChunks *policy)
 
 	ts_bgw_policy_drop_chunks_insert_with_relation(rel, policy);
 	heap_close(rel, RowExclusiveLock);
+}
+
+TSDLLEXPORT int32
+ts_bgw_policy_drop_chunks_count()
+{
+	int32 count = 0;
+	ScanIterator iterator =
+		ts_scan_iterator_create(BGW_POLICY_DROP_CHUNKS, AccessShareLock, CurrentMemoryContext);
+	ts_scanner_foreach(&iterator) { count++; }
+
+	return count;
 }

--- a/src/bgw_policy/drop_chunks.h
+++ b/src/bgw_policy/drop_chunks.h
@@ -20,5 +20,6 @@ extern TSDLLEXPORT BgwPolicyDropChunks *
 ts_bgw_policy_drop_chunks_find_by_hypertable(int32 hypertable_id);
 extern TSDLLEXPORT void ts_bgw_policy_drop_chunks_insert(BgwPolicyDropChunks *policy);
 extern TSDLLEXPORT bool ts_bgw_policy_drop_chunks_delete_row_only_by_job_id(int32 job_id);
+extern TSDLLEXPORT int32 ts_bgw_policy_drop_chunks_count(void);
 
 #endif /* TIMESCALEDB_BGW_POLICY_DROP_CHUNKS_H */

--- a/src/bgw_policy/reorder.c
+++ b/src/bgw_policy/reorder.c
@@ -17,6 +17,7 @@
 #include "utils.h"
 #include "hypertable.h"
 #include "bgw/job.h"
+#include "scan_iterator.h"
 
 static ScanTupleResult
 bgw_policy_reorder_tuple_found(TupleInfo *ti, void *const data)
@@ -132,4 +133,15 @@ ts_bgw_policy_reorder_insert(BgwPolicyReorder *policy)
 
 	ts_bgw_policy_reorder_insert_with_relation(rel, policy);
 	heap_close(rel, RowExclusiveLock);
+}
+
+TSDLLEXPORT int32
+ts_bgw_policy_reorder_count()
+{
+	int32 count = 0;
+	ScanIterator iterator =
+		ts_scan_iterator_create(BGW_POLICY_REORDER, AccessShareLock, CurrentMemoryContext);
+	ts_scanner_foreach(&iterator) { count++; }
+
+	return count;
 }

--- a/src/bgw_policy/reorder.h
+++ b/src/bgw_policy/reorder.h
@@ -19,5 +19,6 @@ extern TSDLLEXPORT BgwPolicyReorder *ts_bgw_policy_reorder_find_by_job(int32 job
 extern TSDLLEXPORT BgwPolicyReorder *ts_bgw_policy_reorder_find_by_hypertable(int32 hypertable_id);
 extern TSDLLEXPORT void ts_bgw_policy_reorder_insert(BgwPolicyReorder *policy);
 extern TSDLLEXPORT bool ts_bgw_policy_reorder_delete_row_only_by_job_id(int32 job_id);
+extern TSDLLEXPORT int32 ts_bgw_policy_reorder_count(void);
 
 #endif /* TIMESCALEDB_BGW_POLICY_REORDER_H */

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -23,6 +23,8 @@
 #include "net/http.h"
 #include "jsonb_utils.h"
 #include "license_guc.h"
+#include "bgw_policy/drop_chunks.h"
+#include "bgw_policy/reorder.h"
 
 #include "cross_module_fn.h"
 
@@ -48,6 +50,8 @@
 #define REQ_DATA_VOLUME "data_volume"
 #define REQ_NUM_HYPERTABLES "num_hypertables"
 #define REQ_NUM_CONTINUOUS_AGGS "num_continuous_aggs"
+#define REQ_NUM_REORDER_POLICIES "num_reorder_policies"
+#define REQ_NUM_DROP_CHUNKS_POLICIES "num_drop_chunks_policies"
 #define REQ_RELATED_EXTENSIONS "related_extensions"
 #define REQ_TELEMETRY_METADATA "db_metadata"
 #define REQ_LICENSE_INFO "license"
@@ -174,6 +178,24 @@ get_num_continuous_aggs()
 }
 
 static char *
+get_num_drop_chunks_policies()
+{
+	StringInfo buf = makeStringInfo();
+
+	appendStringInfo(buf, "%d", ts_bgw_policy_drop_chunks_count());
+	return buf->data;
+}
+
+static char *
+get_num_reorder_policies()
+{
+	StringInfo buf = makeStringInfo();
+
+	appendStringInfo(buf, "%d", ts_bgw_policy_reorder_count());
+	return buf->data;
+}
+
+static char *
 get_database_size()
 {
 	StringInfo buf = makeStringInfo();
@@ -263,6 +285,8 @@ build_version_body(void)
 	ts_jsonb_add_str(parseState, REQ_DATA_VOLUME, get_database_size());
 	ts_jsonb_add_str(parseState, REQ_NUM_HYPERTABLES, get_num_hypertables());
 	ts_jsonb_add_str(parseState, REQ_NUM_CONTINUOUS_AGGS, get_num_continuous_aggs());
+	ts_jsonb_add_str(parseState, REQ_NUM_REORDER_POLICIES, get_num_reorder_policies());
+	ts_jsonb_add_str(parseState, REQ_NUM_DROP_CHUNKS_POLICIES, get_num_drop_chunks_policies());
 
 	/* Add related extensions, which is a nested JSON */
 	ext_key.type = jbvString;

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -285,8 +285,8 @@ WARNING:  telemetry could not connect to "noservice.timescale.com"
 SET timescaledb.telemetry_level=off;
 SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
 WHERE key != 'os_name_pretty';
-         key         
----------------------
+           key            
+--------------------------
  db_uuid
  license
  os_name
@@ -307,7 +307,9 @@ WHERE key != 'os_name_pretty';
  related_extensions
  num_continuous_aggs
  timescaledb_version
-(20 rows)
+ num_reorder_policies
+ num_drop_chunks_policies
+(22 rows)
 
 SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
  json_object_field 

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -98,8 +98,20 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
      5
 (1 row)
 
+SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
+ json_object_field 
+-------------------
+ "0"
+(1 row)
+
 select add_reorder_policy('test_reorder_table', 'test_reorder_table_time_idx') as reorder_job_id \gset
 WARNING:  Timescale License expired
+SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
+ json_object_field 
+-------------------
+ "1"
+(1 row)
+
 -- policy was created
 select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_id;
  job_id | hypertable_id |    hypertable_index_name    
@@ -413,8 +425,20 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
      5
 (1 row)
 
+SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
+ json_object_field 
+-------------------
+ "0"
+(1 row)
+
 SELECT add_drop_chunks_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
 WARNING:  Timescale License expired
+SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
+ json_object_field 
+-------------------
+ "1"
+(1 row)
+
 SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
              alter_job_schedule              
 ---------------------------------------------

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -76,7 +76,9 @@ INSERT INTO test_reorder_table VALUES (5, 5);
 
 SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_reorder_table';
 
+SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
 select add_reorder_policy('test_reorder_table', 'test_reorder_table_time_idx') as reorder_job_id \gset
+SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
 
 -- policy was created
 select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_id;
@@ -217,7 +219,9 @@ INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '8 months', 1);
 SELECT show_chunks('test_drop_chunks_table');
 SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_drop_chunks_table';
 
+SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
 SELECT add_drop_chunks_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
+SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
 
 SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
 


### PR DESCRIPTION
The commit will add telemetry for the number of drop_chunks and
reorder policies in the database. This will allow us to see
how much these features are used.