### PR TITLE
Fix partial view targetlist for continuous aggregates

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1142,9 +1142,12 @@ mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input, int original_q
 			coltypmod = exprTypmod((Node *) tle->expr);
 			colcollation = exprCollation((Node *) tle->expr);
 			col = makeColumnDef(colname, coltype, coltypmod, colcollation);
-			if (timebkt_chk)
-				col->is_not_null = true;
 			part_te = (TargetEntry *) copyObject(input);
+			if (timebkt_chk)
+			{
+				col->is_not_null = true;
+				part_te->resjunk = false; /* always project time_bucket column*/
+			}
 		}
 		break;
 		default:

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -1161,3 +1161,27 @@ WARNING:  type integer bigint
          100 |                              
 (3 rows)
 
+--refresh mat view test when time_bucket is not projected --
+drop view mat_ffunc_test cascade;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_68_chunk
+create or replace view mat_refresh_test
+WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+as
+select location, max(humidity) 
+from conditions
+group by time_bucket(100, timec), location;
+NOTICE:  adding index _materialized_hypertable_29_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_29 USING BTREE(location, time_partition_col)
+insert into conditions
+select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
+REFRESH MATERIALIZED VIEW mat_refresh_test;
+INFO:  new materialization range for public.conditions (time column timec) (400)
+INFO:  materializing continuous aggregate public.mat_refresh_test: new range up to 400
+SELECT * FROM mat_refresh_test order by 1,2 ;
+ location | max 
+----------+-----
+ NYC      |  75
+ POR      |  75
+ POR      |  75
+ POR      |  75
+(4 rows)
+

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -842,3 +842,19 @@ group by time_bucket(100, timec);
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 
 SELECT * FROM mat_ffunc_test;
+
+--refresh mat view test when time_bucket is not projected --
+drop view mat_ffunc_test cascade;
+create or replace view mat_refresh_test
+WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+as
+select location, max(humidity) 
+from conditions
+group by time_bucket(100, timec), location;
+
+insert into conditions
+select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
+
+REFRESH MATERIALIZED VIEW mat_refresh_test;
+SELECT * FROM mat_refresh_test order by 1,2 ;
+


### PR DESCRIPTION
The partial view should always project the time_bucket expression related
column as this is a special column for the materialization table. The partial
view failed to project it when the user query's SELECT targetlist did not
contain the time_bucket expression. The materialization fails in this
scenario.