### PR TITLE
Fix detecting JOINs for continuous aggs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+
+## 1.3.1 (unreleased)
+
+**Bugfixes**
+* #1220 Fix detecting JOINs for continuous aggs
+
+**Thanks**
+* @od0 for reporting an error with continuous aggs and JOINs
+
 ## 1.3.0 (2019-05-06)
 
 This release contains major new functionality that we call continuous aggregates.

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -743,12 +743,12 @@ cagg_validate_query(Query *query)
 	expression_tree_walker((Node *) query->havingQual, cagg_agg_validate, NULL);
 
 	fromList = query->jointree->fromlist;
-	if (list_length(fromList) != 1)
+	if (list_length(fromList) != 1 || !IsA(linitial(fromList), RangeTblRef))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("only 1 hypertable is permitted in SELECT query permitted for continuous "
-						"aggregate")));
+				 errmsg(
+					 "only 1 hypertable is permitted in SELECT query for continuous aggregate")));
 	}
 	/* check if we have a hypertable in the FROM clause */
 	rtref = linitial_node(RangeTblRef, query->jointree->fromlist);

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -35,14 +35,21 @@ as
 select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
 group by location;
-ERROR:  only 1 hypertable is permitted in SELECT query permitted for continuous aggregate
+ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
+-- join multiple tables WITH explicit JOIN
+create  view mat_m1 WITH ( timescaledb.continuous)
+as
+select location, count(*) from conditions JOIN mat_t1 ON true
+where conditions.location = mat_t1.c
+group by location;
+ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 -- LATERAL multiple tables
 create  view mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions,
 LATERAL (Select * from mat_t1 where c = conditions.location) q
 group by location;
-ERROR:  only 1 hypertable is permitted in SELECT query permitted for continuous aggregate
+ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 --non-hypertable
 create  view mat_m1 WITH ( timescaledb.continuous)
 as

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -35,6 +35,13 @@ select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
 group by location;
 
+-- join multiple tables WITH explicit JOIN
+create  view mat_m1 WITH ( timescaledb.continuous)
+as
+select location, count(*) from conditions JOIN mat_t1 ON true
+where conditions.location = mat_t1.c
+group by location;
+
 -- LATERAL multiple tables
 create  view mat_m1 WITH ( timescaledb.continuous)
 as


### PR DESCRIPTION
When explicit JOIN syntax is used the from list will contain a
JoinExpr instead of a list of RangeTblRef which was not detected
properly by cagg_validate_query. This patch adds a check for
RangeTblRef to the validation code.