### PR TITLE
Pass int64 using Int64GetDatum when a Datum is required

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -244,7 +244,7 @@ ts_time_value_to_internal_or_infinite(Datum time_val, Oid type_oid,
 		}
 		case DATEOID:
 		{
-			DateADT d = DatumGetTimestamp(time_val);
+			DateADT d = DatumGetDateADT(time_val);
 			if (DATE_NOT_FINITE(d))
 			{
 				if (DATE_IS_NOBEGIN(d))

--- a/test/src/test_time_to_internal.c
+++ b/test/src/test_time_to_internal.c
@@ -134,7 +134,7 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 											TIMESTAMPOID));
 
 	AssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
-				  ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID));
+				  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID)));
 	EnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID),
 										  TIMESTAMPOID));
 
@@ -163,7 +163,7 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 											TIMESTAMPTZOID));
 
 	AssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
-				  ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID));
+				  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID)));
 	EnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID),
 										  TIMESTAMPTZOID));
 
@@ -173,7 +173,7 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 					  ts_time_value_to_internal(ts_internal_to_time_value(i64, DATEOID), DATEOID));
 
 	EnsureError(ts_internal_to_time_value(PG_INT64_MIN, DATEOID));
-	AssertInt64Eq(106741034, ts_internal_to_time_value(PG_INT64_MAX, DATEOID));
+	AssertInt64Eq(106741034, DatumGetDateADT(ts_internal_to_time_value(PG_INT64_MAX, DATEOID)));
 
 	EnsureError(ts_time_value_to_internal((DATEVAL_NOBEGIN + 1), DATEOID));
 	EnsureError(ts_time_value_to_internal((DATEVAL_NOEND - 1), DATEOID));

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -233,15 +233,15 @@ create_cagg_catlog_entry(int32 matht_id, int32 rawht_id, char *user_schema, char
 		NameGetDatum(&partial_schnm);
 	values[AttrNumberGetAttrOffset(Anum_continuous_agg_partial_view_name)] =
 		NameGetDatum(&partial_viewnm);
-	values[AttrNumberGetAttrOffset(Anum_continuous_agg_bucket_width)] = bucket_width;
+	values[AttrNumberGetAttrOffset(Anum_continuous_agg_bucket_width)] = Int64GetDatum(bucket_width);
 	values[AttrNumberGetAttrOffset(Anum_continuous_agg_job_id)] = job_id;
-	values[AttrNumberGetAttrOffset(Anum_continuous_agg_refresh_lag)] = refresh_lag;
+	values[AttrNumberGetAttrOffset(Anum_continuous_agg_refresh_lag)] = Int64GetDatum(refresh_lag);
 	values[AttrNumberGetAttrOffset(Anum_continuous_agg_direct_view_schema)] =
 		NameGetDatum(&direct_schnm);
 	values[AttrNumberGetAttrOffset(Anum_continuous_agg_direct_view_name)] =
 		NameGetDatum(&direct_viewnm);
 	values[AttrNumberGetAttrOffset(Anum_continuous_agg_max_interval_per_job)] =
-		max_interval_per_job;
+		Int64GetDatum(max_interval_per_job);
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_insert_values(rel, desc, values, nulls);
@@ -265,7 +265,7 @@ cagg_create_hypertable(int32 hypertable_id, Oid mat_tbloid, const char *matpartc
 	namestrcpy(&mat_tbltimecol, matpartcolname);
 	time_dim_info = ts_dimension_info_create_open(mat_tbloid,
 												  &mat_tbltimecol,
-												  mat_tbltimecol_interval,
+												  Int64GetDatum(mat_tbltimecol_interval),
 												  INT8OID,
 												  InvalidOid);
 	// TODO fix this after change in C interface

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -917,9 +917,9 @@ time_range_internal_to_min_time_value(Oid type)
 	switch (type)
 	{
 		case TIMESTAMPOID:
-			return DatumGetTimestampTz(DT_NOBEGIN);
+			return TimestampGetDatum(DT_NOBEGIN);
 		case TIMESTAMPTZOID:
-			return DatumGetTimestampTz(DT_NOBEGIN);
+			return TimestampTzGetDatum(DT_NOBEGIN);
 		case DATEOID:
 			return DateADTGetDatum(DATEVAL_NOBEGIN);
 		default:
@@ -933,9 +933,9 @@ time_range_internal_to_max_time_value(Oid type)
 	switch (type)
 	{
 		case TIMESTAMPOID:
-			return DatumGetTimestampTz(DT_NOEND);
+			return TimestampGetDatum(DT_NOEND);
 		case TIMESTAMPTZOID:
-			return DatumGetTimestampTz(DT_NOEND);
+			return TimestampTzGetDatum(DT_NOEND);
 		case DATEOID:
 			return DateADTGetDatum(DATEVAL_NOEND);
 			break;

--- a/tsl/test/src/test_continuous_aggs.c
+++ b/tsl/test/src/test_continuous_aggs.c
@@ -24,7 +24,7 @@ ts_run_continuous_agg_materialization(PG_FUNCTION_ARGS)
 	Name partial_view_name = PG_GETARG_NAME(2);
 	Datum lowest_modified_value = PG_GETARG_DATUM(3);
 	Datum greatest_modified_value = PG_GETARG_DATUM(4);
-	Datum bucket_width = PG_GETARG_INT64(5);
+	Datum bucket_width = PG_GETARG_DATUM(5);
 	Name partial_view_schema = PG_GETARG_NAME(6);
 	Oid time_type = get_fn_expr_argtype(fcinfo->flinfo, 3);
 	int64 lmv = ts_time_value_to_internal(lowest_modified_value, time_type);


### PR DESCRIPTION
int64 should be passed to functions that take a Datum parameter using Int64GetDatum.
Depending on the platform, postgres either passes int64 by value or allocs a pointer
to hold this value.
Without this change, we get SEGV on raspberry pi.