### PR TITLE
Allow Param as time_bucket_gapfill arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #1220 Fix detecting JOINs for continuous aggs
+* #1232 Allow Param as time_bucket_gapfill arguments
 
 **Thanks**
 * @od0 for reporting an error with continuous aggs and JOINs
+* @rickbatka for reporting an error when using time_bucket_gapfill in functions
 
 ## 1.3.0 (2019-05-06)
 

--- a/tsl/src/gapfill/exec.c
+++ b/tsl/src/gapfill/exec.c
@@ -273,6 +273,7 @@ is_simple_expr_walker(Node *node, void *context)
 		case T_CoerceViaIO:
 		case T_CaseExpr:
 		case T_CaseWhen:
+		case T_Param:
 			break;
 		default:
 			return true;

--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -2447,6 +2447,93 @@ EXECUTE prep_gapfill;
 (6 rows)
 
 DEALLOCATE prep_gapfill;
+-- test prepared statement with variable gapfill arguments
+PREPARE prep_gapfill(int,int,int) AS
+SELECT
+  time_bucket_gapfill($1,time,$2,$3) AS time,
+  device_id,
+  sensor_id,
+  min(value)
+FROM metrics_int m1
+WHERE time >= $2 AND time < $3 AND device_id=1 AND sensor_id=1
+GROUP BY 1,2,3 ORDER BY 2,3,1;
+-- execute 10 times to make sure turning it into generic plan works
+EXECUTE prep_gapfill(5,0,10);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+    0 |         1 |         1 |   5
+    5 |         1 |         1 |    
+(2 rows)
+
+EXECUTE prep_gapfill(4,100,110);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+  100 |         1 |         1 |   0
+  104 |         1 |         1 |    
+  108 |         1 |         1 |    
+(3 rows)
+
+EXECUTE prep_gapfill(5,0,10);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+    0 |         1 |         1 |   5
+    5 |         1 |         1 |    
+(2 rows)
+
+EXECUTE prep_gapfill(4,100,110);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+  100 |         1 |         1 |   0
+  104 |         1 |         1 |    
+  108 |         1 |         1 |    
+(3 rows)
+
+EXECUTE prep_gapfill(5,0,10);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+    0 |         1 |         1 |   5
+    5 |         1 |         1 |    
+(2 rows)
+
+EXECUTE prep_gapfill(4,100,110);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+  100 |         1 |         1 |   0
+  104 |         1 |         1 |    
+  108 |         1 |         1 |    
+(3 rows)
+
+EXECUTE prep_gapfill(5,0,10);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+    0 |         1 |         1 |   5
+    5 |         1 |         1 |    
+(2 rows)
+
+EXECUTE prep_gapfill(4,100,110);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+  100 |         1 |         1 |   0
+  104 |         1 |         1 |    
+  108 |         1 |         1 |    
+(3 rows)
+
+EXECUTE prep_gapfill(5,0,10);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+    0 |         1 |         1 |   5
+    5 |         1 |         1 |    
+(2 rows)
+
+EXECUTE prep_gapfill(4,100,110);
+ time | device_id | sensor_id | min 
+------+-----------+-----------+-----
+  100 |         1 |         1 |   0
+  104 |         1 |         1 |    
+  108 |         1 |         1 |    
+(3 rows)
+
+DEALLOCATE prep_gapfill;
 -- test column references with TIME_COLUMN last
 SELECT
   row_number() OVER (PARTITION BY color),

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -1338,6 +1338,32 @@ EXECUTE prep_gapfill;
 
 DEALLOCATE prep_gapfill;
 
+-- test prepared statement with variable gapfill arguments
+PREPARE prep_gapfill(int,int,int) AS
+
+SELECT
+  time_bucket_gapfill($1,time,$2,$3) AS time,
+  device_id,
+  sensor_id,
+  min(value)
+FROM metrics_int m1
+WHERE time >= $2 AND time < $3 AND device_id=1 AND sensor_id=1
+GROUP BY 1,2,3 ORDER BY 2,3,1;
+
+-- execute 10 times to make sure turning it into generic plan works
+EXECUTE prep_gapfill(5,0,10);
+EXECUTE prep_gapfill(4,100,110);
+EXECUTE prep_gapfill(5,0,10);
+EXECUTE prep_gapfill(4,100,110);
+EXECUTE prep_gapfill(5,0,10);
+EXECUTE prep_gapfill(4,100,110);
+EXECUTE prep_gapfill(5,0,10);
+EXECUTE prep_gapfill(4,100,110);
+EXECUTE prep_gapfill(5,0,10);
+EXECUTE prep_gapfill(4,100,110);
+
+DEALLOCATE prep_gapfill;
+
 -- test column references with TIME_COLUMN last
 SELECT
   row_number() OVER (PARTITION BY color),


### PR DESCRIPTION
When using prepared statements or functions the arguments are turned
into Params when the plan is changed into a generic plan. This patch
allows Params as time_bucket_gapfill arguments so it can be used
in functions and prepared statements with variable time_bucket_gapfill
arguments.

Fixes #1231 