### PR TITLE
Add missing ORDER BY to test query

### DIFF
--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -40,18 +40,18 @@ COPY "two_Partitions"("timeCustom", device_id, series_0, series_1) FROM STDIN DE
 --new chunks
 COPY "two_Partitions"("timeCustom", device_id, series_0, series_1) FROM STDIN DELIMITER ',';
 \copy "two_Partitions"("timeCustom", device_id, series_0, series_1) FROM STDIN DELIMITER ',';
-COPY (SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id) TO STDOUT;
-1257894000000000000	dev1	1.5	2	\N	\N
+COPY (SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1) TO STDOUT;
 1257894000000000000	dev1	1.5	1	2	t
-1257894000000000000	dev2	1.5	2	\N	\N
+1257894000000000000	dev1	1.5	2	\N	\N
 1257894000000000000	dev2	1.5	1	\N	\N
+1257894000000000000	dev2	1.5	2	\N	\N
 1257894000000000000	dev3	1.5	2	\N	\N
 1257894000000000000	dev3	1.5	2	\N	\N
 1257894000000001000	dev1	2.5	3	\N	\N
 1257894001000000000	dev1	3.5	4	\N	\N
 1257894002000000000	dev1	2.5	3	\N	\N
-1257894002000000000	dev1	5.5	7	\N	f
 1257894002000000000	dev1	5.5	6	\N	t
+1257894002000000000	dev1	5.5	7	\N	f
 1257897600000000000	dev1	4.5	5	\N	f
 1257987600000000000	dev1	1.5	1	\N	\N
 1257987600000000000	dev1	1.5	2	\N	\N

--- a/test/expected/delete.out
+++ b/test/expected/delete.out
@@ -34,33 +34,33 @@ INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
 \set QUIET on
 \o
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000000000 | dev1      |      1.5 |        1 |        2 | t
  1257894000000000000 | dev1      |      1.5 |        2 |          | 
- 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000000000 | dev2      |      1.5 |        1 |          | 
+ 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
  1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
- 1257987600000000000 | dev1      |      1.5 |        2 |          | 
  1257987600000000000 | dev1      |      1.5 |        1 |          | 
+ 1257987600000000000 | dev1      |      1.5 |        2 |          | 
 (12 rows)
 
 DELETE FROM "two_Partitions" WHERE series_0 = 1.5;
 DELETE FROM "two_Partitions" WHERE series_0 = 100;
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
+ 1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
- 1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (6 rows)
 
@@ -203,20 +203,20 @@ WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series
                                  Index Cond: (series_1 > (series_val())::double precision)
 (91 rows)
 
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
+ 1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
- 1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (6 rows)
 
 DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000001000 | dev1      |      2.5 |        3 |          | 

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -165,21 +165,21 @@ SELECT * FROM _timescaledb_catalog.chunk;
   4 |             1 | _timescaledb_internal | _hyper_1_4_chunk
 (4 rows)
 
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000000000 | dev1      |      1.5 |        1 |        2 | t
  1257894000000000000 | dev1      |      1.5 |        2 |          | 
- 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000000000 | dev2      |      1.5 |        1 |          | 
+ 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
  1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
- 1257987600000000000 | dev1      |      1.5 |        2 |          | 
  1257987600000000000 | dev1      |      1.5 |        1 |          | 
+ 1257987600000000000 | dev1      |      1.5 |        2 |          | 
 (12 rows)
 
 SELECT * FROM ONLY "two_Partitions";

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -167,36 +167,36 @@ SELECT * FROM test.show_triggers('_timescaledb_internal._hyper_1_1_chunk');
  restore_trigger |    7 | test_trigger |  restore_trigger BEFORE INSERT ON _timescaledb_internal._hyper_1_1_chunk FOR EACH ROW EXECUTE PROCEDURE test_trigger()
 (1 row)
 
-SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000000000 | dev1      |      1.5 |        1 |        2 | t
  1257894000000000000 | dev1      |      1.5 |        2 |          | 
- 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000000000 | dev2      |      1.5 |        1 |          | 
+ 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
  1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
- 1257987600000000000 | dev1      |      1.5 |        2 |          | 
  1257987600000000000 | dev1      |      1.5 |        1 |          | 
+ 1257987600000000000 | dev1      |      1.5 |        2 |          | 
 (12 rows)
 
-SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id;
+SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000000000 | dev1      |      1.5 |        1 |        2 | t
  1257894000000000000 | dev1      |      1.5 |        2 |          | 
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
+ 1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
- 1257894002000000000 | dev1      |      2.5 |        3 |          | 
 (7 rows)
 
-SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id;
+SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
@@ -387,36 +387,36 @@ SELECT * FROM test.show_triggers('_timescaledb_internal._hyper_1_1_chunk');
 (1 row)
 
 --data should be the same
-SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000000000 | dev1      |      1.5 |        1 |        2 | t
  1257894000000000000 | dev1      |      1.5 |        2 |          | 
- 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000000000 | dev2      |      1.5 |        1 |          | 
+ 1257894000000000000 | dev2      |      1.5 |        2 |          | 
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
  1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
- 1257987600000000000 | dev1      |      1.5 |        2 |          | 
  1257987600000000000 | dev1      |      1.5 |        1 |          | 
+ 1257987600000000000 | dev1      |      1.5 |        2 |          | 
 (12 rows)
 
-SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id;
+SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257894000000000000 | dev1      |      1.5 |        1 |        2 | t
  1257894000000000000 | dev1      |      1.5 |        2 |          | 
  1257894000000001000 | dev1      |      2.5 |        3 |          | 
  1257894001000000000 | dev1      |      3.5 |        4 |          | 
+ 1257894002000000000 | dev1      |      2.5 |        3 |          | 
  1257894002000000000 | dev1      |      5.5 |        6 |          | t
  1257894002000000000 | dev1      |      5.5 |        7 |          | f
- 1257894002000000000 | dev1      |      2.5 |        3 |          | 
 (7 rows)
 
-SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id;
+SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
 ---------------------+-----------+----------+----------+----------+-------------
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
@@ -521,7 +521,6 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
  _timescaledb_catalog.tablespace_id_seq
 (10 rows)
 
-        
 -- Make sure we can't run our restoring functions as a normal perm user as that would disable functionality for the whole db
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- Hides error messages in cases where error messages differ between Postgres versions

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -22,7 +22,7 @@ COPY "two_Partitions"("timeCustom", device_id, series_0, series_1) FROM STDIN DE
 2257894000000000000,dev3,1.5,2
 \.
 
-COPY (SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id) TO STDOUT;
+COPY (SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1) TO STDOUT;
 
 
 ---test hypertable with FK

--- a/test/sql/delete.sql
+++ b/test/sql/delete.sql
@@ -6,11 +6,11 @@
 \ir include/insert_two_partitions.sql
 \o
 
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 
 DELETE FROM "two_Partitions" WHERE series_0 = 1.5;
 DELETE FROM "two_Partitions" WHERE series_0 = 100;
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 
 -- Make sure DELETE isn't optimized if it includes Append plans
 -- Need to turn of nestloop to make append appear the same on PG96 and PG10
@@ -35,7 +35,7 @@ DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
 
 
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/sql/insert.sql
+++ b/test/sql/insert.sql
@@ -8,7 +8,7 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal.%_hyper%');
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
 SELECT * FROM _timescaledb_catalog.chunk;
 
-SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id;
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
 SELECT * FROM ONLY "two_Partitions";
 
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -65,9 +65,9 @@ SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_1_1_chunk');
 SELECT * FROM test.show_triggers('"test_schema"."two_Partitions"');
 SELECT * FROM test.show_triggers('_timescaledb_internal._hyper_1_1_chunk');
 
-SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id;
-SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id;
-SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id;
+SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
+SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
 
 -- Show all index mappings
 SELECT * FROM _timescaledb_catalog.chunk_index;
@@ -119,9 +119,9 @@ SELECT * FROM test.show_triggers('"test_schema"."two_Partitions"');
 SELECT * FROM test.show_triggers('_timescaledb_internal._hyper_1_1_chunk');
 
 --data should be the same
-SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id;
-SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id;
-SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id;
+SELECT * FROM "test_schema"."two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+SELECT * FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
+SELECT * FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY "timeCustom", device_id, series_0, series_1;
 
 SELECT * FROM _timescaledb_catalog.chunk_index;
 SELECT * FROM _timescaledb_catalog.chunk_constraint;
@@ -146,11 +146,6 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         deptype = 'e' AND
         classid='pg_catalog.pg_class'::pg_catalog.regclass
         AND objid NOT IN (select unnest(extconfig) from pg_extension where extname='timescaledb');
-
-        
-
-
-
 
 -- Make sure we can't run our restoring functions as a normal perm user as that would disable functionality for the whole db
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER


### PR DESCRIPTION
Some of the ORDER BY clauses did not produce a unique order.
This patch fixes those queries to make the test results consistent.