### PR TITLE
Stop preventing REFRESH in transaction blocks

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2674,8 +2674,6 @@ process_refresh_mat_view_start(ProcessUtilityArgs *args, Node *parsetree)
 	NameData view_name;
 	NameData view_schema;
 
-	PreventInTransactionBlock(args->context == PROCESS_UTILITY_TOPLEVEL, "REFRESH");
-
 	if (!OidIsValid(view_relid))
 		return false;
 
@@ -2706,6 +2704,8 @@ process_refresh_mat_view_start(ProcessUtilityArgs *args, Node *parsetree)
 
 	if (materialization_id == -1)
 		return false;
+
+	PreventInTransactionBlock(args->context == PROCESS_UTILITY_TOPLEVEL, "REFRESH");
 
 	PopActiveSnapshot();
 	CommitTransactionCommand();


### PR DESCRIPTION
We prevent REFRESHing continuous aggregates within a transaction block
since we COMMIT and start our own transactions during this operation,
making it inherently non-transactional. This commit ensures we only
prevent REFRESHing continuous aggregates, and not REFRESH on other
materialized views.