### PR TITLE
Fix release and apache only tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   # First build without OpenSSL
   - docker exec -it pgbuild /bin/sh -c "cd /build/debug-nossl && CFLAGS='-Werror -O2' cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=false -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS} && make install"
   # Now build with OpenSSL
-  - docker exec -it pgbuild /bin/sh -c "cd /build/debug && CFLAGS='-Werror -O2' cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${ADDITIONAL_CMAKE_FLAGS:-} && make install"
+  - docker exec -it pgbuild /bin/sh -c "cd /build/debug && CFLAGS='-Werror -O2' cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install"
   # Ensure postgres user has permissions
   - docker exec -it pgbuild /bin/bash -c "chown -R postgres:postgres /build/"
 script:

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -24,7 +24,6 @@ set(TEST_FILES
   drop_hypertable.sql
   drop_rename_hypertable.sql
   dump_meta.sql
-  edition.sql
   extension.sql
   gapfill.sql
   hash.sql
@@ -52,6 +51,12 @@ set(TEST_FILES
   version.sql
   views.sql
 )
+
+# edition tests need community edition
+if(NOT APACHE_ONLY)
+  list(APPEND TEST_FILES
+    edition.sql)
+endif()
 
 # tests that fail or are unreliable when run in parallel
 set(SOLO_TESTS


### PR DESCRIPTION
Travis did not actually run the release and apache only tests
with the apropriate build flags so they were identical to the
normal debug runs. This patch fixes passing the build flags
and also adjusts regresscheck to not run edition.sql
when compiled as apache only because it tests functionality
not available under this license.

Fixes #1241 