### PR TITLE
Fix telemetry test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
 
   - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug pginstallcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 after_failure:
-  - docker exec -u postgres -it pgbuild cat /build/debug/test/regression.diffs /build/debug/tsl/test/regression.diffs /build/debug/test/isolation/regression.diffs /build/debug/tsl/test/isolation/regression.diffs /build/debug/test/pgtest/regression.diffs
+  - docker exec -u postgres -it pgbuild cat /build/debug/test/regression.diffs /build/debug-nossl/test/regression.diffs /build/debug/tsl/test/regression.diffs /build/debug/test/isolation/regression.diffs /build/debug/tsl/test/isolation/regression.diffs /build/debug/test/pgtest/regression.diffs
 after_success:
   - ci_env=`bash <(curl -s https://codecov.io/env)`
   - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) || echo \"Codecov did not collect coverage reports\" "

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -312,12 +312,6 @@ WHERE key != 'os_name_pretty';
  num_drop_chunks_policies
 (22 rows)
 
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
- json_object_field 
--------------------
- "0"
-(1 row)
-
 -- check telemetry picks up flagged content from metadata
 SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
  json_object_field 
@@ -332,7 +326,18 @@ SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
  {"cloud": "ci"}
 (1 row)
 
---create a continuous agg
+SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+ json_object_field 
+-------------------
+ "0"
+(1 row)
+
+SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+ json_object_field 
+-------------------
+ "0"
+(1 row)
+
 CREATE TABLE device_readings (
       observation_time  TIMESTAMPTZ       NOT NULL
 );
@@ -342,23 +347,9 @@ SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
  device_readings
 (1 row)
 
-CREATE VIEW device_summary
-WITH (timescaledb.continuous) AS
-SELECT
-  time_bucket('1 hour', observation_time) as bucket,
-  min(observation_time)
-FROM
-  device_readings
-GROUP BY bucket;
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
- json_object_field 
--------------------
- "1"
-(1 row)
-
 SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
  json_object_field 
 -------------------
- "2"
+ "1"
 (1 row)
 

--- a/test/expected/telemetry_community.out
+++ b/test/expected/telemetry_community.out
@@ -1,0 +1,57 @@
+--telemetry tests that require a community license
+SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+ json_object_field 
+-------------------
+ "0"
+(1 row)
+
+SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+ json_object_field 
+-------------------
+ "0"
+(1 row)
+
+-- check telemetry picks up flagged content from metadata
+SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
+ json_object_field 
+-------------------
+ {}
+(1 row)
+
+-- check timescaledb_telemetry.cloud
+SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
+ json_object_field 
+-------------------
+ {"cloud": "ci"}
+(1 row)
+
+--create a continuous agg
+CREATE TABLE device_readings (
+      observation_time  TIMESTAMPTZ       NOT NULL
+);
+SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
+   table_name    
+-----------------
+ device_readings
+(1 row)
+
+CREATE VIEW device_summary
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  min(observation_time)
+FROM
+  device_readings
+GROUP BY bucket;
+SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+ json_object_field 
+-------------------
+ "1"
+(1 row)
+
+SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+ json_object_field 
+-------------------
+ "2"
+(1 row)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -55,7 +55,9 @@ set(TEST_FILES
 # edition tests need community edition
 if(NOT APACHE_ONLY)
   list(APPEND TEST_FILES
-    edition.sql)
+    edition.sql
+    telemetry_community.sql
+    )
 endif()
 
 # tests that fail or are unreliable when run in parallel

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -127,28 +127,19 @@ SET timescaledb.telemetry_level=off;
 SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
 WHERE key != 'os_name_pretty';
 
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
-
 -- check telemetry picks up flagged content from metadata
 SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
 
 -- check timescaledb_telemetry.cloud
 SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
 
+SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
 
---create a continuous agg
+SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+
 CREATE TABLE device_readings (
       observation_time  TIMESTAMPTZ       NOT NULL
 );
 SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
-CREATE VIEW device_summary
-WITH (timescaledb.continuous) AS
-SELECT
-  time_bucket('1 hour', observation_time) as bucket,
-  min(observation_time)
-FROM
-  device_readings
-GROUP BY bucket;
 
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
 SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');

--- a/test/sql/telemetry_community.sql
+++ b/test/sql/telemetry_community.sql
@@ -1,0 +1,28 @@
+--telemetry tests that require a community license
+
+SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+
+-- check telemetry picks up flagged content from metadata
+SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
+
+-- check timescaledb_telemetry.cloud
+SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
+
+
+--create a continuous agg
+CREATE TABLE device_readings (
+      observation_time  TIMESTAMPTZ       NOT NULL
+);
+SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
+CREATE VIEW device_summary
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  min(observation_time)
+FROM
+  device_readings
+GROUP BY bucket;
+
+SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');


### PR DESCRIPTION
The current telemetry test fails in ApacheOnly mode because it uses
community functions. The PR separates out the community from the
apache only testing and add a telemetry_community test that only
runs if not in ApacheOnly mode.

Also adjust the travis file to print telemetry output for the
telemetry test run without openssl.