### PR TITLE
Fix compilation errors

### DIFF
--- a/test/expected/rowsecurity-10.out
+++ b/test/expected/rowsecurity-10.out
@@ -4346,14 +4346,12 @@ SELECT * FROM r2;
 -- r2 is read-only
 INSERT INTO r2 VALUES (2); -- Not allowed
 ERROR:  new row violates row-level security policy for table "r2"
+\pset tuples_only 1
 UPDATE r2 SET a = 2 RETURNING *; -- Updates nothing
---
-(0 rows)
 
 DELETE FROM r2 RETURNING *; -- Deletes nothing
---
-(0 rows)
 
+\pset tuples_only 0
 -- r2 can be used as a non-target relation in DML
 INSERT INTO r1 SELECT a + 1 FROM r2 RETURNING *; -- OK
  a  

--- a/test/sql/rowsecurity-10.sql
+++ b/test/sql/rowsecurity-10.sql
@@ -1529,8 +1529,10 @@ SELECT * FROM r2;
 
 -- r2 is read-only
 INSERT INTO r2 VALUES (2); -- Not allowed
+\pset tuples_only 1
 UPDATE r2 SET a = 2 RETURNING *; -- Updates nothing
 DELETE FROM r2 RETURNING *; -- Deletes nothing
+\pset tuples_only 0
 
 -- r2 can be used as a non-target relation in DML
 INSERT INTO r1 SELECT a + 1 FROM r2 RETURNING *; -- OK


### PR DESCRIPTION
In https://github.com/postgres/postgres/commit/05eb923eae46c1698088d555ae590a73d4fc7070 Postgres fixed PARAM_EXEC handling which got backported to 9.6.12, 10.7 and 11.2. To allow TimescaleDB builds built on older versions to work with the latest PG version we need to backport some of the functions added in this commit.