### PR TITLE
Output postmaster.log on travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ script:
   # Run the PG regression tests too
   - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug pginstallcheck PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 after_failure:
-  - docker exec -u postgres -it pgbuild cat /build/debug/test/regression.diffs /build/debug-nossl/test/regression.diffs /build/debug/tsl/test/regression.diffs /build/debug/test/isolation/regression.diffs /build/debug/tsl/test/isolation/regression.diffs /build/debug/test/pgtest/regression.diffs
+  - docker exec -u postgres -it pgbuild find /build -name regression.diffs -exec cat {} +
+  - docker exec -u postgres -it pgbuild find /build -name postmaster.log -exec cat {} +
 after_success:
   - ci_env=`bash <(curl -s https://codecov.io/env)`
   - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) || echo \"Codecov did not collect coverage reports\" "


### PR DESCRIPTION
To make it easier to diagnose problems that only occur in CI it is
useful to have the postgres logs in addition to having the test
diffs. This patch adds all the postgres logs and also removes
the hardcoded locations for the regression diffs and uses find to
locate them instead.