### PR TITLE
Trivial Cleanup

### DIFF
--- a/src/catalog.c
+++ b/src/catalog.c
@@ -256,7 +256,7 @@ static const char *cache_proxy_table_names[_MAX_CACHE_TYPES] = {
 };
 
 /* Catalog information for the current database. */
-static Catalog catalog = {
+static Catalog s_catalog = {
 	.initialized = false,
 };
 
@@ -398,23 +398,23 @@ ts_catalog_get(void)
 	if (!ts_extension_is_loaded())
 		elog(ERROR, "tried calling catalog_get when extension isn't loaded");
 
-	if (catalog.initialized || !IsTransactionState())
-		return &catalog;
+	if (s_catalog.initialized || !IsTransactionState())
+		return &s_catalog;
 
-	memset(&catalog, 0, sizeof(Catalog));
-	ts_catalog_table_info_init(catalog.tables,
+	memset(&s_catalog, 0, sizeof(Catalog));
+	ts_catalog_table_info_init(s_catalog.tables,
 							   _MAX_CATALOG_TABLES,
 							   catalog_table_names,
 							   catalog_table_index_definitions,
 							   catalog_table_serial_id_names);
 
-	catalog.cache_schema_id = get_namespace_oid(CACHE_SCHEMA_NAME, false);
+	s_catalog.cache_schema_id = get_namespace_oid(CACHE_SCHEMA_NAME, false);
 
 	for (i = 0; i < _MAX_CACHE_TYPES; i++)
-		catalog.caches[i].inval_proxy_id =
-			get_relname_relid(cache_proxy_table_names[i], catalog.cache_schema_id);
+		s_catalog.caches[i].inval_proxy_id =
+			get_relname_relid(cache_proxy_table_names[i], s_catalog.cache_schema_id);
 
-	catalog.internal_schema_id = get_namespace_oid(INTERNAL_SCHEMA_NAME, false);
+	s_catalog.internal_schema_id = get_namespace_oid(INTERNAL_SCHEMA_NAME, false);
 
 	for (i = 0; i < _MAX_INTERNAL_FUNCTIONS; i++)
 	{
@@ -434,17 +434,17 @@ ts_catalog_get(void)
 				 def.name,
 				 def.args);
 
-		catalog.functions[i].function_id = funclist->oid;
+		s_catalog.functions[i].function_id = funclist->oid;
 	}
-	catalog.initialized = true;
+	s_catalog.initialized = true;
 
-	return &catalog;
+	return &s_catalog;
 }
 
 void
 ts_catalog_reset(void)
 {
-	catalog.initialized = false;
+	s_catalog.initialized = false;
 	database_info.database_id = InvalidOid;
 }
 

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -13,7 +13,6 @@
 #include <utils/builtins.h>
 #include <utils/array.h>
 #include <utils/snapmgr.h>
-#include <utils/tqual.h>
 #include <utils/typcache.h>
 #include <funcapi.h>
 #include <math.h>

--- a/src/chunk_append/planner.c
+++ b/src/chunk_append/planner.c
@@ -9,7 +9,6 @@
 #include <nodes/extensible.h>
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
-#include <nodes/relation.h>
 #include <optimizer/clauses.h>
 #include <optimizer/pathnode.h>
 #include <optimizer/paths.h>

--- a/src/chunk_append/transform.c
+++ b/src/chunk_append/transform.c
@@ -8,7 +8,6 @@
 #include <catalog/pg_type.h>
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
-#include <nodes/relation.h>
 #include <optimizer/clauses.h>
 #include <utils/lsyscache.h>
 

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -11,7 +11,6 @@
 #include <utils/builtins.h>
 #include <utils/guc.h>
 #include <nodes/plannodes.h>
-#include <nodes/relation.h>
 #include <access/xact.h>
 #include <optimizer/plancat.h>
 #include <optimizer/clauses.h>

--- a/src/hypertable_insert.c
+++ b/src/hypertable_insert.c
@@ -10,7 +10,6 @@
 #include <nodes/makefuncs.h>
 #include <nodes/nodeFuncs.h>
 #include <nodes/plannodes.h>
-#include <nodes/relation.h>
 #include <executor/nodeModifyTable.h>
 #include <utils/rel.h>
 #include <utils/lsyscache.h>

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -4,7 +4,6 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <nodes/relation.h>
 #include <utils/typcache.h>
 #include <optimizer/clauses.h>
 #include <utils/lsyscache.h>

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -4,7 +4,6 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <nodes/relation.h>
 #include <parser/parsetree.h>
 #include <optimizer/clauses.h>
 #include <optimizer/var.h>

--- a/src/planner.c
+++ b/src/planner.c
@@ -5,7 +5,6 @@
  */
 #include <postgres.h>
 #include <nodes/plannodes.h>
-#include <nodes/relation.h>
 #include <parser/parsetree.h>
 #include <optimizer/clauses.h>
 #include <optimizer/planner.h>

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -9,7 +9,6 @@
 #include <storage/lmgr.h>
 #include <storage/bufmgr.h>
 #include <utils/rel.h>
-#include <utils/tqual.h>
 
 #include "scanner.h"
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -12,7 +12,6 @@
 #include <access/heapam.h>
 #include <nodes/lockoptions.h>
 #include <utils.h>
-#include <access/relscan.h>
 
 #include "export.h"
 


### PR DESCRIPTION
Hi,

Remove a parameter hides a global variable warning and unnecessary  includes conflicting with PG12.

Regards
Didier