### PR TITLE
Do not remove Result nodes with one-time filter

### DIFF
--- a/src/constraint_aware_append.c
+++ b/src/constraint_aware_append.c
@@ -380,10 +380,14 @@ constraint_aware_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPa
 	List *children = NIL;
 	ListCell *lc_child;
 
-	/* Postgres will inject Result nodes above mergeappend when target lists don't match
+	/*
+	 * Postgres will inject Result nodes above mergeappend when target lists don't match
 	 * because the nodes themselves do not perform projection. The ConstraintAwareAppend
-	 * node can do this projection itself, however, so just throw away the result node */
-	if (IsA(linitial(custom_plans), Result))
+	 * node can do this projection itself, however, so just throw away the result node
+	 * Removing the Result node is only safe if there is no one-time filter
+	 */
+	if (IsA(linitial(custom_plans), Result) &&
+		castNode(Result, linitial(custom_plans))->resconstantqual == NULL)
 	{
 		Result *result = castNode(Result, linitial(custom_plans));
 


### PR DESCRIPTION
ConstraintAwareAppend removes Result node children from the plan
because usually Result nodes are injected to do projection on top
of nodes that cannot project themselves. ConstraintAwareAppend can
do this projection instead. The Result node must not be removed
when the Result node has a one-time filter though.