### PR TITLE
Fix test output and compiler warning

### DIFF
--- a/src/chunk_append/exec.c
+++ b/src/chunk_append/exec.c
@@ -15,6 +15,7 @@
 #include <parser/parsetree.h>
 #include <rewrite/rewriteManip.h>
 #include <utils/typcache.h>
+#include <utils/memutils.h>
 
 #include "chunk_append/chunk_append.h"
 #include "chunk_append/exec.h"

--- a/test/expected/alternate_users-10.out
+++ b/test/expected/alternate_users-10.out
@@ -205,8 +205,8 @@ psql:include/ddl_ops_1.sql:66: NOTICE:  adding not-null constraint to column "ti
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -220,8 +220,8 @@ psql:include/ddl_ops_1.sql:72: ERROR:  column "val2" of relation "my_ht" already
 -- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -232,8 +232,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 psql:include/ddl_ops_1.sql:80: NOTICE:  column "val3" of relation "my_ht" already exists, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -243,8 +243,8 @@ SELECT * FROM test.show_columns('my_ht');
 -- Should drop
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -254,8 +254,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 psql:include/ddl_ops_1.sql:88: NOTICE:  column "val3" of relation "my_ht" does not exist, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f

--- a/test/expected/alternate_users-11.out
+++ b/test/expected/alternate_users-11.out
@@ -205,8 +205,8 @@ psql:include/ddl_ops_1.sql:66: NOTICE:  adding not-null constraint to column "ti
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -220,8 +220,8 @@ psql:include/ddl_ops_1.sql:72: ERROR:  column "val2" of relation "my_ht" already
 -- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -232,8 +232,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 psql:include/ddl_ops_1.sql:80: NOTICE:  column "val3" of relation "my_ht" already exists, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -243,8 +243,8 @@ SELECT * FROM test.show_columns('my_ht');
 -- Should drop
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -254,8 +254,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 psql:include/ddl_ops_1.sql:88: NOTICE:  column "val3" of relation "my_ht" does not exist, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f

--- a/test/expected/alternate_users-9.6.out
+++ b/test/expected/alternate_users-9.6.out
@@ -205,8 +205,8 @@ psql:include/ddl_ops_1.sql:66: NOTICE:  adding not-null constraint to column "ti
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -220,8 +220,8 @@ psql:include/ddl_ops_1.sql:72: ERROR:  column "val2" of relation "my_ht" already
 -- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -232,8 +232,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 psql:include/ddl_ops_1.sql:80: NOTICE:  column "val3" of relation "my_ht" already exists, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -243,8 +243,8 @@ SELECT * FROM test.show_columns('my_ht');
 -- Should drop
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -254,8 +254,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 psql:include/ddl_ops_1.sql:88: NOTICE:  column "val3" of relation "my_ht" does not exist, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -99,8 +99,8 @@ psql:include/ddl_ops_1.sql:66: NOTICE:  adding not-null constraint to column "ti
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -114,8 +114,8 @@ psql:include/ddl_ops_1.sql:72: ERROR:  column "val2" of relation "my_ht" already
 -- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -126,8 +126,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 psql:include/ddl_ops_1.sql:80: NOTICE:  column "val3" of relation "my_ht" already exists, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -137,8 +137,8 @@ SELECT * FROM test.show_columns('my_ht');
 -- Should drop
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -148,8 +148,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 psql:include/ddl_ops_1.sql:88: NOTICE:  column "val3" of relation "my_ht" does not exist, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -287,8 +287,8 @@ EXPLAIN (costs off) SELECT * FROM ONLY PUBLIC."Hypertable_1";
 (1 row)
 
 SELECT * FROM test.show_columns('PUBLIC."Hypertable_1"');
-  Column   |  Type   | Nullable 
------------+---------+----------
+  Column   |  Type   | NotNull 
+-----------+---------+---------
  time      | bigint  | t
  Device_id | text    | t
  temp_c    | integer | t
@@ -300,8 +300,8 @@ SELECT * FROM test.show_columns('PUBLIC."Hypertable_1"');
 (8 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
-  Column   |  Type   | Nullable 
------------+---------+----------
+  Column   |  Type   | NotNull 
+-----------+---------+---------
  time      | bigint  | t
  Device_id | text    | t
  temp_c    | integer | t
@@ -356,8 +356,8 @@ ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 13
 --create column with same name as previously dropped one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_4 BIGINT NOT NULL DEFAULT 131;
 SELECT * FROM test.show_columns('PUBLIC."Hypertable_1"');
-      Column      |  Type   | Nullable 
-------------------+---------+----------
+      Column      |  Type   | NotNull 
+------------------+---------+---------
  time             | bigint  | t
  Device_id        | text    | t
  humidity         | numeric | f

--- a/test/expected/ddl_alter_column.out
+++ b/test/expected/ddl_alter_column.out
@@ -15,16 +15,16 @@ INSERT INTO alter_test VALUES ('2017-01-20T09:00:01', 17.5, 'blue'),
                               ('2017-04-20T09:00:01', 89.5, 'green'),
                               ('2017-04-21T09:00:01', 17.1, 'black');
 SELECT * FROM test.show_columns('alter_test');
- Column |           Type           | Nullable 
---------+--------------------------+----------
+ Column |           Type           | NotNull 
+--------+--------------------------+---------
  time   | timestamp with time zone | t
  temp   | double precision         | f
  color  | character varying        | f
 (3 rows)
 
 SELECT * FROM test.show_columnsp('_timescaledb_internal.%chunk');
-                Relation                | Kind | Column |       Column type        | Nullable 
-----------------------------------------+------+--------+--------------------------+----------
+                Relation                | Kind | Column |       Column type        | NotNull 
+----------------------------------------+------+--------+--------------------------+---------
  _timescaledb_internal._hyper_1_1_chunk | r    | time   | timestamp with time zone | t
  _timescaledb_internal._hyper_1_1_chunk | r    | temp   | double precision         | f
  _timescaledb_internal._hyper_1_1_chunk | r    | color  | character varying        | f
@@ -70,16 +70,16 @@ ALTER TABLE alter_test ALTER COLUMN colorname TYPE text;
 ERROR:  cannot change the type of a hash-partitioned column
 \set ON_ERROR_STOP 1
 SELECT * FROM test.show_columns('alter_test');
-  Column   |            Type             | Nullable 
------------+-----------------------------+----------
+  Column   |            Type             | NotNull 
+-----------+-----------------------------+---------
  time_us   | timestamp without time zone | t
  temp      | double precision            | f
  colorname | character varying           | f
 (3 rows)
 
 SELECT * FROM test.show_columnsp('_timescaledb_internal.%chunk');
-                Relation                | Kind |  Column   |         Column type         | Nullable 
-----------------------------------------+------+-----------+-----------------------------+----------
+                Relation                | Kind |  Column   |         Column type         | NotNull 
+----------------------------------------+------+-----------+-----------------------------+---------
  _timescaledb_internal._hyper_1_1_chunk | r    | time_us   | timestamp without time zone | t
  _timescaledb_internal._hyper_1_1_chunk | r    | temp      | double precision            | f
  _timescaledb_internal._hyper_1_1_chunk | r    | colorname | character varying           | f

--- a/test/expected/ddl_single.out
+++ b/test/expected/ddl_single.out
@@ -99,8 +99,8 @@ psql:include/ddl_ops_1.sql:66: NOTICE:  adding not-null constraint to column "ti
 
 ALTER TABLE my_ht ADD COLUMN val2 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -114,8 +114,8 @@ psql:include/ddl_ops_1.sql:72: ERROR:  column "val2" of relation "my_ht" already
 -- Should create
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -126,8 +126,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht ADD COLUMN IF NOT EXISTS val3 integer;
 psql:include/ddl_ops_1.sql:80: NOTICE:  column "val3" of relation "my_ht" already exists, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -137,8 +137,8 @@ SELECT * FROM test.show_columns('my_ht');
 -- Should drop
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -148,8 +148,8 @@ SELECT * FROM test.show_columns('my_ht');
 ALTER TABLE my_ht DROP COLUMN IF EXISTS val3;
 psql:include/ddl_ops_1.sql:88: NOTICE:  column "val3" of relation "my_ht" does not exist, skipping
 SELECT * FROM test.show_columns('my_ht');
- Column |  Type   | Nullable 
---------+---------+----------
+ Column |  Type   | NotNull 
+--------+---------+---------
  time   | bigint  | t
  val    | integer | f
  val2   | integer | f
@@ -319,8 +319,8 @@ ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_3 BIGINT NOT NULL DEFAULT 13
 --create column with same name as previously dropped one
 ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_4 BIGINT NOT NULL DEFAULT 131;
 SELECT * FROM test.show_columns('PUBLIC."Hypertable_1"');
-      Column      |  Type   | Nullable 
-------------------+---------+----------
+      Column      |  Type   | NotNull 
+------------------+---------+---------
  time             | bigint  | t
  Device_id        | text    | t
  humidity         | numeric | f
@@ -333,8 +333,8 @@ SELECT * FROM test.show_columns('PUBLIC."Hypertable_1"');
 (9 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
-      Column      |  Type   | Nullable 
-------------------+---------+----------
+      Column      |  Type   | NotNull 
+------------------+---------+---------
  time             | bigint  | t
  Device_id        | text    | t
  humidity         | numeric | f

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -35,8 +35,8 @@ INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 \set QUIET on
 \o
 SELECT * FROM test.show_columnsp('_timescaledb_internal.%_hyper%');
-                                      Relation                                      | Kind |   Column    |   Column type    | Nullable 
-------------------------------------------------------------------------------------+------+-------------+------------------+----------
+                                      Relation                                      | Kind |   Column    |   Column type    | NotNull 
+------------------------------------------------------------------------------------+------+-------------+------------------+---------
  _timescaledb_internal._hyper_1_1_chunk                                             | r    | timeCustom  | bigint           | t
  _timescaledb_internal._hyper_1_1_chunk                                             | r    | device_id   | text             | t
  _timescaledb_internal._hyper_1_1_chunk                                             | r    | series_0    | double precision | f
@@ -117,8 +117,8 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal.%_hyper%');
 
 -- Test that renaming hypertable works
 SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
-   Column    |       Type       | Nullable 
--------------+------------------+----------
+   Column    |       Type       | NotNull 
+-------------+------------------+---------
  timeCustom  | bigint           | t
  device_id   | text             | t
  series_0    | double precision | f

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -89,8 +89,8 @@ SELECT * FROM _timescaledb_catalog.chunk_index;
 DROP TABLE index_test;
 CREATE TABLE index_test(id serial, time timestamptz, device integer, temp float);
 SELECT * FROM test.show_columns('index_test');
- Column |           Type           | Nullable 
---------+--------------------------+----------
+ Column |           Type           | NotNull 
+--------+--------------------------+---------
  id     | integer                  | t
  time   | timestamp with time zone | f
  device | integer                  | f
@@ -101,8 +101,8 @@ SELECT * FROM test.show_columns('index_test');
 -- chunks by dropping the ID column
 ALTER TABLE index_test DROP COLUMN id;
 SELECT * FROM test.show_columns('index_test');
- Column |           Type           | Nullable 
---------+--------------------------+----------
+ Column |           Type           | NotNull 
+--------+--------------------------+---------
  time   | timestamp with time zone | f
  device | integer                  | f
  temp   | double precision         | f

--- a/test/expected/insert.out
+++ b/test/expected/insert.out
@@ -43,8 +43,8 @@ INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 INSERT 0 1
 \set QUIET on
 SELECT * FROM test.show_columnsp('_timescaledb_internal.%_hyper%');
-                                      Relation                                      | Kind |   Column    |   Column type    | Nullable 
-------------------------------------------------------------------------------------+------+-------------+------------------+----------
+                                      Relation                                      | Kind |   Column    |   Column type    | NotNull 
+------------------------------------------------------------------------------------+------+-------------+------------------+---------
  _timescaledb_internal._hyper_1_1_chunk                                             | r    | timeCustom  | bigint           | t
  _timescaledb_internal._hyper_1_1_chunk                                             | r    | device_id   | text             | t
  _timescaledb_internal._hyper_1_1_chunk                                             | r    | series_0    | double precision | f

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -46,8 +46,8 @@ INSERT INTO "one_Partition"("timeCustom", device_id, series_0, series_1) VALUES
 INSERT 0 1
 \set QUIET on
 SELECT * FROM test.show_columnsp('"one_Partition".%');
-                                  Relation                                   | Kind |   Column    |   Column type    | Nullable 
------------------------------------------------------------------------------+------+-------------+------------------+----------
+                                  Relation                                   | Kind |   Column    |   Column type    | NotNull 
+-----------------------------------------------------------------------------+------+-------------+------------------+---------
  "one_Partition"._hyper_1_1_chunk                                            | r    | timeCustom  | bigint           | t
  "one_Partition"._hyper_1_1_chunk                                            | r    | device_id   | text             | t
  "one_Partition"._hyper_1_1_chunk                                            | r    | series_0    | double precision | f

--- a/test/expected/multi_transaction_index.out
+++ b/test/expected/multi_transaction_index.out
@@ -3,8 +3,8 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE index_test(id serial, time timestamptz, device integer, temp float);
 SELECT * FROM test.show_columns('index_test');
- Column |           Type           | Nullable 
---------+--------------------------+----------
+ Column |           Type           | NotNull 
+--------+--------------------------+---------
  id     | integer                  | t
  time   | timestamp with time zone | f
  device | integer                  | f
@@ -15,8 +15,8 @@ SELECT * FROM test.show_columns('index_test');
 -- chunks by dropping the ID column
 ALTER TABLE index_test DROP COLUMN id;
 SELECT * FROM test.show_columns('index_test');
- Column |           Type           | Nullable 
---------+--------------------------+----------
+ Column |           Type           | NotNull 
+--------+--------------------------+---------
  time   | timestamp with time zone | f
  device | integer                  | f
  temp   | double precision         | f

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -109,8 +109,8 @@ ERROR:  cannot change the type of a hash-partitioned column
 -- Should be able to change if not hash partitioned though
 ALTER TABLE part_new_convert1 ALTER COLUMN time TYPE timestamp;
 SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_3_%_chunk');
-                Relation                | Kind | Column |         Column type         | Nullable 
-----------------------------------------+------+--------+-----------------------------+----------
+                Relation                | Kind | Column |         Column type         | NotNull 
+----------------------------------------+------+--------+-----------------------------+---------
  _timescaledb_internal._hyper_3_5_chunk | r    | time   | timestamp without time zone | t
  _timescaledb_internal._hyper_3_5_chunk | r    | temp   | double precision            | f
  _timescaledb_internal._hyper_3_5_chunk | r    | device | integer                     | f

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -93,8 +93,8 @@ SELECT count(*) as num_dependent_objects
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb')
 \gset
 SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');
-   Column    |       Type       | Nullable 
--------------+------------------+----------
+   Column    |       Type       | NotNull 
+-------------+------------------+---------
  timeCustom  | bigint           | t
  device_id   | text             | t
  series_0    | double precision | f
@@ -104,8 +104,8 @@ SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');
 (6 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
-   Column    |       Type       | Nullable 
--------------+------------------+----------
+   Column    |       Type       | NotNull 
+-------------+------------------+---------
  timeCustom  | bigint           | t
  device_id   | text             | t
  series_0    | double precision | f
@@ -312,8 +312,8 @@ SELECT count(*) = :num_dependent_objects as dependent_objects_match
 
 --main table and chunk schemas should be the same
 SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');
-   Column    |       Type       | Nullable 
--------------+------------------+----------
+   Column    |       Type       | NotNull 
+-------------+------------------+---------
  timeCustom  | bigint           | t
  device_id   | text             | t
  series_0    | double precision | f
@@ -323,8 +323,8 @@ SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');
 (6 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._hyper_1_1_chunk');
-   Column    |       Type       | Nullable 
--------------+------------------+----------
+   Column    |       Type       | NotNull 
+-------------+------------------+---------
  timeCustom  | bigint           | t
  device_id   | text             | t
  series_0    | double precision | f

--- a/test/expected/plain.out
+++ b/test/expected/plain.out
@@ -11,8 +11,8 @@ CREATE INDEX time_color_idx ON regular_table(time, color);
 ALTER INDEX time_color_idx RENAME TO time_color_idx2;
 ALTER TABLE regular_table ALTER COLUMN color TYPE bigint;
 SELECT * FROM test.show_columns('regular_table');
- Column |            Type             | Nullable 
---------+-----------------------------+----------
+ Column |            Type             | NotNull 
+--------+-----------------------------+---------
  time   | timestamp without time zone | f
  temp   | double precision            | f
  tag    | text                        | f

--- a/test/expected/reindex.out
+++ b/test/expected/reindex.out
@@ -17,8 +17,8 @@ INSERT INTO reindex_test VALUES ('2017-01-20T09:00:01', 17.5),
                                 ('2017-06-20T09:00:01', 18.5),
                                 ('2017-06-21T09:00:01', 11.0);
 SELECT * FROM test.show_columns('reindex_test');
- Column |            Type             | Nullable 
---------+-----------------------------+----------
+ Column |            Type             | NotNull 
+--------+-----------------------------+---------
  time   | timestamp without time zone | t
  temp   | double precision            | t
 (2 rows)

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -15,7 +15,7 @@ GRANT USAGE ON SCHEMA test TO PUBLIC;
 CREATE OR REPLACE FUNCTION test.show_columns(rel regclass)
 RETURNS TABLE("Column" name,
               "Type" text,
-              "Nullable" boolean) LANGUAGE SQL STABLE AS
+              "NotNull" boolean) LANGUAGE SQL STABLE AS
 $BODY$
     SELECT a.attname,
     format_type(t.oid, t.typtypmod),
@@ -32,7 +32,7 @@ RETURNS TABLE("Relation" regclass,
               "Kind" "char",
               "Column" name,
               "Column type" text,
-              "Nullable" boolean) LANGUAGE PLPGSQL STABLE AS
+              "NotNull" boolean) LANGUAGE PLPGSQL STABLE AS
 $BODY$
 DECLARE
     schema_name name = split_part(pattern, '.', 1);

--- a/tsl/test/expected/ddl_hook.out
+++ b/tsl/test/expected/ddl_hook.out
@@ -36,8 +36,8 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM test.show_columns('htable');
- Column |           Type           | Nullable 
---------+--------------------------+----------
+ Column |           Type           | NotNull 
+--------+--------------------------+---------
  time   | timestamp with time zone | t
  device | integer                  | f
  color  | integer                  | f
@@ -87,8 +87,8 @@ NOTICE:  test_ddl_command_start: public.htable
 NOTICE:  test_sql_drop: constraint: public.htable.color_check
 NOTICE:  test_ddl_command_end: ALTER TABLE
 SELECT * FROM test.show_columns('htable');
- Column |           Type           | Nullable 
---------+--------------------------+----------
+ Column |           Type           | NotNull 
+--------+--------------------------+---------
  time   | timestamp with time zone | t
  device | integer                  | f
  temp   | double precision         | f
@@ -100,8 +100,8 @@ NOTICE:  test_ddl_command_start: 1 hypertables, query: ALTER TABLE htable ADD CO
 NOTICE:  test_ddl_command_start: public.htable
 NOTICE:  test_ddl_command_end: ALTER TABLE
 SELECT * FROM test.show_columns('htable');
-   Column    |           Type           | Nullable 
--------------+--------------------------+----------
+   Column    |           Type           | NotNull 
+-------------+--------------------------+---------
  time        | timestamp with time zone | t
  device      | integer                  | f
  temp        | double precision         | f


### PR DESCRIPTION
This PR contains two commits:

1. Fix column name in show_columns
2. Fix compiler warning in `ChunkAppend`

See individual commits for further descriptions.