### PR TITLE
Remove option REQUIRED from CMake find_program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,7 @@ find_program(PG_CONFIG pg_config
   PATH_SUFFIXES
   bin
   DOC
-  "The path to the pg_config of the PostgreSQL version to compile against"
-  REQUIRED)
+  "The path to the pg_config of the PostgreSQL version to compile against")
 
 if (NOT PG_CONFIG)
   message(FATAL_ERROR "Unable to find 'pg_config'")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Testing support
 find_program(PG_REGRESS pg_regress
   HINTS
-  "${PG_PKGLIBDIR}/pgxs/src/test/regress/"
-  REQUIRED)
+  "${PG_PKGLIBDIR}/pgxs/src/test/regress/")
 
 message(STATUS "Using pg_regress ${PG_REGRESS}")
 
@@ -10,8 +9,7 @@ find_program(PG_ISOLATION_REGRESS pg_isolation_regress
   HINTS
   ${BINDIR}/
   ${PG_PKGLIBDIR}/pgxs/src/test/isolation/
-  ${PG_SOURCE_DIR}/src/test/isolation
-  REQUIRED)
+  ${PG_SOURCE_DIR}/src/test/isolation)
 
 message(STATUS "Using pg_isolation_regress ${PG_ISOLATION_REGRESS}")
 


### PR DESCRIPTION
Remove option `REQUIRED` from calls to `find_program` in CMake files, 
since such options doesn't exist and is ignored. 