### PR TITLE
Update get_telemetry_report to expected behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ accidentally triggering the load of a previous DB version.**
 **Minor features**
 * #1273 Propagate quals to joined hypertables
 
+**Bugfixes**
+* #1300 Fix telemetry report return value
+
 ## 1.3.2 (2019-06-24)
 
 This maintenance release contains bug and security fixes since the 1.3.1 release. We deem it moderate-to-high priority for upgrading.

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -2,7 +2,6 @@ ALTER TABLE _timescaledb_catalog.telemetry_metadata ADD COLUMN include_in_teleme
 ALTER TABLE _timescaledb_catalog.telemetry_metadata ALTER COLUMN include_in_telemetry DROP DEFAULT;
 ALTER TABLE _timescaledb_catalog.telemetry_metadata RENAME TO metadata;
 ALTER INDEX _timescaledb_catalog.telemetry_metadata_pkey RENAME TO metadata_pkey;
-
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_aggs_materialization_invalidation_log(
     materialization_id INTEGER PRIMARY KEY
         REFERENCES _timescaledb_catalog.continuous_agg(mat_hypertable_id)
@@ -16,3 +15,4 @@ CREATE INDEX continuous_aggs_materialization_invalidation_log_idx
     ON _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (materialization_id, lowest_modified_value ASC);
 
 GRANT SELECT ON _timescaledb_catalog.continuous_aggs_materialization_invalidation_log TO PUBLIC;
+DROP FUNCTION IF EXISTS get_telemetry_report();

--- a/sql/version.sql
+++ b/sql/version.sql
@@ -9,5 +9,5 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.get_os_info()
     RETURNS TABLE(sysname TEXT, version TEXT, release TEXT, version_pretty TEXT)
     AS '@MODULE_PATHNAME@', 'ts_get_os_info' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE OR REPLACE FUNCTION get_telemetry_report() RETURNS TEXT
-    AS '@MODULE_PATHNAME@', 'ts_get_telemetry_report' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION get_telemetry_report(always_display_report boolean DEFAULT false) RETURNS TEXT
+    AS '@MODULE_PATHNAME@', 'ts_get_telemetry_report' LANGUAGE C STABLE PARALLEL SAFE;

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -283,7 +283,52 @@ WARNING:  telemetry could not connect to "noservice.timescale.com"
  f
 (1 row)
 
+-- Test error message and override for when telemetry is disabled
 SET timescaledb.telemetry_level=off;
+SELECT get_telemetry_report();
+INFO:  Telemetry is disabled. Call get_telemetry_report(always_display_report := true) to view the report locally.
+ get_telemetry_report 
+----------------------
+ 
+(1 row)
+
+SELECT get_telemetry_report(NULL);
+INFO:  Telemetry is disabled. Call get_telemetry_report(always_display_report := true) to view the report locally.
+ get_telemetry_report 
+----------------------
+ 
+(1 row)
+
+SELECT * FROM json_object_keys(get_telemetry_report(always_display_report := true)::json) AS key
+WHERE key != 'os_name_pretty';
+           key            
+--------------------------
+ db_uuid
+ license
+ os_name
+ os_release
+ os_version
+ data_volume
+ db_metadata
+ build_os_name
+ install_method
+ installed_time
+ last_tuned_time
+ num_hypertables
+ build_os_version
+ exported_db_uuid
+ instance_metadata
+ last_tuned_version
+ postgresql_version
+ related_extensions
+ num_continuous_aggs
+ timescaledb_version
+ num_reorder_policies
+ num_drop_chunks_policies
+(22 rows)
+
+-- Test telemetry report contents
+SET timescaledb.telemetry_level=basic;
 SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
 WHERE key != 'os_name_pretty';
            key            

--- a/test/expected/telemetry_community.out
+++ b/test/expected/telemetry_community.out
@@ -1,25 +1,25 @@
 --telemetry tests that require a community license
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs');
  json_object_field 
 -------------------
  "0"
 (1 row)
 
-SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_hypertables');
  json_object_field 
 -------------------
  "0"
 (1 row)
 
 -- check telemetry picks up flagged content from metadata
-SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'db_metadata');
  json_object_field 
 -------------------
  {}
 (1 row)
 
 -- check timescaledb_telemetry.cloud
-SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'instance_metadata');
  json_object_field 
 -------------------
  {"cloud": "ci"}
@@ -43,13 +43,13 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket;
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs');
  json_object_field 
 -------------------
  "1"
 (1 row)
 
-SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_hypertables');
  json_object_field 
 -------------------
  "2"

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -121,8 +121,16 @@ SELECT * FROM _timescaledb_internal.test_validate_server_version('{"current_time
 SET timescaledb.telemetry_level=basic;
 -- Connect to a bogus host and path to test error handling in telemetry_main()
 SELECT _timescaledb_internal.test_telemetry_main_conn('noservice.timescale.com', 'path');
-SET timescaledb.telemetry_level=off;
 
+-- Test error message and override for when telemetry is disabled
+SET timescaledb.telemetry_level=off;
+SELECT get_telemetry_report();
+SELECT get_telemetry_report(NULL);
+SELECT * FROM json_object_keys(get_telemetry_report(always_display_report := true)::json) AS key
+WHERE key != 'os_name_pretty';
+
+-- Test telemetry report contents
+SET timescaledb.telemetry_level=basic;
 
 SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
 WHERE key != 'os_name_pretty';

--- a/test/sql/telemetry_community.sql
+++ b/test/sql/telemetry_community.sql
@@ -1,13 +1,13 @@
 --telemetry tests that require a community license
 
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
-SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_hypertables');
 
 -- check telemetry picks up flagged content from metadata
-SELECT json_object_field(get_telemetry_report()::json,'db_metadata');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'db_metadata');
 
 -- check timescaledb_telemetry.cloud
-SELECT json_object_field(get_telemetry_report()::json,'instance_metadata');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'instance_metadata');
 
 
 --create a continuous agg
@@ -24,5 +24,5 @@ FROM
   device_readings
 GROUP BY bucket;
 
-SELECT json_object_field(get_telemetry_report()::json,'num_continuous_aggs');
-SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_hypertables');

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -98,7 +98,7 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
      5
 (1 row)
 
-SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_reorder_policies');
  json_object_field 
 -------------------
  "0"
@@ -106,7 +106,7 @@ SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
 
 select add_reorder_policy('test_reorder_table', 'test_reorder_table_time_idx') as reorder_job_id \gset
 WARNING:  Timescale License expired
-SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_reorder_policies');
  json_object_field 
 -------------------
  "1"
@@ -425,7 +425,7 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
      5
 (1 row)
 
-SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
  json_object_field 
 -------------------
  "0"
@@ -433,7 +433,7 @@ SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies'
 
 SELECT add_drop_chunks_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
 WARNING:  Timescale License expired
-SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
  json_object_field 
 -------------------
  "1"

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -76,9 +76,9 @@ INSERT INTO test_reorder_table VALUES (5, 5);
 
 SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_reorder_table';
 
-SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_reorder_policies');
 select add_reorder_policy('test_reorder_table', 'test_reorder_table_time_idx') as reorder_job_id \gset
-SELECT json_object_field(get_telemetry_report()::json,'num_reorder_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_reorder_policies');
 
 -- policy was created
 select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_id;
@@ -219,9 +219,9 @@ INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '8 months', 1);
 SELECT show_chunks('test_drop_chunks_table');
 SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_drop_chunks_table';
 
-SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
 SELECT add_drop_chunks_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
-SELECT json_object_field(get_telemetry_report()::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
 
 SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
 


### PR DESCRIPTION
Previously, get_telemetry_report() returns full report even if telemetry is disabled.
Now, when telemetry is disabled, get_telemetry_report() informs user telemetry is 
disabled and how to view the report locally. 