### PR TITLE
Fix handling of types with custom partitioning

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1080,10 +1080,10 @@ chunks_typecheck_and_find_all_in_range_limit(Hyperspace *hs, Dimension *time_dim
 
 	if (older_than_type != InvalidOid)
 	{
-		ts_dimension_open_typecheck(older_than_type, time_dim->fd.column_type, caller_name);
+		Oid partitioning_type = ts_dimension_get_partition_type(time_dim);
+		ts_dimension_open_typecheck(older_than_type, partitioning_type, caller_name);
 		if (older_than_type == INTERVALOID)
-			older_than =
-				ts_interval_from_now_to_internal(older_than_datum, time_dim->fd.column_type);
+			older_than = ts_interval_from_now_to_internal(older_than_datum, partitioning_type);
 		else
 			older_than = ts_time_value_to_internal(older_than_datum, older_than_type);
 		end_strategy = BTLessStrategyNumber;
@@ -1091,10 +1091,10 @@ chunks_typecheck_and_find_all_in_range_limit(Hyperspace *hs, Dimension *time_dim
 
 	if (newer_than_type != InvalidOid)
 	{
-		ts_dimension_open_typecheck(newer_than_type, time_dim->fd.column_type, caller_name);
+		Oid partitioning_type = ts_dimension_get_partition_type(time_dim);
+		ts_dimension_open_typecheck(newer_than_type, partitioning_type, caller_name);
 		if (newer_than_type == INTERVALOID)
-			newer_than =
-				ts_interval_from_now_to_internal(newer_than_datum, time_dim->fd.column_type);
+			newer_than = ts_interval_from_now_to_internal(newer_than_datum, partitioning_type);
 		else
 			newer_than = ts_time_value_to_internal(newer_than_datum, newer_than_type);
 		start_strategy = BTGreaterEqualStrategyNumber;
@@ -1267,7 +1267,7 @@ chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum ne
 		time_dim = hyperspace_get_open_dimension(ht->space, 0);
 
 		if (time_dim_type == InvalidOid)
-			time_dim_type = time_dim->fd.column_type;
+			time_dim_type = ts_dimension_get_partition_type(time_dim);
 
 		/*
 		 * Even though internally all time columns are represented as bigints,
@@ -1280,7 +1280,7 @@ chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum ne
 		 * across hypertables that is why it is not in the helper function
 		 * below.
 		 */
-		if (time_dim_type != time_dim->fd.column_type &&
+		if (time_dim_type != ts_dimension_get_partition_type(time_dim) &&
 			(older_than_type != InvalidOid || newer_than_type != InvalidOid))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -135,6 +135,7 @@ extern Dimension *ts_hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionT
 extern DimensionVec *ts_dimension_get_slices(Dimension *dim);
 extern int32 ts_dimension_get_hypertable_id(int32 dimension_id);
 extern int ts_dimension_set_type(Dimension *dim, Oid newtype);
+extern TSDLLEXPORT Oid ts_dimension_get_partition_type(Dimension *dim);
 extern int ts_dimension_set_name(Dimension *dim, const char *newname);
 extern int ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
 extern Datum ts_dimension_transform_value(Dimension *dim, Datum value, Oid const_datum_type,

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -214,6 +214,9 @@ ts_hypertable_get_time_type(PG_FUNCTION_ARGS)
 	time_dimension = hyperspace_get_open_dimension(ht->space, 0);
 	if (time_dimension == NULL)
 		PG_RETURN_NULL();
+	/* This is deliberately column_type not partitioning_type, as that is how
+	 * the SQL function is defined
+	 */
 	time_type = time_dimension->fd.column_type;
 	ts_cache_release(hcache);
 	PG_RETURN_OID(time_type);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -62,6 +62,7 @@
 #include "with_clause_parser.h"
 #include "cross_module_fn.h"
 #include "continuous_agg.h"
+#include "partitioning.h"
 
 #include "cross_module_fn.h"
 
@@ -2019,6 +2020,13 @@ process_alter_column_type_start(Hypertable *ht, AlterTableCmd *cmd)
 			ereport(ERROR,
 					(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
 					 errmsg("cannot change the type of a hash-partitioned column")));
+
+		if (dim->partitioning != NULL &&
+			strncmp(NameStr(dim->fd.column_name), cmd->name, NAMEDATALEN) == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
+					 errmsg("cannot change the type of a column with a custom partitioning "
+							"function")));
 	}
 }
 

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1098,6 +1098,7 @@ BEGIN;
 (0 rows)
 
 ROLLBACK;
+SET timezone TO '-5';
 CREATE TABLE chunk_id_from_relid_test(time bigint, temp float8, device_id int);
 SELECT hypertable_id FROM create_hypertable('chunk_id_from_relid_test', 'time', chunk_time_interval => 10) \gset
 NOTICE:  adding not-null constraint to column "time"
@@ -1133,3 +1134,154 @@ SELECT _timescaledb_internal.chunk_id_from_relid('pg_type'::regclass);
 ERROR:  chunk not found
 SELECT _timescaledb_internal.chunk_id_from_relid('chunk_id_from_relid_test'::regclass);
 ERROR:  chunk not found
+-- test drop/show_chunks on custom partition types
+CREATE FUNCTION extract_time(a jsonb)
+RETURNS TIMESTAMPTZ
+LANGUAGE SQL
+AS $$ SELECT (a->>'time')::TIMESTAMPTZ $$ IMMUTABLE;
+CREATE TABLE test_weird_type(a jsonb);
+SELECT create_hypertable('test_weird_type', 'a',
+    time_partitioning_func=>'extract_time'::regproc,
+    chunk_time_interval=>'2 hours'::interval);
+NOTICE:  adding not-null constraint to column "a"
+      create_hypertable       
+------------------------------
+ (9,public,test_weird_type,t)
+(1 row)
+
+INSERT INTO test_weird_type VALUES ('{"time":"2019/06/06 1:00+0"}'), ('{"time":"2019/06/06 5:00+0"}');
+SELECT * FROM test.show_subtables('test_weird_type');
+                  Child                  | Tablespace 
+-----------------------------------------+------------
+ _timescaledb_internal._hyper_9_30_chunk | 
+ _timescaledb_internal._hyper_9_31_chunk | 
+(2 rows)
+
+SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 4:00+0'::TIMESTAMPTZ);
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_9_30_chunk
+(1 row)
+
+SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 10:00+0'::TIMESTAMPTZ);
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_9_30_chunk
+ _timescaledb_internal._hyper_9_31_chunk
+(2 rows)
+
+SELECT drop_chunks('2019/06/06 5:00+0'::TIMESTAMPTZ, 'test_weird_type');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('test_weird_type');
+                  Child                  | Tablespace 
+-----------------------------------------+------------
+ _timescaledb_internal._hyper_9_31_chunk | 
+(1 row)
+
+SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 4:00+0'::TIMESTAMPTZ);
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 10:00+0'::TIMESTAMPTZ);
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_9_31_chunk
+(1 row)
+
+SELECT drop_chunks('2019/06/06 6:00+0'::TIMESTAMPTZ, 'test_weird_type');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('test_weird_type');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 10:00+0'::TIMESTAMPTZ);
+ show_chunks 
+-------------
+(0 rows)
+
+DROP TABLE test_weird_type;
+CREATE FUNCTION extract_int_time(a jsonb)
+RETURNS BIGINT
+LANGUAGE SQL
+AS $$ SELECT (a->>'time')::BIGINT $$ IMMUTABLE;
+CREATE TABLE test_weird_type_i(a jsonb);
+SELECT create_hypertable('test_weird_type_i', 'a',
+    time_partitioning_func=>'extract_int_time'::regproc,
+    chunk_time_interval=>5);
+NOTICE:  adding not-null constraint to column "a"
+        create_hypertable        
+---------------------------------
+ (10,public,test_weird_type_i,t)
+(1 row)
+
+INSERT INTO test_weird_type_i VALUES ('{"time":"0"}'), ('{"time":"5"}');
+SELECT * FROM test.show_subtables('test_weird_type_i');
+                  Child                   | Tablespace 
+------------------------------------------+------------
+ _timescaledb_internal._hyper_10_32_chunk | 
+ _timescaledb_internal._hyper_10_33_chunk | 
+(2 rows)
+
+SELECT show_chunks('test_weird_type_i', older_than=>5);
+               show_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_10_32_chunk
+(1 row)
+
+SELECT show_chunks('test_weird_type_i', older_than=>10);
+               show_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_10_32_chunk
+ _timescaledb_internal._hyper_10_33_chunk
+(2 rows)
+
+SELECT drop_chunks(5, 'test_weird_type_i');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('test_weird_type_i');
+                  Child                   | Tablespace 
+------------------------------------------+------------
+ _timescaledb_internal._hyper_10_33_chunk | 
+(1 row)
+
+SELECT show_chunks('test_weird_type_i', older_than=>5);
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT show_chunks('test_weird_type_i', older_than=>10);
+               show_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_10_33_chunk
+(1 row)
+
+SELECT drop_chunks(10, 'test_weird_type_i');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('test_weird_type_i');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+SELECT show_chunks('test_weird_type_i', older_than=>10);
+ show_chunks 
+-------------
+(0 rows)
+
+DROP TABLE test_weird_type_i CASCADE;

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -68,6 +68,7 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	bool cascade = PG_GETARG_BOOL(2);
 	bool if_not_exists = PG_GETARG_BOOL(3);
 	bool cascade_to_materializations = PG_GETARG_BOOL(4);
+	Oid partitioning_type;
 
 	BgwPolicyDropChunks policy = { .fd = {
 									   .hypertable_id = ts_hypertable_relid_to_id(ht_oid),
@@ -124,9 +125,9 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	}
 
 	/* validate that the open dimension uses a time type */
-	ts_dimension_open_typecheck(INTERVALOID,
-								hyperspace_get_open_dimension(hypertable->space, 0)->fd.column_type,
-								"add_drop_chunks_policy");
+	partitioning_type =
+		ts_dimension_get_partition_type(hyperspace_get_open_dimension(hypertable->space, 0));
+	ts_dimension_open_typecheck(INTERVALOID, partitioning_type, "add_drop_chunks_policy");
 
 	ts_cache_release(hcache);
 

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -101,6 +101,7 @@ reorder_add_policy(PG_FUNCTION_ARGS)
 	bool if_not_exists = PG_GETARG_BOOL(2);
 	int32 hypertable_id = ts_hypertable_relid_to_id(ht_oid);
 	Hypertable *ht = ts_hypertable_get_by_id(hypertable_id);
+	Oid partitioning_type;
 
 	BgwPolicyReorder policy = { .fd = {
 									.hypertable_id = hypertable_id,
@@ -157,7 +158,8 @@ reorder_add_policy(PG_FUNCTION_ARGS)
 	 */
 	dim = hyperspace_get_open_dimension(ht->space, 0);
 
-	if (dim && IS_TIMESTAMP_TYPE(dim->fd.column_type))
+	partitioning_type = ts_dimension_get_partition_type(dim);
+	if (dim && IS_TIMESTAMP_TYPE(partitioning_type))
 		default_schedule_interval = DatumGetIntervalP(
 			DirectFunctionCall7(make_interval,
 								Int32GetDatum(0),

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -769,6 +769,10 @@ cagg_validate_query(Query *query)
 		if (ht != NULL)
 		{
 			part_dimension = hyperspace_get_open_dimension(ht->space, 0);
+			/* NOTE: if we ever allow custom partitioning functions we'll need to
+			 *       change part_dimension->fd.column_type to partitioning_type
+			 *       below, along with any other fallout
+			 */
 			if (part_dimension->partitioning != NULL)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -111,7 +111,7 @@ tuple_get_time(Dimension *d, HeapTuple tuple, AttrNumber col, TupleDesc tupdesc)
 
 	Assert(d->type == DIMENSION_TYPE_OPEN);
 
-	dimtype = (d->partitioning == NULL) ? d->fd.column_type : d->partitioning->partfunc.rettype;
+	dimtype = ts_dimension_get_partition_type(d);
 
 	if (isnull)
 		ereport(ERROR,

--- a/tsl/src/continuous_aggs/job.c
+++ b/tsl/src/continuous_aggs/job.c
@@ -48,6 +48,7 @@ continuous_agg_job_get_default_schedule_interval(int32 raw_table_id, int64 bucke
 	Dimension *dim;
 	Interval *default_schedule_interval = DEFAULT_SCHEDULE_INTERVAL;
 	Hypertable *ht = ts_hypertable_get_by_id(raw_table_id);
+	Oid partition_type;
 
 	Assert(ht != NULL);
 
@@ -57,7 +58,8 @@ continuous_agg_job_get_default_schedule_interval(int32 raw_table_id, int64 bucke
 	 */
 	dim = hyperspace_get_open_dimension(ht->space, 0);
 
-	if (dim != NULL && IS_TIMESTAMP_TYPE(dim->fd.column_type))
+	partition_type = ts_dimension_get_partition_type(dim);
+	if (dim != NULL && IS_TIMESTAMP_TYPE(partition_type))
 	{
 		default_schedule_interval = DatumGetIntervalP(
 			DirectFunctionCall7(make_interval,

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -269,7 +269,7 @@ get_materialization_end_point_for_table(int32 raw_hypertable_id, int32 materiali
 	int64 old_completed_threshold = continuous_aggs_completed_threshold_get(materialization_id);
 	Dimension *time_column = hyperspace_get_open_dimension(raw_table->space, 0);
 	NameData time_column_name = time_column->fd.column_name;
-	Oid time_column_type = time_column->fd.column_type;
+	Oid time_column_type = ts_dimension_get_partition_type(time_column);
 	bool found_new_tuples = false;
 
 	found_new_tuples = hypertable_get_min_and_max(hypertable,
@@ -606,7 +606,7 @@ continuous_agg_execute_materialization(int64 bucket_width, int32 hypertable_id,
 	/* The materialization table always stores our internal representation of time values, so get
 	 * the real type of the time column from the original hypertable */
 	new_materialization_range.type =
-		hyperspace_get_open_dimension(raw_table->space, 0)->fd.column_type;
+		ts_dimension_get_partition_type(hyperspace_get_open_dimension(raw_table->space, 0));
 
 	time_column_name =
 		hyperspace_get_open_dimension(materialization_table->space, 0)->fd.column_name;

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -172,7 +172,8 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		Hypertable *ht = ts_hypertable_cache_get_entry_by_id(hcache, agg->data.raw_hypertable_id);
 		Dimension *time_dimension = hyperspace_get_open_dimension(ht->space, 0);
 		int64 lag =
-			continuous_agg_parse_refresh_lag(time_dimension->fd.column_type, with_clause_options);
+			continuous_agg_parse_refresh_lag(ts_dimension_get_partition_type(time_dimension),
+											 with_clause_options);
 		update_refresh_lag(agg, lag);
 		ts_cache_release(hcache);
 	}
@@ -182,7 +183,8 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		Cache *hcache = ts_hypertable_cache_pin();
 		Hypertable *ht = ts_hypertable_cache_get_entry_by_id(hcache, agg->data.raw_hypertable_id);
 		Dimension *time_dimension = hyperspace_get_open_dimension(ht->space, 0);
-		int64 max = continuous_agg_parse_max_interval_per_job(time_dimension->fd.column_type,
+		int64 max = continuous_agg_parse_max_interval_per_job(ts_dimension_get_partition_type(
+																  time_dimension),
 															  with_clause_options,
 															  agg->data.bucket_width);
 		update_max_interval_per_job(agg, max);


### PR DESCRIPTION
In various places, most notably drop_chunks and show_chunks, we
dispatch based on the type of the "time" column of the hypertable, for
things such as determining which interval type to use. With a custom
partition function, this logic is incorrect, as we should instead be
determining this based on the return type of the partitioning function.

This commit changes all relevant access of dimension.column_type to a
new function, ts_dimension_get_partition_type, which has the correct
behavior: it returns the partitioning function's return type, if one
exists, and only otherwise uses the column type. After this commit, all
references to column_type directly should have a comment explaining why
this is appropriate.

fixes #1250