### PR TITLE
Fix Order display in ChunkAppend EXPLAIN

### DIFF
--- a/src/chunk_append/explain.c
+++ b/src/chunk_append/explain.c
@@ -85,7 +85,8 @@ show_sort_group_keys(ChunkAppendState *state, List *ancestors, ExplainState *es)
 	{
 		/* find key expression in tlist */
 		AttrNumber keyresno = list_nth_oid(sort_indexes, keyno);
-		TargetEntry *target = get_tle_by_resno(plan->targetlist, keyresno);
+		TargetEntry *target =
+			get_tle_by_resno(castNode(CustomScan, plan)->custom_scan_tlist, keyresno);
 		char *exprstr;
 
 		if (!target)

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -407,6 +407,24 @@ ORDER BY time DESC, device_id LIMIT 1;
          ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
 (6 rows)
 
+-- test sort column not in targetlist
+:PREFIX SELECT
+  time_bucket('1h',time)
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: ordered_append."time" DESC
+         ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Heap Fetches: 1
+         ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (never executed)
+               Heap Fetches: 0
+(9 rows)
+
 -- queries with ORDER BY non-time column shouldn't use ordered append
 :PREFIX SELECT
   time, device_id, value

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -397,15 +397,33 @@ ORDER BY time DESC, device_id LIMIT 1;
   (time, device_id, value)
 FROM ordered_append
 ORDER BY time DESC, device_id LIMIT 1;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
-         Order: ROW(ordered_append."time", ordered_append.device_id, ordered_append.value) USING >, ordered_append."time" USING <
+         Order: ordered_append."time" DESC, ordered_append.device_id
          ->  Index Scan using _hyper_1_3_chunk_ordered_append_time_device_id_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
          ->  Index Scan using _hyper_1_2_chunk_ordered_append_time_device_id_idx on _hyper_1_2_chunk (never executed)
          ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk (never executed)
 (6 rows)
+
+-- test sort column not in targetlist
+:PREFIX SELECT
+  time_bucket('1h',time)
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: ordered_append."time" DESC
+         ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Heap Fetches: 1
+         ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (never executed)
+               Heap Fetches: 0
+(9 rows)
 
 -- queries with ORDER BY non-time column shouldn't use ordered append
 :PREFIX SELECT
@@ -655,7 +673,7 @@ ORDER BY time ASC LIMIT 1;
 ----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
    ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
-         Order: time_bucket('@ 1 day'::interval, ordered_append."time")
+         Order: ordered_append."time"
          ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
          ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
          ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -407,6 +407,21 @@ ORDER BY time DESC, device_id LIMIT 1;
          ->  Index Scan using _hyper_1_1_chunk_ordered_append_time_device_id_idx on _hyper_1_1_chunk
 (6 rows)
 
+-- test sort column not in targetlist
+:PREFIX SELECT
+  time_bucket('1h',time)
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ChunkAppend) on ordered_append
+         Order: ordered_append."time" DESC
+         ->  Index Only Scan using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
+(6 rows)
+
 -- queries with ORDER BY non-time column shouldn't use ordered append
 :PREFIX SELECT
   time, device_id, value

--- a/test/sql/include/plan_ordered_append_query.sql
+++ b/test/sql/include/plan_ordered_append_query.sql
@@ -57,6 +57,12 @@ ORDER BY time DESC, device_id LIMIT 1;
 FROM ordered_append
 ORDER BY time DESC, device_id LIMIT 1;
 
+-- test sort column not in targetlist
+:PREFIX SELECT
+  time_bucket('1h',time)
+FROM ordered_append
+ORDER BY time DESC LIMIT 1;
+
 -- queries with ORDER BY non-time column shouldn't use ordered append
 :PREFIX SELECT
   time, device_id, value


### PR DESCRIPTION
The Order display of the ChunkAppend node used the output of
the node instead of the input of the node when resolving the
targetlist index to display the order information leading to
incorrect display when the Sort column was not passed through
or the position changed.