### PR TITLE
Make test runner output filter work on BSDs

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -76,4 +76,4 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
-     $@ -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' -e 's! Memory: [0-9]\+kB!!'
+     $@ -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' -e 's! Memory: [0-9]\{1,\}kB!!'


### PR DESCRIPTION
The regexp-based test output filtering in `runner.sh` does not work
with the Mac OS/BSD version of `sed` since it doesn't use the
extended/modern regexp syntax by default. This makes some tests fail
on Mac OS X/BSD.

This change makes the filter use non-extended regexp syntax to fix
this issue.