### PR TITLE
Support time bucket functions in Ordered Append

### DIFF
--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -261,20 +261,18 @@ psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=1 loops=1)
-   Sort Key: (date_trunc('year'::text, append_test."time")) DESC
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=1 loops=1)
-         Group Key: (date_trunc('year'::text, append_test."time"))
-         ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
-               Chunks excluded during startup: 1
-               ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-               ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(11 rows)
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: (date_trunc('year'::text, append_test."time"))
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
+         Order: date_trunc('year'::text, append_test."time") DESC
+         Chunks excluded during startup: 1
+         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
+         ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
+               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
+(9 rows)
 
 -- querying outside the time range should return nothing. This tests
 -- that ConstraintAwareAppend can handle the case when an Append node

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -261,20 +261,18 @@ psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=1 loops=1)
-   Sort Key: (date_trunc('year'::text, append_test."time")) DESC
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=1 loops=1)
-         Group Key: date_trunc('year'::text, append_test."time")
-         ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
-               Chunks excluded during startup: 1
-               ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-               ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(11 rows)
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: (date_trunc('year'::text, append_test."time"))
+   ->  Custom Scan (ChunkAppend) on append_test (actual rows=3 loops=1)
+         Order: date_trunc('year'::text, append_test."time") DESC
+         Chunks excluded during startup: 1
+         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
+         ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
+               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
+(9 rows)
 
 -- querying outside the time range should return nothing. This tests
 -- that ConstraintAwareAppend can handle the case when an Append node

--- a/test/expected/append-9.6.out
+++ b/test/expected/append-9.6.out
@@ -249,19 +249,18 @@ psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
 psql:include/append_query.sql:58: NOTICE:  Stable function now_s() called!
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Sort
-   Sort Key: (date_trunc('year'::text, append_test."time")) DESC
-   ->  HashAggregate
-         Group Key: (date_trunc('year'::text, append_test."time"))
-         ->  Custom Scan (ChunkAppend) on append_test
-               Chunks excluded during startup: 1
-               ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-               ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
-                     Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
-(10 rows)
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ GroupAggregate
+   Group Key: (date_trunc('year'::text, append_test."time"))
+   ->  Custom Scan (ChunkAppend) on append_test
+         Order: date_trunc('year'::text, append_test."time") DESC
+         Chunks excluded during startup: 1
+         ->  Index Scan using _hyper_1_3_chunk_append_test_time_idx on _hyper_1_3_chunk
+               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
+         ->  Index Scan using _hyper_1_2_chunk_append_test_time_idx on _hyper_1_2_chunk
+               Index Cond: ("time" > (now_s() - '@ 4 mons'::interval))
+(9 rows)
 
 -- querying outside the time range should return nothing. This tests
 -- that ConstraintAwareAppend can handle the case when an Append node

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -457,7 +457,7 @@ ORDER BY device_id, time LIMIT 1;
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=23043 loops=1)
 (8 rows)
 
--- queries without LIMIT shouldnt use ordered append
+-- queries without LIMIT should use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
@@ -471,7 +471,7 @@ ORDER BY time ASC;
    ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=23043 loops=1)
 (5 rows)
 
--- queries without ORDER BY shouldnt use ordered append (still uses append though)
+-- queries without ORDER BY shouldnt use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
@@ -679,39 +679,107 @@ ORDER BY time ASC LIMIT 1;
          ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
 (6 rows)
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY 1 LIMIT 1;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Result (actual rows=1 loops=1)
-         ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time"))
-               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-(7 rows)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: time_bucket('@ 1 day'::interval, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY time_bucket('1d',time) LIMIT 1;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Result (actual rows=1 loops=1)
-         ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time"))
-               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-(7 rows)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: time_bucket('@ 1 day'::interval, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
 
--- test query with now() should result in ordered append with constraint aware append
+-- test query with ORDER BY time_bucket, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, name
+FROM dimension_last
+ORDER BY time_bucket('1d',time), device_id LIMIT 1;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_3_7_chunk."time")), _hyper_3_7_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Result (actual rows=5760 loops=1)
+               ->  Append (actual rows=5760 loops=1)
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_8_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_10_chunk (actual rows=1440 loops=1)
+(10 rows)
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY date_trunc('day', time) LIMIT 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: date_trunc('day'::text, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  date_trunc('day',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: date_trunc('day'::text, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test query with ORDER BY date_trunc, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  date_trunc('day',time), device_id, name
+FROM dimension_last
+ORDER BY 1,2 LIMIT 1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: (date_trunc('day'::text, _hyper_3_7_chunk."time")), _hyper_3_7_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Result (actual rows=5760 loops=1)
+               ->  Append (actual rows=5760 loops=1)
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_8_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_10_chunk (actual rows=1440 loops=1)
+(10 rows)
+
+-- test query with now() should result in ordered ChunkAppend
 :PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
 ORDER BY time DESC limit 1;
                                                     QUERY PLAN                                                     

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -457,7 +457,7 @@ ORDER BY device_id, time LIMIT 1;
                ->  Seq Scan on _hyper_1_3_chunk (actual rows=23043 loops=1)
 (8 rows)
 
--- queries without LIMIT shouldnt use ordered append
+-- queries without LIMIT should use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
@@ -471,7 +471,7 @@ ORDER BY time ASC;
    ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=23043 loops=1)
 (5 rows)
 
--- queries without ORDER BY shouldnt use ordered append (still uses append though)
+-- queries without ORDER BY shouldnt use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
@@ -679,39 +679,107 @@ ORDER BY time ASC LIMIT 1;
          ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
 (6 rows)
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY 1 LIMIT 1;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Result (actual rows=1 loops=1)
-         ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time"))
-               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-(7 rows)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: time_bucket('@ 1 day'::interval, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY time_bucket('1d',time) LIMIT 1;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=1 loops=1)
-   ->  Result (actual rows=1 loops=1)
-         ->  Merge Append (actual rows=1 loops=1)
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time"))
-               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
-(7 rows)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: time_bucket('@ 1 day'::interval, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
 
--- test query with now() should result in ordered append with constraint aware append
+-- test query with ORDER BY time_bucket, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, name
+FROM dimension_last
+ORDER BY time_bucket('1d',time), device_id LIMIT 1;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_3_7_chunk."time")), _hyper_3_7_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Result (actual rows=5760 loops=1)
+               ->  Append (actual rows=5760 loops=1)
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_8_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_10_chunk (actual rows=1440 loops=1)
+(10 rows)
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY date_trunc('day', time) LIMIT 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: date_trunc('day'::text, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  date_trunc('day',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on ordered_append (actual rows=1 loops=1)
+         Order: date_trunc('day'::text, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk (never executed)
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk (never executed)
+(6 rows)
+
+-- test query with ORDER BY date_trunc, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  date_trunc('day',time), device_id, name
+FROM dimension_last
+ORDER BY 1,2 LIMIT 1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Sort (actual rows=1 loops=1)
+         Sort Key: (date_trunc('day'::text, _hyper_3_7_chunk."time")), _hyper_3_7_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Result (actual rows=5760 loops=1)
+               ->  Append (actual rows=5760 loops=1)
+                     ->  Seq Scan on _hyper_3_7_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_8_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_9_chunk (actual rows=1440 loops=1)
+                     ->  Seq Scan on _hyper_3_10_chunk (actual rows=1440 loops=1)
+(10 rows)
+
+-- test query with now() should result in ordered ChunkAppend
 :PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
 ORDER BY time DESC limit 1;
                                                     QUERY PLAN                                                     

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -453,7 +453,7 @@ ORDER BY device_id, time LIMIT 1;
                ->  Seq Scan on _hyper_1_3_chunk
 (7 rows)
 
--- queries without LIMIT shouldnt use ordered append
+-- queries without LIMIT should use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
@@ -467,7 +467,7 @@ ORDER BY time ASC;
    ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
 (5 rows)
 
--- queries without ORDER BY shouldnt use ordered append (still uses append though)
+-- queries without ORDER BY shouldnt use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
@@ -663,39 +663,105 @@ ORDER BY time ASC LIMIT 1;
          ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
 (6 rows)
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY 1 LIMIT 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit
-   ->  Result
-         ->  Merge Append
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time"))
-               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
-               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
-               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
-(7 rows)
+   ->  Custom Scan (ChunkAppend) on ordered_append
+         Order: time_bucket('@ 1 day'::interval, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
+(6 rows)
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY time_bucket('1d',time) LIMIT 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Limit
-   ->  Result
-         ->  Merge Append
-               Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk."time"))
-               ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
-               ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
-               ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
-(7 rows)
+   ->  Custom Scan (ChunkAppend) on ordered_append
+         Order: time_bucket('@ 1 day'::interval, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
+(6 rows)
 
--- test query with now() should result in ordered append with constraint aware append
+-- test query with ORDER BY time_bucket, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, name
+FROM dimension_last
+ORDER BY time_bucket('1d',time), device_id LIMIT 1;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_3_7_chunk."time")), _hyper_3_7_chunk.device_id
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_3_7_chunk
+                     ->  Seq Scan on _hyper_3_8_chunk
+                     ->  Seq Scan on _hyper_3_9_chunk
+                     ->  Seq Scan on _hyper_3_10_chunk
+(9 rows)
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY date_trunc('day', time) LIMIT 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ChunkAppend) on ordered_append
+         Order: date_trunc('day'::text, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
+(6 rows)
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  date_trunc('day',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ChunkAppend) on ordered_append
+         Order: date_trunc('day'::text, ordered_append."time")
+         ->  Index Scan Backward using _hyper_1_1_chunk_ordered_append_time_idx on _hyper_1_1_chunk
+         ->  Index Scan Backward using _hyper_1_2_chunk_ordered_append_time_idx on _hyper_1_2_chunk
+         ->  Index Scan Backward using _hyper_1_3_chunk_ordered_append_time_idx on _hyper_1_3_chunk
+(6 rows)
+
+-- test query with ORDER BY date_trunc, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  date_trunc('day',time), device_id, name
+FROM dimension_last
+ORDER BY 1,2 LIMIT 1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (date_trunc('day'::text, _hyper_3_7_chunk."time")), _hyper_3_7_chunk.device_id
+         ->  Result
+               ->  Append
+                     ->  Seq Scan on _hyper_3_7_chunk
+                     ->  Seq Scan on _hyper_3_8_chunk
+                     ->  Seq Scan on _hyper_3_9_chunk
+                     ->  Seq Scan on _hyper_3_10_chunk
+(9 rows)
+
+-- test query with now() should result in ordered ChunkAppend
 :PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
 ORDER BY time DESC limit 1;
                                         QUERY PLAN                                         

--- a/test/expected/query.out
+++ b/test/expected/query.out
@@ -143,16 +143,15 @@ SHOW timescaledb.disable_optimizations;
 
 --Aggregates use MergeAppend only in optimized
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('minute'::text, hyper_1."time") DESC
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(6 rows)
 
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1_date GROUP BY t ORDER BY t DESC limit 2;
                                                       QUERY PLAN                                                      
@@ -180,28 +179,26 @@ SHOW timescaledb.disable_optimizations;
 
 --the minute and second results should be diff
 :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('minute'::text, hyper_1."time") DESC
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(6 rows)
 
 :PREFIX SELECT date_trunc('second', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('second'::text, _hyper_1_1_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (date_trunc('second'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+         Group Key: (date_trunc('second'::text, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('second'::text, hyper_1."time") DESC
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(6 rows)
 
 --test that when index on time used by constraint, still works correctly
 :PREFIX
@@ -211,19 +208,17 @@ WHERE time < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
          Group Key: (date_trunc('minute'::text, hyper_1."time"))
-         ->  Custom Scan (ConstraintAwareAppend)
-               Hypertable: hyper_1
-               Chunks left after exclusion: 1
-               ->  Merge Append
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-                           Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(10 rows)
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('minute'::text, hyper_1."time") DESC
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+                     Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(8 rows)
 
 --test on table with time partitioning function. Currently not
 --optimized to use index for ordering since the index is an expression
@@ -255,44 +250,41 @@ BEGIN;
   CREATE INDEX "time_trunc" ON PUBLIC.hyper_1 (date_trunc('minute', time));
   ANALYZE hyper_1;
   :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(7 rows)
+         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('minute'::text, hyper_1."time") DESC
+               ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
+(6 rows)
 
   --test that works with both indexes
   CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
   ANALYZE hyper_1;
   :PREFIX SELECT date_trunc('minute', time) t, avg(series_0), min(series_1), avg(series_2) FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (date_trunc('minute'::text, _hyper_1_1_chunk."time")) DESC
-                     ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
-(7 rows)
+         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('minute'::text, hyper_1."time") DESC
+               ->  Index Scan Backward using _hyper_1_1_chunk_time_trunc on _hyper_1_1_chunk
+(6 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric, 5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (time_bucket('@ 1 min'::interval, _hyper_1_1_chunk."time")) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+         Group Key: (time_bucket('@ 1 min'::interval, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: time_bucket('@ 1 min'::interval, hyper_1."time") DESC
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(6 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time, INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -309,16 +301,15 @@ BEGIN;
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval)))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (time_bucket('@ 1 min'::interval, (_hyper_1_1_chunk."time" - '@ 30 secs'::interval))) DESC
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-(7 rows)
+         Group Key: (time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: time_bucket('@ 1 min'::interval, (hyper_1."time" - '@ 30 secs'::interval)) DESC
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+(6 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time - INTERVAL '30 seconds') + INTERVAL '30 seconds' t, avg(series_0), min(series_1), trunc(avg(series_2)::numeric,5)
   FROM hyper_1 GROUP BY t ORDER BY t DESC limit 2;
@@ -335,16 +326,15 @@ BEGIN;
 
   :PREFIX SELECT time_bucket('1 minute', time) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (time_bucket('@ 1 min'::interval, _hyper_2_2_chunk."time")) DESC
-                     ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
-(7 rows)
+         Group Key: (time_bucket('@ 1 min'::interval, hyper_1_tz."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1_tz
+               Order: time_bucket('@ 1 min'::interval, hyper_1_tz."time") DESC
+               ->  Index Scan using _hyper_2_2_chunk_time_plain_tz on _hyper_2_2_chunk
+(6 rows)
 
   :PREFIX SELECT time_bucket('1 minute', time::timestamp) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_tz GROUP BY t ORDER BY t DESC limit 2;
@@ -361,33 +351,31 @@ BEGIN;
 
   :PREFIX SELECT time_bucket(10, time) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket(10, _hyper_3_3_chunk."time"))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (time_bucket(10, _hyper_3_3_chunk."time")) DESC
-                     ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
-                     ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk
-                     ->  Index Scan using _hyper_3_5_chunk_time_plain_int on _hyper_3_5_chunk
-(9 rows)
+         Group Key: (time_bucket(10, hyper_1_int."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1_int
+               Order: time_bucket(10, hyper_1_int."time") DESC
+               ->  Index Scan using _hyper_3_5_chunk_time_plain_int on _hyper_3_5_chunk
+               ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk
+               ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
+(8 rows)
 
   :PREFIX SELECT time_bucket(10, time, 2) t, avg(series_0), min(series_1), avg(series_2)
   FROM hyper_1_int GROUP BY t ORDER BY t DESC limit 2;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Limit
    ->  GroupAggregate
-         Group Key: (time_bucket(10, _hyper_3_3_chunk."time", 2))
-         ->  Result
-               ->  Merge Append
-                     Sort Key: (time_bucket(10, _hyper_3_3_chunk."time", 2)) DESC
-                     ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
-                     ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk
-                     ->  Index Scan using _hyper_3_5_chunk_time_plain_int on _hyper_3_5_chunk
-(9 rows)
+         Group Key: (time_bucket(10, hyper_1_int."time", 2))
+         ->  Custom Scan (ChunkAppend) on hyper_1_int
+               Order: time_bucket(10, hyper_1_int."time", 2) DESC
+               ->  Index Scan using _hyper_3_5_chunk_time_plain_int on _hyper_3_5_chunk
+               ->  Index Scan using _hyper_3_4_chunk_time_plain_int on _hyper_3_4_chunk
+               ->  Index Scan using _hyper_3_3_chunk_time_plain_int on _hyper_3_3_chunk
+(8 rows)
 
 ROLLBACK;
 --plain tables shouldnt be optimized by default

--- a/test/expected/sort_optimization-10.out
+++ b/test/expected/sort_optimization-10.out
@@ -30,13 +30,12 @@ SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
 
 -- should use index scan
 :PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Result
-   ->  Merge Append
-         Sort Key: (time_bucket(10, _hyper_1_1_chunk."time"))
-         ->  Index Scan Backward using _hyper_1_1_chunk_order_test_time_idx on _hyper_1_1_chunk
-(4 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on order_test
+   Order: time_bucket(10, order_test."time")
+   ->  Index Scan Backward using _hyper_1_1_chunk_order_test_time_idx on _hyper_1_1_chunk
+(3 rows)
 
 -- test sort optimization with ordering by multiple columns and time_bucket not last
 SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1,2;

--- a/test/expected/sort_optimization-11.out
+++ b/test/expected/sort_optimization-11.out
@@ -30,13 +30,12 @@ SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
 
 -- should use index scan
 :PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Result
-   ->  Merge Append
-         Sort Key: (time_bucket(10, _hyper_1_1_chunk."time"))
-         ->  Index Scan Backward using _hyper_1_1_chunk_order_test_time_idx on _hyper_1_1_chunk
-(4 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on order_test
+   Order: time_bucket(10, order_test."time")
+   ->  Index Scan Backward using _hyper_1_1_chunk_order_test_time_idx on _hyper_1_1_chunk
+(3 rows)
 
 -- test sort optimization with ordering by multiple columns and time_bucket not last
 SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1,2;

--- a/test/expected/sort_optimization-9.6.out
+++ b/test/expected/sort_optimization-9.6.out
@@ -30,13 +30,12 @@ SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
 
 -- should use index scan
 :PREFIX SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Result
-   ->  Merge Append
-         Sort Key: (time_bucket(10, _hyper_1_1_chunk."time"))
-         ->  Index Scan Backward using _hyper_1_1_chunk_order_test_time_idx on _hyper_1_1_chunk
-(4 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on order_test
+   Order: time_bucket(10, order_test."time")
+   ->  Index Scan Backward using _hyper_1_1_chunk_order_test_time_idx on _hyper_1_1_chunk
+(3 rows)
 
 -- test sort optimization with ordering by multiple columns and time_bucket not last
 SELECT time_bucket(10,time),device_id,value FROM order_test ORDER BY 1,2;

--- a/test/sql/include/plan_ordered_append_query.sql
+++ b/test/sql/include/plan_ordered_append_query.sql
@@ -75,13 +75,13 @@ ORDER BY device_id LIMIT 1;
 FROM ordered_append
 ORDER BY device_id, time LIMIT 1;
 
--- queries without LIMIT shouldnt use ordered append
+-- queries without LIMIT should use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
 ORDER BY time ASC;
 
--- queries without ORDER BY shouldnt use ordered append (still uses append though)
+-- queries without ORDER BY shouldnt use ordered append
 :PREFIX SELECT
   time, device_id, value
 FROM ordered_append
@@ -142,19 +142,45 @@ ORDER BY time ASC LIMIT 1;
 FROM ordered_append
 ORDER BY time ASC LIMIT 1;
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY 1 LIMIT 1;
 
--- test query with order by time_bucket (should not use ordered append)
+-- test query with ORDER BY time_bucket
 :PREFIX SELECT
   time_bucket('1d',time), device_id, value
 FROM ordered_append
 ORDER BY time_bucket('1d',time) LIMIT 1;
 
--- test query with now() should result in ordered append with constraint aware append
+-- test query with ORDER BY time_bucket, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, name
+FROM dimension_last
+ORDER BY time_bucket('1d',time), device_id LIMIT 1;
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  time_bucket('1d',time), device_id, value
+FROM ordered_append
+ORDER BY date_trunc('day', time) LIMIT 1;
+
+-- test query with ORDER BY date_trunc
+:PREFIX SELECT
+  date_trunc('day',time), device_id, value
+FROM ordered_append
+ORDER BY 1 LIMIT 1;
+
+-- test query with ORDER BY date_trunc, device_id
+-- must not use ordered append
+:PREFIX SELECT
+  date_trunc('day',time), device_id, name
+FROM dimension_last
+ORDER BY 1,2 LIMIT 1;
+
+-- test query with now() should result in ordered ChunkAppend
 :PREFIX SELECT * FROM ordered_append WHERE time < now() + '1 month'
 ORDER BY time DESC limit 1;
 


### PR DESCRIPTION
The initial implementation for Ordered Append required the ORDER BY
clause expression to match the time partitioning column.
This patch loosenes that restriction and will apply the Ordered
Append optimizations for queries with ORDER BY time_bucket as well.