### PR TITLE
Implement adding a notion of now for hypertables with integer time columns

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -3,6 +3,7 @@ set(INSTALL_FILE ${PROJECT_NAME}--${PROJECT_VERSION_MOD}.sql)
 # Source files that define the schemas and tables for our metadata
 set(PRE_INSTALL_SOURCE_FILES
   pre_install/schemas.sql # Must be first
+  pre_install/types.sql # Must be before tables.sql
   pre_install/tables.sql
   pre_install/bgw_scheduler_startup.sql
 )
@@ -30,6 +31,7 @@ set(SOURCE_FILES
   ddl_triggers.sql
   bookend.sql
   time_bucket.sql
+  ts_interval.sql
   version.sql
   size_utils.sql
   histogram.sql

--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -21,7 +21,7 @@ INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedul
 (1, 'Telemetry Reporter', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h')
 ON CONFLICT (id) DO NOTHING;
 
-CREATE OR REPLACE FUNCTION add_drop_chunks_policy(hypertable REGCLASS, older_than INTERVAL, cascade BOOL = FALSE, if_not_exists BOOL = false, cascade_to_materializations BOOL = false)
+CREATE OR REPLACE FUNCTION add_drop_chunks_policy(hypertable REGCLASS, older_than "any", cascade BOOL = FALSE, if_not_exists BOOL = false, cascade_to_materializations BOOL = false)
 RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_add_drop_chunks_policy'
 LANGUAGE C VOLATILE STRICT;

--- a/sql/pre_install/types.sql
+++ b/sql/pre_install/types.sql
@@ -1,0 +1,22 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Postgres has special types such as timestamp, date, timestamptz, etc. to
+-- represent logical time values. On top of these, TimescaleDB allows integers
+-- to represent logical time values. Postgres INTERVAL types are suited only for
+-- logical time types in postgres. The type defined below is an INTERVAL equivalent
+-- for TimescaleDB and enables to represent time intervals for both postgres time
+-- type valued and integer valued time columns.
+CREATE TYPE _timescaledb_catalog.ts_interval AS (
+    is_time_interval        BOOLEAN,
+    time_interval		    INTERVAL,
+    integer_interval        BIGINT
+    );
+
+-- PostgreSQL composite types do not support constraint checks. That is why any table having a ts_interval column must use the following
+-- function for constraint validation.
+-- This function needs to be defined before executing pre_install/tables.sql because it is used as
+-- validation constraint for columns of type ts_interval.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.valid_ts_interval(invl _timescaledb_catalog.ts_interval)
+RETURNS BOOLEAN AS '@MODULE_PATHNAME@', 'ts_valid_ts_interval' LANGUAGE C VOLATILE STRICT;

--- a/sql/ts_interval.sql
+++ b/sql/ts_interval.sql
@@ -1,0 +1,8 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+
+CREATE OR REPLACE FUNCTION set_integer_now_func(hypertable REGCLASS, integer_now_func REGPROC, replace_if_exists BOOL = false) RETURNS VOID
+AS '@MODULE_PATHNAME@', 'ts_set_integer_now_func'
+LANGUAGE C VOLATILE STRICT;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,1 +1,60 @@
 DROP FUNCTION IF EXISTS drop_chunks("any",name,name,boolean,"any",boolean,boolean);
+DROP FUNCTION IF EXISTS add_drop_chunks_policy(REGCLASS,INTERVAL,BOOL,BOOL,BOOL);
+
+ALTER TABLE _timescaledb_catalog.dimension
+ADD COLUMN integer_now_func_schema     NAME     NULL;
+
+ALTER TABLE _timescaledb_catalog.dimension
+ADD COLUMN integer_now_func            NAME     NULL;
+
+ALTER TABLE _timescaledb_catalog.dimension
+ADD CONSTRAINT dimension_check2
+CHECK (
+        (integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR
+        (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)
+);
+-- ----------------------
+CREATE TYPE _timescaledb_catalog.ts_interval AS (
+    is_time_interval        BOOLEAN,
+    time_interval		    INTERVAL,
+    integer_interval        BIGINT
+    );
+
+-- q -- todo:: this is probably necessary if we keep the validation constraint in the table definition.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.valid_ts_interval(invl _timescaledb_catalog.ts_interval)
+RETURNS BOOLEAN AS '@MODULE_PATHNAME@', 'ts_valid_ts_interval' LANGUAGE C VOLATILE STRICT;
+
+DROP VIEW IF EXISTS timescaledb_information.drop_chunks_policies;
+DROP VIEW IF EXISTS timescaledb_information.policy_stats;
+
+CREATE TABLE IF NOT EXISTS _timescaledb_config.bgw_policy_drop_chunks_tmp (
+    job_id          		    INTEGER                 PRIMARY KEY REFERENCES _timescaledb_config.bgw_job(id) ON DELETE CASCADE,
+    hypertable_id   		    INTEGER     UNIQUE      NOT NULL REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE,
+    older_than	    _timescaledb_catalog.ts_interval    NOT NULL,
+	cascade					    BOOLEAN                 NOT NULL,
+    cascade_to_materializations BOOLEAN                 NOT NULL,
+    CONSTRAINT valid_older_than CHECK(_timescaledb_internal.valid_ts_interval(older_than))
+);
+
+INSERT INTO _timescaledb_config.bgw_policy_drop_chunks_tmp
+(SELECT job_id, hypertable_id, ROW('t',older_than,NULL)::_timescaledb_catalog.ts_interval  as older_than, cascade, cascade_to_materializations
+FROM _timescaledb_config.bgw_policy_drop_chunks);
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_config.bgw_policy_drop_chunks;
+DROP TABLE _timescaledb_config.bgw_policy_drop_chunks;
+
+CREATE TABLE IF NOT EXISTS _timescaledb_config.bgw_policy_drop_chunks (
+    job_id          		    INTEGER                 PRIMARY KEY REFERENCES _timescaledb_config.bgw_job(id) ON DELETE CASCADE,
+    hypertable_id   		    INTEGER     UNIQUE      NOT NULL REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE,
+    older_than	    _timescaledb_catalog.ts_interval    NOT NULL,
+	cascade					    BOOLEAN                 NOT NULL,
+    cascade_to_materializations BOOLEAN                 NOT NULL,
+    CONSTRAINT valid_older_than CHECK(_timescaledb_internal.valid_ts_interval(older_than))
+);
+
+INSERT INTO _timescaledb_config.bgw_policy_drop_chunks
+(SELECT * FROM _timescaledb_config.bgw_policy_drop_chunks_tmp);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_policy_drop_chunks', '');
+DROP TABLE _timescaledb_config.bgw_policy_drop_chunks_tmp;
+GRANT SELECT ON _timescaledb_config.bgw_policy_drop_chunks TO PUBLIC;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
   hypertable_restrict_info.c
   indexing.c
   init.c
+  interval.c
   metadata.c
   jsonb_utils.c
   license_guc.c

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -172,6 +172,8 @@ enum Anum_dimension
 	Anum_dimension_partitioning_func_schema,
 	Anum_dimension_partitioning_func,
 	Anum_dimension_interval_length,
+	Anum_dimension_integer_now_func_schema,
+	Anum_dimension_integer_now_func,
 	_Anum_dimension_max,
 };
 
@@ -190,6 +192,8 @@ typedef struct FormData_dimension
 	NameData partitioning_func;
 	/* open (time) columns */
 	int64 interval_length;
+	NameData integer_now_func_schema;
+	NameData integer_now_func;
 } FormData_dimension;
 
 typedef FormData_dimension *Form_dimension;
@@ -691,6 +695,23 @@ typedef struct FormData_bgw_policy_reorder_hypertable_id_idx
  *
  ******************************************/
 #define BGW_POLICY_DROP_CHUNKS_TABLE_NAME "bgw_policy_drop_chunks"
+
+typedef enum Anum_ts_interval
+{
+	Anum_is_time_interval = 1,
+	Anum_time_interval,
+	Anum_integer_interval,
+	_Anum_ts_interval_max
+} Anum_ts_interval;
+
+#define Natts_ts_interval (_Anum_ts_interval_max - 1)
+typedef struct FormData_ts_interval
+{
+	bool is_time_interval;
+	Interval time_interval;
+	int64 integer_interval;
+} FormData_ts_interval;
+
 typedef enum Anum_bgw_policy_drop_chunks
 {
 	Anum_bgw_policy_drop_chunks_job_id = 1,
@@ -707,7 +728,7 @@ typedef struct FormData_bgw_policy_drop_chunks
 {
 	int32 job_id;
 	int32 hypertable_id;
-	Interval older_than;
+	FormData_ts_interval older_than;
 	bool cascade;
 	bool cascade_to_materializations;
 } FormData_bgw_policy_drop_chunks;

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -13,6 +13,8 @@
 #include "guc.h"
 #include "bgw/job.h"
 
+TS_FUNCTION_INFO_V1(ts_set_integer_now_func);
+TS_FUNCTION_INFO_V1(ts_valid_ts_interval);
 TS_FUNCTION_INFO_V1(ts_add_drop_chunks_policy);
 TS_FUNCTION_INFO_V1(ts_add_reorder_policy);
 TS_FUNCTION_INFO_V1(ts_remove_drop_chunks_policy);
@@ -23,6 +25,18 @@ TS_FUNCTION_INFO_V1(ts_partialize_agg);
 TS_FUNCTION_INFO_V1(ts_finalize_agg_sfunc);
 TS_FUNCTION_INFO_V1(ts_finalize_agg_ffunc);
 TS_FUNCTION_INFO_V1(continuous_agg_invalidation_trigger);
+
+Datum
+ts_set_integer_now_func(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_DATUM(ts_cm_functions->set_integer_now_func(fcinfo));
+}
+
+Datum
+ts_valid_ts_interval(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_DATUM(ts_cm_functions->valid_ts_interval(fcinfo));
+}
 
 Datum
 ts_add_drop_chunks_policy(PG_FUNCTION_ARGS)
@@ -222,6 +236,8 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.add_tsl_license_info_telemetry = add_telemetry_default,
 	.bgw_policy_job_execute = bgw_policy_job_execute_default_fn,
 	.continuous_agg_materialize = cagg_materialize_default_fn,
+	.set_integer_now_func = error_no_default_fn_pg_enterprise,
+	.valid_ts_interval = error_no_default_fn_pg_enterprise,
 	.add_drop_chunks_policy = error_no_default_fn_pg_enterprise,
 	.add_reorder_policy = error_no_default_fn_pg_enterprise,
 	.remove_drop_chunks_policy = error_no_default_fn_pg_enterprise,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -42,6 +42,9 @@ typedef struct CrossModuleFunctions
 	void (*add_tsl_license_info_telemetry)(JsonbParseState *parseState);
 	bool (*bgw_policy_job_execute)(BgwJob *job);
 	bool (*continuous_agg_materialize)(int32 materialization_id, bool verbose);
+	Datum (*set_integer_now_func)(PG_FUNCTION_ARGS);
+	Datum (*valid_ts_interval)(PG_FUNCTION_ARGS);
+
 	Datum (*add_drop_chunks_policy)(PG_FUNCTION_ARGS);
 	Datum (*add_reorder_policy)(PG_FUNCTION_ARGS);
 	Datum (*remove_drop_chunks_policy)(PG_FUNCTION_ARGS);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -165,6 +165,9 @@ extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_closed(Oid table_reli
 extern void ts_dimension_info_validate(DimensionInfo *info);
 extern void ts_dimension_add_from_info(DimensionInfo *info);
 extern void ts_dimensions_rename_schema_name(char *oldname, char *newname);
+extern TSDLLEXPORT void dimension_update(Oid table_relid, Name dimname, DimensionType dimtype,
+										 Datum *interval, Oid *intervaltype, int16 *num_slices,
+										 Oid *integer_now_func);
 
 #define hyperspace_get_open_dimension(space, i)                                                    \
 	ts_hyperspace_get_dimension(space, DIMENSION_TYPE_OPEN, i)

--- a/src/interval.c
+++ b/src/interval.c
@@ -1,0 +1,384 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <funcapi.h>
+#include <utils/typcache.h>
+#include <parser/parse_type.h>
+#include <access/htup_details.h>
+#include <utils/lsyscache.h>
+#include <utils/syscache.h>
+#include <miscadmin.h>
+#include <utils/elog.h>
+
+#include "interval.h"
+#include "hypertable.h"
+
+#include "dimension.h"
+#include "hypertable_cache.h"
+#include "cache.h"
+#include "utils.h"
+#include "errors.h"
+#include "compat.h"
+
+#if !PG96
+#include <utils/fmgrprotos.h>
+#else
+#include <utils/date.h>
+#endif
+
+/* This function deforms its input argument `ts_interval_datum` into `FormData_ts_interval`
+ * assuming it was read from a postgres table and so the datum represents a TupleHeader
+ */
+FormData_ts_interval *
+ts_interval_from_tuple(Datum interval)
+{
+	bool isnull[Natts_ts_interval];
+	Datum values[Natts_ts_interval];
+	HeapTupleHeader th;
+	HeapTupleData tuple;
+	FormData_ts_interval *invl;
+
+	Oid rowType;
+	int32 rowTypmod;
+	TupleDesc rowdesc;
+
+	th = DatumGetHeapTupleHeader(interval);
+	rowType = HeapTupleHeaderGetTypeId(th);
+	rowTypmod = HeapTupleHeaderGetTypMod(th);
+	rowdesc = lookup_rowtype_tupdesc(rowType, rowTypmod);
+
+	tuple.t_len = HeapTupleHeaderGetDatumLength(th);
+	ItemPointerSetInvalid(&(tuple.t_self));
+	tuple.t_tableOid = InvalidOid;
+	tuple.t_data = th;
+
+	heap_deform_tuple(&tuple, rowdesc, values, isnull);
+	// lookup_rowtype_tupdesc gives a ref counted pointer
+	DecrTupleDescRefCount(rowdesc);
+
+	invl = palloc0(sizeof(FormData_ts_interval));
+
+	Assert(!isnull[AttrNumberGetAttrOffset(Anum_is_time_interval)]);
+
+	invl->is_time_interval = values[AttrNumberGetAttrOffset(Anum_is_time_interval)];
+	if (invl->is_time_interval)
+	{
+		Assert(!isnull[AttrNumberGetAttrOffset(Anum_time_interval)]);
+		Assert(isnull[AttrNumberGetAttrOffset(Anum_integer_interval)]);
+		invl->time_interval =
+			*DatumGetIntervalP(values[AttrNumberGetAttrOffset(Anum_time_interval)]);
+	}
+	else
+	{
+		Assert(isnull[AttrNumberGetAttrOffset(Anum_time_interval)]);
+		Assert(!isnull[AttrNumberGetAttrOffset(Anum_integer_interval)]);
+		invl->integer_interval =
+			DatumGetInt64(values[AttrNumberGetAttrOffset(Anum_integer_interval)]);
+	}
+
+	return invl;
+}
+
+/* This function deforms its input `interval` argument into a FormData_ts_interval assuming interval
+ * was given as a SQL function argument and represents data of type `interval_type` and should
+ * represent an interval on hypertable with oid `relid`
+ */
+FormData_ts_interval *
+ts_interval_from_sql_input(Oid relid, Datum interval, Oid interval_type, char *parameter_name,
+						   char *caller_name)
+{
+	Hypertable *hypertable;
+	Cache *hcache;
+	FormData_ts_interval *invl = palloc0(sizeof(FormData_ts_interval));
+	Oid partitioning_type;
+	Dimension *open_dim;
+
+	ts_hypertable_permissions_check(relid, GetUserId());
+
+	hcache = ts_hypertable_cache_pin();
+	hypertable = ts_hypertable_cache_get_entry(hcache, relid);
+	/* First verify that the hypertable corresponds to a valid table */
+	if (hypertable == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
+				 errmsg("could not add drop_chunks policy because \"%s\" is not a hypertable",
+						get_rel_name(relid))));
+	/* validate that the open dimension uses a time type */
+	open_dim = hyperspace_get_open_dimension(hypertable->space, 0);
+	partitioning_type = ts_dimension_get_partition_type(open_dim);
+	ts_cache_release(hcache);
+
+	switch (interval_type)
+	{
+		case INTERVALOID:
+			if (IS_INTEGER_TYPE(partitioning_type))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("invalid parameter value for %s", parameter_name),
+						 errhint("INTERVAL time duration cannot be used with hypertables with "
+								 "integer-based time dimensions")));
+			ts_dimension_open_typecheck(INTERVALOID, partitioning_type, caller_name);
+			invl->is_time_interval = true;
+			invl->time_interval = *DatumGetIntervalP(interval);
+			break;
+		case INT2OID:
+		case INT4OID:
+		case INT8OID:
+			if (!IS_INTEGER_TYPE(partitioning_type))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("invalid parameter value for %s", parameter_name),
+						 errhint("integer-based time duration cannot be used with hypertables with "
+								 "a timestamp-based time dimensions")));
+
+			if (strlen(NameStr(open_dim->fd.integer_now_func)) == 0 ||
+				strlen(NameStr(open_dim->fd.integer_now_func_schema)) == 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("integer_now_func not set on hypertable %s", get_rel_name(relid))));
+
+			invl->is_time_interval = false;
+			invl->integer_interval = ts_time_value_to_internal(interval, interval_type);
+
+			break;
+		default:
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid type for parameter %s in %s", parameter_name, caller_name)));
+	}
+
+	return invl;
+}
+
+HeapTuple
+ts_interval_form_heaptuple(FormData_ts_interval *invl)
+{
+	Oid typeid;
+	TupleDesc olderthan_tupdesc;
+	Datum values[Natts_ts_interval];
+	bool nulls[Natts_ts_interval] = { false };
+
+	values[AttrNumberGetAttrOffset(Anum_is_time_interval)] = BoolGetDatum(invl->is_time_interval);
+
+	if (invl->is_time_interval)
+	{
+		nulls[AttrNumberGetAttrOffset(Anum_integer_interval)] = true;
+		values[AttrNumberGetAttrOffset(Anum_time_interval)] =
+			IntervalPGetDatum(&invl->time_interval);
+	}
+	else
+	{
+		nulls[AttrNumberGetAttrOffset(Anum_time_interval)] = true;
+		values[AttrNumberGetAttrOffset(Anum_integer_interval)] =
+			DatumGetInt64(invl->integer_interval);
+	}
+
+	typeid =
+		typenameTypeId(NULL, typeStringToTypeName(CATALOG_SCHEMA_NAME "." TS_INTERVAL_TYPE_NAME));
+	olderthan_tupdesc = lookup_type_cache(typeid, -1)->tupDesc;
+
+	olderthan_tupdesc = BlessTupleDesc(olderthan_tupdesc);
+	return heap_form_tuple(olderthan_tupdesc, values, nulls);
+}
+
+bool
+ts_interval_equal(FormData_ts_interval *invl1, FormData_ts_interval *invl2)
+{
+	AssertArg(invl1 != NULL);
+	AssertArg(invl2 != NULL);
+
+	if (invl1->is_time_interval != invl2->is_time_interval)
+		return false;
+
+	if (invl1->is_time_interval &&
+		!DatumGetBool(DirectFunctionCall2(interval_eq,
+										  IntervalPGetDatum(&invl1->time_interval),
+										  IntervalPGetDatum(&invl2->time_interval))))
+		return false;
+
+	if (!invl1->is_time_interval && invl1->integer_interval != invl2->integer_interval)
+	{
+		return false;
+	}
+
+	return true;
+}
+void
+ts_interval_now_func_validate(Oid now_func_oid, Oid open_dim_type)
+{
+	HeapTuple tuple;
+	Form_pg_proc now_func;
+
+	/* this function should only be called for hypertabes with integer open time dimension */
+	Assert(IS_INTEGER_TYPE(open_dim_type));
+
+	if (!OidIsValid(now_func_oid))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_FUNCTION), (errmsg("invalid integer_now function"))));
+
+	tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(now_func_oid));
+	if (!HeapTupleIsValid(tuple))
+	{
+		ReleaseSysCache(tuple);
+		ereport(ERROR,
+				(errcode(ERRCODE_NO_DATA_FOUND),
+				 errmsg("cache lookup failed for function %u", now_func_oid)));
+	}
+
+	now_func = (Form_pg_proc) GETSTRUCT(tuple);
+
+	if ((now_func->provolatile != PROVOLATILE_IMMUTABLE &&
+		 now_func->provolatile != PROVOLATILE_STABLE) ||
+		now_func->pronargs != 0)
+	{
+		ReleaseSysCache(tuple);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("integer_now_func must take no arguments and it must be STABLE")));
+	}
+
+	if (now_func->prorettype != open_dim_type)
+	{
+		ReleaseSysCache(tuple);
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("return type of integer_now_func must be the same as "
+						"the type of the time partitioning column of the hypertable")));
+	}
+	ReleaseSysCache(tuple);
+}
+
+static Datum
+ts_interval_from_now_func_get_datum(int64 interval, Oid time_dim_type, Oid now_func)
+{
+	Datum now;
+	int64 res;
+
+	AssertArg(IS_INTEGER_TYPE(time_dim_type));
+
+	ts_interval_now_func_validate(now_func, time_dim_type);
+	now = OidFunctionCall0(now_func);
+
+	switch (time_dim_type)
+	{
+		case INT2OID:
+			res = DatumGetInt16(now) - interval;
+			if (res < PG_INT16_MIN || res > PG_INT16_MAX)
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERVAL_FIELD_OVERFLOW), errmsg("ts_interval overflow")));
+			return Int16GetDatum(res);
+		case INT4OID:
+			res = DatumGetInt32(now) - interval;
+			if (res < PG_INT32_MIN || res > PG_INT32_MAX)
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERVAL_FIELD_OVERFLOW), errmsg("ts_interval overflow")));
+			return Int32GetDatum(res);
+		case INT8OID:
+			res = DatumGetInt64(now) - interval;
+			if (res > DatumGetInt64(now))
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERVAL_FIELD_OVERFLOW), errmsg("ts_interval overflow")));
+			return Int64GetDatum(res);
+		default:
+			pg_unreachable();
+	}
+}
+
+static bool
+noarg_integer_now_func_filter(Form_pg_proc form, void *arg)
+{
+	Oid *rettype = arg;
+
+	return form->pronargs == 0 && form->prorettype == *rettype;
+}
+
+/* maybe this can be exported later if other parts of the code need
+ * to access the integer_now_func
+ */
+static Oid
+get_integer_now_func(Dimension *open_dim)
+{
+	Oid rettype;
+	Oid now_func;
+
+	rettype = ts_dimension_get_partition_type(open_dim);
+
+	Assert(IS_INTEGER_TYPE(rettype));
+
+	now_func = lookup_proc_filtered(NameStr(open_dim->fd.integer_now_func_schema),
+									NameStr(open_dim->fd.integer_now_func),
+									NULL,
+									noarg_integer_now_func_filter,
+									&rettype);
+	return now_func;
+}
+
+/*
+ * Convert the difference of interval and current timestamp to internal representation
+ * This function interprets the interval as distance in time dimension to the past.
+ * Depending on the type of hypertable time column, the function applies the
+ * necessary granularity to now() - interval and returns the resulting
+ * datum (which incapsulates data of time column type)
+ */
+Datum
+ts_interval_subtract_from_now(FormData_ts_interval *invl, Dimension *open_dim)
+{
+	Oid type_oid;
+	AssertArg(invl != NULL);
+	AssertArg(open_dim != NULL);
+
+	type_oid = ts_dimension_get_partition_type(open_dim);
+
+	if (invl->is_time_interval)
+	{
+		Datum res = TimestampTzGetDatum(GetCurrentTimestamp());
+
+		switch (type_oid)
+		{
+			case TIMESTAMPOID:
+				res = DirectFunctionCall1(timestamptz_timestamp, res);
+				res = DirectFunctionCall2(timestamp_mi_interval,
+										  res,
+										  IntervalPGetDatum(&invl->time_interval));
+
+				return res;
+			case TIMESTAMPTZOID:
+				res = DirectFunctionCall2(timestamptz_mi_interval,
+										  res,
+										  IntervalPGetDatum(&invl->time_interval));
+
+				return res;
+			case DATEOID:
+				res = DirectFunctionCall1(timestamptz_timestamp, res);
+				res = DirectFunctionCall2(timestamp_mi_interval,
+										  res,
+										  IntervalPGetDatum(&invl->time_interval));
+				res = DirectFunctionCall1(timestamp_date, res);
+
+				return res;
+			default:
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("unknown time type OID %d", type_oid)));
+		}
+	}
+	else
+	{
+		Oid now_func = get_integer_now_func(open_dim);
+		ts_interval_now_func_validate(now_func, type_oid);
+
+		if (InvalidOid == now_func)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("integer_now function must be set")));
+
+		return ts_interval_from_now_func_get_datum(invl->integer_interval, type_oid, now_func);
+	}
+	/* suppress compiler warnings on MSVC */
+	pg_unreachable();
+	return 0;
+}

--- a/src/interval.h
+++ b/src/interval.h
@@ -1,0 +1,24 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include "catalog.h"
+#include "dimension.h"
+
+#ifndef TIMESCALEDB_INTERVAL
+#define TIMESCALEDB_INTERVAL
+
+#define TS_INTERVAL_TYPE_NAME "ts_interval"
+TSDLLEXPORT FormData_ts_interval *ts_interval_from_tuple(Datum ts_interval_datum);
+TSDLLEXPORT FormData_ts_interval *ts_interval_from_sql_input(Oid relid, Datum interval,
+															 Oid interval_type,
+															 char *parameter_name,
+															 char *caller_name);
+TSDLLEXPORT HeapTuple ts_interval_form_heaptuple(FormData_ts_interval *invl);
+TSDLLEXPORT bool ts_interval_equal(FormData_ts_interval *invl1, FormData_ts_interval *invl2);
+TSDLLEXPORT void ts_interval_now_func_validate(Oid now_func_oid, Oid open_dim_type);
+TSDLLEXPORT Datum ts_interval_subtract_from_now(FormData_ts_interval *invl, Dimension *open_dim);
+
+#endif /* TIMESCALEDB_INTERVAL */

--- a/src/utils.h
+++ b/src/utils.h
@@ -30,6 +30,8 @@ typedef enum TimevalInfinity
 	TimevalPosInfinity = 1,
 } TimevalInfinity;
 
+typedef bool (*proc_filter)(Form_pg_proc form, void *arg);
+
 /*
  * Convert a column value into the internal time representation.
  * cannot store a timestamp earlier than MIN_TIMESTAMP, or greater than
@@ -47,10 +49,6 @@ extern TSDLLEXPORT int64 ts_interval_value_to_internal(Datum time_val, Oid type_
  */
 extern TSDLLEXPORT Datum ts_internal_to_time_value(int64 value, Oid type);
 extern TSDLLEXPORT Datum ts_internal_to_interval_value(int64 value, Oid type);
-/*
- * Convert the difference of interval and current timestamp to internal representation
- */
-extern int64 ts_interval_from_now_to_internal(Datum time_val, Oid type);
 
 /*
  * Return the period in microseconds of the first argument to date_trunc.
@@ -69,6 +67,8 @@ extern bool ts_function_types_equal(Oid left[], Oid right[], int nargs);
 
 extern Oid get_function_oid(char *name, char *schema_name, int nargs, Oid arg_types[]);
 
+extern TSDLLEXPORT regproc lookup_proc_filtered(const char *schema, const char *funcname,
+												Oid *rettype, proc_filter filter, void *filter_arg);
 extern Oid get_operator(const char *name, Oid namespace, Oid left, Oid right);
 
 extern Oid get_cast_func(Oid source, Oid target);

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -82,9 +82,9 @@ FROM _timescaledb_catalog.hypertable;
 -- Check that adaptive chunking sets a 1 day default chunk time
 -- interval => 86400000000 microseconds
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------
-  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000 |                         | 
 (1 row)
 
 -- Change the target size

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -82,10 +82,10 @@ SELECT set_chunk_time_interval('chunk_test', 5::bigint);
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------
-  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_internal    | get_partition_hash |                
-  1 |             1 | time        | integer     | t       |            |                          |                    |               5
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+  1 |             1 | time        | integer     | t       |            |                          |                    |               5 |                         | 
 (2 rows)
 
 INSERT INTO chunk_test VALUES (7, 24.3, 79669, 1);

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -92,13 +92,13 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                
-  5 |             2 | location    | text        | f       |          4 | _timescaledb_internal    | get_partition_hash |                
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+  5 |             2 | location    | text        | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
 (5 rows)
 
 --test that we can change the number of partitions and that 1 is allowed
@@ -109,9 +109,9 @@ SELECT set_number_partitions('test_schema.test_table', 1, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------
-  5 |             2 | location    | text        | f       |          1 | _timescaledb_internal    | get_partition_hash |                
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  5 |             2 | location    | text        | f       |          1 | _timescaledb_internal    | get_partition_hash |                 |                         | 
 (1 row)
 
 SELECT set_number_partitions('test_schema.test_table', 2, 'location');
@@ -121,9 +121,9 @@ SELECT set_number_partitions('test_schema.test_table', 2, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -155,14 +155,14 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                
-  6 |             2 | id          | integer     | t       |            |                          |                    |            1000
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+  6 |             2 | id          | integer     | t       |            |                          |                    |            1000 |                         | 
 (6 rows)
 
 -- Test add_dimension: can use interval types for TIMESTAMPTZ columns

--- a/test/expected/ddl_alter_column.out
+++ b/test/expected/ddl_alter_column.out
@@ -39,10 +39,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal.%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000
-  2 |             1 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+  2 |             1 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -93,10 +93,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal.%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------
-  1 |             1 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000
-  2 |             1 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  1 |             1 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+  2 |             1 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -7,8 +7,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
 (0 rows)
 
 CREATE TABLE should_drop (time timestamp, temp float8);
@@ -79,9 +79,9 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------
-  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                         | 
 (1 row)
 
 DROP TABLE should_drop;
@@ -101,8 +101,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------
-  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                         | 
 (1 row)
 

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -64,8 +64,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -96,8 +96,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -41,6 +41,7 @@ ORDER BY proname;
  reorder_chunk
  set_adaptive_chunking
  set_chunk_time_interval
+ set_integer_now_func
  set_number_partitions
  show_chunks
  show_tablespaces
@@ -48,5 +49,5 @@ ORDER BY proname;
  time_bucket_gapfill
  timescaledb_post_restore
  timescaledb_pre_restore
-(34 rows)
+(35 rows)
 

--- a/test/expected/partitioning.out
+++ b/test/expected/partitioning.out
@@ -11,10 +11,10 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Show legacy partitioning function is used
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
 (2 rows)
 
 INSERT INTO part_legacy VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -55,12 +55,12 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
-  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000
-  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
+  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
 (4 rows)
 
 INSERT INTO part_new VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -135,17 +135,17 @@ SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => '_times
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000
-  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
-  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000
-  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
-  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
-  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000
-  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000
-  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                
-  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
+  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
+  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
+  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
+  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000 |                         | 
+  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
+  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
+  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
 (9 rows)
 
 -- Test that we support custom SQL-based partitioning functions and

--- a/tsl/src/CMakeLists.txt
+++ b/tsl/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+  hypertable.c
   init.c
   license.c
   reorder.c

--- a/tsl/src/hypertable.c
+++ b/tsl/src/hypertable.c
@@ -1,0 +1,85 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <catalog/pg_type.h>
+#include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/syscache.h>
+#include <miscadmin.h>
+#include <access/xact.h>
+#include <cache.h>
+
+#include "errors.h"
+#include "hypertable.h"
+#include "dimension.h"
+#include "license.h"
+#include "utils.h"
+#include "hypertable_cache.h"
+
+Datum
+hypertable_set_integer_now_func(PG_FUNCTION_ARGS)
+{
+	Oid table_relid = PG_GETARG_OID(0);
+	Oid now_func_oid = PG_GETARG_OID(1);
+	bool replace_if_exists = PG_GETARG_BOOL(2);
+	Hypertable *hypertable;
+	Cache *hcache;
+	Dimension *open_dim;
+	Oid open_dim_type;
+
+	license_enforce_enterprise_enabled();
+	license_print_expiration_warning_if_needed();
+	ts_hypertable_permissions_check(table_relid, GetUserId());
+
+	hcache = ts_hypertable_cache_pin();
+	hypertable = ts_hypertable_cache_get_entry(hcache, table_relid);
+	/* First verify that the hypertable corresponds to a valid table */
+	if (hypertable == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
+				 errmsg("could not set integer_now function because \"%s\" is not a hypertable",
+						get_rel_name(table_relid))));
+
+	/* validate that the open dimension uses numeric type */
+	open_dim = hyperspace_get_open_dimension(hypertable->space, 0);
+
+	if (!replace_if_exists)
+		if (*NameStr(open_dim->fd.integer_now_func_schema) != '\0' ||
+			*NameStr(open_dim->fd.integer_now_func) != '\0')
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_OBJECT),
+					 errmsg("integer_now_func is already set for hypertable \"%s\"",
+							get_rel_name(table_relid))));
+
+	open_dim_type = ts_dimension_get_partition_type(open_dim);
+	if (!IS_INTEGER_TYPE(open_dim_type))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("integer_now_func can only be set for hypertables "
+						"that have integer time dimensions")));
+
+	ts_interval_now_func_validate(now_func_oid, open_dim_type);
+
+	dimension_update(table_relid,
+					 &open_dim->fd.column_name,
+					 DIMENSION_TYPE_OPEN,
+					 NULL,
+					 NULL,
+					 NULL,
+					 &now_func_oid);
+
+	ts_cache_release(hcache);
+	PG_RETURN_NULL();
+}
+Datum
+hypertable_valid_ts_interval(PG_FUNCTION_ARGS)
+{
+	/* this function does all the necessary validation and if successfull,
+	returns the interval which is not necessary here */
+	ts_interval_from_tuple(PG_GETARG_DATUM(0));
+	PG_RETURN_BOOL(true);
+}

--- a/tsl/src/hypertable.h
+++ b/tsl/src/hypertable.h
@@ -1,0 +1,15 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#ifndef TIMESCALEDB_TSL_HYPERTABLE
+#define TIMESCALEDB_TSL_HYPERTABLE
+
+#include "dimension.h"
+#include "interval.h"
+extern Datum hypertable_set_integer_now_func(PG_FUNCTION_ARGS);
+extern Datum hypertable_valid_ts_interval(PG_FUNCTION_ARGS);
+
+#endif /* TIMESCALEDB_TSL_HYPERTABLE */

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -26,6 +26,7 @@
 #include "continuous_aggs/materialize.h"
 #include "continuous_aggs/options.h"
 #include "process_utility.h"
+#include "hypertable.h"
 
 #ifdef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -61,6 +62,8 @@ CrossModuleFunctions tsl_cm_functions = {
 	.add_tsl_license_info_telemetry = tsl_telemetry_add_license_info,
 	.bgw_policy_job_execute = tsl_bgw_policy_job_execute,
 	.continuous_agg_materialize = continuous_agg_materialize,
+	.set_integer_now_func = hypertable_set_integer_now_func,
+	.valid_ts_interval = hypertable_valid_ts_interval,
 	.add_drop_chunks_policy = drop_chunks_add_policy,
 	.add_reorder_policy = reorder_add_policy,
 	.remove_drop_chunks_policy = drop_chunks_remove_policy,

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -420,7 +420,8 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 -- Should be noop again
 select * from test_reorder(:reorder_job_id) \gset  reorder_
 NOTICE:  no chunks need reordering for hypertable public.test_table
-CREATE TABLE test_table_int(time int);
+CREATE TABLE test_table_int(time bigint, junk int);
+CREATE TABLE test_overflow_smallint(time smallint, junk int);
 SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
@@ -428,19 +429,310 @@ NOTICE:  adding not-null constraint to column "time"
  (2,public,test_table_int,t)
 (1 row)
 
+SELECT create_hypertable('test_overflow_smallint', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"
+          create_hypertable          
+-------------------------------------
+ (3,public,test_overflow_smallint,t)
+(1 row)
+
+create or replace function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 1::BIGINT';
+create or replace function dummy_now2() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 2::BIGINT';
+create or replace function overflow_now() returns SMALLINT LANGUAGE SQL IMMUTABLE as  'SELECT 32767::SMALLINT';
 CREATE TABLE test_table_perm(time timestamp PRIMARY KEY);
 SELECT create_hypertable('test_table_perm', 'time', chunk_time_interval => 1);
 WARNING:  unexpected interval: smaller than one second
       create_hypertable       
 ------------------------------
- (3,public,test_table_perm,t)
+ (4,public,test_table_perm,t)
 (1 row)
 
 \set ON_ERROR_STOP 0
--- we cannot add a drop_chunks policy on a table whose open dimension is not time
+-- we cannot add a drop_chunks policy on a table whose open dimension is not time and no now_func is set
 select add_drop_chunks_policy('test_table_int', INTERVAL '4 months', true);
-ERROR:  can only use "add_drop_chunks_policy" with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
+ERROR:  invalid parameter value for older_than
 \set ON_ERROR_STOP 1
+INSERT INTO test_table_int VALUES (-2, -2), (-1, -1), (0,0), (1, 1), (2, 2), (3, 3);
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+CREATE USER unprivileged;
+\c :TEST_DBNAME unprivileged
+-- should fail as the user has no permissions on the table
+\set ON_ERROR_STOP 0
+select set_integer_now_func('test_table_int', 'dummy_now');
+WARNING:  Timescale License expired
+ERROR:  must be owner of hypertable "test_table_int"
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+DROP USER unprivileged;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+select set_integer_now_func('test_table_int', 'dummy_now');
+WARNING:  Timescale License expired
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+select * from test_table_int;
+ time | junk 
+------+------
+   -2 |   -2
+   -1 |   -1
+    0 |    0
+    1 |    1
+    2 |    2
+    3 |    3
+(6 rows)
+
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int';
+ count 
+-------
+     6
+(1 row)
+
+select add_drop_chunks_policy('test_table_int', 1, true) as drop_chunks_job_id \gset
+-- Now simulate drop_chunks running automatically by calling it explicitly
+select test_drop_chunks(:drop_chunks_job_id);
+ test_drop_chunks 
+------------------
+ 
+(1 row)
+
+select * from test_table_int;
+ time | junk 
+------+------
+    0 |    0
+    1 |    1
+    2 |    2
+    3 |    3
+(4 rows)
+
+-- Should have 4 chunks left
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset before_
+select :before_count=4;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Make sure this second call does nothing
+select test_drop_chunks(:drop_chunks_job_id);
+ test_drop_chunks 
+------------------
+ 
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+-- Should be true
+select :before_count=:after_count;
+ ?column? 
+----------
+ t
+(1 row)
+
+INSERT INTO test_table_int VALUES (42, 42);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset before_
+-- This call should also do nothing
+select test_drop_chunks(:drop_chunks_job_id);
+ test_drop_chunks 
+------------------
+ 
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+-- Should be true
+select :before_count=:after_count;
+ ?column? 
+----------
+ t
+(1 row)
+
+INSERT INTO test_table_int VALUES (-1, -1);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset add_one_
+select :before_count+1=:add_one_count;
+ ?column? 
+----------
+ t
+(1 row)
+
+select test_drop_chunks(:drop_chunks_job_id);
+ test_drop_chunks 
+------------------
+ 
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+-- (-1,-1) was in droping range so it should be dropped by background job
+select :before_count=:after_count;
+ ?column? 
+----------
+ t
+(1 row)
+
+select set_integer_now_func('test_table_int', 'dummy_now2', replace_if_exists=>true);
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+select * from test_table_int;
+ time | junk 
+------+------
+    0 |    0
+    1 |    1
+    2 |    2
+    3 |    3
+   42 |   42
+(5 rows)
+
+select test_drop_chunks(:drop_chunks_job_id);
+ test_drop_chunks 
+------------------
+ 
+(1 row)
+
+-- added one to now() so time entry with value 0 should be dropped now
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+select :before_count=:after_count+1;
+ ?column? 
+----------
+ t
+(1 row)
+
+select * from test_table_int;
+ time | junk 
+------+------
+    1 |    1
+    2 |    2
+    3 |    3
+   42 |   42
+(4 rows)
+
+-- make the now() function invalid -- returns INT and not BIGINT
+drop function dummy_now2();
+create or replace function dummy_now2() returns INT LANGUAGE SQL IMMUTABLE as  'SELECT 2::INT';
+\set ON_ERROR_STOP 0
+select test_drop_chunks(:drop_chunks_job_id);
+ERROR:  invalid integer_now function
+\set ON_ERROR_STOP 1
+-- test the expected use case of set_integer_now_func
+ create function nowstamp() returns bigint language sql STABLE as 'SELECT extract(epoch from now())::BIGINT';
+select set_integer_now_func('test_table_int', 'nowstamp', replace_if_exists=>true);
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+select test_drop_chunks(:drop_chunks_job_id);
+ test_drop_chunks 
+------------------
+ 
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+select :after_count=0;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- test the case when now()-interval overflows
+select set_integer_now_func('test_overflow_smallint', 'overflow_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+select add_drop_chunks_policy('test_overflow_smallint', -2) as drop_chunks_job_id \gset
+\set ON_ERROR_STOP 0
+select test_drop_chunks(:drop_chunks_job_id);
+ERROR:  ts_interval overflow
+\set ON_ERROR_STOP 1
+-- test the case when partitioning function and now function are set.
+create table part_time_now_func(time float8, temp float8);
+create or replace function time_partfunc(unixtime float8)
+    returns bigint language plpgsql immutable as
+$body$
+declare
+    retval bigint;
+begin
+
+    retval := unixtime::bigint;
+    raise notice 'time value for % is %', unixtime, retval;
+    return retval;
+end
+$body$;
+create or replace function dummy_now() returns bigint language sql immutable as  'select 2::bigint';
+select create_hypertable('part_time_now_func', 'time', time_partitioning_func => 'time_partfunc', chunk_time_interval=>1);
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (5,public,part_time_now_func,t)
+(1 row)
+
+insert into part_time_now_func values
+(1.1, 23.4), (2.2, 22.3), (3.3, 42.3);
+NOTICE:  time value for 1.1 is 1
+NOTICE:  time value for 1.1 is 1
+NOTICE:  time value for 1.1 is 1
+NOTICE:  time value for 1.1 is 1
+NOTICE:  time value for 2.2 is 2
+NOTICE:  time value for 2.2 is 2
+NOTICE:  time value for 2.2 is 2
+NOTICE:  time value for 2.2 is 2
+NOTICE:  time value for 3.3 is 3
+NOTICE:  time value for 3.3 is 3
+NOTICE:  time value for 3.3 is 3
+NOTICE:  time value for 3.3 is 3
+select * from part_time_now_func;
+ time | temp 
+------+------
+  1.1 | 23.4
+  2.2 | 22.3
+  3.3 | 42.3
+(3 rows)
+
+select set_integer_now_func('part_time_now_func', 'dummy_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+select add_drop_chunks_policy('part_time_now_func', 0) as drop_chunks_job_id \gset
+select test_drop_chunks(:drop_chunks_job_id);
+ test_drop_chunks 
+------------------
+ 
+(1 row)
+
+select * from part_time_now_func;
+ time | temp 
+------+------
+  2.2 | 22.3
+  3.3 | 42.3
+(2 rows)
+
+select remove_drop_chunks_policy('part_time_now_func');
+ remove_drop_chunks_policy 
+---------------------------
+ 
+(1 row)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- todo:: this currently fails:
+-- alter function dummy_now rename to dummy_now_renamed;
+alter schema public rename to new_public;
+select * from  _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                    |    604800000000 |                         | 
+  2 |             1 | chunk_id    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+  5 |             4 | time        | timestamp without time zone | t       |            |                          |                    |               1 |                         | 
+  6 |             5 | time        | double precision            | t       |            | new_public               | time_partfunc      |               1 | new_public              | dummy_now
+  3 |             2 | time        | bigint                      | t       |            |                          |                    |               1 | new_public              | nowstamp
+  4 |             3 | time        | smallint                    | t       |            |                          |                    |               1 | new_public              | overflow_now
+(6 rows)
+
+alter schema new_public rename to public;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
 select add_reorder_policy('test_table_perm', 'test_table_perm_pkey');
@@ -453,3 +745,4 @@ ERROR:  must be owner of hypertable "test_table_perm"
 select remove_drop_chunks_policy('test_table');
 ERROR:  must be owner of hypertable "test_table"
 \set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -446,9 +446,9 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
-   1001 |             2 | @ 4 mons   | f       | f
+ job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
+--------+---------------+-----------------+---------+-----------------------------
+   1001 |             2 | (t,"@ 4 mons",) | f       | f
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
@@ -606,9 +606,9 @@ SELECT show_chunks('test_drop_chunks_table');
 
 --test that views work
 SELECT * FROM timescaledb_information.drop_chunks_policies;
-       hypertable       | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
-------------------------+------------+---------+--------+-------------------+-------------+-------------+--------------+-----------------------------
- test_drop_chunks_table | @ 4 mons   | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours   | f
+       hypertable       |   older_than    | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
+------------------------+-----------------+---------+--------+-------------------+-------------+-------------+--------------+-----------------------------
+ test_drop_chunks_table | (t,"@ 4 mons",) | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours   | f
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -27,11 +27,19 @@ select * from _timescaledb_config.bgw_policy_reorder;
 (0 rows)
 
 CREATE TABLE test_table(time timestamptz, junk int);
+CREATE TABLE test_table_int(time bigint, junk int);
 SELECT create_hypertable('test_table', 'time');
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (1,public,test_table,t)
+(1 row)
+
+SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable      
+-----------------------------
+ (2,public,test_table_int,t)
 (1 row)
 
 CREATE INDEX second_index on test_table (time);
@@ -86,7 +94,7 @@ SELECT create_hypertable('test_table2', 'time', chunk_time_interval=>INTERVAL '1
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
- (2,public,test_table2,t)
+ (3,public,test_table2,t)
 (1 row)
 
 select add_reorder_policy('test_table2', 'test_table2_time_idx');
@@ -118,12 +126,22 @@ select add_drop_chunks_policy('test_table');
 ERROR:  function add_drop_chunks_policy(unknown) does not exist at character 8
 select add_drop_chunks_policy(INTERVAL '3 hours');
 ERROR:  function add_drop_chunks_policy(interval) does not exist at character 8
+select add_drop_chunks_policy('test_table', INTERVAL 'haha');
+ERROR:  invalid input syntax for type interval: "haha" at character 54
+select add_drop_chunks_policy('test_table', 'haha');
+ERROR:  invalid type for parameter older_than in add_drop_chunks_policy
+select add_drop_chunks_policy('test_table', 42);
+ERROR:  invalid parameter value for older_than
 select add_drop_chunks_policy('fake_table', INTERVAL '3 month', true);
 ERROR:  relation "fake_table" does not exist at character 31
 select add_drop_chunks_policy('fake_table', INTERVAL '3 month');
 ERROR:  relation "fake_table" does not exist at character 31
 select add_drop_chunks_policy('test_table', cascade=>true);
 ERROR:  function add_drop_chunks_policy(unknown, cascade => boolean) does not exist at character 8
+select add_drop_chunks_policy('test_table_int', INTERVAL '3 month', true);
+ERROR:  invalid parameter value for older_than
+select add_drop_chunks_policy('test_table_int', 42, true);
+ERROR:  integer_now_func not set on hypertable test_table_int
 \set ON_ERROR_STOP 1
 select add_drop_chunks_policy('test_table', INTERVAL '3 month', true);
  add_drop_chunks_policy 
@@ -176,9 +194,9 @@ WARNING:  could not add drop_chunks policy due to existing policy on hypertable 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
-   1002 |             1 | @ 3 mons   | t       | f
+ job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
+--------+---------------+-----------------+---------+-----------------------------
+   1002 |             1 | (t,"@ 3 mons",) | t       | f
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -194,15 +212,15 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 days', cascade_to_materi
 ERROR:  drop chunks policy already exists for hypertable "test_table"
 \set ON_ERROR_STOP 1
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
-   1002 |             1 | @ 3 mons   | t       | f
+ job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
+--------+---------------+-----------------+---------+-----------------------------
+   1002 |             1 | (t,"@ 3 mons",) | t       | f
 (1 row)
 
 select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
-   1002 |             1 | @ 3 mons   | t
+ job_id | hypertable_id |   older_than    | cascade 
+--------+---------------+-----------------+---------
+   1002 |             1 | (t,"@ 3 mons",) | t
 (1 row)
 
 select remove_drop_chunks_policy('test_table');
@@ -210,6 +228,71 @@ select remove_drop_chunks_policy('test_table');
 ---------------------------
  
 (1 row)
+
+-- Test set_integer_now_func and add_drop_chunks_policy with
+-- hypertables that have integer time dimension
+\set ON_ERROR_STOP 0
+select set_integer_now_func('test_table', 42);
+ERROR:  integer_now_func can only be set for hypertables that have integer time dimensions
+select set_integer_now_func('test_table', 'set_integer_now_func');
+ERROR:  integer_now_func can only be set for hypertables that have integer time dimensions
+select set_integer_now_func('test_table_int', 'set_integer_now_func');
+ERROR:  integer_now_func must take no arguments and it must be STABLE
+\set ON_ERROR_STOP 1
+select * from _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                         | 
+(2 rows)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE SCHEMA IF NOT EXISTS my_schema;
+create or replace function my_schema.dummy_now2() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 1::BIGINT';
+grant execute on ALL FUNCTIONS IN SCHEMA my_schema to public;
+-- \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+create or replace function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 1::BIGINT';
+select set_integer_now_func('test_table_int', 'dummy_now');
+WARNING:  Timescale License expired
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+select set_integer_now_func('test_table_int', 'dummy_now');
+ERROR:  integer_now_func is already set for hypertable "test_table_int"
+\set ON_ERROR_STOP 1
+select * from _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 | public                  | dummy_now
+(2 rows)
+
+select set_integer_now_func('test_table_int', 'my_schema.dummy_now2', replace_if_exists => TRUE);
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+select * from _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 | my_schema               | dummy_now2
+(2 rows)
+
+-- \c :TEST_DBNAME :ROLE_SUPERUSER q:: should all of the following be execed in super user mode?
+-- partitioning.sql test does something similar bu tnot sure why superuser is necessary.
+ALTER SCHEMA my_schema RENAME TO my_new_schema;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+select * from _timescaledb_catalog.dimension;
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 | my_new_schema           | dummy_now2
+(2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
  job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
@@ -222,6 +305,7 @@ select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.
 (0 rows)
 
 select remove_reorder_policy('test_table');
+WARNING:  Timescale License expired
  remove_reorder_policy 
 -----------------------
  
@@ -244,12 +328,57 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 month');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
-   1003 |             1 | @ 3 mons   | f       | f
+ job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
+--------+---------------+-----------------+---------+-----------------------------
+   1003 |             1 | (t,"@ 3 mons",) | f       | f
 (1 row)
 
 select remove_drop_chunks_policy('test_table');
+ remove_drop_chunks_policy 
+---------------------------
+ 
+(1 row)
+
+select * from _timescaledb_config.bgw_policy_drop_chunks;
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+(0 rows)
+
+select add_drop_chunks_policy('test_table_int', 1);
+ add_drop_chunks_policy 
+------------------------
+                   1004
+(1 row)
+
+select * from _timescaledb_config.bgw_policy_drop_chunks;
+ job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
+--------+---------------+------------+---------+-----------------------------
+   1004 |             2 | (f,,1)     | f       | f
+(1 row)
+
+-- Should not add new policy with different parameters
+select add_drop_chunks_policy('test_table_int', 2, false, true);
+WARNING:  could not add drop_chunks policy due to existing policy on hypertable with different arguments
+ add_drop_chunks_policy 
+------------------------
+                     -1
+(1 row)
+
+select add_drop_chunks_policy('test_table_int', 1, false, true, true);
+WARNING:  could not add drop_chunks policy due to existing policy on hypertable with different arguments
+ add_drop_chunks_policy 
+------------------------
+                     -1
+(1 row)
+
+select add_drop_chunks_policy('test_table_int', 1, true, true, false);
+WARNING:  could not add drop_chunks policy due to existing policy on hypertable with different arguments
+ add_drop_chunks_policy 
+------------------------
+                     -1
+(1 row)
+
+select remove_drop_chunks_policy('test_table_int');
  remove_drop_chunks_policy 
 ---------------------------
  
@@ -406,8 +535,8 @@ select * from _timescaledb_config.bgw_job;
   id  |      application_name      |                job_type                | schedule_interval |   max_runtime   | max_retries | retry_period 
 ------+----------------------------+----------------------------------------+-------------------+-----------------+-------------+--------------
     1 | Telemetry Reporter         | telemetry_and_version_check_if_enabled | @ 24 hours        | @ 1 min 40 secs |          -1 | @ 1 hour
- 1006 | Drop Chunks Background Job | drop_chunks                            | @ 1 day           | @ 5 mins        |          -1 | @ 12 hours
- 1007 | Reorder Background Job     | reorder                                | @ 84 hours        | @ 0             |          -1 | @ 1 day
+ 1007 | Drop Chunks Background Job | drop_chunks                            | @ 1 day           | @ 5 mins        |          -1 | @ 12 hours
+ 1008 | Reorder Background Job     | reorder                                | @ 84 hours        | @ 0             |          -1 | @ 1 day
 (3 rows)
 
 DROP TABLE test_table;
@@ -450,7 +579,7 @@ SELECT create_hypertable('test_table', 'time');
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
- (3,public,test_table,t)
+ (4,public,test_table,t)
 (1 row)
 
 CREATE INDEX second_index on test_table (time);
@@ -459,47 +588,48 @@ SELECT create_hypertable('test_table2', 'time');
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
- (4,public,test_table2,t)
+ (5,public,test_table2,t)
 (1 row)
 
 CREATE INDEX junk_index on test_table2 (junk);
 select add_drop_chunks_policy('test_table', INTERVAL '2 days');
  add_drop_chunks_policy 
 ------------------------
-                   1008
+                   1009
 (1 row)
 
 select add_drop_chunks_policy('test_table2', INTERVAL '1 days');
  add_drop_chunks_policy 
 ------------------------
-                   1009
+                   1010
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1008 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
  1009 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
+ 1010 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
 (2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
-   1008 |             3 | @ 2 days   | f       | f
-   1009 |             4 | @ 1 day    | f       | f
+ job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
+--------+---------------+-----------------+---------+-----------------------------
+   1009 |             4 | (t,"@ 2 days",) | f       | f
+   1010 |             5 | (t,"@ 1 day",)  | f       | f
 (2 rows)
 
 DROP TABLE test_table;
+DROP TABLE test_table_int;
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1009 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
+ 1010 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
-   1009 |             4 | @ 1 day    | f       | f
+ job_id | hypertable_id |   older_than   | cascade | cascade_to_materializations 
+--------+---------------+----------------+---------+-----------------------------
+   1010 |             5 | (t,"@ 1 day",) | f       | f
 (1 row)
 
 DROP TABLE test_table2;
@@ -540,7 +670,7 @@ SELECT create_hypertable('test_table', 'time');
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
- (5,public,test_table,t)
+ (6,public,test_table,t)
 (1 row)
 
 CREATE INDEX second_index on test_table (time);
@@ -566,13 +696,13 @@ select ts_test_chunk_stats_insert(:job_id, :chunk_id, 1);
 select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
 --------+----------+-------------------
-   1010 |        1 |                 1
+   1011 |        1 |                 1
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type='reorder';
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1010 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
 (1 row)
 
 -- Deleting a chunk that has nothing to do with the job should do nothing
@@ -582,13 +712,13 @@ DROP TABLE :other_chunk;
 select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
 --------+----------+-------------------
-   1010 |        1 |                 1
+   1011 |        1 |                 1
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type='reorder';
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1010 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
 (1 row)
 
 -- Dropping the hypertable should drop the chunk, which should drop the reorder policy
@@ -609,14 +739,14 @@ SELECT create_hypertable('test_table', 'time');
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
- (6,public,test_table,t)
+ (7,public,test_table,t)
 (1 row)
 
 select add_reorder_policy('test_table', 'test_table_time_idx') as job_id \gset
 select add_drop_chunks_policy('test_table', INTERVAL '2 days', true);
  add_drop_chunks_policy 
 ------------------------
-                   1012
+                   1013
 (1 row)
 
 select ts_test_chunk_stats_insert(:job_id, 123, 1);
@@ -628,14 +758,14 @@ select ts_test_chunk_stats_insert(:job_id, 123, 1);
 select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
 --------+----------+-------------------
-   1011 |      123 |                 1
+   1012 |      123 |                 1
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type in ('drop_chunks', 'reorder');
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1011 | Reorder Background Job     | reorder     | @ 84 hours        | @ 0         |          -1 | @ 1 day
- 1012 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
+ 1012 | Reorder Background Job     | reorder     | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1013 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
 (2 rows)
 
 -- Dropping the drop_chunks job should not affect the chunk_stats row
@@ -648,13 +778,13 @@ select remove_drop_chunks_policy('test_table');
 select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
 --------+----------+-------------------
-   1011 |      123 |                 1
+   1012 |      123 |                 1
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type in ('drop_chunks', 'reorder');
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1012 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
 (1 row)
 
 select remove_reorder_policy('test_table');
@@ -679,70 +809,70 @@ select add_reorder_policy('test_table', 'test_table_time_idx') as job_id \gset
  select * from _timescaledb_config.bgw_job where id=:job_id;
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1013 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1014 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
 (1 row)
 
 -- No change
 select * from alter_job_schedule(:job_id);
  job_id | schedule_interval | max_runtime | max_retries | retry_period 
 --------+-------------------+-------------+-------------+--------------
-   1013 | @ 84 hours        | @ 0         |          -1 | @ 1 day
+   1014 | @ 84 hours        | @ 0         |          -1 | @ 1 day
 (1 row)
 
 -- Changes expected
 select * from alter_job_schedule(:job_id, INTERVAL '3 years', INTERVAL '5 min', 5, INTERVAL '123 sec');
  job_id | schedule_interval | max_runtime | max_retries |  retry_period   
 --------+-------------------+-------------+-------------+-----------------
-   1013 | @ 3 years         | @ 5 mins    |           5 | @ 2 mins 3 secs
+   1014 | @ 3 years         | @ 5 mins    |           5 | @ 2 mins 3 secs
 (1 row)
 
 select * from alter_job_schedule(:job_id, INTERVAL '123 years');
  job_id | schedule_interval | max_runtime | max_retries |  retry_period   
 --------+-------------------+-------------+-------------+-----------------
-   1013 | @ 123 years       | @ 5 mins    |           5 | @ 2 mins 3 secs
+   1014 | @ 123 years       | @ 5 mins    |           5 | @ 2 mins 3 secs
 (1 row)
 
 select * from alter_job_schedule(:job_id, retry_period => INTERVAL '33 hours');
  job_id | schedule_interval | max_runtime | max_retries | retry_period 
 --------+-------------------+-------------+-------------+--------------
-   1013 | @ 123 years       | @ 5 mins    |           5 | @ 33 hours
+   1014 | @ 123 years       | @ 5 mins    |           5 | @ 33 hours
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_runtime => INTERVAL '456 sec');
  job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
 --------+-------------------+------------------+-------------+--------------
-   1013 | @ 123 years       | @ 7 mins 36 secs |           5 | @ 33 hours
+   1014 | @ 123 years       | @ 7 mins 36 secs |           5 | @ 33 hours
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => 0);
  job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
 --------+-------------------+------------------+-------------+--------------
-   1013 | @ 123 years       | @ 7 mins 36 secs |           0 | @ 33 hours
+   1014 | @ 123 years       | @ 7 mins 36 secs |           0 | @ 33 hours
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => -1);
  job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
 --------+-------------------+------------------+-------------+--------------
-   1013 | @ 123 years       | @ 7 mins 36 secs |          -1 | @ 33 hours
+   1014 | @ 123 years       | @ 7 mins 36 secs |          -1 | @ 33 hours
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => 20);
  job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
 --------+-------------------+------------------+-------------+--------------
-   1013 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
+   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
 (1 row)
 
 -- No change
 select * from alter_job_schedule(:job_id, max_runtime => NULL);
  job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
 --------+-------------------+------------------+-------------+--------------
-   1013 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
+   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => NULL);
  job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
 --------+-------------------+------------------+-------------+--------------
-   1013 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
+   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
 (1 row)
 
 -- Check if_exists boolean works correctly
@@ -786,7 +916,7 @@ select add_drop_chunks_policy('test_table', INTERVAL '4 months', true) as drop_c
 \set ON_ERROR_STOP 0
 select from alter_job_schedule(:reorder_job_id, max_runtime => NULL);
 WARNING:  Timescale License expired
-ERROR:  insufficient permssions to alter job 1014
-select from alter_job_schedule(:drop_chunks_job_id, max_runtime => NULL);
 ERROR:  insufficient permssions to alter job 1015
+select from alter_job_schedule(:drop_chunks_job_id, max_runtime => NULL);
+ERROR:  insufficient permssions to alter job 1016
 \set ON_ERROR_STOP 1

--- a/tsl/test/sql/bgw_policy.sql
+++ b/tsl/test/sql/bgw_policy.sql
@@ -216,16 +216,137 @@ select check_chunk_oid(:oldest_chunk_id, :reorder_chunk_oid);
 -- Should be noop again
 select * from test_reorder(:reorder_job_id) \gset  reorder_
 
-CREATE TABLE test_table_int(time int);
+CREATE TABLE test_table_int(time bigint, junk int);
+CREATE TABLE test_overflow_smallint(time smallint, junk int);
+
 SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
+SELECT create_hypertable('test_overflow_smallint', 'time', chunk_time_interval => 1);
+
+create or replace function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 1::BIGINT';
+create or replace function dummy_now2() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 2::BIGINT';
+create or replace function overflow_now() returns SMALLINT LANGUAGE SQL IMMUTABLE as  'SELECT 32767::SMALLINT';
 
 CREATE TABLE test_table_perm(time timestamp PRIMARY KEY);
 SELECT create_hypertable('test_table_perm', 'time', chunk_time_interval => 1);
 
 \set ON_ERROR_STOP 0
--- we cannot add a drop_chunks policy on a table whose open dimension is not time
+-- we cannot add a drop_chunks policy on a table whose open dimension is not time and no now_func is set
 select add_drop_chunks_policy('test_table_int', INTERVAL '4 months', true);
 \set ON_ERROR_STOP 1
+
+INSERT INTO test_table_int VALUES (-2, -2), (-1, -1), (0,0), (1, 1), (2, 2), (3, 3);
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+CREATE USER unprivileged;
+\c :TEST_DBNAME unprivileged
+-- should fail as the user has no permissions on the table
+\set ON_ERROR_STOP 0
+select set_integer_now_func('test_table_int', 'dummy_now');
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+DROP USER unprivileged;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+select set_integer_now_func('test_table_int', 'dummy_now');
+select * from test_table_int;
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int';
+select add_drop_chunks_policy('test_table_int', 1, true) as drop_chunks_job_id \gset
+
+-- Now simulate drop_chunks running automatically by calling it explicitly
+select test_drop_chunks(:drop_chunks_job_id);
+select * from test_table_int;
+-- Should have 4 chunks left
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset before_
+select :before_count=4;
+
+-- Make sure this second call does nothing
+select test_drop_chunks(:drop_chunks_job_id);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+
+-- Should be true
+select :before_count=:after_count;
+
+INSERT INTO test_table_int VALUES (42, 42);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset before_
+
+-- This call should also do nothing
+select test_drop_chunks(:drop_chunks_job_id);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+
+-- Should be true
+select :before_count=:after_count;
+
+INSERT INTO test_table_int VALUES (-1, -1);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset add_one_
+select :before_count+1=:add_one_count;
+select test_drop_chunks(:drop_chunks_job_id);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+
+-- (-1,-1) was in droping range so it should be dropped by background job
+select :before_count=:after_count;
+
+select set_integer_now_func('test_table_int', 'dummy_now2', replace_if_exists=>true);
+select * from test_table_int;
+select test_drop_chunks(:drop_chunks_job_id);
+-- added one to now() so time entry with value 0 should be dropped now
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+select :before_count=:after_count+1;
+select * from test_table_int;
+
+-- make the now() function invalid -- returns INT and not BIGINT
+drop function dummy_now2();
+create or replace function dummy_now2() returns INT LANGUAGE SQL IMMUTABLE as  'SELECT 2::INT';
+
+\set ON_ERROR_STOP 0
+select test_drop_chunks(:drop_chunks_job_id);
+\set ON_ERROR_STOP 1
+
+-- test the expected use case of set_integer_now_func
+ create function nowstamp() returns bigint language sql STABLE as 'SELECT extract(epoch from now())::BIGINT';
+select set_integer_now_func('test_table_int', 'nowstamp', replace_if_exists=>true);
+select test_drop_chunks(:drop_chunks_job_id);
+SELECT count(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_table_int' \gset after_
+select :after_count=0;
+
+-- test the case when now()-interval overflows
+select set_integer_now_func('test_overflow_smallint', 'overflow_now');
+select add_drop_chunks_policy('test_overflow_smallint', -2) as drop_chunks_job_id \gset
+\set ON_ERROR_STOP 0
+select test_drop_chunks(:drop_chunks_job_id);
+\set ON_ERROR_STOP 1
+
+
+-- test the case when partitioning function and now function are set.
+create table part_time_now_func(time float8, temp float8);
+
+create or replace function time_partfunc(unixtime float8)
+    returns bigint language plpgsql immutable as
+$body$
+declare
+    retval bigint;
+begin
+
+    retval := unixtime::bigint;
+    raise notice 'time value for % is %', unixtime, retval;
+    return retval;
+end
+$body$;
+create or replace function dummy_now() returns bigint language sql immutable as  'select 2::bigint';
+
+select create_hypertable('part_time_now_func', 'time', time_partitioning_func => 'time_partfunc', chunk_time_interval=>1);
+insert into part_time_now_func values
+(1.1, 23.4), (2.2, 22.3), (3.3, 42.3);
+select * from part_time_now_func;
+select set_integer_now_func('part_time_now_func', 'dummy_now');
+select add_drop_chunks_policy('part_time_now_func', 0) as drop_chunks_job_id \gset
+select test_drop_chunks(:drop_chunks_job_id);
+select * from part_time_now_func;
+select remove_drop_chunks_policy('part_time_now_func');
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- todo:: this currently fails:
+-- alter function dummy_now rename to dummy_now_renamed;
+alter schema public rename to new_public;
+select * from  _timescaledb_catalog.dimension;
+alter schema new_public rename to public;
 
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
@@ -236,3 +357,4 @@ select add_drop_chunks_policy('test_table_perm', INTERVAL '4 months', true);
 select remove_drop_chunks_policy('test_table');
 
 \set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER


### PR DESCRIPTION
This PR implements functionality for users to give a custom definition of now() for integer open dimension typed hypertables. It also implements the necessary changes in drop chunks policy to use this now() function when handling drop_chunk background worker tasks.

Below is an outline for the PR.

- [x] Add columns to the dimension catalog for the schema/function name of the current_time function.
  - [x] a213746 regression test output changes
  - [x] cb78532 catalog table definition changes

- [x] Modify the current drop_chunks_policy table to use the internal representation rather than an actual interval. 
   - [x] 65874bb  regression test output changes
   - [x] 62d3131  catalog table definition changes

- [x] da4dc1a  Implement set_integer_now_func logic 

- [x] Teach drop_chunks policy as well as any others that use now() to use the current_time function instead for integer hypertables.
  - [x] 91f6fb4 add_drop_chunks_policy
  - (postponed) Reorder chunks

- [x] Modify update scripts accordingly
- [x] Add more tests
  - [ ] More thoroughly test background job failure cases and get appropriate regression test output
  - [x] Test functional cases when integer_now function and partitioning function are both set on a hypertable

I will fixup the commits later but thought detailed breakdown may be useful for reviewing. 