### PR TITLE
Drop_chunks returns list of dropped chunks

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -76,7 +76,7 @@ CREATE OR REPLACE FUNCTION drop_chunks(
     newer_than "any" = NULL,
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL
-) RETURNS SETOF REGCLASS AS '@MODULE_PATHNAME@', 'ts_chunk_drop_chunks'
+) RETURNS SETOF TEXT AS '@MODULE_PATHNAME@', 'ts_chunk_drop_chunks'
 LANGUAGE C STABLE PARALLEL SAFE;
 
 -- show chunks older than or newer than a specific time.

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS drop_chunks("any",name,name,boolean,"any",boolean,boolean);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -104,10 +104,11 @@ extern bool ts_chunk_set_name(Chunk *chunk, const char *newname);
 extern bool ts_chunk_set_schema(Chunk *chunk, const char *newschema);
 extern List *ts_chunk_get_window(int32 dimension_id, int64 point, int count, MemoryContext mctx);
 extern void ts_chunks_rename_schema_name(char *old_schema, char *new_schema);
-extern TSDLLEXPORT void ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum,
-												Datum newer_than_datum, Oid older_than_type,
-												Oid newer_than_type, bool cascade,
-												bool cascades_to_materializations, int32 log_level);
+extern TSDLLEXPORT List *ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum,
+												 Datum newer_than_datum, Oid older_than_type,
+												 Oid newer_than_type, bool cascade,
+												 bool cascades_to_materializations,
+												 int32 log_level);
 
 #define chunk_get_by_name(schema_name, table_name, num_constraints, fail_if_not_found)             \
 	ts_chunk_get_by_name_with_memory_context(schema_name,                                          \

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -1,6 +1,9 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH 'include/query_result_test_equal.sql'
 -- DROP a table's column before making it a hypertable
 CREATE TABLE alter_before(id serial, time timestamp, temp float, colorid integer, notes text, notes_2 text);
 ALTER TABLE alter_before DROP COLUMN id;
@@ -288,10 +291,13 @@ ALTER TABLE hyper_in_space SET TABLESPACE tablespace1;
 DROP TABLESPACE tablespace1;
 ERROR:  tablespace "tablespace1" is still attached to 1 hypertables
 \set ON_ERROR_STOP 1
-SELECT drop_chunks(20, 'hyper_in_space');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(\'hyper_in_space\', 22)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(22, \'hyper_in_space\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       5 |                       5
 (1 row)
 
 SELECT tablename, tablespace FROM pg_tables WHERE tablespace = 'tablespace1' ORDER BY tablename;

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1,6 +1,9 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH 'include/query_result_test_equal.sql'
 CREATE OR REPLACE FUNCTION dimension_get_time(
     hypertable_id INT
 )
@@ -12,10 +15,13 @@ $BODY$
           d.interval_length IS NOT NULL
 $BODY$;
 -- Make sure drop_chunks when there are no tables succeeds
-SELECT drop_chunks(INTERVAL '1 hour', verbose => true);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(older_than => INTERVAL \'1 hour\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(INTERVAL \'1 hour\', verbose => true)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       0 |                       0
 (1 row)
 
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
@@ -415,13 +421,14 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  24 |            3 |                    6 |                   7
 (23 rows)
 
-SELECT drop_chunks(2, CASCADE=>true, verbose => true);
-INFO:  dropping chunk _timescaledb_internal._hyper_1_1_chunk
-NOTICE:  drop cascades to view dependent_view
-INFO:  dropping chunk _timescaledb_internal._hyper_3_13_chunk
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(older_than => 2)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(2, CASCADE=>true)::TEXT'
+\set ECHO errors
+psql:include/query_result_test_equal.sql:14: NOTICE:  drop cascades to view dependent_view
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       2 |                       2
 (1 row)
 
 SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
@@ -553,10 +560,13 @@ SELECT * FROM show_chunks('drop_chunk_test2');
  _timescaledb_internal | _hyper_3_18_chunk | table | default_perm_user
 (15 rows)
 
-SELECT drop_chunks(3, 'drop_chunk_test1');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(\'drop_chunk_test1\', older_than => 3)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(3, \'drop_chunk_test1\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
@@ -623,10 +633,13 @@ SELECT * FROM show_chunks('drop_chunk_test2');
 (5 rows)
 
 -- 2,147,483,647 is the largest int so this tests that BIGINTs work
-SELECT drop_chunks(2147483648, 'drop_chunk_test3');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(\'drop_chunk_test3\', older_than => 2147483648)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(2147483648, \'drop_chunk_test3\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       5 |                       5
 (1 row)
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
@@ -710,11 +723,14 @@ ORDER BY c.id;
 (8 rows)
 
 -- newer_than tests
-SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5, verbose => true);
-INFO:  dropping chunk _timescaledb_internal._hyper_1_5_chunk
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test1\', newer_than=>5)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test1\', newer_than=>5, verbose => true)::TEXT'
+\set ECHO errors
+psql:include/query_result_test_equal.sql:14: INFO:  dropping chunk _timescaledb_internal._hyper_1_5_chunk
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
@@ -751,10 +767,13 @@ SELECT show_chunks('drop_chunk_test1');
  _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
 (7 rows)
 
-SELECT drop_chunks(table_name=>'drop_chunk_test1', older_than=>4, newer_than=>3);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test1\', older_than=>4, newer_than=>3)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test1\', older_than=>4, newer_than=>3)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
@@ -802,10 +821,13 @@ ORDER BY c.id;
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (6 rows)
 
-SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(older_than=>5, newer_than=>4)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(5, schema_name=>\'public\', newer_than=>4)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       2 |                       2
 (1 row)
 
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
@@ -873,16 +895,21 @@ BEGIN;
  _timescaledb_internal._hyper_4_19_chunk
 (1 row)
 
-    SELECT drop_chunks(newer_than => interval '1 minute', table_name => 'drop_chunk_test_ts');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+    \set QUERY1 'SELECT show_chunks(newer_than => interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(newer_than => interval \'1 minute\', table_name => \'drop_chunk_test_ts\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
-    SELECT drop_chunks(older_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
- drop_chunks 
--------------
- 
+    \set QUERY1 'SELECT show_chunks(older_than => interval \'6 minute\', hypertable => \'drop_chunk_test_ts\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(older_than => interval \'6 minute\', table_name => \'drop_chunk_test_ts\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       0 |                       0
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
@@ -891,10 +918,12 @@ BEGIN;
  _timescaledb_internal._hyper_4_19_chunk | 
 (1 row)
 
-    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
- drop_chunks 
--------------
- 
+    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_ts\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
@@ -902,35 +931,37 @@ BEGIN;
 -------+------------
 (0 rows)
 
-    SELECT show_chunks('drop_chunk_test_tstz');
+    SELECT show_chunks(hypertable => 'drop_chunk_test_tstz');
                show_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_5_21_chunk
  _timescaledb_internal._hyper_5_22_chunk
 (2 rows)
 
-    SELECT show_chunks('drop_chunk_test_tstz', now() - interval '1 minute', now() - interval '6 minute');
+    SELECT show_chunks(hypertable => 'drop_chunk_test_tstz', older_than => now() - interval '1 minute', newer_than => now() - interval '6 minute');
                show_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_5_21_chunk
 (1 row)
 
-    SELECT show_chunks('drop_chunk_test_tstz', newer_than => now() - interval '1 minute');
+    SELECT show_chunks(hypertable => 'drop_chunk_test_tstz', newer_than => now() - interval '1 minute');
                show_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_5_22_chunk
 (1 row)
 
-    SELECT show_chunks('drop_chunk_test_tstz', older_than => now() - interval '1 minute');
+    SELECT show_chunks(hypertable => 'drop_chunk_test_tstz', older_than => now() - interval '1 minute');
                show_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_5_21_chunk
 (1 row)
 
-    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_tstz');
- drop_chunks 
--------------
- 
+    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_tstz\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_tstz\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
@@ -941,10 +972,13 @@ BEGIN;
 
 ROLLBACK;
 BEGIN;
-    SELECT drop_chunks(newer_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+    \set QUERY1 'SELECT show_chunks(newer_than => interval \'6 minute\', hypertable => \'drop_chunk_test_ts\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(newer_than => interval \'6 minute\', table_name => \'drop_chunk_test_ts\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       2 |                       2
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
@@ -954,10 +988,13 @@ BEGIN;
 
 ROLLBACK;
 BEGIN;
-    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_ts\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
@@ -966,10 +1003,12 @@ BEGIN;
  _timescaledb_internal._hyper_4_20_chunk | 
 (1 row)
 
-    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_tstz');
- drop_chunks 
--------------
- 
+    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_tstz\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_tstz\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
@@ -980,10 +1019,13 @@ BEGIN;
 
 ROLLBACK;
 BEGIN;
-    SELECT drop_chunks(now()::timestamp-interval '1 minute', 'drop_chunk_test_ts');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+    \set QUERY1 'SELECT show_chunks(older_than => now()::timestamp-interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(now()::timestamp-interval \'1 minute\', \'drop_chunk_test_ts\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_ts');
@@ -992,10 +1034,12 @@ BEGIN;
  _timescaledb_internal._hyper_4_20_chunk | 
 (1 row)
 
-    SELECT drop_chunks(now()-interval '1 minute', 'drop_chunk_test_tstz');
- drop_chunks 
--------------
- 
+    \set QUERY1 'SELECT show_chunks(older_than => now()-interval \'1 minute\', hypertable => \'drop_chunk_test_tstz\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(now()-interval \'1 minute\', \'drop_chunk_test_tstz\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
@@ -1073,10 +1117,13 @@ NOTICE:  adding not-null constraint to column "time"
 SET timezone = '+100';
 INSERT INTO PUBLIC.drop_chunk_test_date VALUES(now()-INTERVAL '2 day', 1.0, 'dev1');
 BEGIN;
-    SELECT drop_chunks(interval '1 day', 'drop_chunk_test_date');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 day\', hypertable => \'drop_chunk_test_date\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks(interval \'1 day\', \'drop_chunk_test_date\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_date');
@@ -1086,10 +1133,13 @@ BEGIN;
 
 ROLLBACK;
 BEGIN;
-    SELECT drop_chunks((now()-interval '1 day')::date, 'drop_chunk_test_date');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+    \set QUERY1 'SELECT show_chunks(older_than => (now()-interval \'1 day\')::date, hypertable => \'drop_chunk_test_date\')::REGCLASS::TEXT'
+    \set QUERY2 'SELECT drop_chunks((now()-interval \'1 day\')::date, \'drop_chunk_test_date\')::TEXT'
+    \set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
     SELECT * FROM test.show_subtables('drop_chunk_test_date');
@@ -1157,23 +1207,26 @@ SELECT * FROM test.show_subtables('test_weird_type');
  _timescaledb_internal._hyper_9_31_chunk | 
 (2 rows)
 
-SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 4:00+0'::TIMESTAMPTZ);
+SELECT show_chunks(hypertable => 'test_weird_type', older_than=>'2019/06/06 4:00+0'::TIMESTAMPTZ);
                show_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_9_30_chunk
 (1 row)
 
-SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 10:00+0'::TIMESTAMPTZ);
+SELECT show_chunks(hypertable => 'test_weird_type', older_than=>'2019/06/06 10:00+0'::TIMESTAMPTZ);
                show_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_9_30_chunk
  _timescaledb_internal._hyper_9_31_chunk
 (2 rows)
 
-SELECT drop_chunks('2019/06/06 5:00+0'::TIMESTAMPTZ, 'test_weird_type');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(older_than => \'2019/06/06 5:00+0\'::TIMESTAMPTZ, hypertable => \'test_weird_type\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(\'2019/06/06 5:00+0\'::TIMESTAMPTZ, \'test_weird_type\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT * FROM test.show_subtables('test_weird_type');
@@ -1193,10 +1246,13 @@ SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 10:00+0'::TIMESTAM
  _timescaledb_internal._hyper_9_31_chunk
 (1 row)
 
-SELECT drop_chunks('2019/06/06 6:00+0'::TIMESTAMPTZ, 'test_weird_type');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(older_than => \'2019/06/06 6:00+0\'::TIMESTAMPTZ, hypertable => \'test_weird_type\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(\'2019/06/06 6:00+0\'::TIMESTAMPTZ, \'test_weird_type\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT * FROM test.show_subtables('test_weird_type');
@@ -1245,10 +1301,13 @@ SELECT show_chunks('test_weird_type_i', older_than=>10);
  _timescaledb_internal._hyper_10_33_chunk
 (2 rows)
 
-SELECT drop_chunks(5, 'test_weird_type_i');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(older_than=>5, hypertable => \'test_weird_type_i\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(5, \'test_weird_type_i\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT * FROM test.show_subtables('test_weird_type_i');
@@ -1268,10 +1327,13 @@ SELECT show_chunks('test_weird_type_i', older_than=>10);
  _timescaledb_internal._hyper_10_33_chunk
 (1 row)
 
-SELECT drop_chunks(10, 'test_weird_type_i');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(older_than=>10, hypertable => \'test_weird_type_i\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(10, \'test_weird_type_i\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT * FROM test.show_subtables('test_weird_type_i');
@@ -1304,10 +1366,13 @@ ERROR:  must be owner of hypertable "drop_chunk_test1"
 SELECT drop_chunks(2, CASCADE=>true, verbose => true);
 ERROR:  must be owner of hypertable "drop_chunk_test1"
 --works with modified owner tables
-SELECT drop_chunks(table_name=>'drop_chunk_test2', older_than=>4, newer_than=>3);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test2\', older_than=>4, newer_than=>3)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test2\', older_than=>4, newer_than=>3)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 --this fails because there is a dependent object
@@ -1315,11 +1380,14 @@ SELECT drop_chunks(table_name=>'drop_chunk_test3', older_than=>100);
 ERROR:  cannot drop table _timescaledb_internal._hyper_3_34_chunk because other objects depend on it
 --this will succeed even though there is a depenent object I don't have permission
 --to drop. This matches PostgreSQL semantics.
-SELECT drop_chunks(table_name=>'drop_chunk_test3', older_than=>100, cascade=>true);
-NOTICE:  drop cascades to view dependent_view
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test3\', older_than=>100)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test3\', older_than=>100, cascade=>true)::TEXT'
+\set ECHO errors
+psql:include/query_result_test_equal.sql:14: NOTICE:  drop cascades to view dependent_view
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 \set ON_ERROR_STOP 1

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -1,6 +1,9 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH 'include/query_result_test_equal.sql'
 \c postgres :ROLE_SUPERUSER
 DROP DATABASE :TEST_DBNAME;
 CREATE DATABASE :TEST_DBNAME;
@@ -109,10 +112,13 @@ SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '
 
 -- testing time_bucket END
 -- testing drop_chunks START
-SELECT "testSchema0".drop_chunks('2017-03-01'::timestamp, 'test_ts');
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT "testSchema0".show_chunks(older_than => \'2017-03-01\'::timestamp, hypertable => \'test_ts\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'2017-03-01\'::timestamp, \'test_ts\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       0 |                       0
 (1 row)
 
 SELECT * FROM test_ts ORDER BY time;
@@ -124,10 +130,12 @@ SELECT * FROM test_ts ORDER BY time;
  Mon Mar 20 09:37:00.936242 2017 |   30 | dev3
 (4 rows)
 
-SELECT "testSchema0".drop_chunks(interval '1 minutes', 'test_tz');
- drop_chunks 
--------------
- 
+\set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_tz\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_tz\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       2 |                       2
 (1 row)
 
 SELECT * FROM test_tz ORDER BY time;
@@ -135,10 +143,12 @@ SELECT * FROM test_tz ORDER BY time;
 ------+------+--------
 (0 rows)
 
-SELECT "testSchema0".drop_chunks(interval '1 minutes', 'test_dt');
- drop_chunks 
--------------
- 
+\set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_dt\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_dt\')::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       3 |                       3
 (1 row)
 
 SELECT * FROM test_dt ORDER BY time;

--- a/test/isolation/expected/deadlock_dropchunks_select.out
+++ b/test/isolation/expected/deadlock_dropchunks_select.out
@@ -1,10 +1,10 @@
 Parsed test spec with 2 sessions
 
 starting permutation: s1a s1b s2a s2b
-step s1a: select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
-drop_chunks    
+step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+count          
 
-               
+24             
 step s1b: COMMIT;
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ;
 typ            loc            mtim           
@@ -12,10 +12,10 @@ typ            loc            mtim
 step s2b: COMMIT;
 
 starting permutation: s1a s2a s1b s2b
-step s1a: select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
-drop_chunks    
+step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+count          
 
-               
+24             
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ; <waiting ...>
 step s1b: COMMIT;
 step s2a: <... completed>
@@ -24,10 +24,10 @@ typ            loc            mtim
 step s2b: COMMIT;
 
 starting permutation: s1a s2a s2b s1b
-step s1a: select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
-drop_chunks    
+step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+count          
 
-               
+24             
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ; <waiting ...>
 step s2a: <... completed>
 ERROR:  canceling statement due to lock timeout
@@ -38,7 +38,7 @@ starting permutation: s2a s1a s1b s2b
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ;
 typ            loc            mtim           
 
-step s1a: select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); <waiting ...>
+step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); <waiting ...>
 step s1a: <... completed>
 ERROR:  canceling statement due to lock timeout
 step s1b: COMMIT;
@@ -48,12 +48,12 @@ starting permutation: s2a s1a s2b s1b
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ;
 typ            loc            mtim           
 
-step s1a: select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); <waiting ...>
+step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); <waiting ...>
 step s2b: COMMIT;
 step s1a: <... completed>
-drop_chunks    
+count          
 
-               
+24             
 step s1b: COMMIT;
 
 starting permutation: s2a s2b s1a s1b
@@ -61,8 +61,8 @@ step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.s
 typ            loc            mtim           
 
 step s2b: COMMIT;
-step s1a: select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
-drop_chunks    
+step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+count          
 
-               
+24             
 step s1b: COMMIT;

--- a/test/isolation/specs/deadlock_dropchunks_select.spec
+++ b/test/isolation/specs/deadlock_dropchunks_select.spec
@@ -17,7 +17,7 @@ teardown
 
 session "s1"
 setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
-step "s1a"	{ select drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); }
+step "s1a"	{ SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); }
 step "s1b"	{ COMMIT; }
 
 session "s2"

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -2,6 +2,10 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH 'include/query_result_test_equal.sql'
+
 -- DROP a table's column before making it a hypertable
 CREATE TABLE alter_before(id serial, time timestamp, temp float, colorid integer, notes text, notes_2 text);
 ALTER TABLE alter_before DROP COLUMN id;
@@ -155,7 +159,12 @@ ALTER TABLE hyper_in_space SET TABLESPACE tablespace1;
 DROP TABLESPACE tablespace1;
 \set ON_ERROR_STOP 1
 
-SELECT drop_chunks(20, 'hyper_in_space');
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(\'hyper_in_space\', 22)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(22, \'hyper_in_space\')::TEXT'
+\set ECHO errors
+\ir :QUERY_RESULT_TEST_EQUAL_RELPATH
+\set ECHO all
 SELECT tablename, tablespace FROM pg_tables WHERE tablespace = 'tablespace1' ORDER BY tablename;
 
 \set ON_ERROR_STOP 0

--- a/test/sql/include/query_result_test_equal.sql
+++ b/test/sql/include/query_result_test_equal.sql
@@ -1,0 +1,14 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+--expects QUERY1 and QUERY2 to be set, expects data can be compared 
+with query1 AS (
+  SELECT row_number() OVER(ORDER BY q.*) row_number, * FROM (:QUERY1) as q
+),
+query2 AS (
+  SELECT row_number() OVER (ORDER BY v.*) row_number, * FROM (:QUERY2) as v
+)
+SELECT count(*) FILTER (WHERE query1.* IS DISTINCT FROM (query2.*)) AS "Different Rows", 
+coalesce(max(query1.row_number), 0) AS "Total Rows from Query 1", coalesce(max(query2.row_number), 0) AS "Total Rows from Query 2" 
+FROM query1 FULL OUTER JOIN query2 ON (query1.row_number = query2.row_number);

--- a/test/sql/relocate_extension.sql
+++ b/test/sql/relocate_extension.sql
@@ -2,6 +2,10 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH 'include/query_result_test_equal.sql'
+
 \c postgres :ROLE_SUPERUSER
 DROP DATABASE :TEST_DBNAME;
 CREATE DATABASE :TEST_DBNAME;
@@ -49,11 +53,24 @@ SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '
 -- testing time_bucket END
 
 -- testing drop_chunks START
-SELECT "testSchema0".drop_chunks('2017-03-01'::timestamp, 'test_ts');
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT "testSchema0".show_chunks(older_than => \'2017-03-01\'::timestamp, hypertable => \'test_ts\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'2017-03-01\'::timestamp, \'test_ts\')::TEXT'
+\set ECHO errors
+\ir  :QUERY_RESULT_TEST_EQUAL_RELPATH
+\set ECHO all
 SELECT * FROM test_ts ORDER BY time;
-SELECT "testSchema0".drop_chunks(interval '1 minutes', 'test_tz');
+\set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_tz\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_tz\')::TEXT'
+\set ECHO errors
+\ir  :QUERY_RESULT_TEST_EQUAL_RELPATH
+\set ECHO all
 SELECT * FROM test_tz ORDER BY time;
-SELECT "testSchema0".drop_chunks(interval '1 minutes', 'test_dt');
+\set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_dt\')::REGCLASS::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_dt\')::TEXT'
+\set ECHO errors
+\ir  :QUERY_RESULT_TEST_EQUAL_RELPATH
+\set ECHO all
 SELECT * FROM test_dt ORDER BY time;
 -- testing drop_chunks END
 

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -1,6 +1,9 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH '../../../test/sql/include/query_result_test_equal.sql'
 \set ON_ERROR_STOP 0
 --DDL commands on continuous aggregates
 CREATE TABLE conditions (
@@ -320,10 +323,13 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           10 |     5
 (3 rows)
 
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 13, cascade_to_materializations => true);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
@@ -389,10 +395,13 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           12 |     3
 (5 rows)
 
-SELECT drop_chunks(table_name => 'drop_chunks_table_u', older_than => 13, cascade_to_materializations => true);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table_u\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table_u\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 -- everything in the first chunk (values within [0, 6]) should be dropped

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -1,6 +1,9 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH '../../../test/sql/include/query_result_test_equal.sql'
 \set ON_ERROR_STOP 0
 --DDL commands on continuous aggregates
 CREATE TABLE conditions (
@@ -320,10 +323,13 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           10 |     5
 (3 rows)
 
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 13, cascade_to_materializations => true);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
@@ -389,10 +395,13 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           12 |     3
 (5 rows)
 
-SELECT drop_chunks(table_name => 'drop_chunks_table_u', older_than => 13, cascade_to_materializations => true);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table_u\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table_u\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 -- everything in the first chunk (values within [0, 6]) should be dropped

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -1,6 +1,9 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH '../../../test/sql/include/query_result_test_equal.sql'
 \set ON_ERROR_STOP 0
 --DDL commands on continuous aggregates
 CREATE TABLE conditions (
@@ -320,10 +323,13 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           10 |     5
 (3 rows)
 
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 13, cascade_to_materializations => true);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
@@ -389,10 +395,13 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           12 |     3
 (5 rows)
 
-SELECT drop_chunks(table_name => 'drop_chunks_table_u', older_than => 13, cascade_to_materializations => true);
- drop_chunks 
--------------
- 
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table_u\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table_u\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+ Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
+----------------+-------------------------+-------------------------
+              0 |                       1 |                       1
 (1 row)
 
 -- everything in the first chunk (values within [0, 6]) should be dropped

--- a/tsl/test/sql/continuous_aggs_ddl.sql.in
+++ b/tsl/test/sql/continuous_aggs_ddl.sql.in
@@ -2,6 +2,10 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+-- Set this variable to avoid using a hard-coded path each time query
+-- results are compared
+\set QUERY_RESULT_TEST_EQUAL_RELPATH '../../../test/sql/include/query_result_test_equal.sql'
+
 \set ON_ERROR_STOP 0
 
 --DDL commands on continuous aggregates
@@ -206,7 +210,12 @@ SELECT count(c) FROM show_chunks(:'drop_chunks_mat_table') AS c;
 
 SELECT * FROM drop_chunks_view ORDER BY 1;
 
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 13, cascade_to_materializations => true);
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+\ir :QUERY_RESULT_TEST_EQUAL_RELPATH
+\set ECHO all
 
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
 SELECT count(c) FROM show_chunks(:'drop_chunks_mat_table') AS c;
@@ -240,7 +249,12 @@ SELECT count(c) FROM show_chunks(:'drop_chunks_mat_table_u') AS c;
 
 SELECT * FROM drop_chunks_view ORDER BY 1;
 
-SELECT drop_chunks(table_name => 'drop_chunks_table_u', older_than => 13, cascade_to_materializations => true);
+-- show_chunks and drop_chunks output should be the same
+\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table_u\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table_u\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set ECHO errors
+\ir :QUERY_RESULT_TEST_EQUAL_RELPATH
+\set ECHO all
 
 -- everything in the first chunk (values within [0, 6]) should be dropped
 -- the time_bucket [6, 8] will lose it's first value, but should still have


### PR DESCRIPTION
Previously, drop_chunks returned an empty table, giving the user
no indication of what (if anything) had happened.
Now, drop_chunks returns a list of the chunks identifiers in the
same style as show_chunks, with the chunk's schema and table name.