### PR TITLE
Add architecture and bit size to telemetry

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -9,6 +9,8 @@
 #define TIMESCALEDB_MOD_VERSION "@VERSION_MOD@"
 #define BUILD_OS_NAME "@CMAKE_SYSTEM_NAME@"
 #define BUILD_OS_VERSION "@CMAKE_SYSTEM_VERSION@"
+#define BUILD_PROCESSOR "@CMAKE_SYSTEM_PROCESSOR@"
+#define BUILD_POINTER_BYTES @CMAKE_SIZEOF_VOID_P@
 /*
  * Value should be set in package release scripts. Otherwise
  * defaults to "source"

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -47,6 +47,8 @@
 #define REQ_TS_VERSION "timescaledb_version"
 #define REQ_BUILD_OS "build_os_name"
 #define REQ_BUILD_OS_VERSION "build_os_version"
+#define REQ_BUILD_ARCHITECTURE_BIT_SIZE "build_architecture_bit_size"
+#define REQ_BUILD_ARCHITECTURE "build_architecture"
 #define REQ_DATA_VOLUME "data_volume"
 #define REQ_NUM_HYPERTABLES "num_hypertables"
 #define REQ_NUM_CONTINUOUS_AGGS "num_continuous_aggs"
@@ -170,6 +172,15 @@ get_num_hypertables()
 }
 
 static char *
+get_architecture_bit_size()
+{
+	StringInfo buf = makeStringInfo();
+
+	appendStringInfo(buf, "%d", BUILD_POINTER_BYTES * 8);
+	return buf->data;
+}
+
+static char *
 get_num_continuous_aggs()
 {
 	StringInfo buf = makeStringInfo();
@@ -285,6 +296,8 @@ build_version_body(void)
 	ts_jsonb_add_str(parseState, REQ_TS_VERSION, TIMESCALEDB_VERSION_MOD);
 	ts_jsonb_add_str(parseState, REQ_BUILD_OS, BUILD_OS_NAME);
 	ts_jsonb_add_str(parseState, REQ_BUILD_OS_VERSION, BUILD_OS_VERSION);
+	ts_jsonb_add_str(parseState, REQ_BUILD_ARCHITECTURE, BUILD_PROCESSOR);
+	ts_jsonb_add_str(parseState, REQ_BUILD_ARCHITECTURE_BIT_SIZE, get_architecture_bit_size());
 	ts_jsonb_add_str(parseState, REQ_DATA_VOLUME, get_database_size());
 	ts_jsonb_add_str(parseState, REQ_NUM_HYPERTABLES, get_num_hypertables());
 	ts_jsonb_add_str(parseState, REQ_NUM_CONTINUOUS_AGGS, get_num_continuous_aggs());

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -301,8 +301,8 @@ INFO:  Telemetry is disabled. Call get_telemetry_report(always_display_report :=
 
 SELECT * FROM json_object_keys(get_telemetry_report(always_display_report := true)::json) AS key
 WHERE key != 'os_name_pretty';
-           key            
---------------------------
+             key             
+-----------------------------
  db_uuid
  license
  os_name
@@ -318,6 +318,7 @@ WHERE key != 'os_name_pretty';
  build_os_version
  exported_db_uuid
  instance_metadata
+ build_architecture
  last_tuned_version
  postgresql_version
  related_extensions
@@ -325,14 +326,15 @@ WHERE key != 'os_name_pretty';
  timescaledb_version
  num_reorder_policies
  num_drop_chunks_policies
-(22 rows)
+ build_architecture_bit_size
+(24 rows)
 
 -- Test telemetry report contents
 SET timescaledb.telemetry_level=basic;
 SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
 WHERE key != 'os_name_pretty';
-           key            
---------------------------
+             key             
+-----------------------------
  db_uuid
  license
  os_name
@@ -348,6 +350,7 @@ WHERE key != 'os_name_pretty';
  build_os_version
  exported_db_uuid
  instance_metadata
+ build_architecture
  last_tuned_version
  postgresql_version
  related_extensions
@@ -355,7 +358,8 @@ WHERE key != 'os_name_pretty';
  timescaledb_version
  num_reorder_policies
  num_drop_chunks_policies
-(22 rows)
+ build_architecture_bit_size
+(24 rows)
 
 -- check telemetry picks up flagged content from metadata
 SELECT json_object_field(get_telemetry_report()::json,'db_metadata');


### PR DESCRIPTION
Add architecture and pointer bit size fields to what is sent in
telemetry. This will allow us to evaluate the product usage on
different architectures.