### PR TITLE
Fix chunk exclusion with ordered append

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -56,10 +56,20 @@ typedef struct ChunkScanCtx
 	HTAB *htab;
 	Hyperspace *space;
 	Point *point;
+	unsigned int num_complete_chunks;
 	bool early_abort;
 	LOCKMODE lockmode;
 	void *data;
 } ChunkScanCtx;
+
+/* Returns true if the chunk has a full set of constraints, otherwise
+ * false. Used to find a chunk matching a point in an N-dimensional
+ * hyperspace. */
+static inline bool
+chunk_is_complete(Chunk *chunk, Hyperspace *space)
+{
+	return space->num_dimensions == chunk->constraints->num_dimension_constraints;
+}
 
 /* The hash table entry for the ChunkScanCtx */
 typedef struct ChunkScanEntry
@@ -71,7 +81,10 @@ typedef struct ChunkScanEntry
 extern Chunk *ts_chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
 extern Chunk *ts_chunk_create_stub(int32 id, int16 num_constraints);
 extern Chunk *ts_chunk_find(Hyperspace *hs, Point *p);
+extern Chunk **ts_chunk_find_all(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode,
+								 unsigned int *num_chunks);
 extern List *ts_chunk_find_all_oids(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode);
+
 extern Chunk *ts_chunk_copy(Chunk *chunk);
 extern Chunk *ts_chunk_get_by_name_with_memory_context(const char *schema_name,
 													   const char *table_name,

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -468,10 +468,17 @@ ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx 
 
 		ts_hypercube_add_slice(chunk->cube, slice);
 
-		if (ctx->early_abort && chunk->constraints->num_dimension_constraints == hs->num_dimensions)
+		/* A chunk is complete when we've added slices for all its dimensions,
+		 * i.e., a complete hypercube */
+		if (chunk_is_complete(chunk, ctx->space))
 		{
-			ts_scan_iterator_close(&iterator);
-			break;
+			ctx->num_complete_chunks++;
+
+			if (ctx->early_abort)
+			{
+				ts_scan_iterator_close(&iterator);
+				break;
+			}
 		}
 	}
 	return count;

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -68,21 +68,12 @@ ts_dimension_slice_create(int dimension_id, int64 range_start, int64 range_end)
 int
 ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right)
 {
-	if (left->fd.range_start == right->fd.range_start)
-	{
-		if (left->fd.range_end == right->fd.range_end)
-			return 0;
+	int res = DIMENSION_SLICE_RANGE_START_CMP(left, right);
 
-		if (left->fd.range_end > right->fd.range_end)
-			return 1;
+	if (res == 0)
+		res = DIMENSION_SLICE_RANGE_END_CMP(left, right);
 
-		return -1;
-	}
-
-	if (left->fd.range_start > right->fd.range_start)
-		return 1;
-
-	return -1;
+	return res;
 }
 
 int

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -19,6 +19,21 @@
 /* partition functions return int32 */
 #define DIMENSION_SLICE_CLOSED_MAX ((int64) PG_INT32_MAX)
 
+#define VALUE_GT(v1, v2) ((v1) > (v2))
+#define VALUE_LT(v1, v2) ((v1) < (v2))
+/*
+ * Compare two values, returning -1, 1, 0 if the left one is, less, greater,
+ * or equal to the right one, respectively.
+ */
+#define VALUE_CMP(v1, v2) VALUE_GT(v1, v2) - VALUE_LT(v1, v2)
+
+/* Compare the range start values of two slices */
+#define DIMENSION_SLICE_RANGE_START_CMP(s1, s2)                                                    \
+	VALUE_CMP((s1)->fd.range_start, (s2)->fd.range_start)
+
+/* Compare the range end values of two slices */
+#define DIMENSION_SLICE_RANGE_END_CMP(s1, s2) VALUE_CMP((s1)->fd.range_end, (s2)->fd.range_end)
+
 typedef struct DimensionSlice
 {
 	FormData_dimension_slice fd;

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -737,8 +737,7 @@ get_chunk_oids(CollectQualCtx *ctx, PlannerInfo *root, RelOptInfo *rel, Hypertab
 																	  nested_oids,
 																	  reverse);
 		}
-		else
-			return find_children_oids(hri, ht, AccessShareLock);
+		return find_children_oids(hri, ht, AccessShareLock);
 	}
 	else
 		return get_explicit_chunk_oids(ctx, ht);

--- a/test/expected/plan_ordered_append-10.out
+++ b/test/expected/plan_ordered_append-10.out
@@ -1088,6 +1088,50 @@ ORDER BY time;
          ->  Index Scan Backward using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk (actual rows=12482 loops=1)
 (14 rows)
 
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 3 of 4 space partitions (2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id = 1
+ORDER BY time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on space (actual rows=12961 loops=1)
+   Order: space."time"
+   ->  Index Scan Backward using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
+         Filter: (device_id = 1)
+   ->  Index Scan Backward using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
+         Filter: (device_id = 1)
+(6 rows)
+
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 2 of 4 space partitions (2 + 2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id IN (1, 4)
+ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on space (actual rows=25922 loops=1)
+   Order: space."time"
+   ->  Merge Append (actual rows=13440 loops=1)
+         Sort Key: _hyper_7_24_chunk."time"
+         ->  Index Scan Backward using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+         ->  Index Scan Backward using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk (actual rows=6720 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+               Rows Removed by Filter: 6720
+   ->  Merge Append (actual rows=12482 loops=1)
+         Sort Key: _hyper_7_23_chunk."time"
+         ->  Index Scan Backward using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+         ->  Index Scan Backward using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk (actual rows=6241 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+               Rows Removed by Filter: 6241
+(16 rows)
+
 -- test hypertable with space partitioning and reverse order
 :PREFIX SELECT
   time, device_id, value
@@ -1098,17 +1142,17 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space (actual rows=77766 loops=1)
    Order: space."time" DESC
    ->  Merge Append (actual rows=37446 loops=1)
-         Sort Key: _hyper_7_23_chunk."time" DESC
-         ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk (actual rows=12482 loops=1)
-         ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk (actual rows=6241 loops=1)
+         Sort Key: _hyper_7_29_chunk."time" DESC
          ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk (actual rows=12482 loops=1)
+         ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk (actual rows=12482 loops=1)
+         ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
    ->  Merge Append (actual rows=40320 loops=1)
-         Sort Key: _hyper_7_24_chunk."time" DESC
-         ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk (actual rows=13440 loops=1)
-         ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk (actual rows=6720 loops=1)
+         Sort Key: _hyper_7_30_chunk."time" DESC
          ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk (actual rows=13440 loops=1)
+         ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk (actual rows=13440 loops=1)
+         ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
 (14 rows)
 
 -- test hypertable with space partitioning ORDER BY multiple columns
@@ -1167,27 +1211,27 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space2 (actual rows=116649 loops=1)
    Order: space2."time" DESC
    ->  Merge Append (actual rows=56169 loops=1)
-         Sort Key: _hyper_8_31_chunk."time" DESC
-         ->  Index Scan using _hyper_8_31_chunk_space2_time_idx on _hyper_8_31_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_33_chunk_space2_time_idx on _hyper_8_33_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_35_chunk_space2_time_idx on _hyper_8_35_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_37_chunk_space2_time_idx on _hyper_8_37_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_39_chunk_space2_time_idx on _hyper_8_39_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_41_chunk_space2_time_idx on _hyper_8_41_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_43_chunk_space2_time_idx on _hyper_8_43_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_45_chunk_space2_time_idx on _hyper_8_45_chunk (actual rows=6241 loops=1)
+         Sort Key: _hyper_8_47_chunk."time" DESC
          ->  Index Scan using _hyper_8_47_chunk_space2_time_idx on _hyper_8_47_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_45_chunk_space2_time_idx on _hyper_8_45_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_43_chunk_space2_time_idx on _hyper_8_43_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_41_chunk_space2_time_idx on _hyper_8_41_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_39_chunk_space2_time_idx on _hyper_8_39_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_37_chunk_space2_time_idx on _hyper_8_37_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_35_chunk_space2_time_idx on _hyper_8_35_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_33_chunk_space2_time_idx on _hyper_8_33_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_31_chunk_space2_time_idx on _hyper_8_31_chunk (actual rows=6241 loops=1)
    ->  Merge Append (actual rows=60480 loops=1)
-         Sort Key: _hyper_8_32_chunk."time" DESC
-         ->  Index Scan using _hyper_8_32_chunk_space2_time_idx on _hyper_8_32_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_34_chunk_space2_time_idx on _hyper_8_34_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_36_chunk_space2_time_idx on _hyper_8_36_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_38_chunk_space2_time_idx on _hyper_8_38_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_40_chunk_space2_time_idx on _hyper_8_40_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_42_chunk_space2_time_idx on _hyper_8_42_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_44_chunk_space2_time_idx on _hyper_8_44_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_46_chunk_space2_time_idx on _hyper_8_46_chunk (actual rows=6720 loops=1)
+         Sort Key: _hyper_8_48_chunk."time" DESC
          ->  Index Scan using _hyper_8_48_chunk_space2_time_idx on _hyper_8_48_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_46_chunk_space2_time_idx on _hyper_8_46_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_44_chunk_space2_time_idx on _hyper_8_44_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_42_chunk_space2_time_idx on _hyper_8_42_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_40_chunk_space2_time_idx on _hyper_8_40_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_38_chunk_space2_time_idx on _hyper_8_38_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_36_chunk_space2_time_idx on _hyper_8_36_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_34_chunk_space2_time_idx on _hyper_8_34_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_32_chunk_space2_time_idx on _hyper_8_32_chunk (actual rows=6720 loops=1)
 (24 rows)
 
 -- test hypertable with 3 space dimensions
@@ -1200,40 +1244,40 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space3 (actual rows=103688 loops=1)
    Order: space3."time" DESC
    ->  Merge Append (actual rows=49928 loops=1)
-         Sort Key: _hyper_9_49_chunk."time" DESC
-         ->  Index Only Scan using _hyper_9_49_chunk_space3_time_idx on _hyper_9_49_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_51_chunk_space3_time_idx on _hyper_9_51_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_53_chunk_space3_time_idx on _hyper_9_53_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_55_chunk_space3_time_idx on _hyper_9_55_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_57_chunk_space3_time_idx on _hyper_9_57_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_59_chunk_space3_time_idx on _hyper_9_59_chunk (actual rows=6241 loops=1)
+         Sort Key: _hyper_9_63_chunk."time" DESC
+         ->  Index Only Scan using _hyper_9_63_chunk_space3_time_idx on _hyper_9_63_chunk (actual rows=6241 loops=1)
                Heap Fetches: 6241
          ->  Index Only Scan using _hyper_9_61_chunk_space3_time_idx on _hyper_9_61_chunk (actual rows=6241 loops=1)
                Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_63_chunk_space3_time_idx on _hyper_9_63_chunk (actual rows=6241 loops=1)
+         ->  Index Only Scan using _hyper_9_59_chunk_space3_time_idx on _hyper_9_59_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_57_chunk_space3_time_idx on _hyper_9_57_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_55_chunk_space3_time_idx on _hyper_9_55_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_53_chunk_space3_time_idx on _hyper_9_53_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_51_chunk_space3_time_idx on _hyper_9_51_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_49_chunk_space3_time_idx on _hyper_9_49_chunk (actual rows=6241 loops=1)
                Heap Fetches: 6241
    ->  Merge Append (actual rows=53760 loops=1)
-         Sort Key: _hyper_9_50_chunk."time" DESC
-         ->  Index Only Scan using _hyper_9_50_chunk_space3_time_idx on _hyper_9_50_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_52_chunk_space3_time_idx on _hyper_9_52_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_54_chunk_space3_time_idx on _hyper_9_54_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_56_chunk_space3_time_idx on _hyper_9_56_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_58_chunk_space3_time_idx on _hyper_9_58_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_60_chunk_space3_time_idx on _hyper_9_60_chunk (actual rows=6720 loops=1)
+         Sort Key: _hyper_9_64_chunk."time" DESC
+         ->  Index Only Scan using _hyper_9_64_chunk_space3_time_idx on _hyper_9_64_chunk (actual rows=6720 loops=1)
                Heap Fetches: 6720
          ->  Index Only Scan using _hyper_9_62_chunk_space3_time_idx on _hyper_9_62_chunk (actual rows=6720 loops=1)
                Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_64_chunk_space3_time_idx on _hyper_9_64_chunk (actual rows=6720 loops=1)
+         ->  Index Only Scan using _hyper_9_60_chunk_space3_time_idx on _hyper_9_60_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_58_chunk_space3_time_idx on _hyper_9_58_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_56_chunk_space3_time_idx on _hyper_9_56_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_54_chunk_space3_time_idx on _hyper_9_54_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_52_chunk_space3_time_idx on _hyper_9_52_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_50_chunk_space3_time_idx on _hyper_9_50_chunk (actual rows=6720 loops=1)
                Heap Fetches: 6720
 (38 rows)
 
@@ -1578,23 +1622,23 @@ LEFT OUTER JOIN LATERAL(
                Order: o."time" DESC
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_1."time" DESC
-                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_1 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_1 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_2 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_2 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_3 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_3 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_4 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_4 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                ->  Merge Append (actual rows=1 loops=3)
                      Sort Key: o_5."time" DESC
-                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_5 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_5 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_6 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_6 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_7 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_7 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_8 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_8 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
 (25 rows)
 
@@ -1614,23 +1658,23 @@ LEFT OUTER JOIN LATERAL(
                Order: o."time" DESC
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_1."time" DESC
-                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_1 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_1 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_2 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_2 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_3 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_3 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_4 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_4 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                ->  Merge Append (actual rows=1 loops=3)
                      Sort Key: o_5."time" DESC
-                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_5 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_5 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_6 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_6 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_7 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_7 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_8 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_8 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
 (25 rows)
 

--- a/test/expected/plan_ordered_append-11.out
+++ b/test/expected/plan_ordered_append-11.out
@@ -1088,6 +1088,50 @@ ORDER BY time;
          ->  Index Scan Backward using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk (actual rows=12482 loops=1)
 (14 rows)
 
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 3 of 4 space partitions (2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id = 1
+ORDER BY time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on space (actual rows=12961 loops=1)
+   Order: space."time"
+   ->  Index Scan Backward using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
+         Filter: (device_id = 1)
+   ->  Index Scan Backward using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
+         Filter: (device_id = 1)
+(6 rows)
+
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 2 of 4 space partitions (2 + 2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id IN (1, 4)
+ORDER BY time;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on space (actual rows=25922 loops=1)
+   Order: space."time"
+   ->  Merge Append (actual rows=13440 loops=1)
+         Sort Key: _hyper_7_24_chunk."time"
+         ->  Index Scan Backward using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+         ->  Index Scan Backward using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk (actual rows=6720 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+               Rows Removed by Filter: 6720
+   ->  Merge Append (actual rows=12482 loops=1)
+         Sort Key: _hyper_7_23_chunk."time"
+         ->  Index Scan Backward using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+         ->  Index Scan Backward using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk (actual rows=6241 loops=1)
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+               Rows Removed by Filter: 6241
+(16 rows)
+
 -- test hypertable with space partitioning and reverse order
 :PREFIX SELECT
   time, device_id, value
@@ -1098,17 +1142,17 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space (actual rows=77766 loops=1)
    Order: space."time" DESC
    ->  Merge Append (actual rows=37446 loops=1)
-         Sort Key: _hyper_7_23_chunk."time" DESC
-         ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk (actual rows=12482 loops=1)
-         ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk (actual rows=6241 loops=1)
+         Sort Key: _hyper_7_29_chunk."time" DESC
          ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk (actual rows=12482 loops=1)
+         ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk (actual rows=12482 loops=1)
+         ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk (actual rows=6241 loops=1)
    ->  Merge Append (actual rows=40320 loops=1)
-         Sort Key: _hyper_7_24_chunk."time" DESC
-         ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk (actual rows=13440 loops=1)
-         ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk (actual rows=6720 loops=1)
+         Sort Key: _hyper_7_30_chunk."time" DESC
          ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk (actual rows=13440 loops=1)
+         ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk (actual rows=13440 loops=1)
+         ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk (actual rows=6720 loops=1)
 (14 rows)
 
 -- test hypertable with space partitioning ORDER BY multiple columns
@@ -1167,27 +1211,27 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space2 (actual rows=116649 loops=1)
    Order: space2."time" DESC
    ->  Merge Append (actual rows=56169 loops=1)
-         Sort Key: _hyper_8_31_chunk."time" DESC
-         ->  Index Scan using _hyper_8_31_chunk_space2_time_idx on _hyper_8_31_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_33_chunk_space2_time_idx on _hyper_8_33_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_35_chunk_space2_time_idx on _hyper_8_35_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_37_chunk_space2_time_idx on _hyper_8_37_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_39_chunk_space2_time_idx on _hyper_8_39_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_41_chunk_space2_time_idx on _hyper_8_41_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_43_chunk_space2_time_idx on _hyper_8_43_chunk (actual rows=6241 loops=1)
-         ->  Index Scan using _hyper_8_45_chunk_space2_time_idx on _hyper_8_45_chunk (actual rows=6241 loops=1)
+         Sort Key: _hyper_8_47_chunk."time" DESC
          ->  Index Scan using _hyper_8_47_chunk_space2_time_idx on _hyper_8_47_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_45_chunk_space2_time_idx on _hyper_8_45_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_43_chunk_space2_time_idx on _hyper_8_43_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_41_chunk_space2_time_idx on _hyper_8_41_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_39_chunk_space2_time_idx on _hyper_8_39_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_37_chunk_space2_time_idx on _hyper_8_37_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_35_chunk_space2_time_idx on _hyper_8_35_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_33_chunk_space2_time_idx on _hyper_8_33_chunk (actual rows=6241 loops=1)
+         ->  Index Scan using _hyper_8_31_chunk_space2_time_idx on _hyper_8_31_chunk (actual rows=6241 loops=1)
    ->  Merge Append (actual rows=60480 loops=1)
-         Sort Key: _hyper_8_32_chunk."time" DESC
-         ->  Index Scan using _hyper_8_32_chunk_space2_time_idx on _hyper_8_32_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_34_chunk_space2_time_idx on _hyper_8_34_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_36_chunk_space2_time_idx on _hyper_8_36_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_38_chunk_space2_time_idx on _hyper_8_38_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_40_chunk_space2_time_idx on _hyper_8_40_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_42_chunk_space2_time_idx on _hyper_8_42_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_44_chunk_space2_time_idx on _hyper_8_44_chunk (actual rows=6720 loops=1)
-         ->  Index Scan using _hyper_8_46_chunk_space2_time_idx on _hyper_8_46_chunk (actual rows=6720 loops=1)
+         Sort Key: _hyper_8_48_chunk."time" DESC
          ->  Index Scan using _hyper_8_48_chunk_space2_time_idx on _hyper_8_48_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_46_chunk_space2_time_idx on _hyper_8_46_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_44_chunk_space2_time_idx on _hyper_8_44_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_42_chunk_space2_time_idx on _hyper_8_42_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_40_chunk_space2_time_idx on _hyper_8_40_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_38_chunk_space2_time_idx on _hyper_8_38_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_36_chunk_space2_time_idx on _hyper_8_36_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_34_chunk_space2_time_idx on _hyper_8_34_chunk (actual rows=6720 loops=1)
+         ->  Index Scan using _hyper_8_32_chunk_space2_time_idx on _hyper_8_32_chunk (actual rows=6720 loops=1)
 (24 rows)
 
 -- test hypertable with 3 space dimensions
@@ -1200,40 +1244,40 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space3 (actual rows=103688 loops=1)
    Order: space3."time" DESC
    ->  Merge Append (actual rows=49928 loops=1)
-         Sort Key: _hyper_9_49_chunk."time" DESC
-         ->  Index Only Scan using _hyper_9_49_chunk_space3_time_idx on _hyper_9_49_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_51_chunk_space3_time_idx on _hyper_9_51_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_53_chunk_space3_time_idx on _hyper_9_53_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_55_chunk_space3_time_idx on _hyper_9_55_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_57_chunk_space3_time_idx on _hyper_9_57_chunk (actual rows=6241 loops=1)
-               Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_59_chunk_space3_time_idx on _hyper_9_59_chunk (actual rows=6241 loops=1)
+         Sort Key: _hyper_9_63_chunk."time" DESC
+         ->  Index Only Scan using _hyper_9_63_chunk_space3_time_idx on _hyper_9_63_chunk (actual rows=6241 loops=1)
                Heap Fetches: 6241
          ->  Index Only Scan using _hyper_9_61_chunk_space3_time_idx on _hyper_9_61_chunk (actual rows=6241 loops=1)
                Heap Fetches: 6241
-         ->  Index Only Scan using _hyper_9_63_chunk_space3_time_idx on _hyper_9_63_chunk (actual rows=6241 loops=1)
+         ->  Index Only Scan using _hyper_9_59_chunk_space3_time_idx on _hyper_9_59_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_57_chunk_space3_time_idx on _hyper_9_57_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_55_chunk_space3_time_idx on _hyper_9_55_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_53_chunk_space3_time_idx on _hyper_9_53_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_51_chunk_space3_time_idx on _hyper_9_51_chunk (actual rows=6241 loops=1)
+               Heap Fetches: 6241
+         ->  Index Only Scan using _hyper_9_49_chunk_space3_time_idx on _hyper_9_49_chunk (actual rows=6241 loops=1)
                Heap Fetches: 6241
    ->  Merge Append (actual rows=53760 loops=1)
-         Sort Key: _hyper_9_50_chunk."time" DESC
-         ->  Index Only Scan using _hyper_9_50_chunk_space3_time_idx on _hyper_9_50_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_52_chunk_space3_time_idx on _hyper_9_52_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_54_chunk_space3_time_idx on _hyper_9_54_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_56_chunk_space3_time_idx on _hyper_9_56_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_58_chunk_space3_time_idx on _hyper_9_58_chunk (actual rows=6720 loops=1)
-               Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_60_chunk_space3_time_idx on _hyper_9_60_chunk (actual rows=6720 loops=1)
+         Sort Key: _hyper_9_64_chunk."time" DESC
+         ->  Index Only Scan using _hyper_9_64_chunk_space3_time_idx on _hyper_9_64_chunk (actual rows=6720 loops=1)
                Heap Fetches: 6720
          ->  Index Only Scan using _hyper_9_62_chunk_space3_time_idx on _hyper_9_62_chunk (actual rows=6720 loops=1)
                Heap Fetches: 6720
-         ->  Index Only Scan using _hyper_9_64_chunk_space3_time_idx on _hyper_9_64_chunk (actual rows=6720 loops=1)
+         ->  Index Only Scan using _hyper_9_60_chunk_space3_time_idx on _hyper_9_60_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_58_chunk_space3_time_idx on _hyper_9_58_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_56_chunk_space3_time_idx on _hyper_9_56_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_54_chunk_space3_time_idx on _hyper_9_54_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_52_chunk_space3_time_idx on _hyper_9_52_chunk (actual rows=6720 loops=1)
+               Heap Fetches: 6720
+         ->  Index Only Scan using _hyper_9_50_chunk_space3_time_idx on _hyper_9_50_chunk (actual rows=6720 loops=1)
                Heap Fetches: 6720
 (38 rows)
 
@@ -1578,23 +1622,23 @@ LEFT OUTER JOIN LATERAL(
                Order: o."time" DESC
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_1."time" DESC
-                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_1 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_1 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_2 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_2 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_3 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_3 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_4 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_4 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                ->  Merge Append (actual rows=1 loops=3)
                      Sort Key: o_5."time" DESC
-                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_5 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_5 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_6 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_6 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_7 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_7 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_8 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_8 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
 (25 rows)
 
@@ -1614,23 +1658,23 @@ LEFT OUTER JOIN LATERAL(
                Order: o."time" DESC
                ->  Merge Append (actual rows=0 loops=3)
                      Sort Key: o_1."time" DESC
-                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_1 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_1 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_2 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_2 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_3 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_3 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_4 (actual rows=0 loops=3)
+                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_4 (actual rows=0 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                ->  Merge Append (actual rows=1 loops=3)
                      Sort Key: o_5."time" DESC
-                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_5 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_5 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_6 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_6 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_7 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_7 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_8 (actual rows=1 loops=3)
+                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_8 (actual rows=1 loops=3)
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
 (25 rows)
 

--- a/test/expected/plan_ordered_append-9.6.out
+++ b/test/expected/plan_ordered_append-9.6.out
@@ -1063,6 +1063,48 @@ ORDER BY time;
          ->  Index Scan Backward using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk
 (14 rows)
 
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 3 of 4 space partitions (2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id = 1
+ORDER BY time;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on space
+   Order: space."time"
+   ->  Index Scan Backward using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk
+         Filter: (device_id = 1)
+   ->  Index Scan Backward using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk
+         Filter: (device_id = 1)
+(6 rows)
+
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 2 of 4 space partitions (2 + 2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id IN (1, 4)
+ORDER BY time;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on space
+   Order: space."time"
+   ->  Merge Append
+         Sort Key: _hyper_7_24_chunk."time"
+         ->  Index Scan Backward using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+         ->  Index Scan Backward using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+   ->  Merge Append
+         Sort Key: _hyper_7_23_chunk."time"
+         ->  Index Scan Backward using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+         ->  Index Scan Backward using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk
+               Filter: (device_id = ANY ('{1,4}'::integer[]))
+(14 rows)
+
 -- test hypertable with space partitioning and reverse order
 :PREFIX SELECT
   time, device_id, value
@@ -1073,17 +1115,17 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space
    Order: space."time" DESC
    ->  Merge Append
-         Sort Key: _hyper_7_23_chunk."time" DESC
-         ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk
-         ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk
-         ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk
+         Sort Key: _hyper_7_29_chunk."time" DESC
          ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk
+         ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk
+         ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk
+         ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk
    ->  Merge Append
-         Sort Key: _hyper_7_24_chunk."time" DESC
-         ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk
-         ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk
-         ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk
+         Sort Key: _hyper_7_30_chunk."time" DESC
          ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk
+         ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk
+         ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk
+         ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk
 (14 rows)
 
 -- test hypertable with space partitioning ORDER BY multiple columns
@@ -1140,27 +1182,27 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space2
    Order: space2."time" DESC
    ->  Merge Append
-         Sort Key: _hyper_8_31_chunk."time" DESC
-         ->  Index Scan using _hyper_8_31_chunk_space2_time_idx on _hyper_8_31_chunk
-         ->  Index Scan using _hyper_8_33_chunk_space2_time_idx on _hyper_8_33_chunk
-         ->  Index Scan using _hyper_8_35_chunk_space2_time_idx on _hyper_8_35_chunk
-         ->  Index Scan using _hyper_8_37_chunk_space2_time_idx on _hyper_8_37_chunk
-         ->  Index Scan using _hyper_8_39_chunk_space2_time_idx on _hyper_8_39_chunk
-         ->  Index Scan using _hyper_8_41_chunk_space2_time_idx on _hyper_8_41_chunk
-         ->  Index Scan using _hyper_8_43_chunk_space2_time_idx on _hyper_8_43_chunk
-         ->  Index Scan using _hyper_8_45_chunk_space2_time_idx on _hyper_8_45_chunk
+         Sort Key: _hyper_8_47_chunk."time" DESC
          ->  Index Scan using _hyper_8_47_chunk_space2_time_idx on _hyper_8_47_chunk
+         ->  Index Scan using _hyper_8_45_chunk_space2_time_idx on _hyper_8_45_chunk
+         ->  Index Scan using _hyper_8_43_chunk_space2_time_idx on _hyper_8_43_chunk
+         ->  Index Scan using _hyper_8_41_chunk_space2_time_idx on _hyper_8_41_chunk
+         ->  Index Scan using _hyper_8_39_chunk_space2_time_idx on _hyper_8_39_chunk
+         ->  Index Scan using _hyper_8_37_chunk_space2_time_idx on _hyper_8_37_chunk
+         ->  Index Scan using _hyper_8_35_chunk_space2_time_idx on _hyper_8_35_chunk
+         ->  Index Scan using _hyper_8_33_chunk_space2_time_idx on _hyper_8_33_chunk
+         ->  Index Scan using _hyper_8_31_chunk_space2_time_idx on _hyper_8_31_chunk
    ->  Merge Append
-         Sort Key: _hyper_8_32_chunk."time" DESC
-         ->  Index Scan using _hyper_8_32_chunk_space2_time_idx on _hyper_8_32_chunk
-         ->  Index Scan using _hyper_8_34_chunk_space2_time_idx on _hyper_8_34_chunk
-         ->  Index Scan using _hyper_8_36_chunk_space2_time_idx on _hyper_8_36_chunk
-         ->  Index Scan using _hyper_8_38_chunk_space2_time_idx on _hyper_8_38_chunk
-         ->  Index Scan using _hyper_8_40_chunk_space2_time_idx on _hyper_8_40_chunk
-         ->  Index Scan using _hyper_8_42_chunk_space2_time_idx on _hyper_8_42_chunk
-         ->  Index Scan using _hyper_8_44_chunk_space2_time_idx on _hyper_8_44_chunk
-         ->  Index Scan using _hyper_8_46_chunk_space2_time_idx on _hyper_8_46_chunk
+         Sort Key: _hyper_8_48_chunk."time" DESC
          ->  Index Scan using _hyper_8_48_chunk_space2_time_idx on _hyper_8_48_chunk
+         ->  Index Scan using _hyper_8_46_chunk_space2_time_idx on _hyper_8_46_chunk
+         ->  Index Scan using _hyper_8_44_chunk_space2_time_idx on _hyper_8_44_chunk
+         ->  Index Scan using _hyper_8_42_chunk_space2_time_idx on _hyper_8_42_chunk
+         ->  Index Scan using _hyper_8_40_chunk_space2_time_idx on _hyper_8_40_chunk
+         ->  Index Scan using _hyper_8_38_chunk_space2_time_idx on _hyper_8_38_chunk
+         ->  Index Scan using _hyper_8_36_chunk_space2_time_idx on _hyper_8_36_chunk
+         ->  Index Scan using _hyper_8_34_chunk_space2_time_idx on _hyper_8_34_chunk
+         ->  Index Scan using _hyper_8_32_chunk_space2_time_idx on _hyper_8_32_chunk
 (24 rows)
 
 -- test hypertable with 3 space dimensions
@@ -1173,25 +1215,25 @@ ORDER BY time DESC;
  Custom Scan (ChunkAppend) on space3
    Order: space3."time" DESC
    ->  Merge Append
-         Sort Key: _hyper_9_49_chunk."time" DESC
-         ->  Index Only Scan using _hyper_9_49_chunk_space3_time_idx on _hyper_9_49_chunk
-         ->  Index Only Scan using _hyper_9_51_chunk_space3_time_idx on _hyper_9_51_chunk
-         ->  Index Only Scan using _hyper_9_53_chunk_space3_time_idx on _hyper_9_53_chunk
-         ->  Index Only Scan using _hyper_9_55_chunk_space3_time_idx on _hyper_9_55_chunk
-         ->  Index Only Scan using _hyper_9_57_chunk_space3_time_idx on _hyper_9_57_chunk
-         ->  Index Only Scan using _hyper_9_59_chunk_space3_time_idx on _hyper_9_59_chunk
-         ->  Index Only Scan using _hyper_9_61_chunk_space3_time_idx on _hyper_9_61_chunk
+         Sort Key: _hyper_9_63_chunk."time" DESC
          ->  Index Only Scan using _hyper_9_63_chunk_space3_time_idx on _hyper_9_63_chunk
+         ->  Index Only Scan using _hyper_9_61_chunk_space3_time_idx on _hyper_9_61_chunk
+         ->  Index Only Scan using _hyper_9_59_chunk_space3_time_idx on _hyper_9_59_chunk
+         ->  Index Only Scan using _hyper_9_57_chunk_space3_time_idx on _hyper_9_57_chunk
+         ->  Index Only Scan using _hyper_9_55_chunk_space3_time_idx on _hyper_9_55_chunk
+         ->  Index Only Scan using _hyper_9_53_chunk_space3_time_idx on _hyper_9_53_chunk
+         ->  Index Only Scan using _hyper_9_51_chunk_space3_time_idx on _hyper_9_51_chunk
+         ->  Index Only Scan using _hyper_9_49_chunk_space3_time_idx on _hyper_9_49_chunk
    ->  Merge Append
-         Sort Key: _hyper_9_50_chunk."time" DESC
-         ->  Index Only Scan using _hyper_9_50_chunk_space3_time_idx on _hyper_9_50_chunk
-         ->  Index Only Scan using _hyper_9_52_chunk_space3_time_idx on _hyper_9_52_chunk
-         ->  Index Only Scan using _hyper_9_54_chunk_space3_time_idx on _hyper_9_54_chunk
-         ->  Index Only Scan using _hyper_9_56_chunk_space3_time_idx on _hyper_9_56_chunk
-         ->  Index Only Scan using _hyper_9_58_chunk_space3_time_idx on _hyper_9_58_chunk
-         ->  Index Only Scan using _hyper_9_60_chunk_space3_time_idx on _hyper_9_60_chunk
-         ->  Index Only Scan using _hyper_9_62_chunk_space3_time_idx on _hyper_9_62_chunk
+         Sort Key: _hyper_9_64_chunk."time" DESC
          ->  Index Only Scan using _hyper_9_64_chunk_space3_time_idx on _hyper_9_64_chunk
+         ->  Index Only Scan using _hyper_9_62_chunk_space3_time_idx on _hyper_9_62_chunk
+         ->  Index Only Scan using _hyper_9_60_chunk_space3_time_idx on _hyper_9_60_chunk
+         ->  Index Only Scan using _hyper_9_58_chunk_space3_time_idx on _hyper_9_58_chunk
+         ->  Index Only Scan using _hyper_9_56_chunk_space3_time_idx on _hyper_9_56_chunk
+         ->  Index Only Scan using _hyper_9_54_chunk_space3_time_idx on _hyper_9_54_chunk
+         ->  Index Only Scan using _hyper_9_52_chunk_space3_time_idx on _hyper_9_52_chunk
+         ->  Index Only Scan using _hyper_9_50_chunk_space3_time_idx on _hyper_9_50_chunk
 (22 rows)
 
 -- test LATERAL with correlated query
@@ -1524,23 +1566,23 @@ LEFT OUTER JOIN LATERAL(
                Order: o."time" DESC
                ->  Merge Append
                      Sort Key: o_1."time" DESC
-                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_1
+                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_1
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_2
+                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_2
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_3
+                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_3
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_4
+                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_4
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
                ->  Merge Append
                      Sort Key: o_5."time" DESC
-                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_5
+                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_5
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_6
+                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_6
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_7
+                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_7
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
-                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_8
+                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_8
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)))
 (25 rows)
 
@@ -1560,23 +1602,23 @@ LEFT OUTER JOIN LATERAL(
                Order: o."time" DESC
                ->  Merge Append
                      Sort Key: o_1."time" DESC
-                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_1
+                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_1
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_2
+                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_2
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_27_chunk_space_time_idx on _hyper_7_27_chunk o_3
+                     ->  Index Scan using _hyper_7_25_chunk_space_time_idx on _hyper_7_25_chunk o_3
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_29_chunk_space_time_idx on _hyper_7_29_chunk o_4
+                     ->  Index Scan using _hyper_7_23_chunk_space_time_idx on _hyper_7_23_chunk o_4
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
                ->  Merge Append
                      Sort Key: o_5."time" DESC
-                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_5
+                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_5
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_6
+                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_6
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_28_chunk_space_time_idx on _hyper_7_28_chunk o_7
+                     ->  Index Scan using _hyper_7_26_chunk_space_time_idx on _hyper_7_26_chunk o_7
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
-                     ->  Index Scan using _hyper_7_30_chunk_space_time_idx on _hyper_7_30_chunk o_8
+                     ->  Index Scan using _hyper_7_24_chunk_space_time_idx on _hyper_7_24_chunk o_8
                            Index Cond: (("time" >= g."time") AND ("time" < (g."time" + '@ 1 day'::interval)) AND ("time" < now()))
 (25 rows)
 

--- a/test/expected/sql_query-10.out
+++ b/test/expected/sql_query-10.out
@@ -148,11 +148,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" ORDER BY "t
          ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
 (17 rows)
 
 --shows that more specific indexes are used if the WHERE clauses "match", uses the series_1 index here.
@@ -171,11 +171,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
          ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
 (17 rows)
 
 --here the "match" is implication series_1 > 1 => series_1 IS NOT NULL
@@ -196,13 +196,13 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
                Index Cond: (_hyper_1_2_chunk.series_1 > '1'::double precision)
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
-                     Index Cond: (_hyper_1_1_chunk.series_1 > '1'::double precision)
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
                      Index Cond: (_hyper_1_4_chunk.series_1 > '1'::double precision)
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+                     Index Cond: (_hyper_1_1_chunk.series_1 > '1'::double precision)
 (21 rows)
 
 --note that without time transform things work too
@@ -224,11 +224,11 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_chunk
                      Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.series_0
                ->  Merge Append
-                     Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-                     ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
-                           Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
+                     Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                      ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_4_chunk
                            Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.series_0
+                     ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
 (20 rows)
 
 --TODO: time transform doesn't work

--- a/test/expected/sql_query-11.out
+++ b/test/expected/sql_query-11.out
@@ -148,11 +148,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" ORDER BY "t
          ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
 (17 rows)
 
 --shows that more specific indexes are used if the WHERE clauses "match", uses the series_1 index here.
@@ -171,11 +171,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
          ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
 (17 rows)
 
 --here the "match" is implication series_1 > 1 => series_1 IS NOT NULL
@@ -196,13 +196,13 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
                Index Cond: (_hyper_1_2_chunk.series_1 > '1'::double precision)
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
-                     Index Cond: (_hyper_1_1_chunk.series_1 > '1'::double precision)
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
                      Index Cond: (_hyper_1_4_chunk.series_1 > '1'::double precision)
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+                     Index Cond: (_hyper_1_1_chunk.series_1 > '1'::double precision)
 (21 rows)
 
 --note that without time transform things work too
@@ -224,11 +224,11 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_chunk
                      Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.series_0
                ->  Merge Append
-                     Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-                     ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
-                           Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
+                     Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                      ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_4_chunk
                            Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.series_0
+                     ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
 (20 rows)
 
 --TODO: time transform doesn't work

--- a/test/expected/sql_query-9.6.out
+++ b/test/expected/sql_query-9.6.out
@@ -148,11 +148,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" ORDER BY "t
          ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
 (17 rows)
 
 --shows that more specific indexes are used if the WHERE clauses "match", uses the series_1 index here.
@@ -171,11 +171,11 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
          ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
 (17 rows)
 
 --here the "match" is implication series_1 > 1 => series_1 IS NOT NULL
@@ -196,13 +196,13 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
                Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.series_0, _hyper_1_2_chunk.series_1, _hyper_1_2_chunk.series_2, _hyper_1_2_chunk.series_bool
                Index Cond: (_hyper_1_2_chunk.series_1 > '1'::double precision)
          ->  Merge Append
-               Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
-                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
-                     Index Cond: (_hyper_1_1_chunk.series_1 > '1'::double precision)
+               Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_4_chunk
                      Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.device_id, _hyper_1_4_chunk.series_0, _hyper_1_4_chunk.series_1, _hyper_1_4_chunk.series_2, _hyper_1_4_chunk.series_bool
                      Index Cond: (_hyper_1_4_chunk.series_1 > '1'::double precision)
+               ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _timescaledb_internal._hyper_1_1_chunk
+                     Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.series_0, _hyper_1_1_chunk.series_1, _hyper_1_1_chunk.series_2, _hyper_1_1_chunk.series_bool
+                     Index Cond: (_hyper_1_1_chunk.series_1 > '1'::double precision)
 (21 rows)
 
 --note that without time transform things work too
@@ -224,11 +224,11 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_2_chunk
                      Output: _hyper_1_2_chunk."timeCustom", _hyper_1_2_chunk.series_0
                ->  Merge Append
-                     Sort Key: _hyper_1_1_chunk."timeCustom" DESC NULLS LAST
-                     ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
-                           Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
+                     Sort Key: _hyper_1_4_chunk."timeCustom" DESC NULLS LAST
                      ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_4_chunk
                            Output: _hyper_1_4_chunk."timeCustom", _hyper_1_4_chunk.series_0
+                     ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_device_id_idx" on _timescaledb_internal._hyper_1_1_chunk
+                           Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
 (20 rows)
 
 --TODO: time transform doesn't work

--- a/test/sql/include/plan_ordered_append_query.sql
+++ b/test/sql/include/plan_ordered_append_query.sql
@@ -267,6 +267,22 @@ ORDER BY time DESC;
 FROM space
 ORDER BY time;
 
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 3 of 4 space partitions (2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id = 1
+ORDER BY time;
+
+-- test hypertable with space partitioning and exclusion in space
+-- should remove 2 of 4 space partitions (2 + 2 chunks scanned)
+:PREFIX SELECT
+  time, device_id, value
+FROM space
+WHERE device_id IN (1, 4)
+ORDER BY time;
+
 -- test hypertable with space partitioning and reverse order
 :PREFIX SELECT
   time, device_id, value
@@ -467,4 +483,3 @@ LEFT OUTER JOIN LATERAL(
 
 -- test NULLS LAST
 :PREFIX SELECT * FROM sortopt_test ORDER BY time, device DESC NULLS LAST;
-


### PR DESCRIPTION
With ordered append, chunk exclusion occur only along the primary open
"time" dimension, failing to exclude chunks along additional
partitioning dimensions. For instance, a query on a two-dimensional
table "hyper" (time, device), such as

```
SELECT * FROM hyper
WHERE time > '2019-06-11 12:30'
AND device = 1
ORDER BY time;
```

would only exclude chunks based on the "time" column restriction, but
not the "device" column restriction. This causes an unnecessary number
of chunks to be included in the query plan.

The reason this happens is because chunk exclusion during ordered
append is based on pre-sorting the set of slices in the primary
dimension to determine ordering. This is followed by a scan for
chunks slice-by-slice in the order of the sorted slices. Since those
scans do not include the restrictions in other dimensions, chunks that
would otherwise not match are included in the result.

This change fixes this issue by using the "regular" chunk scan that
account for multi-dimensional restrictions. This is followed by a sort
of the resulting chunks along the primary "time" dimension.

While this, sometimes, means sorting a larger set than the initial
slices in the primary "time" dimension, the resulting chunk set is
smaller instead. Sorting chunks also allows doing secondary ordering
on chunk ID for those chunks that belong to the same "time"
slice. While this additional ordering is not required for correct
tuple ordering, it gives slightly nicer EXPLAIN output since chunks
are also ordered by ID.