### PR TITLE
Fail when adding space dimension with no partitions

### DIFF
--- a/src/dimension.h
+++ b/src/dimension.h
@@ -106,8 +106,7 @@ typedef struct DimensionInfo
 } DimensionInfo;
 
 #define DIMENSION_INFO_IS_SET(di)                                                                  \
-	(di != NULL && OidIsValid((di)->table_relid) && (di)->colname != NULL &&                       \
-	 ((di)->num_slices_is_set || OidIsValid((di)->interval_datum)))
+	(di != NULL && OidIsValid((di)->table_relid) && (di)->colname != NULL)
 
 /* add_dimension record attribute numbers */
 enum Anum_add_dimension

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1433,6 +1433,8 @@ Datum
 ts_hypertable_create(PG_FUNCTION_ARGS)
 {
 	Oid table_relid = PG_GETARG_OID(0);
+	Name time_dim_name = PG_ARGISNULL(1) ? NULL : PG_GETARG_NAME(1);
+	Name space_dim_name = PG_ARGISNULL(2) ? NULL : PG_GETARG_NAME(2);
 	Name associated_schema_name = PG_ARGISNULL(4) ? NULL : PG_GETARG_NAME(4);
 	Name associated_table_prefix = PG_ARGISNULL(5) ? NULL : PG_GETARG_NAME(5);
 	bool create_default_indexes =
@@ -1442,7 +1444,7 @@ ts_hypertable_create(PG_FUNCTION_ARGS)
 	DimensionInfo *time_dim_info =
 		ts_dimension_info_create_open(table_relid,
 									  /* column name */
-									  PG_ARGISNULL(1) ? NULL : PG_GETARG_NAME(1),
+									  time_dim_name,
 									  /* interval */
 									  PG_ARGISNULL(6) ? Int64GetDatum(-1) : PG_GETARG_DATUM(6),
 									  /* interval type */
@@ -1465,12 +1467,12 @@ ts_hypertable_create(PG_FUNCTION_ARGS)
 	bool created;
 	uint32 flags = 0;
 
-	if (!PG_ARGISNULL(3))
+	if (NULL != space_dim_name)
 	{
 		space_dim_info =
 			ts_dimension_info_create_closed(table_relid,
 											/* column name */
-											PG_ARGISNULL(2) ? NULL : PG_GETARG_NAME(2),
+											space_dim_name,
 											/* number partitions */
 											PG_ARGISNULL(3) ? -1 : PG_GETARG_INT16(3),
 											/* partitioning func */

--- a/test/expected/ddl_errors.out
+++ b/test/expected/ddl_errors.out
@@ -12,6 +12,12 @@ SELECT * FROM create_hypertable(NULL, NULL);
 ERROR:  invalid main_table: cannot be NULL
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', NULL);
 ERROR:  invalid time_column_name: cannot be NULL
+-- integer time dimensions require an explicit interval
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time');
+ERROR:  integer dimensions require an explicit interval
+-- space dimensions require explicit number of partitions
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
+ERROR:  invalid number of partitions for dimension "Device_id"
 SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 ERROR:  relation "public.Hypertable_1_mispelled" does not exist at character 33
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));

--- a/test/sql/ddl_errors.sql
+++ b/test/sql/ddl_errors.sql
@@ -12,6 +12,10 @@ CREATE INDEX ON PUBLIC."Hypertable_1" (time, "Device_id");
 \set ON_ERROR_STOP 0
 SELECT * FROM create_hypertable(NULL, NULL);
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', NULL);
+-- integer time dimensions require an explicit interval
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time');
+-- space dimensions require explicit number of partitions
+SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time', 'Device_id', chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 SELECT * FROM create_hypertable('"public"."Hypertable_1_mispelled"', 'time', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'time_mispelled', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));
 SELECT * FROM create_hypertable('"public"."Hypertable_1"', 'Device_id', 'Device_id', 2, chunk_time_interval=>_timescaledb_internal.interval_to_usec('1 month'));


### PR DESCRIPTION
Calling `create_hypertable` with a space dimension silently succeeds
without actually creating the space dimension if `num_partitions` is
not specified.

This change ensures that we raise an appropriate error when a user
fails to specify the number of partitions.