### PR TITLE
Add job statistics columns to timescaledb_information.continuous_aggregate_stats view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Minor features**
 * #1273 Propagate quals to joined hypertables
+* #1332 Add job statistics columns to timescaledb_information.continuous_aggregate_stats view
 
 **Bugfixes**
 * #1300 Fix telemetry report return value

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -16,3 +16,5 @@ CREATE INDEX continuous_aggs_materialization_invalidation_log_idx
 
 GRANT SELECT ON _timescaledb_catalog.continuous_aggs_materialization_invalidation_log TO PUBLIC;
 DROP FUNCTION IF EXISTS get_telemetry_report();
+
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregate_stats;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -115,12 +115,19 @@ CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregate_stats as
     END AS invalidation_threshold,
     cagg.job_id as job_id,
     bgw_job_stat.last_start as last_run_started_at,
+    CASE when bgw_job_stat.last_run_success = 't' then 'Success'
+         when bgw_job_stat.last_run_success = 'f' then 'Failed'
+    END AS last_run_status,
     case when bgw_job_stat.last_finish < '4714-11-24 00:00:00+00 BC' then 'running'
        when bgw_job_stat.next_start is not null then 'scheduled'
     end as job_status,
     case when bgw_job_stat.last_finish > bgw_job_stat.last_start then (bgw_job_stat.last_finish - bgw_job_stat.last_start)
     end as last_run_duration,
-    bgw_job_stat.next_start as next_scheduled_run
+    bgw_job_stat.next_start as next_scheduled_run,
+    bgw_job_stat.total_runs,
+    bgw_job_stat.total_successes,
+    bgw_job_stat.total_failures,
+    bgw_job_stat.total_crashes
   FROM
     _timescaledb_catalog.continuous_agg as cagg
     LEFT JOIN _timescaledb_internal.bgw_job_stat as bgw_job_stat

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -99,9 +99,14 @@ completed_threshold    | Sun Dec 30 22:00:00 2018 PST
 invalidation_threshold | Sun Dec 30 22:00:00 2018 PST
 job_id                 | 1000
 last_run_started_at    | 
+last_run_status        | 
 job_status             | 
 last_run_duration      | 
 next_scheduled_run     | 
+total_runs             | 
+total_successes        | 
+total_failures         | 
+total_crashes          | 
 
 \x
 --


### PR DESCRIPTION
Add more information about job history for continuous aggregate
background worker jobs.