### PR TITLE
Fix continuous agg catalog table insert failure

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -268,7 +268,7 @@ CREATE INDEX continuous_aggs_hypertable_invalidation_log_idx
 
 -- per cagg copy of invalidation log
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_aggs_materialization_invalidation_log(
-    materialization_id INTEGER PRIMARY KEY
+    materialization_id INTEGER 
         REFERENCES _timescaledb_catalog.continuous_agg(mat_hypertable_id)
         ON DELETE CASCADE,
     lowest_modified_value BIGINT NOT NULL,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -3,7 +3,7 @@ ALTER TABLE _timescaledb_catalog.telemetry_metadata ALTER COLUMN include_in_tele
 ALTER TABLE _timescaledb_catalog.telemetry_metadata RENAME TO metadata;
 ALTER INDEX _timescaledb_catalog.telemetry_metadata_pkey RENAME TO metadata_pkey;
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_aggs_materialization_invalidation_log(
-    materialization_id INTEGER PRIMARY KEY
+    materialization_id INTEGER
         REFERENCES _timescaledb_catalog.continuous_agg(mat_hypertable_id)
         ON DELETE CASCADE,
     lowest_modified_value BIGINT NOT NULL,

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -218,6 +218,13 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
      1
 (1 row)
 
+--cagg_2 still exists
+select view_name from timescaledb_information.continuous_aggregates;
+ view_name 
+-----------
+ cagg_2
+(1 row)
+
 drop table continuous_agg_test cascade;
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_6_chunk
@@ -226,6 +233,11 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
 -------
      0
 (1 row)
+
+select view_name from timescaledb_information.continuous_aggregates;
+ view_name 
+-----------
+(0 rows)
 
 --TEST4: invalidations that are copied over by cagg1 are not deleted by cagg2 refresh if
 -- they do not meet materialization invalidation threshold for cagg2.
@@ -339,5 +351,32 @@ select * from cagg_2 order by 1;
     12 |      9
     14 |    100
 (3 rows)
+
+--TEST5 2 inserts with the same value can be copied over to materialization invalidation log
+insert into continuous_agg_test values( 18, -2, 100); 
+insert into continuous_agg_test values( 18, -2, 100); 
+select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             4 |                    18 |                      18
+             4 |                    18 |                      18
+(2 rows)
+
+refresh materialized view cagg_1;
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): no new data
+INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
+select * from cagg_1 where timed = 18 ;
+ timed | cnt 
+-------+-----
+    18 |   3
+(1 row)
+
+--copied over for cagg_2 to process later?
+select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
+                  6 |                    18 |                      18
+                  6 |                    18 |                      18
+(2 rows)
 
  

--- a/tsl/test/sql/continuous_aggs_multi.sql
+++ b/tsl/test/sql/continuous_aggs_multi.sql
@@ -88,8 +88,11 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
 --now drop cagg_1, should still have materialization_invalidation_log
 drop view cagg_1 cascade;
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+--cagg_2 still exists
+select view_name from timescaledb_information.continuous_aggregates;
 drop table continuous_agg_test cascade;
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+select view_name from timescaledb_information.continuous_aggregates;
 
 --TEST4: invalidations that are copied over by cagg1 are not deleted by cagg2 refresh if
 -- they do not meet materialization invalidation threshold for cagg2.
@@ -133,4 +136,13 @@ refresh materialized view cagg_1;
 select * from cagg_1 order by 1;
 refresh materialized view cagg_2;
 select * from cagg_2 order by 1;
+
+--TEST5 2 inserts with the same value can be copied over to materialization invalidation log
+insert into continuous_agg_test values( 18, -2, 100); 
+insert into continuous_agg_test values( 18, -2, 100); 
+select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
+refresh materialized view cagg_1;
+select * from cagg_1 where timed = 18 ;
+--copied over for cagg_2 to process later?
+select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
  


### PR DESCRIPTION
The primary key on continuous_aggs_materialization_invalidation_log
prevents multiple records with the same materialization id. Remove
the primary key to fix this problem.