### PR TITLE
Fix partitioned table check and enhance PG macros

### DIFF
--- a/src/base64_compat.h
+++ b/src/base64_compat.h
@@ -8,7 +8,7 @@
 
 #include <compat.h>
 
-#if PG10 || PG11
+#if PG10_GE
 
 #include <common/base64.h>
 

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -463,7 +463,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 #if !PG96
 		zero_guc("max_parallel_workers");
 #endif
-#if !(PG96 || PG10)
+#if PG11_GE
 		zero_guc("max_parallel_maintenance_workers");
 #endif
 

--- a/src/chunk_dispatch_state.c
+++ b/src/chunk_dispatch_state.c
@@ -120,7 +120,7 @@ chunk_dispatch_exec(CustomScanState *node)
 				ExecSetSlotDescriptor(state->parent->mt_existing, chunk_desc);
 			}
 		}
-#if defined(USE_ASSERT_CHECKING) && !PG96 && !PG10
+#if defined(USE_ASSERT_CHECKING) && PG11_GE
 		if (state->parent->mt_conflproj != NULL)
 		{
 			TupleTableSlot *slot = get_projection_info_slot_compat(

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -192,7 +192,7 @@ create_chunk_result_relation_info(ChunkDispatch *dispatch, Relation rel, Index r
 	rri->ri_WithCheckOptionExprs = rri_orig->ri_WithCheckOptionExprs;
 	rri->ri_junkFilter = rri_orig->ri_junkFilter;
 	rri->ri_projectReturning = rri_orig->ri_projectReturning;
-#if PG96 || PG10
+#if PG11_LT
 	ResultRelInfo_OnConflictProjInfoCompat(rri) = ResultRelInfo_OnConflictProjInfoCompat(rri_orig);
 	ResultRelInfo_OnConflictWhereCompat(rri) = ResultRelInfo_OnConflictWhereCompat(rri_orig);
 #else
@@ -480,7 +480,7 @@ chunk_insert_state_set_arbiter_indexes(ChunkInsertState *state, ChunkDispatch *d
 
 		state->arbiter_indexes = lappend_oid(state->arbiter_indexes, cim.indexoid);
 	}
-#if !PG96 && !PG10
+#if PG11_GE
 	state->result_relation_info->ri_onConflictArbiterIndexes = state->arbiter_indexes;
 #endif
 }

--- a/src/compat.h
+++ b/src/compat.h
@@ -27,6 +27,10 @@
 #define PG96 is_supported_pg_version_96(PG_VERSION_NUM)
 #define PG10 is_supported_pg_version_10(PG_VERSION_NUM)
 #define PG11 is_supported_pg_version_11(PG_VERSION_NUM)
+#define PG10_LT PG96
+#define PG10_GE !(PG10_LT)
+#define PG11_LT (PG96 || PG10)
+#define PG11_GE !(PG11_LT)
 
 #if !(is_supported_pg_version(PG_VERSION_NUM))
 #error "Unsupported PostgreSQL version"

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1591,7 +1591,7 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 	/* Is this the right kind of relation? */
 	switch (get_rel_relkind(table_relid))
 	{
-#if PG10
+#if PG10_GE
 		case RELKIND_PARTITIONED_TABLE:
 			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),

--- a/src/planner.c
+++ b/src/planner.c
@@ -30,7 +30,7 @@
 
 #include <catalog/pg_constraint.h>
 #include "compat.h"
-#if PG96 || PG10 /* PG11 consolidates pg_foo_fn.h -> pg_foo.h */
+#if PG11_LT /* PG11 consolidates pg_foo_fn.h -> pg_foo.h */
 #include <catalog/pg_constraint_fn.h>
 #endif
 #include "compat-msvc-exit.h"
@@ -297,7 +297,7 @@ is_append_parent(RelOptInfo *rel, RangeTblEntry *rte)
 static Oid
 get_parentoid(PlannerInfo *root, Index rti)
 {
-#if PG96 || PG10
+#if PG11_LT
 	ListCell *lc;
 	foreach (lc, root->append_rel_list)
 	{
@@ -466,7 +466,7 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 		rel->fdw_private = palloc0(sizeof(TimescaleDBPrivate));
 
 		ts_plan_expand_hypertable_chunks(ht, root, relation_objectid, inhparent, rel);
-#if !PG96 && !PG10
+#if PG11_GE
 		setup_append_rel_array(root);
 #endif
 
@@ -605,7 +605,7 @@ replace_hypertable_insert_paths(PlannerInfo *root, List *pathlist)
 }
 
 static void
-#if PG96 || PG10
+#if PG11_LT
 timescale_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptInfo *input_rel,
 								  RelOptInfo *output_rel)
 {

--- a/src/planner_import.c
+++ b/src/planner_import.c
@@ -946,7 +946,7 @@ replace_nestloop_params_mutator(Node *node, PlannerInfo *root)
 	return expression_tree_mutator(node, replace_nestloop_params_mutator, (void *) root);
 }
 
-#if PG96 || PG10
+#if PG11_LT
 /*
  * ExecSetTupleBound
  *
@@ -1188,7 +1188,7 @@ generate_new_exec_param(PlannerInfo *root, Oid paramtype, int32 paramtypmod, Oid
 
 	retval = makeNode(Param);
 	retval->paramkind = PARAM_EXEC;
-#if PG96 || PG10
+#if PG11_LT
 	retval->paramid = root->glob->nParamExec++;
 #else
 	retval->paramid = list_length(root->glob->paramExecTypes);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -35,7 +35,7 @@
 #include <catalog/pg_constraint.h>
 #include <catalog/pg_inherits.h>
 #include "compat.h"
-#if PG96 || PG10 /* PG11 consolidates pg_foo_fn.h -> pg_foo.h */
+#if PG11_LT /* PG11 consolidates pg_foo_fn.h -> pg_foo.h */
 #include <catalog/pg_inherits_fn.h>
 #include <catalog/pg_constraint_fn.h>
 #endif
@@ -414,7 +414,7 @@ foreach_chunk_multitransaction(Oid relid, MemoryContext mctx, mt_process_chunk_t
  * Given this change it seemed easier to take rewrite this completely for 11 to
  * take advantage of the new changes.
  */
-#if PG96 || PG10
+#if PG11_LT
 typedef struct VacuumCtx
 {
 	VacuumStmt *stmt;
@@ -810,7 +810,7 @@ process_grant_and_revoke(ProcessUtilityArgs *args)
  * so we can't simply #define OBJECT_TABLESPACE ACL_OBJECT_TABLESPACE and have
  * things work correctly for previous versions.
  */
-#if PG96 || PG10
+#if PG11_LT
 		case ACL_OBJECT_TABLESPACE:
 #else
 		case OBJECT_TABLESPACE:
@@ -2474,7 +2474,7 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_DropNotNull:
 		case AT_AddOf:
 		case AT_DropOf:
-#if !PG96
+#if PG10_GE
 		case AT_AddIdentity:
 		case AT_SetIdentity:
 		case AT_DropIdentity:
@@ -2518,12 +2518,12 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_AddColumnToView:		   /* only used with views */
 		case AT_AlterColumnGenericOptions: /* only used with foreign tables */
 		case AT_GenericOptions:			   /* only used with foreign tables */
-#if !PG96 && !PG10
+#if PG11_GE
 		case AT_ReAddDomainConstraint: /* We should handle this in future,
 										* new subset of constraints in PG11
 										* currently not hit in test code */
 #endif
-#if !PG96
+#if PG10_GE
 		case AT_AttachPartition: /* handled in
 								  * process_altertable_start_table but also
 								  * here as failsafe */
@@ -2678,7 +2678,7 @@ process_viewstmt(ProcessUtilityArgs *args)
 				 errmsg("only timescaledb parameters allowed in WITH clause for continuous "
 						"aggregate")));
 
-#if !PG96
+#if PG10_GE
 	return ts_cm_functions->process_cagg_viewstmt(stmt,
 												  args->query_string,
 												  args->pstmt,
@@ -3005,13 +3005,13 @@ process_ddl_sql_drop(EventTriggerDropObject *obj)
  */
 static void
 timescaledb_ddl_command_start(
-#if !PG96
+#if PG10_GE
 	PlannedStmt *pstmt,
 #else
 	Node *parsetree,
 #endif
 	const char *query_string, ProcessUtilityContext context, ParamListInfo params,
-#if !PG96
+#if PG10_GE
 	QueryEnvironment *queryEnv,
 #endif
 	DestReceiver *dest, char *completion_tag)
@@ -3022,7 +3022,7 @@ timescaledb_ddl_command_start(
 		.params = params,
 		.dest = dest,
 		.completion_tag = completion_tag,
-#if !PG96
+#if PG10_GE
 		.pstmt = pstmt,
 		.parsetree = pstmt->utilityStmt,
 		.queryEnv = queryEnv,

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -16,7 +16,7 @@
 #include "trigger.h"
 #include "compat.h"
 
-#if !PG96
+#if PG10_GE
 #include <parser/analyze.h>
 #endif
 
@@ -101,7 +101,7 @@ create_trigger_handler(Trigger *trigger, void *arg)
 {
 	Chunk *chunk = arg;
 
-#if !PG96
+#if PG10_GE
 	if (TRIGGER_USES_TRANSITION_TABLE(trigger->tgnewtable) ||
 		TRIGGER_USES_TRANSITION_TABLE(trigger->tgoldtable))
 		ereport(ERROR,
@@ -146,7 +146,7 @@ ts_trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk)
 		SetUserIdAndSecContext(saved_uid, sec_ctx);
 }
 
-#if !PG96
+#if PG10_GE
 static bool
 check_for_transition_table(Trigger *trigger, void *arg)
 {
@@ -168,7 +168,7 @@ ts_relation_has_transition_table_trigger(Oid relid)
 {
 	bool found = false;
 
-#if !PG96
+#if PG10_GE
 	for_each_trigger(relid, check_for_transition_table, &found);
 #endif
 

--- a/test/expected/partitioning-11.out
+++ b/test/expected/partitioning-11.out
@@ -5,7 +5,7 @@
 \set ON_ERROR_STOP 0
 CREATE TABLE partitioned_ht_create(time timestamptz, temp float, device int) PARTITION BY RANGE (time);
 SELECT create_hypertable('partitioned_ht_create', 'time');
-ERROR:  invalid relation type
+ERROR:  table "partitioned_ht_create" is already partitioned
 \set ON_ERROR_STOP 1
 -- Should expect an error when attaching a hypertable to a partition
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
This change enables a check in `create_hypertable` that prohibits
turning partitioned tables into hypertables. The check was only
enabled when compiling against PG10, but should be there for PG
version 10 and greater.

To avoid such disabled code in the future, some extra convenience
macros have been added. For instance `PG10_GE` means PG10 and greater.