### PR TITLE
Update continuous agg bgw job start time

### DIFF
--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -373,6 +373,23 @@ ts_bgw_job_stat_set_next_start(BgwJob *job, TimestampTz next_start)
 		elog(ERROR, "unable to find job statistics for job %d", job->fd.id);
 }
 
+/* update next_start if job stat exists */
+TSDLLEXPORT bool
+ts_bgw_job_stat_update_next_start(BgwJob *job, TimestampTz next_start)
+{
+	bool found = false;
+	/* Cannot use DT_NOBEGIN as that's the value used to indicate "not set" */
+	if (next_start == DT_NOBEGIN)
+		elog(ERROR, "cannot set next start to -infinity");
+
+	found = bgw_job_stat_scan_job_id(job->fd.id,
+									 bgw_job_stat_tuple_set_next_start,
+									 NULL,
+									 &next_start,
+									 RowExclusiveLock);
+	return found;
+}
+
 bool
 ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job)
 {

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -27,6 +27,7 @@ extern void ts_bgw_job_stat_mark_end(BgwJob *job, JobResult result);
 extern bool ts_bgw_job_stat_end_was_marked(BgwJobStat *jobstat);
 
 extern TSDLLEXPORT void ts_bgw_job_stat_set_next_start(BgwJob *job, TimestampTz next_start);
+extern TSDLLEXPORT bool ts_bgw_job_stat_update_next_start(BgwJob *job, TimestampTz next_start);
 
 extern bool ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
 

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -162,6 +162,20 @@ SELECT job_id, next_start, last_finish as until_next, last_run_success, total_ru
    1000 | Sat Jan 01 04:00:00 2000 PST | Fri Dec 31 16:00:00 1999 PST | t                |          1 |               1 |              0 |             0
 (1 row)
 
+--alter the refresh interval and check if next_scheduled_run is altered
+ALTER VIEW test_continuous_agg_view SET(timescaledb.refresh_interval= '1h');
+SELECT view_name, 
+case when next_scheduled_run - now() > '59 min'::interval 
+      and  next_scheduled_run - now() < '60 min'::interval then 'Success'
+     else 'Fail'
+end 
+ from 
+timescaledb_information.continuous_aggregate_stats;
+        view_name         |  case   
+--------------------------+---------
+ test_continuous_agg_view | Success
+(1 row)
+
 -- data before 8
 SELECT * FROM test_continuous_agg_view ORDER BY 1;
  time_bucket | value 

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -116,6 +116,16 @@ SELECT job_id, next_start, last_finish as until_next, last_run_success, total_ru
     FROM _timescaledb_internal.bgw_job_stat
     where job_id=:job_id;
 
+--alter the refresh interval and check if next_scheduled_run is altered
+ALTER VIEW test_continuous_agg_view SET(timescaledb.refresh_interval= '1h');
+SELECT view_name, 
+case when next_scheduled_run - now() > '59 min'::interval 
+      and  next_scheduled_run - now() < '60 min'::interval then 'Success'
+     else 'Fail'
+end 
+ from 
+timescaledb_information.continuous_aggregate_stats;
+
 -- data before 8
 SELECT * FROM test_continuous_agg_view ORDER BY 1;
 


### PR DESCRIPTION
When the continuous aggregate refresh_interval setting is modified,
it does not modify the job schedule until the next scheduled job
runs. This fix addresses it by updating the next_start time for
the bgw job.