### PR TITLE
Add missing license information

### DIFF
--- a/scripts/check_license_all.sh
+++ b/scripts/check_license_all.sh
@@ -3,4 +3,8 @@ SCRIPT_DIR=$(dirname $0)
 BASE_DIR=$(dirname ${SCRIPT_DIR})
 
 SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -c ${BASE_DIR}/src -s ${BASE_DIR}/sql -c ${BASE_DIR}/test -t ${BASE_DIR}/test
+exit_apache=$?
 SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -e ${BASE_DIR}/tsl/src -u ${BASE_DIR}/tsl/test/sql -e ${BASE_DIR}/tsl/test/src
+exit_tsl=$?
+
+exit ${exit_apache} || ${exit_tsl}

--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -1,10 +1,11 @@
 /*
- * This file and its contents are licensed under the Timescale License.
+ * This file and its contents are licensed under the Apache License 2.0.
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
 
-/* This file handles commands on continuous aggs that should be allowed in
+/*
+ * This file handles commands on continuous aggs that should be allowed in
  * apache only mode. Right now this consists mostly of drop commands
  */
 

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -1,10 +1,11 @@
 /*
- * This file and its contents are licensed under the Timescale License.
+ * This file and its contents are licensed under the Apache License 2.0.
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_CONTIGUOUS_AGG_H
-#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_CONTIGUOUS_AGG_H
+
+#ifndef TIMESCALEDB_CONTINUOUS_AGG_H
+#define TIMESCALEDB_CONTINUOUS_AGG_H
 #include <postgres.h>
 #include <catalog/pg_type.h>
 
@@ -73,4 +74,4 @@ extern TSDLLEXPORT int32 ts_number_of_continuous_aggs(void);
 
 extern Oid ts_continuous_agg_get_user_view_oid(ContinuousAgg *agg);
 
-#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_CONTIGUOUS_AGG_H */
+#endif /* TIMESCALEDB_CONTINUOUS_AGG_H */

--- a/test/expected/cursor.out
+++ b/test/expected/cursor.out
@@ -1,3 +1,6 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
 CREATE TABLE cursor_test(time timestamptz, device_id int, temp float);
 SELECT create_hypertable('cursor_test','time');
 NOTICE:  adding not-null constraint to column "time"

--- a/test/expected/sort_optimization-10.out
+++ b/test/expected/sort_optimization-10.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
---
 \set PREFIX 'EXPLAIN (COSTS OFF) '
 CREATE TABLE order_test(time int NOT NULL, device_id int, value float);
 CREATE INDEX ON order_test(time,device_id);

--- a/test/expected/sort_optimization-11.out
+++ b/test/expected/sort_optimization-11.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
---
 \set PREFIX 'EXPLAIN (COSTS OFF) '
 CREATE TABLE order_test(time int NOT NULL, device_id int, value float);
 CREATE INDEX ON order_test(time,device_id);

--- a/test/expected/sort_optimization-9.6.out
+++ b/test/expected/sort_optimization-9.6.out
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
---
 \set PREFIX 'EXPLAIN (COSTS OFF) '
 CREATE TABLE order_test(time int NOT NULL, device_id int, value float);
 CREATE INDEX ON order_test(time,device_id);

--- a/test/expected/telemetry_community.out
+++ b/test/expected/telemetry_community.out
@@ -1,3 +1,6 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
 --telemetry tests that require a community license
 SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs');
  json_object_field 

--- a/test/sql/cursor.sql
+++ b/test/sql/cursor.sql
@@ -1,3 +1,6 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
 
 CREATE TABLE cursor_test(time timestamptz, device_id int, temp float);
 SELECT create_hypertable('cursor_test','time');

--- a/test/sql/sort_optimization.sql.in
+++ b/test/sql/sort_optimization.sql.in
@@ -1,7 +1,6 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
---
 
 \set PREFIX 'EXPLAIN (COSTS OFF) '
 

--- a/test/sql/telemetry_community.sql
+++ b/test/sql/telemetry_community.sql
@@ -1,3 +1,7 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
 --telemetry tests that require a community license
 
 SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs');

--- a/test/sql/with_clause_parser.sql
+++ b/test/sql/with_clause_parser.sql
@@ -1,3 +1,7 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE OR REPLACE FUNCTION test_with_clause_filter(with_clauses TEXT[][])
     RETURNS TABLE(namespace TEXT, name TEXT, value TEXT, filtered BOOLEAN)

--- a/test/src/test_time_to_internal.c
+++ b/test/src/test_time_to_internal.c
@@ -1,3 +1,9 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
 #include <postgres.h>
 #include <fmgr.h>
 #include <catalog/pg_type.h>

--- a/test/src/test_with_clause_parser.c
+++ b/test/src/test_with_clause_parser.c
@@ -1,3 +1,9 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
 #include <postgres.h>
 #include <fmgr.h>
 #include <funcapi.h>


### PR DESCRIPTION
Add license information to files missing it and fix the license
check script to honor the return code of both the apache license
check and the TSL license check. Previously errors occurring during
apache license check would not be reflected in the return code of
the script, so only the TSL license check was effective.