### PR TITLE
Mark drop_chunks as VOLATILE and PARALLEL UNSAFE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 1.4.1 (unreleased)
+
+**Bugfixes**
+* #1363 Mark drop_chunks as VOLATILE and not PARALLEL SAFE
+
+**Thanks**
+* @overhacked for reporting an issue with drop_chunks and parallel queries
+
 ## 1.4.0 (2019-07-18)
 
 This release contains major new functionality for continuous aggregates

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -77,7 +77,7 @@ CREATE OR REPLACE FUNCTION drop_chunks(
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL
 ) RETURNS SETOF TEXT AS '@MODULE_PATHNAME@', 'ts_chunk_drop_chunks'
-LANGUAGE C STABLE PARALLEL SAFE;
+LANGUAGE C VOLATILE PARALLEL UNSAFE;
 
 -- show chunks older than or newer than a specific time.
 -- `hypertable` argument can be a valid hypertable or NULL.


### PR DESCRIPTION
The drop_chunks function was incorrectly marked as stable and
parallel safe this patch fixes the attributes.

Fixes #1333 