### PR TITLE
Fix ChunkAppend with prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #1362 Fix ConstraintAwareAppend subquery exclusion
 * #1363 Mark drop_chunks as VOLATILE and not PARALLEL SAFE
+* #1369 Fix ChunkAppend with prepared statements
 
 **Thanks**
 * @overhacked for reporting an issue with drop_chunks and parallel queries
 * @fvannee for reporting an issue with ConstraintAwareAppend and subqueries
+* @rrb3942 for reporting a segfault with ChunkAppend and prepared statements
 
 ## 1.4.0 (2019-07-18)
 

--- a/src/chunk_append/exec.c
+++ b/src/chunk_append/exec.c
@@ -147,15 +147,12 @@ chunk_append_begin(CustomScanState *node, EState *estate, int eflags)
 	ListCell *lc;
 	int i;
 
-	Assert(list_length(cscan->custom_plans) == list_length(state->initial_subplans));
 	initialize_constraints(state, lthird(cscan->custom_private));
 
 	if (state->startup_exclusion)
 		do_startup_exclusion(state);
 
-	cscan->custom_plans = state->filtered_subplans;
-
-	state->num_subplans = list_length(cscan->custom_plans);
+	state->num_subplans = list_length(state->filtered_subplans);
 
 	if (state->num_subplans == 0)
 		return;
@@ -163,7 +160,7 @@ chunk_append_begin(CustomScanState *node, EState *estate, int eflags)
 	state->subplanstates = palloc0(state->num_subplans * sizeof(PlanState *));
 
 	i = 0;
-	foreach (lc, cscan->custom_plans)
+	foreach (lc, state->filtered_subplans)
 	{
 		/*
 		 * we use an array for the states but put it in custom_ps as well

--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -1327,6 +1327,537 @@ ORDER BY time DESC;
                Heap Fetches: 312
 (11 rows)
 
+-- test prepared statements
+-- executor startup exclusion with no chunks excluded
+PREPARE prep AS SELECT time FROM metrics_timestamptz WHERE time < now() AND device_id = 1 ORDER BY time;
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+DEALLOCATE prep;
+-- executor startup exclusion with chunks excluded
+PREPARE prep AS SELECT time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz AND device_id = 1 ORDER BY time;
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+DEALLOCATE prep;
+-- runtime exclusion with LATERAL and 2 hypertables
+PREPARE prep AS SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time LIMIT 1) m2 ON true ORDER BY m1.time;
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+DEALLOCATE prep;
+-- executor startup exclusion with subquery
+PREPARE prep AS SELECT time FROM (SELECT time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY time) m;
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+DEALLOCATE prep;
+-- test constraint exclusion for subqueries with mergeappend
+PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY device_id, time) m;
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+DEALLOCATE prep;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -1327,6 +1327,537 @@ ORDER BY time DESC;
                Heap Fetches: 312
 (11 rows)
 
+-- test prepared statements
+-- executor startup exclusion with no chunks excluded
+PREPARE prep AS SELECT time FROM metrics_timestamptz WHERE time < now() AND device_id = 1 ORDER BY time;
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=745 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=168 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 168
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=129 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+         Heap Fetches: 129
+(18 rows)
+
+DEALLOCATE prep;
+-- executor startup exclusion with chunks excluded
+PREPARE prep AS SELECT time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz AND device_id = 1 ORDER BY time;
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=216 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=112 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 112
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=104 loops=1)
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+         Heap Fetches: 104
+(9 rows)
+
+DEALLOCATE prep;
+-- runtime exclusion with LATERAL and 2 hypertables
+PREPARE prep AS SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time LIMIT 1) m2 ON true ORDER BY m1.time;
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+:PREFIX EXECUTE prep;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=2235 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=2235 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=336 loops=1)
+               Heap Fetches: 336
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=504 loops=1)
+               Heap Fetches: 504
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=387 loops=1)
+               Heap Fetches: 387
+   ->  Limit (actual rows=1 loops=2235)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=1 loops=2235)
+               Chunks excluded during runtime: 4
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=336)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 336
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4 (actual rows=1 loops=504)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 504
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5 (actual rows=1 loops=387)
+                     Index Cond: ("time" = m1."time")
+                     Heap Fetches: 387
+(31 rows)
+
+DEALLOCATE prep;
+-- executor startup exclusion with subquery
+PREPARE prep AS SELECT time FROM (SELECT time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY time) m;
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=648 loops=1)
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 336
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         Heap Fetches: 312
+(9 rows)
+
+DEALLOCATE prep;
+-- test constraint exclusion for subqueries with mergeappend
+PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY device_id, time) m;
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+:PREFIX EXECUTE prep;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend) (actual rows=648 loops=1)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append (actual rows=648 loops=1)
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=336 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 336
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=312 loops=1)
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+               Heap Fetches: 312
+(11 rows)
+
+DEALLOCATE prep;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-9.6.out
+++ b/test/expected/append-9.6.out
@@ -1161,6 +1161,427 @@ ORDER BY time DESC;
                Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
 (9 rows)
 
+-- test prepared statements
+-- executor startup exclusion with no chunks excluded
+PREPARE prep AS SELECT time FROM metrics_timestamptz WHERE time < now() AND device_id = 1 ORDER BY time;
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+(13 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+(13 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+(13 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+(13 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 0
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+   ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk
+         Index Cond: ((device_id = 1) AND ("time" < now()))
+(13 rows)
+
+DEALLOCATE prep;
+-- executor startup exclusion with chunks excluded
+PREPARE prep AS SELECT time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz AND device_id = 1 ORDER BY time;
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+   ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+         Index Cond: ((device_id = 1) AND ("time" < ('2000-01-10'::cstring)::timestamp with time zone))
+(7 rows)
+
+DEALLOCATE prep;
+-- runtime exclusion with LATERAL and 2 hypertables
+PREPARE prep AS SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time LIMIT 1) m2 ON true ORDER BY m1.time;
+:PREFIX EXECUTE prep;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5
+   ->  Limit
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5
+                     Index Cond: ("time" = m1."time")
+(20 rows)
+
+:PREFIX EXECUTE prep;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5
+   ->  Limit
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5
+                     Index Cond: ("time" = m1."time")
+(20 rows)
+
+:PREFIX EXECUTE prep;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5
+   ->  Limit
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5
+                     Index Cond: ("time" = m1."time")
+(20 rows)
+
+:PREFIX EXECUTE prep;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5
+   ->  Limit
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5
+                     Index Cond: ("time" = m1."time")
+(20 rows)
+
+:PREFIX EXECUTE prep;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5
+   ->  Limit
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m2_3
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m2_4
+                     Index Cond: ("time" = m1."time")
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m2_5
+                     Index Cond: ("time" = m1."time")
+(20 rows)
+
+DEALLOCATE prep;
+-- executor startup exclusion with subquery
+PREPARE prep AS SELECT time FROM (SELECT time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY time) m;
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(7 rows)
+
+:PREFIX EXECUTE prep;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   Chunks excluded during startup: 3
+   ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+   ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk
+         Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(7 rows)
+
+DEALLOCATE prep;
+-- test constraint exclusion for subqueries with mergeappend
+PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY device_id, time) m;
+:PREFIX EXECUTE prep;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(9 rows)
+
+:PREFIX EXECUTE prep;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ConstraintAwareAppend)
+   Hypertable: metrics_timestamptz
+   Chunks left after exclusion: 2
+   ->  Merge Append
+         Sort Key: _hyper_5_17_chunk.device_id, _hyper_5_17_chunk."time"
+         ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+         ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+               Index Cond: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
+(9 rows)
+
+DEALLOCATE prep;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results


### PR DESCRIPTION
ChunkAppend replaced the list of child plans on the plan node with
a local copy which corrupted the child plans when the plan was
turned into a generic plan.

Fixes #1368 