### PR TITLE
Only allow PARAM_EXTERN as time_bucket_gapfill arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ accidentally triggering the load of a previous DB version.**
 * #1362 Fix ConstraintAwareAppend subquery exclusion
 * #1363 Mark drop_chunks as VOLATILE and not PARALLEL SAFE
 * #1369 Fix ChunkAppend with prepared statements
+* #1373 Only allow PARAM_EXTERN as time_bucket_gapfill arguments
 
 **Thanks**
 * @overhacked for reporting an issue with drop_chunks and parallel queries
 * @fvannee for reporting an issue with ConstraintAwareAppend and subqueries
 * @rrb3942 for reporting a segfault with ChunkAppend and prepared statements
+* @mchesser for reporting a segfault with time_bucket_gapfill and subqueries
 
 ## 1.4.0 (2019-07-18)
 

--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -224,6 +224,54 @@ SELECT
 FROM (VALUES (1),(2)) v(time)
 GROUP BY 1;
 ERROR:  invalid time_bucket_gapfill argument: could not infer finish boundary from WHERE clause
+-- test 0 bucket_width
+SELECT
+  time_bucket_gapfill(0,time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
+SELECT
+  time_bucket_gapfill('0d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::date),('2000-02-01'::date)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
+SELECT
+  time_bucket_gapfill('0d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
+-- test negative bucket_width
+SELECT
+  time_bucket_gapfill(-1,time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
+SELECT
+  time_bucket_gapfill('-1d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::date),('2000-02-01'::date)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
+SELECT
+  time_bucket_gapfill('-1d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: bucket_width must be greater than 0
+-- test subqueries as interval, start and stop (not supported atm)
+SELECT
+  time_bucket_gapfill((SELECT 1),time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: bucket_width must be a simple expression
+SELECT
+  time_bucket_gapfill(1,time,(SELECT 1),11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: start must be a simple expression
+SELECT
+  time_bucket_gapfill(1,time,1,(SELECT 11))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+ERROR:  invalid time_bucket_gapfill argument: finish must be a simple expression
 \set ON_ERROR_STOP 1
 -- test time_bucket_gapfill without aggregation
 -- this will not trigger gapfilling

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -208,6 +208,56 @@ SELECT
   time_bucket_gapfill(1,time,1,NULL)
 FROM (VALUES (1),(2)) v(time)
 GROUP BY 1;
+
+-- test 0 bucket_width
+SELECT
+  time_bucket_gapfill(0,time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill('0d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::date),('2000-02-01'::date)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill('0d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
+GROUP BY 1;
+
+-- test negative bucket_width
+SELECT
+  time_bucket_gapfill(-1,time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill('-1d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::date),('2000-02-01'::date)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill('-1d',time,'2000-01-01','2000-02-01')
+FROM (VALUES ('2000-01-01'::timestamptz),('2000-02-01'::timestamptz)) v(time)
+GROUP BY 1;
+
+-- test subqueries as interval, start and stop (not supported atm)
+SELECT
+  time_bucket_gapfill((SELECT 1),time,1,11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill(1,time,(SELECT 1),11)
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+SELECT
+  time_bucket_gapfill(1,time,1,(SELECT 11))
+FROM (VALUES (1),(2)) v(time)
+GROUP BY 1;
+
+
 \set ON_ERROR_STOP 1
 
 -- test time_bucket_gapfill without aggregation


### PR DESCRIPTION
Since bucket_width, start and stop of the gapfill node are
initialized during executor startup only PARAM_EXTERN params
are safe to be used.  This patch will make the gapfill node
throw an error if any argument is a param that is not
PARAM_EXTERN. This patch also improves the error message
for negative or 0 bucket_width.

Fixes #1372 