### PR TITLE
Handle Result nodes gracefully in ChunkAppend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ accidentally triggering the load of a previous DB version.**
 * #1363 Mark drop_chunks as VOLATILE and not PARALLEL SAFE
 * #1369 Fix ChunkAppend with prepared statements
 * #1373 Only allow PARAM_EXTERN as time_bucket_gapfill arguments
+* #1380 Handle Result nodes gracefully in ChunkAppend
 
 **Thanks**
 * @overhacked for reporting an issue with drop_chunks and parallel queries
 * @fvannee for reporting an issue with ConstraintAwareAppend and subqueries
 * @rrb3942 for reporting a segfault with ChunkAppend and prepared statements
 * @mchesser for reporting a segfault with time_bucket_gapfill and subqueries
+* @lolizeppelin for reporting and helping debug an issue with ChunkAppend and Result nodes
 
 ## 1.4.0 (2019-07-18)
 

--- a/src/chunk_append/planner.c
+++ b/src/chunk_append/planner.c
@@ -163,6 +163,15 @@ chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path, L
 
 		forboth (lc_path, path->custom_paths, lc_plan, custom_plans)
 		{
+			/*
+			 * If the planner injected a Result node to do projection
+			 * we can safely remove the Result node if it does not have
+			 * a one-time filter because ChunkAppend can do projection.
+			 */
+			if (IsA(lfirst(lc_plan), Result) &&
+				castNode(Result, lfirst(lc_plan))->resconstantqual == NULL)
+				lfirst(lc_plan) = ((Plan *) lfirst(lc_plan))->lefttree;
+
 			if (IsA(lfirst(lc_plan), MergeAppend))
 			{
 				ListCell *lc_childpath, *lc_childplan;


### PR DESCRIPTION
In some occasions (other extensions modifying plans) MergeAppend
nodes might be wrapped in Result nodes when Projection is needed
and since MergeAppend cannot do projection a Result node is put
on top of MergeAppend. Since ChunkAppend can do projection we can
remove the Result node if it has no one-time filter.

Fixes #1379 