### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
-## 1.4.1 (unreleased)
+## 1.4.1 (2019-08-01)
+
+This maintenance release contains bugfixes since the 1.4.0 release. We deem it medium
+priority for upgrading.
+
+In particular the fixes contained in this maintenance release address 2 potential
+segfaults and no other security vulnerabilities. The bugfixes are related to queries
+with prepared statements, PL/pgSQL functions and interoperability with other extensions.
+More details below.
 
 **Bugfixes**
 * #1362 Fix ConstraintAwareAppend subquery exclusion

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -90,6 +90,7 @@ set(MOD_FILES
   updates/1.3.0--1.3.1.sql
   updates/1.3.1--1.3.2.sql
   updates/1.3.2--1.4.0.sql
+  updates/1.4.0--1.4.1.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
 version = 1.5.0-dev
-update_from_version = 1.4.0
+update_from_version = 1.4.1


### PR DESCRIPTION
This maintenance release contains bugfixes since the 1.4.0 release.

**Bugfixes**
* #1362 Fix ConstraintAwareAppend subquery exclusion
* #1363 Mark drop_chunks as VOLATILE and not PARALLEL SAFE
* #1369 Fix ChunkAppend with prepared statements
* #1373 Only allow PARAM_EXTERN as time_bucket_gapfill arguments
* #1380 Handle Result nodes gracefully in ChunkAppend

**Thanks**
* @overhacked for reporting an issue with drop_chunks and parallel queries
* @fvannee for reporting an issue with ConstraintAwareAppend and subqueries
* @rrb3942 for reporting a segfault with ChunkAppend and prepared statements
* @mchesser for reporting a segfault with time_bucket_gapfill and subqueries
* @lolizeppelin for reporting and helping debug an issue with ChunkAppend and Result nodes