### PR TITLE
Fix deletes of background workers while a job is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #1327 Fix chunk exclusion with ordered append
+* #1390 Fix deletes of background workers while a job is running
 * #1392 Fix cagg_agg_validate expression handling
 * #1408 Fix ChunkAppend space partitioning support for ordered append
 * #1420 Fix OUTER JOIN qual propagation
@@ -19,6 +20,7 @@ accidentally triggering the load of a previous DB version.**
 * @shahidhk for reporting an issue with OUTER JOINs
 * @cossbow and @xxGL1TCHxx for reporting reporting issues with ChunkAppend and space partitioning
 * @est for reporting an issue with CASE expressions in continuous aggregates
+* @devlucasc for reporting the issue with deleting a background worker while a job is running
 
 ## 1.4.1 (2019-08-01)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,8 +314,8 @@ if (UNIX)
   add_subdirectory(scripts)
 endif (UNIX)
 
-add_subdirectory(test)
 add_subdirectory(sql)
+add_subdirectory(test)
 add_subdirectory(src)
 
 option(APACHE_ONLY "only compile apache code" off)

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -6,9 +6,12 @@
 #ifndef BGW_JOB_H
 #define BGW_JOB_H
 
+#include <postgres.h>
+#include <storage/lock.h>
+#include <postmaster/bgworker.h>
+
 #include "export.h"
 #include "catalog.h"
-#include <postmaster/bgworker.h>
 
 typedef enum JobType
 {
@@ -25,7 +28,6 @@ typedef struct BgwJob
 {
 	FormData_bgw_job fd;
 	JobType bgw_type;
-
 } BgwJob;
 
 typedef bool job_main_func(void);
@@ -38,6 +40,8 @@ extern BackgroundWorkerHandle *ts_bgw_start_worker(const char *function, const c
 extern BackgroundWorkerHandle *ts_bgw_job_start(BgwJob *job, Oid user_oid);
 
 extern List *ts_bgw_job_get_all(size_t alloc_size, MemoryContext mctx);
+
+extern bool ts_bgw_job_get_share_lock(int32 bgw_job_id, MemoryContext mctx);
 
 TSDLLEXPORT BgwJob *ts_bgw_job_find(int job_id, MemoryContext mctx, bool fail_if_not_found);
 

--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -352,6 +352,10 @@ drop_continuous_agg(ContinuousAgg *agg, bool drop_user_view)
 
 	/* NOTE: the lock order matters, see tsl/src/materialization.c. Perform all locking upfront */
 
+	/* delete the job before taking locks as it kills long-running jobs which we would otherwise
+	 * wait on */
+	ts_bgw_job_delete_by_id(agg->data.job_id);
+
 	if (drop_user_view)
 	{
 		user_view = (ObjectAddress){
@@ -430,8 +434,7 @@ drop_continuous_agg(ContinuousAgg *agg, bool drop_user_view)
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
 		HeapTuple tuple = ti->tuple;
 		Form_continuous_agg form = (Form_continuous_agg) GETSTRUCT(tuple);
-		/* delete the job */
-		ts_bgw_job_delete_by_id(form->job_id);
+
 		ts_catalog_delete(ti->scanrel, ti->tuple);
 
 		/* delete all related rows */

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,6 +16,10 @@
 
 #include "export.h"
 
+/* Use a special pseudo-random field 4 value to avoid conflicting with user-advisory-locks */
+#define TS_SET_LOCKTAG_ADVISORY(tag, id1, id2, id3)                                                \
+	SET_LOCKTAG_ADVISORY((tag), (id1), (id2), (id3), 29749)
+
 #define TS_EPOCH_DIFF_MICROSECONDS ((POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY)
 #define TS_INTERNAL_TIMESTAMP_MIN ((int64) USECS_PER_DAY * (DATETIME_MIN_JULIAN - UNIX_EPOCH_JDATE))
 

--- a/test/isolation/expected/bgw_job_delete.out
+++ b/test/isolation/expected/bgw_job_delete.out
@@ -1,0 +1,105 @@
+Parsed test spec with 4 sessions
+
+starting permutation: cjj5 s2a s1a s3a s1b s1c
+step cjj5: 
+    INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+    ('test_job_1', 'bgw_test_job_5_lock', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+
+step s2a: SELECT pg_advisory_lock(1);
+pg_advisory_lock
+
+               
+step s1a: SELECT ts_bgw_db_scheduler_test_run(25); select pg_sleep(0.2);
+ts_bgw_db_scheduler_test_run
+
+               
+pg_sleep       
+
+               
+step s3a: select ts_test_bgw_job_delete_by_id(id) FROM _timescaledb_config.bgw_job;
+ts_test_bgw_job_delete_by_id
+
+               
+step s1b: SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+ts_bgw_db_scheduler_test_wait_for_scheduler_finish
+
+               
+step s1c: COMMIT;
+msg_no         mock_time      application_namemsg            
+
+0              0              DB Scheduler   [TESTING] Registered new background worker
+1              0              DB Scheduler   [TESTING] Wait until 25000, started at 0
+0              0              test_job_1     Before lock job 5
+1              0              test_job_1     canceling statement due to user request
+pg_advisory_unlock_all
+
+               
+
+starting permutation: cjj5 s2a s3a s1a s1b s1c
+step cjj5: 
+    INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+    ('test_job_1', 'bgw_test_job_5_lock', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+
+step s2a: SELECT pg_advisory_lock(1);
+pg_advisory_lock
+
+               
+step s3a: select ts_test_bgw_job_delete_by_id(id) FROM _timescaledb_config.bgw_job;
+ts_test_bgw_job_delete_by_id
+
+               
+step s1a: SELECT ts_bgw_db_scheduler_test_run(25); select pg_sleep(0.2);
+ts_bgw_db_scheduler_test_run
+
+               
+pg_sleep       
+
+               
+step s1b: SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+ts_bgw_db_scheduler_test_wait_for_scheduler_finish
+
+               
+step s1c: COMMIT;
+msg_no         mock_time      application_namemsg            
+
+0              0              DB Scheduler   [TESTING] Wait until 25000, started at 0
+pg_advisory_unlock_all
+
+               
+
+starting permutation: cjj6 s2a s1a s3a s2u s1b s1c
+step cjj6: 
+    INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+    ('test_job_1', 'bgw_test_job_6_lock_notxn', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+
+step s2a: SELECT pg_advisory_lock(1);
+pg_advisory_lock
+
+               
+step s1a: SELECT ts_bgw_db_scheduler_test_run(25); select pg_sleep(0.2);
+ts_bgw_db_scheduler_test_run
+
+               
+pg_sleep       
+
+               
+step s3a: select ts_test_bgw_job_delete_by_id(id) FROM _timescaledb_config.bgw_job;
+ERROR:  canceling statement due to lock timeout
+step s2u: SELECT pg_advisory_unlock(1);
+pg_advisory_unlock
+
+t              
+step s1b: SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+ts_bgw_db_scheduler_test_wait_for_scheduler_finish
+
+               
+step s1c: COMMIT;
+msg_no         mock_time      application_namemsg            
+
+0              0              DB Scheduler   [TESTING] Registered new background worker
+1              0              DB Scheduler   [TESTING] Wait until 25000, started at 0
+0              0              test_job_1     Before lock job 6
+1              0              test_job_1     After lock job 5
+pg_advisory_unlock_all
+
+               

--- a/test/isolation/specs/CMakeLists.txt
+++ b/test/isolation/specs/CMakeLists.txt
@@ -10,6 +10,24 @@ set(TEST_FILES
 
 file(REMOVE ${ISOLATION_TEST_SCHEDULE})
 
+set(TEST_TEMPLATES
+)
+
+set(TEST_TEMPLATES_DEBUG
+ bgw_job_delete.spec.in
+)
+
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+  list(APPEND TEST_TEMPLATES ${TEST_TEMPLATES_DEBUG})
+endif(CMAKE_BUILD_TYPE MATCHES Debug)
+
+foreach(TEMPLATE_FILE ${TEST_TEMPLATES})
+  get_filename_component(TEMPLATE ${TEMPLATE_FILE} NAME_WE)
+  set(TEST_FILE ${TEMPLATE}.spec)
+  configure_file(${TEMPLATE_FILE} ${TEST_FILE})
+  list(APPEND TEST_FILES "${TEST_FILE}")
+endforeach(TEMPLATE_FILE)
+
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES
     multi_transaction_indexing.spec)

--- a/test/isolation/specs/bgw_job_delete.spec.in
+++ b/test/isolation/specs/bgw_job_delete.spec.in
@@ -1,0 +1,100 @@
+setup
+{
+CREATE OR REPLACE FUNCTION ts_bgw_params_create() RETURNS VOID
+AS '@TS_MODULE_PATHNAME@'  LANGUAGE C VOLATILE;
+
+SELECT _timescaledb_internal.stop_background_workers();
+
+CREATE TABLE public.bgw_dsm_handle_store(
+    handle BIGINT
+);
+INSERT INTO public.bgw_dsm_handle_store VALUES (0);
+SELECT ts_bgw_params_create();
+
+CREATE TABLE public.bgw_log(
+    msg_no INT,
+    mock_time BIGINT,
+    application_name TEXT,
+    msg TEXT
+);
+
+
+DELETE FROM _timescaledb_config.bgw_job;
+ALTER TABLE _timescaledb_config.bgw_job DROP CONSTRAINT IF EXISTS valid_job_type;
+}
+
+teardown {
+  CREATE OR REPLACE FUNCTION ts_bgw_params_destroy() RETURNS VOID
+  AS '@TS_MODULE_PATHNAME@'  LANGUAGE C VOLATILE;
+  SELECT * from ts_bgw_params_destroy(); 
+  DROP TABLE  public.bgw_log;
+  DROP TABLE public.bgw_dsm_handle_store; 
+}
+
+session "cj"
+step "cjj5" {
+    INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+    ('test_job_1', 'bgw_test_job_5_lock', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+}
+step "cjj6" {
+    INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
+    ('test_job_1', 'bgw_test_job_6_lock_notxn', INTERVAL '100ms', INTERVAL '100s', 3, INTERVAL '1s');
+}
+
+session "s1"
+setup	{ 
+BEGIN; 
+
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS '@TS_MODULE_PATHNAME@' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_run(timeout INT = -1, mock_start_time INT = 0) RETURNS VOID
+AS '@TS_MODULE_PATHNAME@' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION ts_bgw_db_scheduler_test_wait_for_scheduler_finish() RETURNS VOID
+AS '@TS_MODULE_PATHNAME@' LANGUAGE C VOLATILE;
+
+SET  role default_perm_user;
+}
+
+
+step "s1a"	{ SELECT ts_bgw_db_scheduler_test_run(25); select pg_sleep(0.2); }
+step "s1b"  { SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish(); } 
+step "s1c"	{ COMMIT; }
+
+teardown {
+    reset role;
+    SELECT * FROM public.bgw_log; 
+}
+
+
+session "s2"
+step "s2a"	{ SELECT pg_advisory_lock(1); }
+step "s2u"	{ SELECT pg_advisory_unlock(1); }
+teardown {
+    select pg_advisory_unlock_all();
+}
+
+session "s3"
+setup { 
+CREATE OR REPLACE FUNCTION ts_test_bgw_job_delete_by_id(job_id INTEGER)
+RETURNS VOID
+AS '@TS_MODULE_PATHNAME@'
+LANGUAGE C VOLATILE STRICT;
+
+SET lock_timeout = '50ms';
+SET  role default_perm_user;
+}
+step "s3a" { select ts_test_bgw_job_delete_by_id(id) FROM _timescaledb_config.bgw_job; }
+teardown {
+    reset role;
+}
+
+# a delete should kill a running job 
+permutation "cjj5" "s2a" "s1a" "s3a" "s1b" "s1c"
+# a delete before the job is run should work fine too
+permutation "cjj5" "s2a"  "s3a" "s1a" "s1b" "s1c"
+
+# if a job doesn't have a txn, the delete will not be able to kill the job
+# and will thus wait on the lock (and lock_timeout in the test below)
+permutation "cjj6" "s2a" "s1a" "s3a" "s2u" "s1b" "s1c"

--- a/test/pg_isolation_regress.sh
+++ b/test/pg_isolation_regress.sh
@@ -69,9 +69,10 @@ else
     # passing in only those tests from the directory which are found in TESTS
     FILTER=${TESTS}
     TESTS=
-    for t in ${SPECS_DIR}/*.spec; do
+    for t in ${SPECS_DIR}/*.spec*; do
         t=${t##${SPECS_DIR}/}
         t=${t%.spec}
+        t=${t%.spec.in}
 
         if contains "${FILTER}" "${t}" && ! contains "${SKIPS}" "${t}"; then
             TESTS="${TESTS} $t"

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -5,3 +5,4 @@ timescaledb.telemetry_level=off
 timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'
 timescaledb.last_tuned_version='0.0.1'
 timescaledb_telemetry.cloud='ci'
+log_line_prefix='%u [%p] '

--- a/test/src/bgw/params.c
+++ b/test/src/bgw/params.c
@@ -111,6 +111,8 @@ params_open_wrapper()
 			StartTransactionCommand();
 #endif
 		seg = dsm_attach(handle);
+		if (seg == NULL)
+			elog(ERROR, "got NULL segment in params_open_wrapper");
 #if PG96
 		dsm_pin_mapping(seg);
 		if (!started)


### PR DESCRIPTION
Previously there were at least 2 problems with deletes of BGWs:

1) A delete of a job or job_stats row while a BGW was running
would often cause "tuple concurrently updated" errors in the
deleting backend, worker, or, worst of all, scheduler.
Sometimes the scheduler would abort because of these errors.
2) A delete of a job did not cause the BGW to quit, thus this
operation could take a long time and would not help with
misbehaving BGWs.

This commit solves both problems. We introduce a new job-row heavyweight
tuple lock that is taken by any running worker and that prevents
concurrent job deletes. We also use this lock to determine the PID
of the worker and cancel (SIGINT) the worker during job deletes.

Furthermore we make the scheduler more gracefully handle unexpected
job deletions and take share locks on the job row when performing
operations on the row.