### PR TITLE
Fix cagg_agg_validate expression handling

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -674,6 +674,9 @@ get_max_interval_per_job(Oid column_type, WithClauseResult *with_clause_options,
 static bool
 cagg_agg_validate(Node *node, void *context)
 {
+	if (node == NULL)
+		return false;
+
 	if (IsA(node, Aggref))
 	{
 		Aggref *agg = (Aggref *) node;
@@ -774,8 +777,8 @@ cagg_validate_query(Query *query)
 						"function and a GROUP BY clause with time_bucket")));
 	}
 	/*validate aggregates allowed */
-	expression_tree_walker((Node *) query->targetList, cagg_agg_validate, NULL);
-	expression_tree_walker((Node *) query->havingQual, cagg_agg_validate, NULL);
+	cagg_agg_validate((Node *) query->targetList, NULL);
+	cagg_agg_validate((Node *) query->havingQual, NULL);
 
 	fromList = query->jointree->fromlist;
 	if (list_length(fromList) != 1 || !IsA(linitial(fromList), RangeTblRef))

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -500,3 +500,43 @@ AS SELECT time_bucket('6', time_bucket), SUM(count)
 ERROR:  invalid SELECT query for continuous aggregate
 \set ON_ERROR_STOP 1
 DROP INDEX new_name_idx;
+CREATE TABLE metrics(time timestamptz, device_id int, v1 float, v2 float);
+SELECT create_hypertable('metrics','time');
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (9,public,metrics,t)
+(1 row)
+
+INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
+-- check expressions in view definition
+CREATE VIEW cagg_expr WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1d', time) AS time,
+  'Const'::text AS Const,
+  4.3::numeric AS "numeric",
+  first(metrics,time),
+  CASE WHEN true THEN 'foo' ELSE 'bar' END,
+  COALESCE(NULL,'coalesce'),
+  avg(v1) + avg(v2) AS avg1,
+  avg(v1+v2) AS avg2
+FROM metrics
+GROUP BY 1;
+NOTICE:  adding index _materialized_hypertable_10_const_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(const, time)
+NOTICE:  adding index _materialized_hypertable_10_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(numeric, time)
+NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(case, time)
+NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
+REFRESH MATERIALIZED VIEW cagg_expr;
+INFO:  new materialization range for public.metrics (time column time) (947289600000000)
+INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000
+SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
+             time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
+------------------------------+-------+---------+----------------------------------------------+------+----------+------+------
+ Fri Dec 31 16:00:00 1999 PST | Const |     4.3 | ("Sat Jan 01 00:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Sat Jan 01 16:00:00 2000 PST | Const |     4.3 | ("Sat Jan 01 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Sun Jan 02 16:00:00 2000 PST | Const |     4.3 | ("Sun Jan 02 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Mon Jan 03 16:00:00 2000 PST | Const |     4.3 | ("Mon Jan 03 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Tue Jan 04 16:00:00 2000 PST | Const |     4.3 | ("Tue Jan 04 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+(5 rows)
+

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -500,3 +500,43 @@ AS SELECT time_bucket('6', time_bucket), SUM(count)
 ERROR:  invalid SELECT query for continuous aggregate
 \set ON_ERROR_STOP 1
 DROP INDEX new_name_idx;
+CREATE TABLE metrics(time timestamptz, device_id int, v1 float, v2 float);
+SELECT create_hypertable('metrics','time');
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (9,public,metrics,t)
+(1 row)
+
+INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
+-- check expressions in view definition
+CREATE VIEW cagg_expr WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1d', time) AS time,
+  'Const'::text AS Const,
+  4.3::numeric AS "numeric",
+  first(metrics,time),
+  CASE WHEN true THEN 'foo' ELSE 'bar' END,
+  COALESCE(NULL,'coalesce'),
+  avg(v1) + avg(v2) AS avg1,
+  avg(v1+v2) AS avg2
+FROM metrics
+GROUP BY 1;
+NOTICE:  adding index _materialized_hypertable_10_const_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(const, time)
+NOTICE:  adding index _materialized_hypertable_10_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(numeric, time)
+NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(case, time)
+NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
+REFRESH MATERIALIZED VIEW cagg_expr;
+INFO:  new materialization range for public.metrics (time column time) (947289600000000)
+INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000
+SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
+             time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
+------------------------------+-------+---------+----------------------------------------------+------+----------+------+------
+ Fri Dec 31 16:00:00 1999 PST | Const |     4.3 | ("Sat Jan 01 00:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Sat Jan 01 16:00:00 2000 PST | Const |     4.3 | ("Sat Jan 01 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Sun Jan 02 16:00:00 2000 PST | Const |     4.3 | ("Sun Jan 02 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Mon Jan 03 16:00:00 2000 PST | Const |     4.3 | ("Mon Jan 03 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Tue Jan 04 16:00:00 2000 PST | Const |     4.3 | ("Tue Jan 04 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+(5 rows)
+

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -500,3 +500,43 @@ AS SELECT time_bucket('6', time_bucket), SUM(count)
 ERROR:  invalid SELECT query for continuous aggregate
 \set ON_ERROR_STOP 1
 DROP INDEX new_name_idx;
+CREATE TABLE metrics(time timestamptz, device_id int, v1 float, v2 float);
+SELECT create_hypertable('metrics','time');
+NOTICE:  adding not-null constraint to column "time"
+  create_hypertable   
+----------------------
+ (9,public,metrics,t)
+(1 row)
+
+INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
+-- check expressions in view definition
+CREATE VIEW cagg_expr WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1d', time) AS time,
+  'Const'::text AS Const,
+  4.3::numeric AS "numeric",
+  first(metrics,time),
+  CASE WHEN true THEN 'foo' ELSE 'bar' END,
+  COALESCE(NULL,'coalesce'),
+  avg(v1) + avg(v2) AS avg1,
+  avg(v1+v2) AS avg2
+FROM metrics
+GROUP BY 1;
+NOTICE:  adding index _materialized_hypertable_10_const_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(const, time)
+NOTICE:  adding index _materialized_hypertable_10_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(numeric, time)
+NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(case, time)
+NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
+REFRESH MATERIALIZED VIEW cagg_expr;
+INFO:  new materialization range for public.metrics (time column time) (947289600000000)
+INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000
+SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
+             time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
+------------------------------+-------+---------+----------------------------------------------+------+----------+------+------
+ Fri Dec 31 16:00:00 1999 PST | Const |     4.3 | ("Sat Jan 01 00:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Sat Jan 01 16:00:00 2000 PST | Const |     4.3 | ("Sat Jan 01 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Sun Jan 02 16:00:00 2000 PST | Const |     4.3 | ("Sun Jan 02 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Mon Jan 03 16:00:00 2000 PST | Const |     4.3 | ("Mon Jan 03 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+ Tue Jan 04 16:00:00 2000 PST | Const |     4.3 | ("Tue Jan 04 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+(5 rows)
+

--- a/tsl/test/sql/continuous_aggs_ddl.sql.in
+++ b/tsl/test/sql/continuous_aggs_ddl.sql.in
@@ -315,3 +315,28 @@ AS SELECT time_bucket('6', time_bucket), SUM(count)
 \set ON_ERROR_STOP 1
 
 DROP INDEX new_name_idx;
+
+CREATE TABLE metrics(time timestamptz, device_id int, v1 float, v2 float);
+SELECT create_hypertable('metrics','time');
+
+INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
+
+-- check expressions in view definition
+CREATE VIEW cagg_expr WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1d', time) AS time,
+  'Const'::text AS Const,
+  4.3::numeric AS "numeric",
+  first(metrics,time),
+  CASE WHEN true THEN 'foo' ELSE 'bar' END,
+  COALESCE(NULL,'coalesce'),
+  avg(v1) + avg(v2) AS avg1,
+  avg(v1+v2) AS avg2
+FROM metrics
+GROUP BY 1;
+
+REFRESH MATERIALIZED VIEW cagg_expr;
+SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
+
+


### PR DESCRIPTION
The expression tree walker function used to validate the definition
did not check for NULL values. This patch adds checking for NULL
and also fixes the expression_tree_walker call.

Fixes #1391 