### PR TITLE
Add support for moving chunks to different tablespaces

### DIFF
--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -10,3 +10,11 @@ CREATE OR REPLACE FUNCTION reorder_chunk(
     index REGCLASS=NULL,
     verbose BOOLEAN=FALSE
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_reorder_chunk' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION move_chunk(
+    chunk REGCLASS,
+    destination_tablespace Name,
+    index_destination_tablespace Name=NULL,
+    reorder_index REGCLASS=NULL,
+    verbose BOOLEAN=FALSE
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_move_chunk' LANGUAGE C VOLATILE;

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -60,7 +60,7 @@ extern TSDLLEXPORT bool ts_chunk_index_get_by_indexrelid(Chunk *chunk, Oid chunk
 extern TSDLLEXPORT void ts_chunk_index_mark_clustered(Oid chunkrelid, Oid indexrelid);
 
 extern TSDLLEXPORT List *ts_chunk_index_duplicate(Oid src_chunkrelid, Oid dest_chunkrelid,
-												  List **src_index_oids);
+												  List **src_index_oids, Oid index_tablespace);
 
 /* chunk_index_recreate  is a process akin to reindex
  * except that indexes are created in 2 steps

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -21,6 +21,7 @@ TS_FUNCTION_INFO_V1(ts_remove_drop_chunks_policy);
 TS_FUNCTION_INFO_V1(ts_remove_reorder_policy);
 TS_FUNCTION_INFO_V1(ts_alter_job_schedule);
 TS_FUNCTION_INFO_V1(ts_reorder_chunk);
+TS_FUNCTION_INFO_V1(ts_move_chunk);
 TS_FUNCTION_INFO_V1(ts_partialize_agg);
 TS_FUNCTION_INFO_V1(ts_finalize_agg_sfunc);
 TS_FUNCTION_INFO_V1(ts_finalize_agg_ffunc);
@@ -72,6 +73,12 @@ Datum
 ts_reorder_chunk(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_DATUM(ts_cm_functions->reorder_chunk(fcinfo));
+}
+
+Datum
+ts_move_chunk(PG_FUNCTION_ARGS)
+{
+	return ts_cm_functions->move_chunk(fcinfo);
 }
 
 Datum
@@ -252,6 +259,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.gapfill_timestamptz_time_bucket = error_no_default_fn_pg_community,
 	.alter_job_schedule = error_no_default_fn_pg_enterprise,
 	.reorder_chunk = error_no_default_fn_pg_community,
+	.move_chunk = error_no_default_fn_pg_enterprise,
 	.ddl_command_start = NULL,
 	.ddl_command_end = NULL,
 	.sql_drop = NULL,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -59,6 +59,7 @@ typedef struct CrossModuleFunctions
 	PGFunction gapfill_timestamptz_time_bucket;
 	PGFunction alter_job_schedule;
 	PGFunction reorder_chunk;
+	PGFunction move_chunk;
 	void (*ddl_command_start)(ProcessUtilityArgs *args);
 	void (*ddl_command_end)(EventTriggerData *command);
 	void (*sql_drop)(List *dropped_objects);

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -36,6 +36,7 @@ ORDER BY proname;
  interpolate
  last
  locf
+ move_chunk
  remove_drop_chunks_policy
  remove_reorder_policy
  reorder_chunk
@@ -49,5 +50,5 @@ ORDER BY proname;
  time_bucket_gapfill
  timescaledb_post_restore
  timescaledb_pre_restore
-(35 rows)
+(36 rows)
 

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -7,7 +7,7 @@ SET client_min_messages = ERROR;
 DROP TABLESPACE IF EXISTS tablespace1;
 DROP TABLESPACE IF EXISTS tablespace2;
 SET client_min_messages = NOTICE;
---test hypertable with tables space
+--test hypertable with tablespace
 CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 --assigning a tablespace via the main table should work

--- a/test/sql/tablespace.sql
+++ b/test/sql/tablespace.sql
@@ -10,7 +10,7 @@ DROP TABLESPACE IF EXISTS tablespace1;
 DROP TABLESPACE IF EXISTS tablespace2;
 SET client_min_messages = NOTICE;
 
---test hypertable with tables space
+--test hypertable with tablespace
 CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -127,6 +127,8 @@ execute_reorder_policy(BgwJob *job, reorder_func reorder, bool fast_continue)
 			get_relname_relid(NameStr(args->fd.hypertable_index_name),
 							  get_namespace_oid(NameStr(ht->fd.schema_name), false)),
 			false,
+			InvalidOid,
+			InvalidOid,
 			InvalidOid);
 	elog(LOG,
 		 "completed reordering chunk %s.%s",

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -14,7 +14,8 @@
 #include "bgw_policy/chunk_stats.h"
 
 /* Reorder function type. Necessary for testing */
-typedef void (*reorder_func)(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id);
+typedef void (*reorder_func)(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id,
+							 Oid destination_tablespace, Oid index_tablespace);
 
 /* Functions exposed only for testing */
 extern bool execute_reorder_policy(BgwJob *job, reorder_func reorder, bool fast_continue);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -78,6 +78,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.gapfill_timestamptz_time_bucket = gapfill_timestamptz_time_bucket,
 	.alter_job_schedule = bgw_policy_alter_job_schedule,
 	.reorder_chunk = tsl_reorder_chunk,
+	.move_chunk = tsl_move_chunk,
 	.partialize_agg = tsl_partialize_agg,
 	.finalize_agg_sfunc = tsl_finalize_agg_sfunc,
 	.finalize_agg_ffunc = tsl_finalize_agg_ffunc,

--- a/tsl/src/reorder.h
+++ b/tsl/src/reorder.h
@@ -14,6 +14,8 @@
 #include <utils/relcache.h>
 
 extern Datum tsl_reorder_chunk(PG_FUNCTION_ARGS);
-extern void reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id);
+extern Datum tsl_move_chunk(PG_FUNCTION_ARGS);
+extern void reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id,
+						  Oid destination_tablespace, Oid index_tablespace);
 
 #endif /* TIMESCALEDB_TSL_REORDER_H */

--- a/tsl/test/expected/move.out
+++ b/tsl/test/expected/move.out
@@ -1,0 +1,469 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ON_ERROR_STOP 0
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+DROP TABLESPACE IF EXISTS tablespace2;
+DROP TABLESPACE IF EXISTS tablespace3;
+SET client_min_messages = NOTICE;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER_2 LOCATION :TEST_TABLESPACE2_PATH;
+--Running some of the same tests as we do for reorder/cluster because that's how move is implemented
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set ON_ERROR_STOP 1
+\ir include/cluster_test_setup.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE cluster_test(time INTEGER, temp float, location int, value TEXT);
+SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => 5);
+psql:include/cluster_test_setup.sql:7: NOTICE:  adding not-null constraint to column "time"
+     create_hypertable     
+---------------------------
+ (1,public,cluster_test,t)
+(1 row)
+
+CREATE INDEX on cluster_test (location);
+CREATE OR REPLACE FUNCTION ensure_scans_work(table_name TEXT, should_output REGCLASS=NULL, seqscan BOOLEAN=FALSE, indexscan BOOLEAN=FALSE, bitmapscan BOOLEAN=FALSE) RETURNS TABLE (a TEXT, b TEXT)
+LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT format($INNER$
+            SET LOCAL enable_seqscan=%1$s;
+            SET LOCAL enable_indexscan=%2$s;
+            SET LOCAL enable_bitmapscan=%3$s;
+            EXPLAIN (costs off) SELECT * FROM %4$I WHERE time=7
+        $INNER$, seqscan, indexscan, bitmapscan, table_name) as a,
+        format($INNER$
+            WITH T1 as (SELECT * FROM %1$I WHERE time=7),
+                 T2 as (SELECT * FROM %2$I WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        $INNER$, table_name, should_output) as b;
+$BODY$;
+CREATE OR REPLACE FUNCTION ensure_scans_work_no_val(table_name TEXT, should_output REGCLASS=NULL, seqscan BOOLEAN=FALSE, indexscan BOOLEAN=FALSE, bitmapscan BOOLEAN=FALSE) RETURNS TABLE (a TEXT, b TEXT)
+LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT format($INNER$
+            SET LOCAL enable_seqscan=%1$s;
+            SET LOCAL enable_indexscan=%2$s;
+            SET LOCAL enable_bitmapscan=%3$s;
+            EXPLAIN (costs off) SELECT * FROM %4$I WHERE time=6
+        $INNER$, seqscan, indexscan, bitmapscan, table_name) as a,
+        format($INNER$
+            WITH T1 as (SELECT * FROM %1$I WHERE time=7),
+                 T2 as (SELECT * FROM %2$I WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        $INNER$, table_name, should_output) as b;
+$BODY$;
+-- Show default indexes
+SELECT * FROM test.show_indexes('cluster_test');
+           Index           |  Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
+---------------------------+------------+------+--------+---------+-----------+------------
+ cluster_test_location_idx | {location} |      | f      | f       | f         | 
+ cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+(2 rows)
+
+-- Show clustered indexes
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true ORDER BY 1;
+ indexrelid | indisclustered 
+------------+----------------
+(0 rows)
+
+-- Create two chunks
+INSERT INTO cluster_test VALUES
+    ( 0, 18.9, 3, 'a'),
+    ( 8, 13.3, 7, 'b'),
+    ( 3, 19.4, 3, 'c'),
+    ( 6, 27.3, 9, 'd'),
+    ( 5, 25.4, 1, 'e'),
+    ( 4, 18.3, 2, 'f'),
+    ( 2, 12.4, 8, 'g'),
+    ( 7, 20.3, 4, repeat('xyzzy', 100000)), -- toasted value
+    ( 9, 11.4, 1, 'h'),
+    ( 1, 23.4, 5, 'i');
+CREATE TABLE expected AS SELECT * FROM cluster_test;
+-- original results to be compared against
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY ctid;
+ ctid  | time | temp | location | substring | length 
+-------+------+------+----------+-----------+--------
+ (0,1) |    0 | 18.9 |        3 | a         |      1
+ (0,2) |    3 | 19.4 |        3 | c         |      1
+ (0,3) |    4 | 18.3 |        2 | f         |      1
+ (0,4) |    2 | 12.4 |        8 | g         |      1
+ (0,5) |    1 | 23.4 |        5 | i         |      1
+(5 rows)
+
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY ctid;
+ ctid  | time | temp | location |           substring            | length 
+-------+------+------+----------+--------------------------------+--------
+ (0,1) |    8 | 13.3 |        7 | b                              |      1
+ (0,2) |    6 | 27.3 |        9 | d                              |      1
+ (0,3) |    5 | 25.4 |        1 | e                              |      1
+ (0,4) |    7 | 20.3 |        4 | xyzzyxyzzyxyzzyxyzzyxyzzyxyzzy | 500000
+ (0,5) |    9 | 11.4 |        1 | h                              |      1
+(5 rows)
+
+BEGIN;
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', seqscan => true) \gexec
+
+            SET LOCAL enable_seqscan=t;
+            SET LOCAL enable_indexscan=f;
+            SET LOCAL enable_bitmapscan=f;
+            EXPLAIN (costs off) SELECT * FROM cluster_test WHERE time=7
+        
+             QUERY PLAN             
+------------------------------------
+ Append
+   ->  Seq Scan on _hyper_1_2_chunk
+         Filter: ("time" = 7)
+(3 rows)
+
+
+            WITH T1 as (SELECT * FROM cluster_test WHERE time=7),
+                 T2 as (SELECT * FROM expected WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        
+ time | time | temp | temp | location | location | substring | substring | length | length 
+------+------+------+------+----------+----------+-----------+-----------+--------+--------
+(0 rows)
+
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', indexscan => true) \gexec
+
+            SET LOCAL enable_seqscan=f;
+            SET LOCAL enable_indexscan=t;
+            SET LOCAL enable_bitmapscan=f;
+            EXPLAIN (costs off) SELECT * FROM cluster_test WHERE time=7
+        
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Scan using _hyper_1_2_chunk_cluster_test_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" = 7)
+(3 rows)
+
+
+            WITH T1 as (SELECT * FROM cluster_test WHERE time=7),
+                 T2 as (SELECT * FROM expected WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        
+ time | time | temp | temp | location | location | substring | substring | length | length 
+------+------+------+------+----------+----------+-----------+-----------+--------+--------
+(0 rows)
+
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', bitmapscan => true) \gexec
+
+            SET LOCAL enable_seqscan=f;
+            SET LOCAL enable_indexscan=f;
+            SET LOCAL enable_bitmapscan=t;
+            EXPLAIN (costs off) SELECT * FROM cluster_test WHERE time=7
+        
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_1_2_chunk
+         Recheck Cond: ("time" = 7)
+         ->  Bitmap Index Scan on _hyper_1_2_chunk_cluster_test_time_idx
+               Index Cond: ("time" = 7)
+(5 rows)
+
+
+            WITH T1 as (SELECT * FROM cluster_test WHERE time=7),
+                 T2 as (SELECT * FROM expected WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        
+ time | time | temp | temp | location | location | substring | substring | length | length 
+------+------+------+------+----------+----------+-----------+-----------+--------+--------
+(0 rows)
+
+COMMIT;
+-- Show chunk indexes
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
+                              Index                               |  Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
+------------------------------------------------------------------+------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_1_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+(2 rows)
+
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_2_chunk');
+                              Index                               |  Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
+------------------------------------------------------------------+------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_2_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+(2 rows)
+
+\set ON_ERROR_STOP 0
+-- cannot move a chunk with no reorder index on first call 
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1');
+WARNING:  Timescale License expired
+ERROR:  there is no previously clustered index for table "_hyper_1_2_chunk"
+-- cannot move a chunk without a destination tablespace set
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>NULL, index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  valid chunk, destination_tablespace, and index_destination_tablespaces are required
+-- cannot move a chunk without an index_destination_tablespace set
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  valid chunk, destination_tablespace, and index_destination_tablespaces are required
+-- cannot move a chunk or an index to a tablespace we do not have create permissions on 
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace2', index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  permission denied for tablespace "tablespace2"
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  permission denied for tablespace "tablespace2"
+-- cannot move to a nonexistent tablespace 
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace3', index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  tablespace "tablespace3" does not exist
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace3', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  tablespace "tablespace3" does not exist
+-- cannot move a hypertable (must specify a chunk)
+SELECT move_chunk(chunk=>'cluster_test', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  "cluster_test" is not a chunk
+-- cannot move a NULL chunk
+SELECT move_chunk(chunk=>NULL, destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  valid chunk, destination_tablespace, and index_destination_tablespaces are required
+-- cannot move within a transaction
+BEGIN;
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+ERROR:  move cannot run inside a transaction block
+END;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2 
+-- must be hypertable owner to move a chunk
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace2', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+WARNING:  Timescale License expired
+ERROR:  must be owner of hypertable "cluster_test"
+\set ON_ERROR_STOP 1
+-- grant create permissions on tablespace2 so we can use it later
+GRANT CREATE ON TABLESPACE tablespace2 TO :ROLE_DEFAULT_PERM_USER;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- move with chunk index for reorder
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+WARNING:  Timescale License expired
+INFO:  reordering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
+INFO:  "_hyper_1_2_chunk": found 0 removable, 5 nonremovable row versions in 1 pages
+ move_chunk 
+------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('cluster_test');
+                 Child                  | Tablespace  
+----------------------------------------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | 
+ _timescaledb_internal._hyper_1_2_chunk | tablespace1
+(2 rows)
+
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+                 Table                  |                              Index                               |  Columns   | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+------------------------------------------------------------------+------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | tablespace1
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | tablespace1
+(4 rows)
+
+BEGIN;
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', seqscan => true) \gexec
+
+            SET LOCAL enable_seqscan=t;
+            SET LOCAL enable_indexscan=f;
+            SET LOCAL enable_bitmapscan=f;
+            EXPLAIN (costs off) SELECT * FROM cluster_test WHERE time=7
+        
+             QUERY PLAN             
+------------------------------------
+ Append
+   ->  Seq Scan on _hyper_1_2_chunk
+         Filter: ("time" = 7)
+(3 rows)
+
+
+            WITH T1 as (SELECT * FROM cluster_test WHERE time=7),
+                 T2 as (SELECT * FROM expected WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        
+ time | time | temp | temp | location | location | substring | substring | length | length 
+------+------+------+------+----------+----------+-----------+-----------+--------+--------
+(0 rows)
+
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', indexscan => true) \gexec
+
+            SET LOCAL enable_seqscan=f;
+            SET LOCAL enable_indexscan=t;
+            SET LOCAL enable_bitmapscan=f;
+            EXPLAIN (costs off) SELECT * FROM cluster_test WHERE time=7
+        
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Scan using _hyper_1_2_chunk_cluster_test_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" = 7)
+(3 rows)
+
+
+            WITH T1 as (SELECT * FROM cluster_test WHERE time=7),
+                 T2 as (SELECT * FROM expected WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        
+ time | time | temp | temp | location | location | substring | substring | length | length 
+------+------+------+------+----------+----------+-----------+-----------+--------+--------
+(0 rows)
+
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', bitmapscan => true) \gexec
+
+            SET LOCAL enable_seqscan=f;
+            SET LOCAL enable_indexscan=f;
+            SET LOCAL enable_bitmapscan=t;
+            EXPLAIN (costs off) SELECT * FROM cluster_test WHERE time=7
+        
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_1_2_chunk
+         Recheck Cond: ("time" = 7)
+         ->  Bitmap Index Scan on _hyper_1_2_chunk_cluster_test_time_idx
+               Index Cond: ("time" = 7)
+(5 rows)
+
+
+            WITH T1 as (SELECT * FROM cluster_test WHERE time=7),
+                 T2 as (SELECT * FROM expected WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        
+ time | time | temp | temp | location | location | substring | substring | length | length 
+------+------+------+------+----------+----------+-----------+-----------+--------+--------
+(0 rows)
+
+COMMIT;
+SET enable_seqscan=Default;
+SET enable_indexscan=Default;
+SET enable_bitmapscan=Default;
+-- check that move puts things in the correct order, as it also reorders
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY ctid;
+ ctid  | time | temp | location | substring | length 
+-------+------+------+----------+-----------+--------
+ (0,1) |    0 | 18.9 |        3 | a         |      1
+ (0,2) |    3 | 19.4 |        3 | c         |      1
+ (0,3) |    4 | 18.3 |        2 | f         |      1
+ (0,4) |    2 | 12.4 |        8 | g         |      1
+ (0,5) |    1 | 23.4 |        5 | i         |      1
+(5 rows)
+
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY ctid;
+ ctid  | time | temp | location |           substring            | length 
+-------+------+------+----------+--------------------------------+--------
+ (0,1) |    9 | 11.4 |        1 | h                              |      1
+ (0,2) |    8 | 13.3 |        7 | b                              |      1
+ (0,3) |    7 | 20.3 |        4 | xyzzyxyzzyxyzzyxyzzyxyzzyxyzzy | 500000
+ (0,4) |    6 | 27.3 |        9 | d                              |      1
+ (0,5) |    5 | 25.4 |        1 | e                              |      1
+(5 rows)
+
+-- move back to pg_default
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'pg_default', index_destination_tablespace=>'pg_default', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+INFO:  reordering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
+INFO:  "_hyper_1_2_chunk": found 0 removable, 5 nonremovable row versions in 1 pages
+ move_chunk 
+------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('cluster_test');
+                 Child                  | Tablespace 
+----------------------------------------+------------
+ _timescaledb_internal._hyper_1_1_chunk | 
+ _timescaledb_internal._hyper_1_2_chunk | 
+(2 rows)
+
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+                 Table                  |                              Index                               |  Columns   | Expr | Unique | Primary | Exclusion | Tablespace 
+----------------------------------------+------------------------------------------------------------------+------------+------+--------+---------+-----------+------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | 
+(4 rows)
+
+-- move chunk and indexes to different tablespaces
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+INFO:  reordering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
+INFO:  "_hyper_1_2_chunk": found 0 removable, 5 nonremovable row versions in 1 pages
+ move_chunk 
+------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('cluster_test');
+                 Child                  | Tablespace  
+----------------------------------------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | 
+ _timescaledb_internal._hyper_1_2_chunk | tablespace1
+(2 rows)
+
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+                 Table                  |                              Index                               |  Columns   | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+------------------------------------------------------------------+------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | tablespace2
+(4 rows)
+
+-- keep chunk in same space and move index tablespace
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'pg_default', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+INFO:  reordering "_timescaledb_internal._hyper_1_2_chunk" using sequential scan and sort
+INFO:  "_hyper_1_2_chunk": found 0 removable, 5 nonremovable row versions in 1 pages
+ move_chunk 
+------------
+ 
+(1 row)
+
+SELECT * FROM test.show_subtables('cluster_test');
+                 Child                  | Tablespace 
+----------------------------------------+------------
+ _timescaledb_internal._hyper_1_1_chunk | 
+ _timescaledb_internal._hyper_1_2_chunk | 
+(2 rows)
+
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+                 Table                  |                              Index                               |  Columns   | Expr | Unique | Primary | Exclusion | Tablespace  
+----------------------------------------+------------------------------------------------------------------+------------+------+--------+---------+-----------+-------------
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_1_chunk | _timescaledb_internal._hyper_1_1_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx     | {time}     |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_1_2_chunk | _timescaledb_internal._hyper_1_2_chunk_cluster_test_location_idx | {location} |      | f      | f       | f         | tablespace2
+(4 rows)
+

--- a/tsl/test/expected/reorder.out
+++ b/tsl/test/expected/reorder.out
@@ -1,9 +1,13 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\ir include/cluster_test_setup.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE cluster_test(time INTEGER, temp float, location int, value TEXT);
 SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => 5);
-NOTICE:  adding not-null constraint to column "time"
+psql:include/cluster_test_setup.sql:7: NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
  (1,public,cluster_test,t)
@@ -1292,6 +1296,15 @@ INFO:  "_hyper_2_3_chunk": found 0 removable, 5 nonremovable row versions in 1 p
  
 (1 row)
 
+-- if we drop a CLUSTERed index we still fail correctly
+DROP INDEX ct2_time_idx;
+\set ON_ERROR_STOP 0
+SELECT reorder_chunk('_timescaledb_internal._hyper_2_3_chunk', verbose => TRUE);
+ERROR:  there is no previously clustered index for table "_hyper_2_3_chunk"
+\set ON_ERROR_STOP 1
+-- but re-create for future tests
+CREATE INDEX ct2_time_idx ON ct2(time DESC);
+CLUSTER ct2 USING ct2_time_idx;
 -- deleted chunks are removed correctly
 DELETE FROM ct2 where time < 2 OR val < 2;
 SELECT reorder_chunk('_timescaledb_internal._hyper_2_3_chunk', verbose => TRUE);

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_FILES
     continuous_aggs_watermark.sql
     edition.sql
     gapfill.sql
+    move.sql
     reorder.sql
     partialize_finalize.sql
 )

--- a/tsl/test/sql/include/cluster_test_setup.sql
+++ b/tsl/test/sql/include/cluster_test_setup.sql
@@ -1,0 +1,76 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE cluster_test(time INTEGER, temp float, location int, value TEXT);
+
+SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => 5);
+
+CREATE INDEX on cluster_test (location);
+
+CREATE OR REPLACE FUNCTION ensure_scans_work(table_name TEXT, should_output REGCLASS=NULL, seqscan BOOLEAN=FALSE, indexscan BOOLEAN=FALSE, bitmapscan BOOLEAN=FALSE) RETURNS TABLE (a TEXT, b TEXT)
+LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT format($INNER$
+            SET LOCAL enable_seqscan=%1$s;
+            SET LOCAL enable_indexscan=%2$s;
+            SET LOCAL enable_bitmapscan=%3$s;
+            EXPLAIN (costs off) SELECT * FROM %4$I WHERE time=7
+        $INNER$, seqscan, indexscan, bitmapscan, table_name) as a,
+        format($INNER$
+            WITH T1 as (SELECT * FROM %1$I WHERE time=7),
+                 T2 as (SELECT * FROM %2$I WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
+                   substring(T1.value for 30), substring(T2.value for 30),
+                   length(T1.value), length(T2.value)
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        $INNER$, table_name, should_output) as b;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION ensure_scans_work_no_val(table_name TEXT, should_output REGCLASS=NULL, seqscan BOOLEAN=FALSE, indexscan BOOLEAN=FALSE, bitmapscan BOOLEAN=FALSE) RETURNS TABLE (a TEXT, b TEXT)
+LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT format($INNER$
+            SET LOCAL enable_seqscan=%1$s;
+            SET LOCAL enable_indexscan=%2$s;
+            SET LOCAL enable_bitmapscan=%3$s;
+            EXPLAIN (costs off) SELECT * FROM %4$I WHERE time=6
+        $INNER$, seqscan, indexscan, bitmapscan, table_name) as a,
+        format($INNER$
+            WITH T1 as (SELECT * FROM %1$I WHERE time=7),
+                 T2 as (SELECT * FROM %2$I WHERE time=7)
+            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location
+            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
+            WHERE T1 IS NULL OR T2 IS NULL
+        $INNER$, table_name, should_output) as b;
+$BODY$;
+
+-- Show default indexes
+SELECT * FROM test.show_indexes('cluster_test');
+
+-- Show clustered indexes
+SELECT indexrelid::regclass, indisclustered
+FROM pg_index
+WHERE indisclustered = true ORDER BY 1;
+
+-- Create two chunks
+INSERT INTO cluster_test VALUES
+    ( 0, 18.9, 3, 'a'),
+    ( 8, 13.3, 7, 'b'),
+    ( 3, 19.4, 3, 'c'),
+    ( 6, 27.3, 9, 'd'),
+    ( 5, 25.4, 1, 'e'),
+    ( 4, 18.3, 2, 'f'),
+    ( 2, 12.4, 8, 'g'),
+    ( 7, 20.3, 4, repeat('xyzzy', 100000)), -- toasted value
+    ( 9, 11.4, 1, 'h'),
+    ( 1, 23.4, 5, 'i');
+
+CREATE TABLE expected AS SELECT * FROM cluster_test;
+
+-- original results to be compared against
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY ctid;
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY ctid;

--- a/tsl/test/sql/move.sql
+++ b/tsl/test/sql/move.sql
@@ -1,0 +1,99 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set ON_ERROR_STOP 0
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+DROP TABLESPACE IF EXISTS tablespace2;
+DROP TABLESPACE IF EXISTS tablespace3;
+SET client_min_messages = NOTICE;
+
+CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER_2 LOCATION :TEST_TABLESPACE2_PATH;
+
+--Running some of the same tests as we do for reorder/cluster because that's how move is implemented
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+\set ON_ERROR_STOP 1
+
+\ir include/cluster_test_setup.sql
+
+BEGIN;
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', seqscan => true) \gexec
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', indexscan => true) \gexec
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', bitmapscan => true) \gexec
+COMMIT;
+
+-- Show chunk indexes
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_1_chunk');
+SELECT * FROM test.show_indexes('_timescaledb_internal._hyper_1_2_chunk');
+
+\set ON_ERROR_STOP 0
+-- cannot move a chunk with no reorder index on first call 
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1');
+-- cannot move a chunk without a destination tablespace set
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>NULL, index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+-- cannot move a chunk without an index_destination_tablespace set
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+-- cannot move a chunk or an index to a tablespace we do not have create permissions on 
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace2', index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+-- cannot move to a nonexistent tablespace 
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace3', index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace3', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+-- cannot move a hypertable (must specify a chunk)
+SELECT move_chunk(chunk=>'cluster_test', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+-- cannot move a NULL chunk
+SELECT move_chunk(chunk=>NULL, destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+-- cannot move within a transaction
+BEGIN;
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx');
+END;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2 
+-- must be hypertable owner to move a chunk
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace2', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+\set ON_ERROR_STOP 1
+
+-- grant create permissions on tablespace2 so we can use it later
+GRANT CREATE ON TABLESPACE tablespace2 TO :ROLE_DEFAULT_PERM_USER;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-- move with chunk index for reorder
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+SELECT * FROM test.show_subtables('cluster_test');
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+BEGIN;
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', seqscan => true) \gexec
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', indexscan => true) \gexec
+SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', bitmapscan => true) \gexec
+COMMIT;
+SET enable_seqscan=Default;
+SET enable_indexscan=Default;
+SET enable_bitmapscan=Default;
+-- check that move puts things in the correct order, as it also reorders
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY ctid;
+SELECT ctid, time, temp, location, substring(value for 30), length(value)
+FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY ctid;
+
+-- move back to pg_default
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'pg_default', index_destination_tablespace=>'pg_default', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+SELECT * FROM test.show_subtables('cluster_test');
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+
+
+-- move chunk and indexes to different tablespaces
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+SELECT * FROM test.show_subtables('cluster_test');
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
+
+
+-- keep chunk in same space and move index tablespace
+SELECT move_chunk(chunk=>'_timescaledb_internal._hyper_1_2_chunk', destination_tablespace=>'pg_default', index_destination_tablespace=>'tablespace2', reorder_index=>'_timescaledb_internal._hyper_1_2_chunk_cluster_test_time_idx', verbose=>TRUE);
+SELECT * FROM test.show_subtables('cluster_test');
+SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');

--- a/tsl/test/sql/reorder.sql
+++ b/tsl/test/sql/reorder.sql
@@ -2,78 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-CREATE TABLE cluster_test(time INTEGER, temp float, location int, value TEXT);
-
-SELECT create_hypertable('cluster_test', 'time', chunk_time_interval => 5);
-
-CREATE INDEX on cluster_test (location);
-
-CREATE OR REPLACE FUNCTION ensure_scans_work(table_name TEXT, should_output REGCLASS=NULL, seqscan BOOLEAN=FALSE, indexscan BOOLEAN=FALSE, bitmapscan BOOLEAN=FALSE) RETURNS TABLE (a TEXT, b TEXT)
-LANGUAGE SQL STABLE AS
-$BODY$
-    SELECT format($INNER$
-            SET LOCAL enable_seqscan=%1$s;
-            SET LOCAL enable_indexscan=%2$s;
-            SET LOCAL enable_bitmapscan=%3$s;
-            EXPLAIN (costs off) SELECT * FROM %4$I WHERE time=7
-        $INNER$, seqscan, indexscan, bitmapscan, table_name) as a,
-        format($INNER$
-            WITH T1 as (SELECT * FROM %1$I WHERE time=7),
-                 T2 as (SELECT * FROM %2$I WHERE time=7)
-            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location,
-                   substring(T1.value for 30), substring(T2.value for 30),
-                   length(T1.value), length(T2.value)
-            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
-            WHERE T1 IS NULL OR T2 IS NULL
-        $INNER$, table_name, should_output) as b;
-$BODY$;
-
-CREATE OR REPLACE FUNCTION ensure_scans_work_no_val(table_name TEXT, should_output REGCLASS=NULL, seqscan BOOLEAN=FALSE, indexscan BOOLEAN=FALSE, bitmapscan BOOLEAN=FALSE) RETURNS TABLE (a TEXT, b TEXT)
-LANGUAGE SQL STABLE AS
-$BODY$
-    SELECT format($INNER$
-            SET LOCAL enable_seqscan=%1$s;
-            SET LOCAL enable_indexscan=%2$s;
-            SET LOCAL enable_bitmapscan=%3$s;
-            EXPLAIN (costs off) SELECT * FROM %4$I WHERE time=6
-        $INNER$, seqscan, indexscan, bitmapscan, table_name) as a,
-        format($INNER$
-            WITH T1 as (SELECT * FROM %1$I WHERE time=7),
-                 T2 as (SELECT * FROM %2$I WHERE time=7)
-            SELECT T1.time, T2.time, T1.temp, T2.temp, T1.location, T2.location
-            FROM T1 FULL OUTER JOIN T2 ON T1 = T2
-            WHERE T1 IS NULL OR T2 IS NULL
-        $INNER$, table_name, should_output) as b;
-$BODY$;
-
--- Show default indexes
-SELECT * FROM test.show_indexes('cluster_test');
-
--- Show clustered indexes
-SELECT indexrelid::regclass, indisclustered
-FROM pg_index
-WHERE indisclustered = true ORDER BY 1;
-
--- Create two chunks
-INSERT INTO cluster_test VALUES
-    ( 0, 18.9, 3, 'a'),
-    ( 8, 13.3, 7, 'b'),
-    ( 3, 19.4, 3, 'c'),
-    ( 6, 27.3, 9, 'd'),
-    ( 5, 25.4, 1, 'e'),
-    ( 4, 18.3, 2, 'f'),
-    ( 2, 12.4, 8, 'g'),
-    ( 7, 20.3, 4, repeat('xyzzy', 100000)), -- toasted value
-    ( 9, 11.4, 1, 'h'),
-    ( 1, 23.4, 5, 'i');
-
-CREATE TABLE expected AS SELECT * FROM cluster_test;
-
--- original results to be compared against
-SELECT ctid, time, temp, location, substring(value for 30), length(value)
-FROM _timescaledb_internal._hyper_1_1_chunk ORDER BY ctid;
-SELECT ctid, time, temp, location, substring(value for 30), length(value)
-FROM _timescaledb_internal._hyper_1_2_chunk ORDER BY ctid;
+\ir include/cluster_test_setup.sql
 
 BEGIN;
 SELECT * FROM ensure_scans_work('cluster_test', should_output => 'expected', seqscan => true) \gexec
@@ -258,6 +187,16 @@ SELECT reorder_chunk('_timescaledb_internal._hyper_2_3_chunk', '_timescaledb_int
 -- if the hypertable has a CLUSTERed index we can use it
 CLUSTER ct2 USING ct2_time_idx;
 SELECT reorder_chunk('_timescaledb_internal._hyper_2_3_chunk', verbose => TRUE);
+
+-- if we drop a CLUSTERed index we still fail correctly
+DROP INDEX ct2_time_idx;
+\set ON_ERROR_STOP 0
+SELECT reorder_chunk('_timescaledb_internal._hyper_2_3_chunk', verbose => TRUE);
+\set ON_ERROR_STOP 1
+-- but re-create for future tests
+CREATE INDEX ct2_time_idx ON ct2(time DESC);
+CLUSTER ct2 USING ct2_time_idx;
+
 
 -- deleted chunks are removed correctly
 DELETE FROM ct2 where time < 2 OR val < 2;

--- a/tsl/test/src/test_auto_policy.c
+++ b/tsl/test/src/test_auto_policy.c
@@ -23,11 +23,12 @@ static Oid chunk_oid;
 static Oid index_oid;
 
 static void
-dummy_reorder_func(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id)
+dummy_reorder_func(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id,
+				   Oid destination_tablespace, Oid index_tablespace)
 {
 	chunk_oid = tableOid;
 	index_oid = indexOid;
-	reorder_chunk(tableOid, indexOid, true, wait_id);
+	reorder_chunk(tableOid, indexOid, true, wait_id, InvalidOid, InvalidOid);
 }
 
 Datum


### PR DESCRIPTION
Adds a move_chunk function which to a different tablespace. This is
implemented as an extension to the reorder command.
Given that the heap, toast tables, and indexes are being rewritten
during the reorder operation, adding the ability to modify the tablespace
is relatively simple and mostly requires adding parameters to the relevant
functions for the destination tablespace (and index tablespace). The tests
do not focus on further exercising the reorder infrastructure, but instead
ensure that tablespace movement and permissions checks properly occur.