### PR TITLE
Enable some compiler warnings and fix code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,30 @@ if (NOT CMAKE_C_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
    message(FATAL_ERROR "Unsupported compiler ${CMAKE_C_COMPILER_ID}. Supported compilers are: ${SUPPORTED_COMPILERS}")
 endif ()
 
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
+  # These two flags generate too many errors currently, but we
+  # probably want these optimizations enabled.
+
+  # TODO: -fdelete-null-pointer-checks -Wnull-dereference
+
+  # This flag avoid some subtle bugs related to standard conversions,
+  # but currently does not compile because we are using too many
+  # implicit conversions that potentially lose precision.
+
+  # TODO: -Wconversions
+  add_compile_options(-Wempty-body -Wvla)
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "7")
+    add_compile_options(-Wimplicit-fallthrough)
+  endif()
+
+  # Not sure when it was added to Clang, but it is mentioned in the
+  # release notes for Clang 3.3
+  if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "3.3")
+    add_compile_options(-Wimplicit-fallthrough)
+  endif()
+
+endif()
+
 # Check for supported platforms and compiler flags
 if (WIN32)
   if (NOT CMAKE_CONFIGURATION_TYPES)

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -66,6 +66,7 @@ index_has_attribute(List *indexelems, const char *attrname)
 					break;
 				}
 			}
+			/* FALLTHROUGH */
 			default:
 				elog(ERROR, "unsupported index list element");
 		}

--- a/test/src/bgw/timer_mock.c
+++ b/test/src/bgw/timer_mock.c
@@ -57,7 +57,7 @@ mock_wait(TimestampTz until)
 				WaitForBackgroundWorkerShutdown(bgw_handle);
 				bgw_handle = NULL;
 			}
-			/* Now fall through to set the time */
+			/* FALLTHROUGH */
 		case IMMEDIATELY_SET_UNTIL:
 			ts_params_set_time(until, false);
 			return true;

--- a/test/src/test_with_clause_parser.c
+++ b/test/src/test_with_clause_parser.c
@@ -34,6 +34,7 @@ def_elem_from_texts(Datum *texts, int nelems)
 			break;
 		case 3:
 			elem->arg = (Node *) makeString(text_to_cstring(DatumGetTextP(texts[2])));
+			/* FALLTHROUGH */
 		case 2:
 			elem->defname = text_to_cstring(DatumGetTextP(texts[1]));
 			elem->defnamespace = text_to_cstring(DatumGetTextP(texts[0]));


### PR DESCRIPTION
It is not possible to enable both `-Wall` and `-Wextra` since that generate
too many warnings, so enabling some additional warnings to
get a decent level of checking.

Warnings enabled are:

    -Werror -Wempty-body

For GCC version 7 and above and Clang version 3.3 and later:

    -Wimplicit-fallthrough