### PR TITLE
Ignore .psqlrc in test_fatal_command

### DIFF
--- a/test/sql/utils/test_fatal_command.sh
+++ b/test/sql/utils/test_fatal_command.sh
@@ -1,3 +1,3 @@
 DB=$1
 COMMAND=$2
-${PG_BINDIR}/psql -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -d ${DB} --command="${COMMAND}"
+${PG_BINDIR}/psql -X -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -d ${DB} --command="${COMMAND}"


### PR DESCRIPTION
When a local .psqlrc sets options that modify output of psql the
loader test will fail. This patch changes the test to ignore
the .psqlrc file.