### PR TITLE
Fix ChunkAppend LIMIT pushdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,11 +96,12 @@ jobs:
         - docker exec docker_arm_emulator /bin/bash -c "cd /build && make install"
       before_script:
       after_failure:
+        - docker exec -u postgres -it docker_arm_emulator find /build -name regression.diffs -exec cat {} +
+        - docker exec -u postgres -it docker_arm_emulator find /build -name postmaster.log -exec cat {} +
       script:
       # allow 50 mins to run
-        - travis_wait 50 docker exec -u postgres docker_arm_emulator /bin/bash -c "cd /build && make installcheck IGNORES='multi_transaction_indexing bgw_db_scheduler continuous_aggs_insert'"
+        - travis_wait 50 docker exec -u postgres docker_arm_emulator /bin/bash -c "cd /build && make installcheck IGNORES='multi_transaction_indexing bgw_db_scheduler continuous_aggs_insert continuous_aggs_bgw'"
       after_script:
-        - docker exec -u postgres -it docker_arm_emulator cat /build/test/regression.diffs /build/tsl/test/regression.diffs /build/test/isolation/regression.diffs /build/tsl/test/isolation/regression.diffs /build/test/pgtest/regression.diffs
         - docker rm -f docker_arm_emulator
 
     - if: (type = cron) OR (branch = prerelease_test)
@@ -118,11 +119,12 @@ jobs:
         - docker exec docker_arm_emulator /bin/bash -c "cd /build && make install"
       before_script:
       after_failure:
+        - docker exec -u postgres -it docker_arm_emulator find /build -name regression.diffs -exec cat {} +
+        - docker exec -u postgres -it docker_arm_emulator find /build -name postmaster.log -exec cat {} +
       script:
       # allow 50 mins to run
-        - travis_wait 50 docker exec -u postgres docker_arm_emulator /bin/bash -c "cd /build && make installcheck IGNORES='multi_transaction_indexing bgw_db_scheduler continuous_aggs_insert plan_ordered_append-10'"
+        - travis_wait 50 docker exec -u postgres docker_arm_emulator /bin/bash -c "cd /build && make installcheck IGNORES='multi_transaction_indexing bgw_db_scheduler continuous_aggs_insert continuous_aggs_bgw plan_ordered_append-10'"
       after_script:
-        - docker exec -u postgres -it docker_arm_emulator cat /build/test/regression.diffs /build/tsl/test/regression.diffs /build/test/isolation/regression.diffs /build/tsl/test/isolation/regression.diffs /build/test/pgtest/regression.diffs
         - docker rm -f docker_arm_emulator
 
     - if: (type = cron) OR (branch = prerelease_test)
@@ -140,11 +142,12 @@ jobs:
         - docker exec docker_arm_emulator /bin/bash -c "cd /build && make install"
       before_script:
       after_failure:
+        - docker exec -u postgres -it docker_arm_emulator find /build -name regression.diffs -exec cat {} +
+        - docker exec -u postgres -it docker_arm_emulator find /build -name postmaster.log -exec cat {} +
       script:
       # allow 50 mins to run
-        - travis_wait 50 docker exec -u postgres docker_arm_emulator /bin/bash -c "cd /build && make installcheck IGNORES='multi_transaction_indexing bgw_db_scheduler continuous_aggs_insert plan_ordered_append-11 parallel-11'"
+        - travis_wait 50 docker exec -u postgres docker_arm_emulator /bin/bash -c "cd /build && make installcheck IGNORES='multi_transaction_indexing bgw_db_scheduler continuous_aggs_insert continuous_aggs_bgw plan_ordered_append-11 parallel-11'"
       after_script:
-        - docker exec -u postgres -it docker_arm_emulator cat /build/test/regression.diffs /build/tsl/test/regression.diffs /build/test/isolation/regression.diffs /build/tsl/test/isolation/regression.diffs /build/test/pgtest/regression.diffs
         - docker rm -f docker_arm_emulator
 
     # to maximize code code coverage on PRs we run tests on earliest 9.6, latest 10 and earliest and latest 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ accidentally triggering the load of a previous DB version.**
 ## 1.4.2 (unreleased)
 
 **Bugfixes**
+* #1327 Fix chunk exclusion with ordered append
+* #1392 Fix cagg_agg_validate expression handling
+* #1408 Fix ChunkAppend space partitioning support for ordered append
 * #1420 Fix OUTER JOIN qual propagation
+* #1422 Fix background worker segfaults
+* #1423 Fix segfault on ARM/32-bit builds
+* #1424 Fix ChunkAppend LIMIT pushdown
 
 **Thanks**
 * @shahidhk for reporting an issue with OUTER JOINs
+* @cossbow and @xxGL1TCHxx for reporting reporting issues with ChunkAppend and space partitioning
+* @est for reporting an issue with CASE expressions in continuous aggregates
 
 ## 1.4.1 (2019-08-01)
 

--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -2477,6 +2477,137 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 (11 rows)
 
 DEALLOCATE prep;
+-- test LIMIT pushdown
+-- no aggregates/window functions/SRF should pushdown limit
+:PREFIX SELECT FROM metrics_timestamptz ORDER BY time LIMIT 1;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
+         Order: metrics_timestamptz."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
+               Heap Fetches: 1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (never executed)
+               Heap Fetches: 0
+(13 rows)
+
+-- aggregates should prevent pushdown
+:PREFIX SELECT count(*) FROM metrics_timestamptz LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Append (actual rows=2235 loops=1)
+               ->  Seq Scan on _hyper_5_17_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_5_18_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_19_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_20_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_21_chunk (actual rows=387 loops=1)
+(8 rows)
+
+:PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Append (actual rows=3130 loops=1)
+               ->  Seq Scan on _hyper_6_22_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_23_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_24_chunk (actual rows=224 loops=1)
+               ->  Seq Scan on _hyper_6_25_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_26_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_27_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_6_28_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_29_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_30_chunk (actual rows=66 loops=1)
+(12 rows)
+
+-- HAVING should prevent pushdown
+:PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         Filter: (count(*) > 1)
+         ->  Append (actual rows=2235 loops=1)
+               ->  Seq Scan on _hyper_5_17_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_5_18_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_19_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_20_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_21_chunk (actual rows=387 loops=1)
+(9 rows)
+
+:PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         Filter: (count(*) > 1)
+         ->  Append (actual rows=3130 loops=1)
+               ->  Seq Scan on _hyper_6_22_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_23_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_24_chunk (actual rows=224 loops=1)
+               ->  Seq Scan on _hyper_6_25_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_26_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_27_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_6_28_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_29_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_30_chunk (actual rows=66 loops=1)
+(13 rows)
+
+-- DISTINCT should prevent pushdown
+:PREFIX SELECT DISTINCT device_id FROM metrics_timestamptz ORDER BY device_id LIMIT 3;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=1491 loops=1)
+               Sort Key: _hyper_5_17_chunk.device_id
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=225 loops=1)
+                     Heap Fetches: 225
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=337 loops=1)
+                     Heap Fetches: 337
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=337 loops=1)
+                     Heap Fetches: 337
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=337 loops=1)
+                     Heap Fetches: 337
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=259 loops=1)
+                     Heap Fetches: 259
+(14 rows)
+
+:PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=627 loops=1)
+               Sort Key: _hyper_6_22_chunk.device_id
+               ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=113 loops=1)
+                     Heap Fetches: 113
+               ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=113 loops=1)
+                     Heap Fetches: 113
+               ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
+                     Heap Fetches: 1
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=169 loops=1)
+                     Heap Fetches: 169
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=169 loops=1)
+                     Heap Fetches: 169
+               ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
+                     Heap Fetches: 1
+               ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=34 loops=1)
+                     Heap Fetches: 34
+               ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=34 loops=1)
+                     Heap Fetches: 34
+               ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
+                     Heap Fetches: 1
+(22 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -2394,7 +2394,8 @@ PREPARE prep AS SELECT time FROM (SELECT time FROM metrics_timestamptz WHERE tim
 (9 rows)
 
 DEALLOCATE prep;
--- test constraint exclusion for subqueries with mergeappend
+-- test constraint exclusion for subqueries with ConstraintAwareAppend
+SET timescaledb.enable_chunk_append TO false;
 PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY device_id, time) m;
 :PREFIX EXECUTE prep;
                                                                 QUERY PLAN                                                                 
@@ -2477,6 +2478,7 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 (11 rows)
 
 DEALLOCATE prep;
+RESET timescaledb.enable_chunk_append;
 -- test LIMIT pushdown
 -- no aggregates/window functions/SRF should pushdown limit
 :PREFIX SELECT FROM metrics_timestamptz ORDER BY time LIMIT 1;

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -2477,6 +2477,137 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 (11 rows)
 
 DEALLOCATE prep;
+-- test LIMIT pushdown
+-- no aggregates/window functions/SRF should pushdown limit
+:PREFIX SELECT FROM metrics_timestamptz ORDER BY time LIMIT 1;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz (actual rows=1 loops=1)
+         Order: metrics_timestamptz."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk (actual rows=1 loops=1)
+               Heap Fetches: 1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk (never executed)
+               Heap Fetches: 0
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk (never executed)
+               Heap Fetches: 0
+(13 rows)
+
+-- aggregates should prevent pushdown
+:PREFIX SELECT count(*) FROM metrics_timestamptz LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Append (actual rows=2235 loops=1)
+               ->  Seq Scan on _hyper_5_17_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_5_18_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_19_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_20_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_21_chunk (actual rows=387 loops=1)
+(8 rows)
+
+:PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Append (actual rows=3130 loops=1)
+               ->  Seq Scan on _hyper_6_22_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_23_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_24_chunk (actual rows=224 loops=1)
+               ->  Seq Scan on _hyper_6_25_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_26_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_27_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_6_28_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_29_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_30_chunk (actual rows=66 loops=1)
+(12 rows)
+
+-- HAVING should prevent pushdown
+:PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         Filter: (count(*) > 1)
+         ->  Append (actual rows=2235 loops=1)
+               ->  Seq Scan on _hyper_5_17_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_5_18_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_19_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_20_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_5_21_chunk (actual rows=387 loops=1)
+(9 rows)
+
+:PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Aggregate (actual rows=1 loops=1)
+         Filter: (count(*) > 1)
+         ->  Append (actual rows=3130 loops=1)
+               ->  Seq Scan on _hyper_6_22_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_23_chunk (actual rows=448 loops=1)
+               ->  Seq Scan on _hyper_6_24_chunk (actual rows=224 loops=1)
+               ->  Seq Scan on _hyper_6_25_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_26_chunk (actual rows=672 loops=1)
+               ->  Seq Scan on _hyper_6_27_chunk (actual rows=336 loops=1)
+               ->  Seq Scan on _hyper_6_28_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_29_chunk (actual rows=132 loops=1)
+               ->  Seq Scan on _hyper_6_30_chunk (actual rows=66 loops=1)
+(13 rows)
+
+-- DISTINCT should prevent pushdown
+:PREFIX SELECT DISTINCT device_id FROM metrics_timestamptz ORDER BY device_id LIMIT 3;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=1491 loops=1)
+               Sort Key: _hyper_5_17_chunk.device_id
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk (actual rows=225 loops=1)
+                     Heap Fetches: 225
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk (actual rows=337 loops=1)
+                     Heap Fetches: 337
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk (actual rows=337 loops=1)
+                     Heap Fetches: 337
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk (actual rows=337 loops=1)
+                     Heap Fetches: 337
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk (actual rows=259 loops=1)
+                     Heap Fetches: 259
+(14 rows)
+
+:PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=627 loops=1)
+               Sort Key: _hyper_6_22_chunk.device_id
+               ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk (actual rows=113 loops=1)
+                     Heap Fetches: 113
+               ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk (actual rows=113 loops=1)
+                     Heap Fetches: 113
+               ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk (actual rows=1 loops=1)
+                     Heap Fetches: 1
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk (actual rows=169 loops=1)
+                     Heap Fetches: 169
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk (actual rows=169 loops=1)
+                     Heap Fetches: 169
+               ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk (actual rows=1 loops=1)
+                     Heap Fetches: 1
+               ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk (actual rows=34 loops=1)
+                     Heap Fetches: 34
+               ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk (actual rows=34 loops=1)
+                     Heap Fetches: 34
+               ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk (actual rows=1 loops=1)
+                     Heap Fetches: 1
+(22 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -2394,7 +2394,8 @@ PREPARE prep AS SELECT time FROM (SELECT time FROM metrics_timestamptz WHERE tim
 (9 rows)
 
 DEALLOCATE prep;
--- test constraint exclusion for subqueries with mergeappend
+-- test constraint exclusion for subqueries with ConstraintAwareAppend
+SET timescaledb.enable_chunk_append TO false;
 PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY device_id, time) m;
 :PREFIX EXECUTE prep;
                                                                 QUERY PLAN                                                                 
@@ -2477,6 +2478,7 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 (11 rows)
 
 DEALLOCATE prep;
+RESET timescaledb.enable_chunk_append;
 -- test LIMIT pushdown
 -- no aggregates/window functions/SRF should pushdown limit
 :PREFIX SELECT FROM metrics_timestamptz ORDER BY time LIMIT 1;

--- a/test/expected/append-9.6.out
+++ b/test/expected/append-9.6.out
@@ -2003,7 +2003,8 @@ PREPARE prep AS SELECT time FROM (SELECT time FROM metrics_timestamptz WHERE tim
 (7 rows)
 
 DEALLOCATE prep;
--- test constraint exclusion for subqueries with mergeappend
+-- test constraint exclusion for subqueries with ConstraintAwareAppend
+SET timescaledb.enable_chunk_append TO false;
 PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY device_id, time) m;
 :PREFIX EXECUTE prep;
                                                    QUERY PLAN                                                    
@@ -2076,6 +2077,7 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 (9 rows)
 
 DEALLOCATE prep;
+RESET timescaledb.enable_chunk_append;
 -- test LIMIT pushdown
 -- no aggregates/window functions/SRF should pushdown limit
 :PREFIX SELECT FROM metrics_timestamptz ORDER BY time LIMIT 1;

--- a/test/expected/append-9.6.out
+++ b/test/expected/append-9.6.out
@@ -2076,6 +2076,118 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 (9 rows)
 
 DEALLOCATE prep;
+-- test LIMIT pushdown
+-- no aggregates/window functions/SRF should pushdown limit
+:PREFIX SELECT FROM metrics_timestamptz ORDER BY time LIMIT 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz
+         Order: metrics_timestamptz."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk
+(8 rows)
+
+-- aggregates should prevent pushdown
+:PREFIX SELECT count(*) FROM metrics_timestamptz LIMIT 1;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Limit
+   ->  Aggregate
+         ->  Append
+               ->  Seq Scan on _hyper_5_17_chunk
+               ->  Seq Scan on _hyper_5_18_chunk
+               ->  Seq Scan on _hyper_5_19_chunk
+               ->  Seq Scan on _hyper_5_20_chunk
+               ->  Seq Scan on _hyper_5_21_chunk
+(8 rows)
+
+:PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Limit
+   ->  Aggregate
+         ->  Append
+               ->  Seq Scan on _hyper_6_22_chunk
+               ->  Seq Scan on _hyper_6_23_chunk
+               ->  Seq Scan on _hyper_6_24_chunk
+               ->  Seq Scan on _hyper_6_25_chunk
+               ->  Seq Scan on _hyper_6_26_chunk
+               ->  Seq Scan on _hyper_6_27_chunk
+               ->  Seq Scan on _hyper_6_28_chunk
+               ->  Seq Scan on _hyper_6_29_chunk
+               ->  Seq Scan on _hyper_6_30_chunk
+(12 rows)
+
+-- HAVING should prevent pushdown
+:PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Limit
+   ->  Aggregate
+         Filter: (count(*) > 1)
+         ->  Append
+               ->  Seq Scan on _hyper_5_17_chunk
+               ->  Seq Scan on _hyper_5_18_chunk
+               ->  Seq Scan on _hyper_5_19_chunk
+               ->  Seq Scan on _hyper_5_20_chunk
+               ->  Seq Scan on _hyper_5_21_chunk
+(9 rows)
+
+:PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Limit
+   ->  Aggregate
+         Filter: (count(*) > 1)
+         ->  Append
+               ->  Seq Scan on _hyper_6_22_chunk
+               ->  Seq Scan on _hyper_6_23_chunk
+               ->  Seq Scan on _hyper_6_24_chunk
+               ->  Seq Scan on _hyper_6_25_chunk
+               ->  Seq Scan on _hyper_6_26_chunk
+               ->  Seq Scan on _hyper_6_27_chunk
+               ->  Seq Scan on _hyper_6_28_chunk
+               ->  Seq Scan on _hyper_6_29_chunk
+               ->  Seq Scan on _hyper_6_30_chunk
+(13 rows)
+
+-- DISTINCT should prevent pushdown
+:PREFIX SELECT DISTINCT device_id FROM metrics_timestamptz ORDER BY device_id LIMIT 3;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Merge Append
+               Sort Key: _hyper_5_17_chunk.device_id
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_17_chunk
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_18_chunk
+               ->  Index Only Scan using _hyper_5_19_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_19_chunk
+               ->  Index Only Scan using _hyper_5_20_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_20_chunk
+               ->  Index Only Scan using _hyper_5_21_chunk_metrics_timestamptz_device_id_time_idx on _hyper_5_21_chunk
+(9 rows)
+
+:PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Merge Append
+               Sort Key: _hyper_6_22_chunk.device_id
+               ->  Index Only Scan using _hyper_6_22_chunk_metrics_space_device_id_time_idx on _hyper_6_22_chunk
+               ->  Index Only Scan using _hyper_6_23_chunk_metrics_space_device_id_time_idx on _hyper_6_23_chunk
+               ->  Index Only Scan using _hyper_6_24_chunk_metrics_space_device_id_time_idx on _hyper_6_24_chunk
+               ->  Index Only Scan using _hyper_6_25_chunk_metrics_space_device_id_time_idx on _hyper_6_25_chunk
+               ->  Index Only Scan using _hyper_6_26_chunk_metrics_space_device_id_time_idx on _hyper_6_26_chunk
+               ->  Index Only Scan using _hyper_6_27_chunk_metrics_space_device_id_time_idx on _hyper_6_27_chunk
+               ->  Index Only Scan using _hyper_6_28_chunk_metrics_space_device_id_time_idx on _hyper_6_28_chunk
+               ->  Index Only Scan using _hyper_6_29_chunk_metrics_space_device_id_time_idx on _hyper_6_29_chunk
+               ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk
+(13 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/sql/include/append_query.sql
+++ b/test/sql/include/append_query.sql
@@ -326,7 +326,8 @@ PREPARE prep AS SELECT time FROM (SELECT time FROM metrics_timestamptz WHERE tim
 :PREFIX EXECUTE prep;
 DEALLOCATE prep;
 
--- test constraint exclusion for subqueries with mergeappend
+-- test constraint exclusion for subqueries with ConstraintAwareAppend
+SET timescaledb.enable_chunk_append TO false;
 PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics_timestamptz WHERE time < '2000-01-10'::text::timestamptz ORDER BY device_id, time) m;
 :PREFIX EXECUTE prep;
 :PREFIX EXECUTE prep;
@@ -334,6 +335,7 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 :PREFIX EXECUTE prep;
 :PREFIX EXECUTE prep;
 DEALLOCATE prep;
+RESET timescaledb.enable_chunk_append;
 
 -- test LIMIT pushdown
 -- no aggregates/window functions/SRF should pushdown limit

--- a/test/sql/include/append_query.sql
+++ b/test/sql/include/append_query.sql
@@ -335,3 +335,19 @@ PREPARE prep AS SELECT device_id, time FROM (SELECT device_id, time FROM metrics
 :PREFIX EXECUTE prep;
 DEALLOCATE prep;
 
+-- test LIMIT pushdown
+-- no aggregates/window functions/SRF should pushdown limit
+:PREFIX SELECT FROM metrics_timestamptz ORDER BY time LIMIT 1;
+
+-- aggregates should prevent pushdown
+:PREFIX SELECT count(*) FROM metrics_timestamptz LIMIT 1;
+:PREFIX SELECT count(*) FROM metrics_space LIMIT 1;
+
+-- HAVING should prevent pushdown
+:PREFIX SELECT 1 FROM metrics_timestamptz HAVING count(*) > 1 LIMIT 1;
+:PREFIX SELECT 1 FROM metrics_space HAVING count(*) > 1 LIMIT 1;
+
+-- DISTINCT should prevent pushdown
+:PREFIX SELECT DISTINCT device_id FROM metrics_timestamptz ORDER BY device_id LIMIT 3;
+:PREFIX SELECT DISTINCT device_id FROM metrics_space ORDER BY device_id LIMIT 3;
+


### PR DESCRIPTION
Do not push down limit to subplan when the query has operations
that modify the number of tuples returned.  Even if we know a
hard limit overall, it doesn't apply if the query has any
grouping/aggregation operations, or SRFs in the tlist.