### PR TITLE
Prevent LIMIT pushdown in JOINs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 1.5.0 (unreleased)
+
+**Bugfixes**
+* #1444 Prevent LIMIT pushdown in JOINs
+
 ## 1.4.2 (2019-09-11)
 
 This maintenance release contains bugfixes since the 1.4.1 release. We deem it medium

--- a/src/chunk_append/chunk_append.h
+++ b/src/chunk_append/chunk_append.h
@@ -18,6 +18,7 @@ typedef struct ChunkAppendPath
 	bool startup_exclusion;
 	bool runtime_exclusion;
 	bool pushdown_limit;
+	int limit_tuples;
 } ChunkAppendPath;
 
 extern Path *ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht,

--- a/src/chunk_append/planner.c
+++ b/src/chunk_append/planner.c
@@ -257,8 +257,8 @@ chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path, L
 		Assert(list_length(chunk_ri_clauses) == list_length(chunk_rt_indexes));
 	}
 
-	if (capath->pushdown_limit && root->limit_tuples > 0 && root->limit_tuples <= PG_UINT32_MAX)
-		limit = root->limit_tuples;
+	if (capath->pushdown_limit && capath->limit_tuples > 0)
+		limit = capath->limit_tuples;
 
 	custom_private = list_make1(
 		list_make3_oid((Oid) capath->startup_exclusion, (Oid) capath->runtime_exclusion, limit));

--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -2610,6 +2610,63 @@ RESET timescaledb.enable_chunk_append;
                      Heap Fetches: 1
 (22 rows)
 
+-- JOINs should prevent pushdown
+-- when LIMIT gets pushed to a Sort node it will switch to top-N heapsort
+-- if more tuples then LIMIT are requested this will trigger an error
+-- to trigger this we need a Sort node that is below ChunkAppend
+CREATE TABLE join_limit (time timestamptz, device_id int);
+SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
+psql:include/append_query.sql:361: NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ join_limit
+(1 row)
+
+CREATE INDEX ON join_limit(time,device_id);
+INSERT INTO join_limit SELECT time, device_id FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time), generate_series(1,10,1) g2(device_id);
+-- get 2nd chunk oid
+SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
+\gset
+--get index name for 2nd chunk
+SELECT indexrelid::regclass AS "INDEX_NAME" FROM pg_index WHERE indrelid = :CHUNK_OID
+\gset
+DROP INDEX :INDEX_NAME;
+:PREFIX SELECT * FROM metrics_timestamptz m1 INNER JOIN join_limit m2 ON m1.time = m2.time AND m1.device_id=m2.device_id WHERE m1.time > '2000-01-07' ORDER BY m1.time, m1.device_id LIMIT 3;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Merge Join (actual rows=3 loops=1)
+         Merge Cond: (m2."time" = m1."time")
+         Join Filter: (m1.device_id = m2.device_id)
+         Rows Removed by Join Filter: 6
+         ->  Custom Scan (ChunkAppend) on join_limit m2 (actual rows=13 loops=1)
+               Order: m2."time", m2.device_id
+               ->  Sort (actual rows=13 loops=1)
+                     Sort Key: m2_1."time", m2_1.device_id
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_7_32_chunk m2_1 (actual rows=2710 loops=1)
+                           Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 650
+               ->  Index Only Scan using _hyper_7_33_chunk_join_limit_time_device_id_idx on _hyper_7_33_chunk m2_2 (never executed)
+                     Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_7_34_chunk_join_limit_time_device_id_idx on _hyper_7_34_chunk m2_3 (never executed)
+                     Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     Heap Fetches: 0
+         ->  Materialize (actual rows=9 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=4 loops=1)
+                     Order: m1."time"
+                     ->  Index Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_1 (actual rows=4 loops=1)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_2 (never executed)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_3 (never executed)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_4 (never executed)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(30 rows)
+
+DROP TABLE join_limit;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -2610,6 +2610,63 @@ RESET timescaledb.enable_chunk_append;
                      Heap Fetches: 1
 (22 rows)
 
+-- JOINs should prevent pushdown
+-- when LIMIT gets pushed to a Sort node it will switch to top-N heapsort
+-- if more tuples then LIMIT are requested this will trigger an error
+-- to trigger this we need a Sort node that is below ChunkAppend
+CREATE TABLE join_limit (time timestamptz, device_id int);
+SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
+psql:include/append_query.sql:361: NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ join_limit
+(1 row)
+
+CREATE INDEX ON join_limit(time,device_id);
+INSERT INTO join_limit SELECT time, device_id FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time), generate_series(1,10,1) g2(device_id);
+-- get 2nd chunk oid
+SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
+\gset
+--get index name for 2nd chunk
+SELECT indexrelid::regclass AS "INDEX_NAME" FROM pg_index WHERE indrelid = :CHUNK_OID
+\gset
+DROP INDEX :INDEX_NAME;
+:PREFIX SELECT * FROM metrics_timestamptz m1 INNER JOIN join_limit m2 ON m1.time = m2.time AND m1.device_id=m2.device_id WHERE m1.time > '2000-01-07' ORDER BY m1.time, m1.device_id LIMIT 3;
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Merge Join (actual rows=3 loops=1)
+         Merge Cond: (m2."time" = m1."time")
+         Join Filter: (m1.device_id = m2.device_id)
+         Rows Removed by Join Filter: 6
+         ->  Custom Scan (ChunkAppend) on join_limit m2 (actual rows=13 loops=1)
+               Order: m2."time", m2.device_id
+               ->  Sort (actual rows=13 loops=1)
+                     Sort Key: m2_1."time", m2_1.device_id
+                     Sort Method: quicksort 
+                     ->  Seq Scan on _hyper_7_32_chunk m2_1 (actual rows=2710 loops=1)
+                           Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 650
+               ->  Index Only Scan using _hyper_7_33_chunk_join_limit_time_device_id_idx on _hyper_7_33_chunk m2_2 (never executed)
+                     Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     Heap Fetches: 0
+               ->  Index Only Scan using _hyper_7_34_chunk_join_limit_time_device_id_idx on _hyper_7_34_chunk m2_3 (never executed)
+                     Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     Heap Fetches: 0
+         ->  Materialize (actual rows=9 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=4 loops=1)
+                     Order: m1."time"
+                     ->  Index Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_1 (actual rows=4 loops=1)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_2 (never executed)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_3 (never executed)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_4 (never executed)
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(30 rows)
+
+DROP TABLE join_limit;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-9.6.out
+++ b/test/expected/append-9.6.out
@@ -2190,6 +2190,58 @@ RESET timescaledb.enable_chunk_append;
                ->  Index Only Scan using _hyper_6_30_chunk_metrics_space_device_id_time_idx on _hyper_6_30_chunk
 (13 rows)
 
+-- JOINs should prevent pushdown
+-- when LIMIT gets pushed to a Sort node it will switch to top-N heapsort
+-- if more tuples then LIMIT are requested this will trigger an error
+-- to trigger this we need a Sort node that is below ChunkAppend
+CREATE TABLE join_limit (time timestamptz, device_id int);
+SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
+psql:include/append_query.sql:361: NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ join_limit
+(1 row)
+
+CREATE INDEX ON join_limit(time,device_id);
+INSERT INTO join_limit SELECT time, device_id FROM generate_series('2000-01-01'::timestamptz,'2000-01-21','30m') g1(time), generate_series(1,10,1) g2(device_id);
+-- get 2nd chunk oid
+SELECT tableoid AS "CHUNK_OID" FROM join_limit WHERE time > '2000-01-07' ORDER BY time LIMIT 1
+\gset
+--get index name for 2nd chunk
+SELECT indexrelid::regclass AS "INDEX_NAME" FROM pg_index WHERE indrelid = :CHUNK_OID
+\gset
+DROP INDEX :INDEX_NAME;
+:PREFIX SELECT * FROM metrics_timestamptz m1 INNER JOIN join_limit m2 ON m1.time = m2.time AND m1.device_id=m2.device_id WHERE m1.time > '2000-01-07' ORDER BY m1.time, m1.device_id LIMIT 3;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Merge Join
+         Merge Cond: (m2."time" = m1."time")
+         Join Filter: (m1.device_id = m2.device_id)
+         ->  Custom Scan (ChunkAppend) on join_limit m2
+               Order: m2."time", m2.device_id
+               ->  Sort
+                     Sort Key: m2_1."time", m2_1.device_id
+                     ->  Seq Scan on _hyper_7_32_chunk m2_1
+                           Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Only Scan using _hyper_7_33_chunk_join_limit_time_device_id_idx on _hyper_7_33_chunk m2_2
+                     Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Index Only Scan using _hyper_7_34_chunk_join_limit_time_device_id_idx on _hyper_7_34_chunk m2_3
+                     Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Materialize
+               ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
+                     Order: m1."time"
+                     ->  Index Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_1
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_2
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_3
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+                     ->  Index Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_4
+                           Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
+(25 rows)
+
+DROP TABLE join_limit;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results


### PR DESCRIPTION
Pushing down limit in ChunkApppend is not safe in the JOIN case
because the decision about required tuples can happen above
ChunkAppend node. This patch disables LIMIT pushdown for all
JOINs.