### PR TITLE
Fix runtime exclusion memory leak

### DIFF
--- a/src/chunk_append/exec.h
+++ b/src/chunk_append/exec.h
@@ -20,6 +20,9 @@ typedef struct ChunkAppendState
 {
 	CustomScanState csstate;
 	PlanState **subplanstates;
+
+	MemoryContext exclusion_ctx;
+
 	int num_subplans;
 	int current;
 

--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -1682,7 +1682,7 @@ ORDER BY time DESC, device_id;
    Hash Cond: (g."time" = m."time")
    ->  Function Scan on generate_series g (actual rows=32 loops=1)
    ->  Hash (actual rows=26787 loops=1)
-         Buckets: 32768  Batches: 1  Memory Usage: 1303kB
+         Buckets: 32768  Batches: 1 
          ->  Append (actual rows=26787 loops=1)
                ->  Seq Scan on _hyper_5_17_chunk m (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_5_18_chunk m_1 (actual rows=6048 loops=1)

--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -1595,6 +1595,35 @@ ORDER BY time DESC, device_id;
                      Heap Fetches: 4611
 (31 rows)
 
+-- test runtime exclusion and startup exclusions
+:PREFIX SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time AND m2.time < '2000-01-10'::text::timestamptz LIMIT 1) m2 ON true ORDER BY m1.time;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=26787 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
+               Heap Fetches: 4032
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
+               Heap Fetches: 6048
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
+               Heap Fetches: 6048
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
+               Heap Fetches: 6048
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
+               Heap Fetches: 4611
+   ->  Limit (actual rows=0 loops=26787)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
+               Chunks excluded during startup: 3
+               Chunks excluded during runtime: 1
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
+                     Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
+                     Heap Fetches: 4032
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
+                     Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
+                     Heap Fetches: 3744
+(23 rows)
+
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
 -- should not use runtime exclusion
 :PREFIX SELECT * FROM append_test a LEFT JOIN LATERAL(SELECT * FROM join_test j WHERE a.colorid = j.colorid ORDER BY time DESC LIMIT 1) j ON true ORDER BY a.time LIMIT 1;
@@ -2621,7 +2650,7 @@ RESET enable_hashagg;
 -- to trigger this we need a Sort node that is below ChunkAppend
 CREATE TABLE join_limit (time timestamptz, device_id int);
 SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
-psql:include/append_query.sql:363: NOTICE:  adding not-null constraint to column "time"
+psql:include/append_query.sql:366: NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  join_limit

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -1682,7 +1682,7 @@ ORDER BY time DESC, device_id;
    Hash Cond: (g."time" = m."time")
    ->  Function Scan on generate_series g (actual rows=32 loops=1)
    ->  Hash (actual rows=26787 loops=1)
-         Buckets: 32768  Batches: 1  Memory Usage: 1303kB
+         Buckets: 32768  Batches: 1 
          ->  Append (actual rows=26787 loops=1)
                ->  Seq Scan on _hyper_5_17_chunk m (actual rows=4032 loops=1)
                ->  Seq Scan on _hyper_5_18_chunk m_1 (actual rows=6048 loops=1)

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -1595,6 +1595,35 @@ ORDER BY time DESC, device_id;
                      Heap Fetches: 4611
 (31 rows)
 
+-- test runtime exclusion and startup exclusions
+:PREFIX SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time AND m2.time < '2000-01-10'::text::timestamptz LIMIT 1) m2 ON true ORDER BY m1.time;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join (actual rows=26787 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1 (actual rows=26787 loops=1)
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1 (actual rows=4032 loops=1)
+               Heap Fetches: 4032
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2 (actual rows=6048 loops=1)
+               Heap Fetches: 6048
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3 (actual rows=6048 loops=1)
+               Heap Fetches: 6048
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4 (actual rows=6048 loops=1)
+               Heap Fetches: 6048
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5 (actual rows=4611 loops=1)
+               Heap Fetches: 4611
+   ->  Limit (actual rows=0 loops=26787)
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2 (actual rows=0 loops=26787)
+               Chunks excluded during startup: 3
+               Chunks excluded during runtime: 1
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1 (actual rows=1 loops=4032)
+                     Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
+                     Heap Fetches: 4032
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2 (actual rows=1 loops=6048)
+                     Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
+                     Heap Fetches: 3744
+(23 rows)
+
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
 -- should not use runtime exclusion
 :PREFIX SELECT * FROM append_test a LEFT JOIN LATERAL(SELECT * FROM join_test j WHERE a.colorid = j.colorid ORDER BY time DESC LIMIT 1) j ON true ORDER BY a.time LIMIT 1;
@@ -2621,7 +2650,7 @@ RESET enable_hashagg;
 -- to trigger this we need a Sort node that is below ChunkAppend
 CREATE TABLE join_limit (time timestamptz, device_id int);
 SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
-psql:include/append_query.sql:363: NOTICE:  adding not-null constraint to column "time"
+psql:include/append_query.sql:366: NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  join_limit

--- a/test/expected/append-9.6.out
+++ b/test/expected/append-9.6.out
@@ -1372,6 +1372,27 @@ ORDER BY time DESC, device_id;
                      Index Cond: ("time" = m1."time")
 (20 rows)
 
+-- test runtime exclusion and startup exclusions
+:PREFIX SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time AND m2.time < '2000-01-10'::text::timestamptz LIMIT 1) m2 ON true ORDER BY m1.time;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Nested Loop Left Join
+   ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
+         Order: m1."time"
+         ->  Index Only Scan Backward using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m1_1
+         ->  Index Only Scan Backward using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m1_2
+         ->  Index Only Scan Backward using _hyper_5_19_chunk_metrics_timestamptz_time_idx on _hyper_5_19_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_5_20_chunk_metrics_timestamptz_time_idx on _hyper_5_20_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_5_21_chunk_metrics_timestamptz_time_idx on _hyper_5_21_chunk m1_5
+   ->  Limit
+         ->  Custom Scan (ChunkAppend) on metrics_timestamptz m2
+               Chunks excluded during startup: 3
+               ->  Index Only Scan using _hyper_5_17_chunk_metrics_timestamptz_time_idx on _hyper_5_17_chunk m2_1
+                     Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
+               ->  Index Only Scan using _hyper_5_18_chunk_metrics_timestamptz_time_idx on _hyper_5_18_chunk m2_2
+                     Index Cond: (("time" < ('2000-01-10'::cstring)::timestamp with time zone) AND ("time" = m1."time"))
+(15 rows)
+
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
 -- should not use runtime exclusion
 :PREFIX SELECT * FROM append_test a LEFT JOIN LATERAL(SELECT * FROM join_test j WHERE a.colorid = j.colorid ORDER BY time DESC LIMIT 1) j ON true ORDER BY a.time LIMIT 1;
@@ -2200,7 +2221,7 @@ RESET enable_hashagg;
 -- to trigger this we need a Sort node that is below ChunkAppend
 CREATE TABLE join_limit (time timestamptz, device_id int);
 SELECT table_name FROM create_hypertable('join_limit','time',create_default_indexes:=false);
-psql:include/append_query.sql:363: NOTICE:  adding not-null constraint to column "time"
+psql:include/append_query.sql:366: NOTICE:  adding not-null constraint to column "time"
  table_name 
 ------------
  join_limit

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -76,4 +76,4 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
-     $@ -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' -e 's! Memory: [0-9]\{1,\}kB!!'
+     $@ -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' -e 's! Memory: [0-9]\{1,\}kB!!' -e 's! Memory Usage: [0-9]\{1,\}kB!!'

--- a/test/sql/include/append_query.sql
+++ b/test/sql/include/append_query.sql
@@ -253,6 +253,9 @@ ORDER BY time DESC, device_id;
 -- test runtime exclusion with LATERAL and 2 hypertables
 :PREFIX SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time LIMIT 1) m2 ON true ORDER BY m1.time;
 
+-- test runtime exclusion and startup exclusions
+:PREFIX SELECT m1.time, m2.time FROM metrics_timestamptz m1 LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m2 WHERE m1.time = m2.time AND m2.time < '2000-01-10'::text::timestamptz LIMIT 1) m2 ON true ORDER BY m1.time;
+
 -- test runtime exclusion does not activate for constraints on non-partitioning columns
 -- should not use runtime exclusion
 :PREFIX SELECT * FROM append_test a LEFT JOIN LATERAL(SELECT * FROM join_test j WHERE a.colorid = j.colorid ORDER BY time DESC LIMIT 1) j ON true ORDER BY a.time LIMIT 1;


### PR DESCRIPTION
The intermediate expressions used for runtime exclusions would
only be freed at the end of a query leading to excessive memory
usage for nested loop joins with many loops. This patch changes
runtime exclusion to free intermediate expressions as soon as
they are no longer needed.

Fixes #1442