### PR TITLE
Fix postgres version reported by telemetry

### DIFF
--- a/src/plan_agg_bookend.c
+++ b/src/plan_agg_bookend.c
@@ -48,6 +48,7 @@
 #include "optimizer/tlist.h"
 #include "parser/parsetree.h"
 #include "parser/parse_clause.h"
+#include "parser/parse_func.h"
 #include "rewrite/rewriteManip.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
@@ -149,7 +150,8 @@ static struct FuncStrategy last_func_strategy = { .func_oid = InvalidOid,
 static FuncStrategy *
 initialize_func_strategy(FuncStrategy *func_strategy, char *name, int nargs, Oid arg_types[])
 {
-	func_strategy->func_oid = get_function_oid(name, ts_extension_schema_name(), nargs, arg_types);
+	List *l = list_make2(makeString(ts_extension_schema_name()), makeString(name));
+	func_strategy->func_oid = LookupFuncName(l, nargs, arg_types, false);
 	return func_strategy;
 }
 

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -4,29 +4,30 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <parser/parsetree.h>
-#include <optimizer/clauses.h>
-#include <optimizer/var.h>
-#include <optimizer/restrictinfo.h>
-#include <nodes/plannodes.h>
-#include <optimizer/prep.h>
-#include <nodes/nodeFuncs.h>
-#include <nodes/makefuncs.h>
-#include <utils/date.h>
-
 #include <catalog/pg_constraint.h>
 #include <catalog/pg_inherits.h>
 #include <catalog/pg_namespace.h>
+#include <catalog/pg_type.h>
+#include <nodes/makefuncs.h>
+#include <nodes/nodeFuncs.h>
+#include <nodes/plannodes.h>
+#include <optimizer/clauses.h>
+#include <optimizer/pathnode.h>
+#include <optimizer/prep.h>
+#include <optimizer/restrictinfo.h>
+#include <optimizer/tlist.h>
+#include <optimizer/var.h>
+#include <parser/parse_func.h>
+#include <parser/parsetree.h>
+#include <utils/date.h>
+#include <utils/errcodes.h>
+#include <utils/syscache.h>
+
 #include "compat.h"
 #if PG11_LT /* PG11 consolidates pg_foo_fn.h -> pg_foo.h */
 #include <catalog/pg_constraint_fn.h>
 #include <catalog/pg_inherits_fn.h>
 #endif
-#include <optimizer/pathnode.h>
-#include <optimizer/tlist.h>
-#include <catalog/pg_type.h>
-#include <utils/errcodes.h>
-#include <utils/syscache.h>
 #if PG11_GE
 #include <partitioning/partbounds.h>
 #include <optimizer/cost.h>
@@ -65,10 +66,11 @@ static void
 init_chunk_exclusion_func()
 {
 	if (chunk_exclusion_func == InvalidOid)
-		chunk_exclusion_func = get_function_oid(CHUNK_EXCL_FUNC_NAME,
-												INTERNAL_SCHEMA_NAME,
-												lengthof(ts_chunks_arg_types),
-												ts_chunks_arg_types);
+	{
+		List *l = list_make2(makeString(INTERNAL_SCHEMA_NAME), makeString(CHUNK_EXCL_FUNC_NAME));
+		chunk_exclusion_func =
+			LookupFuncName(l, lengthof(ts_chunks_arg_types), ts_chunks_arg_types, false);
+	}
 	Assert(chunk_exclusion_func != InvalidOid);
 }
 

--- a/src/plan_partialize.c
+++ b/src/plan_partialize.c
@@ -7,7 +7,9 @@
 #include <catalog/pg_type.h>
 #include <nodes/nodeFuncs.h>
 #include <optimizer/planner.h>
+#include <parser/parse_func.h>
 #include <utils/lsyscache.h>
+
 #include "plan_partialize.h"
 #include "extension_constants.h"
 #include "utils.h"
@@ -81,11 +83,12 @@ plan_process_partialize_agg(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo
 	PartializeWalkerState state = { .found_partialize = false,
 									.looking_for_agg = false,
 									.fnoid = InvalidOid };
+	List *name = list_make2(makeString(INTERNAL_SCHEMA_NAME), makeString(TS_PARTIALFN));
 	ListCell *lc;
 
 	if (CMD_SELECT != parse->commandType)
 		return;
-	partialfnoid = get_function_oid(TS_PARTIALFN, INTERNAL_SCHEMA_NAME, lengthof(argtyp), argtyp);
+	partialfnoid = LookupFuncName(name, lengthof(argtyp), argtyp, false);
 	Assert(partialfnoid != InvalidOid);
 
 	state.fnoid = partialfnoid;

--- a/src/utils.c
+++ b/src/utils.c
@@ -483,41 +483,6 @@ ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_si
 	return struct_ptr;
 }
 
-bool
-ts_function_types_equal(Oid left[], Oid right[], int nargs)
-{
-	int arg_index;
-
-	for (arg_index = 0; arg_index < nargs; arg_index++)
-	{
-		if (left[arg_index] != right[arg_index])
-			return false;
-	}
-	return true;
-}
-
-Oid
-get_function_oid(char *name, char *schema_name, int nargs, Oid arg_types[])
-{
-	FuncCandidateList func_candidates;
-
-	func_candidates = FuncnameGetCandidates(list_make2(makeString(schema_name), makeString(name)),
-											nargs,
-											NIL,
-											false,
-											false,
-											false);
-	while (func_candidates != NULL)
-	{
-		if (func_candidates->nargs == nargs &&
-			ts_function_types_equal(func_candidates->args, arg_types, nargs))
-			return func_candidates->oid;
-		func_candidates = func_candidates->next;
-	}
-	elog(ERROR, "failed to find function %s in schema %s with %d args", name, schema_name, nargs);
-	pg_unreachable();
-}
-
 /*
  * Find a partitioning function with a given schema and name.
  *

--- a/src/utils.h
+++ b/src/utils.h
@@ -68,10 +68,6 @@ extern int64 ts_get_interval_period_approx(Interval *interval);
 
 extern Oid ts_inheritance_parent_relid(Oid relid);
 
-extern bool ts_function_types_equal(Oid left[], Oid right[], int nargs);
-
-extern Oid get_function_oid(char *name, char *schema_name, int nargs, Oid arg_types[]);
-
 extern TSDLLEXPORT regproc lookup_proc_filtered(const char *schema, const char *funcname,
 												Oid *rettype, proc_filter filter, void *filter_arg);
 extern Oid get_operator(const char *name, Oid namespace, Oid left, Oid right);


### PR DESCRIPTION
Telemetry would send the postgres version the extension was compiled
against as postgres_version instead of the postgres version that is
currently running. This patch fixes telemetry to send the version
actually in use.