### PR TITLE
Enable multiple worker per child for ChunkAppend

### DIFF
--- a/src/chunk_append/exec.h
+++ b/src/chunk_append/exec.h
@@ -14,6 +14,8 @@
 typedef struct ParallelChunkAppendState
 {
 	int last_plan;
+	int workers_last_plan;
+	int workers_per_child;
 } ParallelChunkAppendState;
 
 typedef struct ChunkAppendState

--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -290,9 +290,9 @@ SET max_parallel_workers_per_gather TO 2;
                      One-Time Filter: (length(version()) > 0)
                      ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=166667 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=500000 loops=1)
+                           ->  Result (actual rows=250000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
                                        Filter: (i >= 500000)
 (13 rows)
 

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -288,9 +288,9 @@ SET max_parallel_workers_per_gather TO 2;
                      One-Time Filter: (length(version()) > 0)
                      ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=166667 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=500000 loops=1)
+                           ->  Result (actual rows=250000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
                                        Filter: (i >= 500000)
 (13 rows)
 


### PR DESCRIPTION
This patch changes ChunkAppend to assign multiple worker per child
if the number of worker exceeds the number of children.