### PR TITLE
Improve ChunkAppend parallel worker assignment

### DIFF
--- a/src/chunk_append/exec.h
+++ b/src/chunk_append/exec.h
@@ -13,9 +13,8 @@
 
 typedef struct ParallelChunkAppendState
 {
-	int last_plan;
-	int workers_last_plan;
-	int workers_per_child;
+	int next_plan;
+	bool finished[FLEXIBLE_ARRAY_MEMBER];
 } ParallelChunkAppendState;
 
 typedef struct ChunkAppendState

--- a/src/planner.c
+++ b/src/planner.c
@@ -216,6 +216,14 @@ should_chunk_append(PlannerInfo *root, RelOptInfo *rel, Path *path, bool ordered
 			{
 				ListCell *lc;
 
+#if PG11_GE
+				AppendPath *append = castNode(AppendPath, path);
+
+				/* ChunkAppend doesnt support mixing partial and non-partial paths */
+				if (append->path.parallel_aware && append->first_partial_path > 0)
+					return false;
+#endif
+
 				foreach (lc, rel->baserestrictinfo)
 				{
 					RestrictInfo *rinfo = (RestrictInfo *) lfirst(lc);

--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -8,7 +8,8 @@ SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
     THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
     ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
+  END AS "PREFIX",
+  'EXPLAIN (costs off)' AS "PREFIX_NO_ANALYZE"
 \gset
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
@@ -83,36 +84,35 @@ LIMIT 5;
 (13 rows)
 
 -- test single copy parallel plan with parallel chunk append
-:PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- output with analyze is not stable because it depends on worker assignment
+:PREFIX_NO_ANALYZE SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 WHERE length(version()) > 0
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=5 loops=1)
-   ->  Sort (actual rows=5 loops=1)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
          Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
-         Sort Method: top-N heapsort 
-         ->  Finalize HashAggregate (actual rows=1000 loops=1)
+         ->  Finalize HashAggregate
                Group Key: (time_bucket('@ 1 sec'::interval, test.ts))
-               ->  Gather (actual rows=1000 loops=1)
+               ->  Gather
                      Workers Planned: 2
-                     Workers Launched: 2
-                     ->  Partial HashAggregate (actual rows=333 loops=3)
+                     ->  Partial HashAggregate
                            Group Key: time_bucket('@ 1 sec'::interval, test.ts)
-                           ->  Result (actual rows=333333 loops=3)
+                           ->  Result
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=333333 loops=3)
+                                 ->  Parallel Custom Scan (ChunkAppend) on test
                                        Chunks excluded during startup: 0
-                                       ->  Result (actual rows=500000 loops=1)
+                                       ->  Result
                                              One-Time Filter: (length(version()) > 0)
-                                             ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-                                       ->  Result (actual rows=500000 loops=1)
+                                             ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       ->  Result
                                              One-Time Filter: (length(version()) > 0)
-                                             ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
-(21 rows)
+                                             ->  Parallel Seq Scan on _hyper_1_2_chunk
+(19 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
@@ -221,31 +221,67 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
 (14 rows)
 
--- test ChunkAppend with parallel aggregation
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+-- test worker assignment
+-- first chunk should have 1 worker and second chunk should have 2
+SET max_parallel_workers_per_gather TO 2;
+:PREFIX SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=333333 loops=3)
+               ->  Result (actual rows=200000 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=333333 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=500000 loops=1)
+                           ->  Result (actual rows=100000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-                           ->  Result (actual rows=500000 loops=1)
+                                 ->  Parallel Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=100000 loops=1)
+                                       Index Cond: (i >= 400000)
+                                       Heap Fetches: 0
+                           ->  Result (actual rows=250000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
-(15 rows)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+                                       Filter: (i >= 400000)
+(18 rows)
 
-SELECT count(*) FROM "test" WHERE length(version()) > 0;
-  count  
----------
- 1000000
+SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
+ count  
+--------
+ 600000
+(1 row)
+
+-- test worker assignment
+-- first chunk should have 2 worker and second chunk should have 1
+:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
+         Workers Planned: 2
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Result (actual rows=200000 loops=3)
+                     One-Time Filter: (length(version()) > 0)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
+                           Chunks excluded during startup: 0
+                           ->  Result (actual rows=250000 loops=2)
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
+                                       Filter: (i < 600000)
+                           ->  Result (actual rows=100000 loops=1)
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=100000 loops=1)
+                                       Index Cond: (i < 600000)
+                                       Heap Fetches: 0
+(18 rows)
+
+SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
+ count  
+--------
+ 600000
 (1 row)
 
 -- test ChunkAppend with # workers < # childs

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -8,7 +8,8 @@ SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
     THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
     ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
+  END AS "PREFIX",
+  'EXPLAIN (costs off)' AS "PREFIX_NO_ANALYZE"
 \gset
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
@@ -82,35 +83,34 @@ LIMIT 5;
 (12 rows)
 
 -- test single copy parallel plan with parallel chunk append
-:PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- output with analyze is not stable because it depends on worker assignment
+:PREFIX_NO_ANALYZE SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 WHERE length(version()) > 0
 GROUP BY sec
 ORDER BY sec
 LIMIT 5;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Gather (actual rows=5 loops=1)
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather
    Workers Planned: 1
-   Workers Launched: 1
    Single Copy: true
-   ->  Limit (actual rows=5 loops=1)
-         ->  Sort (actual rows=5 loops=1)
+   ->  Limit
+         ->  Sort
                Sort Key: (time_bucket('@ 1 sec'::interval, test.ts))
-               Worker 0:  Sort Method: top-N heapsort 
-               ->  HashAggregate (actual rows=1000 loops=1)
+               ->  HashAggregate
                      Group Key: time_bucket('@ 1 sec'::interval, test.ts)
-                     ->  Result (actual rows=1000000 loops=1)
+                     ->  Result
                            One-Time Filter: (length(version()) > 0)
-                           ->  Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+                           ->  Custom Scan (ChunkAppend) on test
                                  Chunks excluded during startup: 0
-                                 ->  Result (actual rows=500000 loops=1)
+                                 ->  Result
                                        One-Time Filter: (length(version()) > 0)
-                                       ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-                                 ->  Result (actual rows=500000 loops=1)
+                                       ->  Seq Scan on _hyper_1_1_chunk
+                                 ->  Result
                                        One-Time Filter: (length(version()) > 0)
-                                       ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
-(20 rows)
+                                       ->  Seq Scan on _hyper_1_2_chunk
+(18 rows)
 
 SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
@@ -219,31 +219,67 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
                      ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
 (14 rows)
 
--- test ChunkAppend with parallel aggregation
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+-- test worker assignment
+-- first chunk should have 1 worker and second chunk should have 2
+SET max_parallel_workers_per_gather TO 2;
+:PREFIX SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=333333 loops=3)
+               ->  Result (actual rows=200000 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=333333 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=500000 loops=1)
+                           ->  Result (actual rows=100000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-                           ->  Result (actual rows=500000 loops=1)
+                                 ->  Parallel Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=100000 loops=1)
+                                       Index Cond: (i >= 400000)
+                                       Heap Fetches: 100000
+                           ->  Result (actual rows=250000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
-(15 rows)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+                                       Filter: (i >= 400000)
+(18 rows)
 
-SELECT count(*) FROM "test" WHERE length(version()) > 0;
-  count  
----------
- 1000000
+SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
+ count  
+--------
+ 600000
+(1 row)
+
+-- test worker assignment
+-- first chunk should have 2 worker and second chunk should have 1
+:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
+         Workers Planned: 2
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Result (actual rows=200000 loops=3)
+                     One-Time Filter: (length(version()) > 0)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
+                           Chunks excluded during startup: 0
+                           ->  Result (actual rows=100000 loops=1)
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=100000 loops=1)
+                                       Index Cond: (i < 600000)
+                                       Heap Fetches: 100000
+                           ->  Result (actual rows=250000 loops=2)
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
+                                       Filter: (i < 600000)
+(18 rows)
+
+SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
+ count  
+--------
+ 600000
 (1 row)
 
 -- test ChunkAppend with # workers < # childs

--- a/test/expected/parallel-9.6.out
+++ b/test/expected/parallel-9.6.out
@@ -8,7 +8,8 @@ SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
     THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
     ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
+  END AS "PREFIX",
+  'EXPLAIN (costs off)' AS "PREFIX_NO_ANALYZE"
 \gset
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
@@ -83,7 +84,8 @@ LIMIT 5;
 (13 rows)
 
 -- test single copy parallel plan with parallel chunk append
-:PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- output with analyze is not stable because it depends on worker assignment
+:PREFIX_NO_ANALYZE SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 WHERE length(version()) > 0
 GROUP BY sec
@@ -218,8 +220,10 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
                      ->  Seq Scan on _hyper_1_2_chunk
 (13 rows)
 
--- test ChunkAppend with parallel aggregation
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
+-- test worker assignment
+-- first chunk should have 1 worker and second chunk should have 2
+SET max_parallel_workers_per_gather TO 2;
+:PREFIX SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Finalize Aggregate
@@ -233,15 +237,46 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
                            ->  Result
                                  One-Time Filter: (length(version()) > 0)
                                  ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       Filter: (i >= 400000)
                            ->  Result
                                  One-Time Filter: (length(version()) > 0)
                                  ->  Parallel Seq Scan on _hyper_1_2_chunk
-(14 rows)
+                                       Filter: (i >= 400000)
+(16 rows)
 
-SELECT count(*) FROM "test" WHERE length(version()) > 0;
-  count  
----------
- 1000000
+SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
+ count  
+--------
+ 600000
+(1 row)
+
+-- test worker assignment
+-- first chunk should have 2 worker and second chunk should have 1
+:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Result
+                     One-Time Filter: (length(version()) > 0)
+                     ->  Parallel Custom Scan (ChunkAppend) on test
+                           Chunks excluded during startup: 0
+                           ->  Result
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk
+                                       Filter: (i < 600000)
+                           ->  Result
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk
+                                       Filter: (i < 600000)
+(16 rows)
+
+SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
+ count  
+--------
+ 600000
 (1 row)
 
 -- test ChunkAppend with # workers < # childs

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -10,7 +10,8 @@ SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
     THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
     ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
+  END AS "PREFIX",
+  'EXPLAIN (costs off)' AS "PREFIX_NO_ANALYZE"
 \gset
 
 CREATE TABLE test (i int, j double precision, ts timestamp);
@@ -37,7 +38,8 @@ ORDER BY sec
 LIMIT 5;
 
 -- test single copy parallel plan with parallel chunk append
-:PREFIX SELECT time_bucket('1 second', ts) sec, last(i, j)
+-- output with analyze is not stable because it depends on worker assignment
+:PREFIX_NO_ANALYZE SELECT time_bucket('1 second', ts) sec, last(i, j)
 FROM "test"
 WHERE length(version()) > 0
 GROUP BY sec
@@ -66,9 +68,16 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
 -- test parallel ChunkAppend
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
 
--- test ChunkAppend with parallel aggregation
-:PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
-SELECT count(*) FROM "test" WHERE length(version()) > 0;
+-- test worker assignment
+-- first chunk should have 1 worker and second chunk should have 2
+SET max_parallel_workers_per_gather TO 2;
+:PREFIX SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
+SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
+
+-- test worker assignment
+-- first chunk should have 2 worker and second chunk should have 1
+:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
+SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
 
 -- test ChunkAppend with # workers < # childs
 SET max_parallel_workers_per_gather TO 1;


### PR DESCRIPTION
The initial iteration of assigning multiple workers per subplan
would always assign a fixed amount of workers per child. This
patch changes the logic to assign each child one worker and then
moving to the next subplan, iterating until all subplans are finished.
This will lead to a much better distribution of workers especially
when the children are not well balanced.