### PR TITLE
Disable running 11.0 on every branch on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,7 @@ jobs:
       name: "Regression 10.9"
       env: PG_VERSION=10.9 CODECOV_FLAGS="-F cron -F pr"
 
-    - if: (type = cron) OR NOT (branch = master)
+    - if: (type = cron) OR (branch = prerelease_test)
       stage: test
       name: "Regression 11.0"
       env: PG_VERSION=11.0


### PR DESCRIPTION
Since a build job for PG 11.4 is run on every PR and every feature
branch, there is no need to run PG 11.0 on every commit on every
feature branch.