### PR TITLE
Disable autovacuum in tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,6 +74,8 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "max_worker_processes=16"
 
+    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "autovacuum=false"
+
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "random_page_cost=1.0"
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'"

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -1,5 +1,6 @@
 shared_preload_libraries=timescaledb
 max_worker_processes=16
+autovacuum=false
 random_page_cost=1.0
 timescaledb.telemetry_level=off
 timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'

--- a/tsl/test/postgresql.conf
+++ b/tsl/test/postgresql.conf
@@ -1,5 +1,6 @@
 shared_preload_libraries=timescaledb
 max_worker_processes=16
+autovacuum=false
 timescaledb.telemetry_level=off
 # when changing this, also update the one in appveyor.yml
 timescaledb.license_key='E1eyJlbmRfdGltZSI6IjIwMTgtMTAtMDEgKzAwMDAiLCAic3RhcnRfdGltZSI6IjIwMTgtMDktMDEgKzAwMDAiLCAiaWQiOiI0OTBGQjI2MC1BMjkyLTRBRDktOUFBMi0wMzYwODM1NzkxQjgiLCAia2luZCI6InRyaWFsIn0K'


### PR DESCRIPTION
The tests do not expect that autovacuum is run. The most of the tests
finishes before it runs, but some ARM tests might fail due if autovacuum
is executed.