### PR TITLE
Speed up parallel test

### DIFF
--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -21,12 +21,14 @@ NOTICE:  adding not-null constraint to column "i"
  (1,public,test,t)
 (1 row)
 
---has to be big enough to force at least 2 workers below.
-INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
+INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1,10) AS x;
 ANALYZE test;
+ALTER TABLE :CHUNK1 SET (parallel_workers=2);
+ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost TO 0;
 EXPLAIN (costs off) SELECT first(i, j) FROM "test";
                           QUERY PLAN                           
 ---------------------------------------------------------------
@@ -60,7 +62,7 @@ EXPLAIN (costs off) SELECT last(i, j) FROM "test";
 SELECT last(i, j) FROM "test";
   last  
 --------
- 999999
+ 999990
 (1 row)
 
 EXPLAIN (costs off) SELECT time_bucket('1 second', ts) sec, last(i, j)
@@ -123,11 +125,11 @@ ORDER BY sec
 LIMIT 5;
            sec            | last 
 --------------------------+------
- Wed Dec 31 16:00:00 1969 |  999
- Wed Dec 31 16:00:01 1969 | 1999
- Wed Dec 31 16:00:02 1969 | 2999
- Wed Dec 31 16:00:03 1969 | 3999
- Wed Dec 31 16:00:04 1969 | 4999
+ Wed Dec 31 16:00:00 1969 |  990
+ Wed Dec 31 16:00:01 1969 | 1990
+ Wed Dec 31 16:00:02 1969 | 2990
+ Wed Dec 31 16:00:03 1969 | 3990
+ Wed Dec 31 16:00:04 1969 | 4990
 (5 rows)
 
 --test variants of histogram
@@ -144,9 +146,9 @@ EXPLAIN (costs off) SELECT histogram(i, 1, 1000000, 2) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 1, 1000000, 2) FROM "test";
-      histogram      
----------------------
- {1,500000,499999,0}
+     histogram     
+-------------------
+ {1,50000,49999,0}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 1,1000001,10) FROM "test";
@@ -162,9 +164,9 @@ EXPLAIN (costs off) SELECT histogram(i, 1,1000001,10) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 1, 1000001, 10) FROM "test";
-                                 histogram                                  
-----------------------------------------------------------------------------
- {1,100000,100000,100000,100000,100000,100000,100000,100000,100000,99999,0}
+                            histogram                             
+------------------------------------------------------------------
+ {1,10000,10000,10000,10000,10000,10000,10000,10000,10000,9999,0}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 0,100000,5) FROM "test";
@@ -180,9 +182,9 @@ EXPLAIN (costs off) SELECT histogram(i, 0,100000,5) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 0, 100000, 5) FROM "test";
-                histogram                 
-------------------------------------------
- {0,20000,20000,20000,20000,20000,900000}
+             histogram              
+------------------------------------
+ {0,2000,2000,2000,2000,2000,90000}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
@@ -198,146 +200,146 @@ EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 10, 100000, 5) FROM "test";
-                 histogram                 
--------------------------------------------
- {10,19998,19998,19998,19998,19998,900000}
+             histogram              
+------------------------------------
+ {1,2000,2000,2000,2000,1999,90000}
 (1 row)
 
 -- test parallel ChunkAppend
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather (actual rows=1000000 loops=1)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather (actual rows=100000 loops=1)
    Workers Planned: 1
    Workers Launched: 1
    Single Copy: true
-   ->  Result (actual rows=1000000 loops=1)
+   ->  Result (actual rows=100000 loops=1)
          One-Time Filter: (length(version()) > 0)
-         ->  Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+         ->  Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
                Chunks excluded during startup: 0
-               ->  Result (actual rows=500000 loops=1)
+               ->  Result (actual rows=50000 loops=1)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-               ->  Result (actual rows=500000 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
+               ->  Result (actual rows=50000 loops=1)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
 (14 rows)
 
 -- test worker assignment
 -- first chunk should have 1 worker and second chunk should have 2
 SET max_parallel_workers_per_gather TO 2;
 :PREFIX SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=200000 loops=3)
+               ->  Result (actual rows=20000 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=20000 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=100000 loops=1)
+                           ->  Result (actual rows=10000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=100000 loops=1)
+                                 ->  Parallel Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=10000 loops=1)
                                        Index Cond: (i >= 400000)
                                        Heap Fetches: 0
-                           ->  Result (actual rows=250000 loops=2)
+                           ->  Result (actual rows=25000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=25000 loops=2)
                                        Filter: (i >= 400000)
 (18 rows)
 
 SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
- count  
---------
- 600000
+ count 
+-------
+ 60000
 (1 row)
 
 -- test worker assignment
 -- first chunk should have 2 worker and second chunk should have 1
 :PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=200000 loops=3)
+               ->  Result (actual rows=20000 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=20000 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=250000 loops=2)
+                           ->  Result (actual rows=25000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=25000 loops=2)
                                        Filter: (i < 600000)
-                           ->  Result (actual rows=100000 loops=1)
+                           ->  Result (actual rows=10000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=100000 loops=1)
+                                 ->  Parallel Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=10000 loops=1)
                                        Index Cond: (i < 600000)
                                        Heap Fetches: 0
 (18 rows)
 
 SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
- count  
---------
- 600000
+ count 
+-------
+ 60000
 (1 row)
 
 -- test ChunkAppend with # workers < # childs
 SET max_parallel_workers_per_gather TO 1;
 :PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=2 loops=1)
          Workers Planned: 1
          Workers Launched: 1
          ->  Partial Aggregate (actual rows=1 loops=2)
-               ->  Result (actual rows=500000 loops=2)
+               ->  Result (actual rows=50000 loops=2)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=500000 loops=2)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=50000 loops=2)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=500000 loops=1)
+                           ->  Result (actual rows=50000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-                           ->  Result (actual rows=500000 loops=1)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
+                           ->  Result (actual rows=50000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
 (15 rows)
 
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
-  count  
----------
- 1000000
+ count  
+--------
+ 100000
 (1 row)
 
 -- test ChunkAppend with # workers > # childs
 SET max_parallel_workers_per_gather TO 2;
 :PREFIX SELECT count(*) FROM "test" WHERE i >= 500000 AND length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=166667 loops=3)
+               ->  Result (actual rows=16667 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=166667 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=16667 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=250000 loops=2)
+                           ->  Result (actual rows=25000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=25000 loops=2)
                                        Filter: (i >= 500000)
 (13 rows)
 
 SELECT count(*) FROM "test" WHERE i >= 500000 AND length(version()) > 0;
- count  
---------
- 500000
+ count 
+-------
+ 50000
 (1 row)
 
 RESET max_parallel_workers_per_gather;
@@ -346,6 +348,31 @@ RESET max_parallel_workers_per_gather;
 ALTER TABLE :CHUNK1 SET (parallel_workers=0);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 :PREFIX SELECT count(*) FROM "test" WHERE i > 400000 AND length(version()) > 0;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Gather (actual rows=1 loops=1)
+   Workers Planned: 1
+   Workers Launched: 1
+   Single Copy: true
+   ->  Aggregate (actual rows=1 loops=1)
+         ->  Result (actual rows=59999 loops=1)
+               One-Time Filter: (length(version()) > 0)
+               ->  Custom Scan (ChunkAppend) on test (actual rows=59999 loops=1)
+                     Chunks excluded during startup: 0
+                     ->  Result (actual rows=9999 loops=1)
+                           One-Time Filter: (length(version()) > 0)
+                           ->  Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=9999 loops=1)
+                                 Index Cond: (i > 400000)
+                                 Heap Fetches: 0
+                     ->  Result (actual rows=50000 loops=1)
+                           One-Time Filter: (length(version()) > 0)
+                           ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
+                                 Filter: (i > 400000)
+(18 rows)
+
+ALTER TABLE :CHUNK1 SET (parallel_workers=2);
+ALTER TABLE :CHUNK2 SET (parallel_workers=0);
+:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
  Gather (actual rows=1 loops=1)
@@ -353,42 +380,17 @@ ALTER TABLE :CHUNK2 SET (parallel_workers=2);
    Workers Launched: 1
    Single Copy: true
    ->  Aggregate (actual rows=1 loops=1)
-         ->  Result (actual rows=599999 loops=1)
+         ->  Result (actual rows=60000 loops=1)
                One-Time Filter: (length(version()) > 0)
-               ->  Custom Scan (ChunkAppend) on test (actual rows=599999 loops=1)
+               ->  Custom Scan (ChunkAppend) on test (actual rows=60000 loops=1)
                      Chunks excluded during startup: 0
-                     ->  Result (actual rows=99999 loops=1)
+                     ->  Result (actual rows=50000 loops=1)
                            One-Time Filter: (length(version()) > 0)
-                           ->  Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=99999 loops=1)
-                                 Index Cond: (i > 400000)
-                                 Heap Fetches: 0
-                     ->  Result (actual rows=500000 loops=1)
-                           One-Time Filter: (length(version()) > 0)
-                           ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
-                                 Filter: (i > 400000)
-(18 rows)
-
-ALTER TABLE :CHUNK1 SET (parallel_workers=2);
-ALTER TABLE :CHUNK2 SET (parallel_workers=0);
-:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Gather (actual rows=1 loops=1)
-   Workers Planned: 1
-   Workers Launched: 1
-   Single Copy: true
-   ->  Aggregate (actual rows=1 loops=1)
-         ->  Result (actual rows=600000 loops=1)
-               One-Time Filter: (length(version()) > 0)
-               ->  Custom Scan (ChunkAppend) on test (actual rows=600000 loops=1)
-                     Chunks excluded during startup: 0
-                     ->  Result (actual rows=500000 loops=1)
-                           One-Time Filter: (length(version()) > 0)
-                           ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+                           ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
                                  Filter: (i < 600000)
-                     ->  Result (actual rows=100000 loops=1)
+                     ->  Result (actual rows=10000 loops=1)
                            One-Time Filter: (length(version()) > 0)
-                           ->  Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=100000 loops=1)
+                           ->  Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=10000 loops=1)
                                  Index Cond: (i < 600000)
                                  Heap Fetches: 0
 (18 rows)
@@ -399,44 +401,44 @@ ALTER TABLE :CHUNK2 RESET (parallel_workers);
 -- in a query will prevent parallelism but CURRENT_TIMESTAMP and
 -- transaction_timestamp() are marked parallel safe
 :PREFIX SELECT i FROM "test" WHERE ts < CURRENT_TIMESTAMP;
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Gather (actual rows=1000000 loops=1)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather (actual rows=100000 loops=1)
    Workers Planned: 1
    Workers Launched: 1
    Single Copy: true
-   ->  Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+   ->  Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
          Chunks excluded during startup: 0
-         ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
                Filter: (ts < CURRENT_TIMESTAMP)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
                Filter: (ts < CURRENT_TIMESTAMP)
 (10 rows)
 
 :PREFIX SELECT i FROM "test" WHERE ts < transaction_timestamp();
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Gather (actual rows=1000000 loops=1)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather (actual rows=100000 loops=1)
    Workers Planned: 1
    Workers Launched: 1
    Single Copy: true
-   ->  Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+   ->  Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
          Chunks excluded during startup: 0
-         ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
                Filter: (ts < transaction_timestamp())
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
                Filter: (ts < transaction_timestamp())
 (10 rows)
 
 -- this won't be parallel query because now() is parallel restricted in PG < 12
 :PREFIX SELECT i FROM "test" WHERE ts < now();
-                           QUERY PLAN                            
------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
    Chunks excluded during startup: 0
-   ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+   ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
          Filter: (ts < now())
-   ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+   ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
          Filter: (ts < now())
 (6 rows)
 

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -21,12 +21,14 @@ NOTICE:  adding not-null constraint to column "i"
  (1,public,test,t)
 (1 row)
 
---has to be big enough to force at least 2 workers below.
-INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
+INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1,10) AS x;
 ANALYZE test;
+ALTER TABLE :CHUNK1 SET (parallel_workers=2);
+ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost TO 0;
 EXPLAIN (costs off) SELECT first(i, j) FROM "test";
                           QUERY PLAN                           
 ---------------------------------------------------------------
@@ -60,7 +62,7 @@ EXPLAIN (costs off) SELECT last(i, j) FROM "test";
 SELECT last(i, j) FROM "test";
   last  
 --------
- 999999
+ 999990
 (1 row)
 
 EXPLAIN (costs off) SELECT time_bucket('1 second', ts) sec, last(i, j)
@@ -121,11 +123,11 @@ ORDER BY sec
 LIMIT 5;
            sec            | last 
 --------------------------+------
- Wed Dec 31 16:00:00 1969 |  999
- Wed Dec 31 16:00:01 1969 | 1999
- Wed Dec 31 16:00:02 1969 | 2999
- Wed Dec 31 16:00:03 1969 | 3999
- Wed Dec 31 16:00:04 1969 | 4999
+ Wed Dec 31 16:00:00 1969 |  990
+ Wed Dec 31 16:00:01 1969 | 1990
+ Wed Dec 31 16:00:02 1969 | 2990
+ Wed Dec 31 16:00:03 1969 | 3990
+ Wed Dec 31 16:00:04 1969 | 4990
 (5 rows)
 
 --test variants of histogram
@@ -142,9 +144,9 @@ EXPLAIN (costs off) SELECT histogram(i, 1, 1000000, 2) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 1, 1000000, 2) FROM "test";
-      histogram      
----------------------
- {1,500000,499999,0}
+     histogram     
+-------------------
+ {1,50000,49999,0}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 1,1000001,10) FROM "test";
@@ -160,9 +162,9 @@ EXPLAIN (costs off) SELECT histogram(i, 1,1000001,10) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 1, 1000001, 10) FROM "test";
-                                 histogram                                  
-----------------------------------------------------------------------------
- {1,100000,100000,100000,100000,100000,100000,100000,100000,100000,99999,0}
+                            histogram                             
+------------------------------------------------------------------
+ {1,10000,10000,10000,10000,10000,10000,10000,10000,10000,9999,0}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 0,100000,5) FROM "test";
@@ -178,9 +180,9 @@ EXPLAIN (costs off) SELECT histogram(i, 0,100000,5) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 0, 100000, 5) FROM "test";
-                histogram                 
-------------------------------------------
- {0,20000,20000,20000,20000,20000,900000}
+             histogram              
+------------------------------------
+ {0,2000,2000,2000,2000,2000,90000}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
@@ -196,146 +198,146 @@ EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 10, 100000, 5) FROM "test";
-                 histogram                 
--------------------------------------------
- {10,19998,19998,19998,19998,19998,900000}
+             histogram              
+------------------------------------
+ {1,2000,2000,2000,2000,1999,90000}
 (1 row)
 
 -- test parallel ChunkAppend
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather (actual rows=1000000 loops=1)
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Gather (actual rows=100000 loops=1)
    Workers Planned: 1
    Workers Launched: 1
    Single Copy: true
-   ->  Result (actual rows=1000000 loops=1)
+   ->  Result (actual rows=100000 loops=1)
          One-Time Filter: (length(version()) > 0)
-         ->  Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+         ->  Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
                Chunks excluded during startup: 0
-               ->  Result (actual rows=500000 loops=1)
+               ->  Result (actual rows=50000 loops=1)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-               ->  Result (actual rows=500000 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
+               ->  Result (actual rows=50000 loops=1)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
 (14 rows)
 
 -- test worker assignment
 -- first chunk should have 1 worker and second chunk should have 2
 SET max_parallel_workers_per_gather TO 2;
 :PREFIX SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=200000 loops=3)
+               ->  Result (actual rows=20000 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=20000 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=100000 loops=1)
+                           ->  Result (actual rows=10000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=100000 loops=1)
+                                 ->  Parallel Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=10000 loops=1)
                                        Index Cond: (i >= 400000)
-                                       Heap Fetches: 100000
-                           ->  Result (actual rows=250000 loops=2)
+                                       Heap Fetches: 10000
+                           ->  Result (actual rows=25000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=25000 loops=2)
                                        Filter: (i >= 400000)
 (18 rows)
 
 SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
- count  
---------
- 600000
+ count 
+-------
+ 60000
 (1 row)
 
 -- test worker assignment
 -- first chunk should have 2 worker and second chunk should have 1
 :PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=200000 loops=3)
+               ->  Result (actual rows=20000 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=20000 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=100000 loops=1)
+                           ->  Result (actual rows=10000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=100000 loops=1)
+                                 ->  Parallel Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=10000 loops=1)
                                        Index Cond: (i < 600000)
-                                       Heap Fetches: 100000
-                           ->  Result (actual rows=250000 loops=2)
+                                       Heap Fetches: 10000
+                           ->  Result (actual rows=25000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=25000 loops=2)
                                        Filter: (i < 600000)
 (18 rows)
 
 SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
- count  
---------
- 600000
+ count 
+-------
+ 60000
 (1 row)
 
 -- test ChunkAppend with # workers < # childs
 SET max_parallel_workers_per_gather TO 1;
 :PREFIX SELECT count(*) FROM "test" WHERE length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=2 loops=1)
          Workers Planned: 1
          Workers Launched: 1
          ->  Partial Aggregate (actual rows=1 loops=2)
-               ->  Result (actual rows=500000 loops=2)
+               ->  Result (actual rows=50000 loops=2)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=500000 loops=2)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=50000 loops=2)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=500000 loops=1)
+                           ->  Result (actual rows=50000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
-                           ->  Result (actual rows=500000 loops=1)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
+                           ->  Result (actual rows=50000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
 (15 rows)
 
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
-  count  
----------
- 1000000
+ count  
+--------
+ 100000
 (1 row)
 
 -- test ChunkAppend with # workers > # childs
 SET max_parallel_workers_per_gather TO 2;
 :PREFIX SELECT count(*) FROM "test" WHERE i >= 500000 AND length(version()) > 0;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
    ->  Gather (actual rows=3 loops=1)
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=166667 loops=3)
+               ->  Result (actual rows=16667 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=166667 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=16667 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=250000 loops=2)
+                           ->  Result (actual rows=25000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=25000 loops=2)
                                        Filter: (i >= 500000)
 (13 rows)
 
 SELECT count(*) FROM "test" WHERE i >= 500000 AND length(version()) > 0;
- count  
---------
- 500000
+ count 
+-------
+ 50000
 (1 row)
 
 RESET max_parallel_workers_per_gather;
@@ -344,6 +346,31 @@ RESET max_parallel_workers_per_gather;
 ALTER TABLE :CHUNK1 SET (parallel_workers=0);
 ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 :PREFIX SELECT count(*) FROM "test" WHERE i > 400000 AND length(version()) > 0;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate (actual rows=1 loops=1)
+   ->  Gather (actual rows=3 loops=1)
+         Workers Planned: 2
+         Workers Launched: 2
+         ->  Partial Aggregate (actual rows=1 loops=3)
+               ->  Result (actual rows=20000 loops=3)
+                     One-Time Filter: (length(version()) > 0)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=20000 loops=3)
+                           Chunks excluded during startup: 0
+                           ->  Result (actual rows=9999 loops=1)
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=9999 loops=1)
+                                       Index Cond: (i > 400000)
+                                       Heap Fetches: 9999
+                           ->  Result (actual rows=25000 loops=2)
+                                 One-Time Filter: (length(version()) > 0)
+                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=25000 loops=2)
+                                       Filter: (i > 400000)
+(18 rows)
+
+ALTER TABLE :CHUNK1 SET (parallel_workers=2);
+ALTER TABLE :CHUNK2 SET (parallel_workers=0);
+:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate (actual rows=1 loops=1)
@@ -351,43 +378,18 @@ ALTER TABLE :CHUNK2 SET (parallel_workers=2);
          Workers Planned: 2
          Workers Launched: 2
          ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=200000 loops=3)
+               ->  Result (actual rows=20000 loops=3)
                      One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
+                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=20000 loops=3)
                            Chunks excluded during startup: 0
-                           ->  Result (actual rows=99999 loops=1)
+                           ->  Result (actual rows=10000 loops=1)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Index Only Scan using _hyper_1_1_chunk_test_i_idx on _hyper_1_1_chunk (actual rows=99999 loops=1)
-                                       Index Cond: (i > 400000)
-                                       Heap Fetches: 99999
-                           ->  Result (actual rows=250000 loops=2)
-                                 One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_2_chunk (actual rows=250000 loops=2)
-                                       Filter: (i > 400000)
-(18 rows)
-
-ALTER TABLE :CHUNK1 SET (parallel_workers=2);
-ALTER TABLE :CHUNK2 SET (parallel_workers=0);
-:PREFIX SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate (actual rows=1 loops=1)
-   ->  Gather (actual rows=3 loops=1)
-         Workers Planned: 2
-         Workers Launched: 2
-         ->  Partial Aggregate (actual rows=1 loops=3)
-               ->  Result (actual rows=200000 loops=3)
-                     One-Time Filter: (length(version()) > 0)
-                     ->  Parallel Custom Scan (ChunkAppend) on test (actual rows=200000 loops=3)
-                           Chunks excluded during startup: 0
-                           ->  Result (actual rows=100000 loops=1)
-                                 One-Time Filter: (length(version()) > 0)
-                                 ->  Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=100000 loops=1)
+                                 ->  Index Only Scan using _hyper_1_2_chunk_test_i_idx on _hyper_1_2_chunk (actual rows=10000 loops=1)
                                        Index Cond: (i < 600000)
-                                       Heap Fetches: 100000
-                           ->  Result (actual rows=250000 loops=2)
+                                       Heap Fetches: 10000
+                           ->  Result (actual rows=25000 loops=2)
                                  One-Time Filter: (length(version()) > 0)
-                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=250000 loops=2)
+                                 ->  Parallel Seq Scan on _hyper_1_1_chunk (actual rows=25000 loops=2)
                                        Filter: (i < 600000)
 (18 rows)
 
@@ -397,44 +399,44 @@ ALTER TABLE :CHUNK2 RESET (parallel_workers);
 -- in a query will prevent parallelism but CURRENT_TIMESTAMP and
 -- transaction_timestamp() are marked parallel safe
 :PREFIX SELECT i FROM "test" WHERE ts < CURRENT_TIMESTAMP;
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Gather (actual rows=1000000 loops=1)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather (actual rows=100000 loops=1)
    Workers Planned: 1
    Workers Launched: 1
    Single Copy: true
-   ->  Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+   ->  Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
          Chunks excluded during startup: 0
-         ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
                Filter: (ts < CURRENT_TIMESTAMP)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
                Filter: (ts < CURRENT_TIMESTAMP)
 (10 rows)
 
 :PREFIX SELECT i FROM "test" WHERE ts < transaction_timestamp();
-                              QUERY PLAN                               
------------------------------------------------------------------------
- Gather (actual rows=1000000 loops=1)
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather (actual rows=100000 loops=1)
    Workers Planned: 1
    Workers Launched: 1
    Single Copy: true
-   ->  Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+   ->  Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
          Chunks excluded during startup: 0
-         ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
                Filter: (ts < transaction_timestamp())
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
                Filter: (ts < transaction_timestamp())
 (10 rows)
 
 -- this won't be parallel query because now() is parallel restricted in PG < 12
 :PREFIX SELECT i FROM "test" WHERE ts < now();
-                           QUERY PLAN                            
------------------------------------------------------------------
- Custom Scan (ChunkAppend) on test (actual rows=1000000 loops=1)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test (actual rows=100000 loops=1)
    Chunks excluded during startup: 0
-   ->  Seq Scan on _hyper_1_1_chunk (actual rows=500000 loops=1)
+   ->  Seq Scan on _hyper_1_1_chunk (actual rows=50000 loops=1)
          Filter: (ts < now())
-   ->  Seq Scan on _hyper_1_2_chunk (actual rows=500000 loops=1)
+   ->  Seq Scan on _hyper_1_2_chunk (actual rows=50000 loops=1)
          Filter: (ts < now())
 (6 rows)
 

--- a/test/expected/parallel-9.6.out
+++ b/test/expected/parallel-9.6.out
@@ -21,12 +21,14 @@ NOTICE:  adding not-null constraint to column "i"
  (1,public,test,t)
 (1 row)
 
---has to be big enough to force at least 2 workers below.
-INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
+INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1,10) AS x;
 ANALYZE test;
+ALTER TABLE :CHUNK1 SET (parallel_workers=2);
+ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost TO 0;
 EXPLAIN (costs off) SELECT first(i, j) FROM "test";
                           QUERY PLAN                           
 ---------------------------------------------------------------
@@ -60,7 +62,7 @@ EXPLAIN (costs off) SELECT last(i, j) FROM "test";
 SELECT last(i, j) FROM "test";
   last  
 --------
- 999999
+ 999990
 (1 row)
 
 EXPLAIN (costs off) SELECT time_bucket('1 second', ts) sec, last(i, j)
@@ -123,11 +125,11 @@ ORDER BY sec
 LIMIT 5;
            sec            | last 
 --------------------------+------
- Wed Dec 31 16:00:00 1969 |  999
- Wed Dec 31 16:00:01 1969 | 1999
- Wed Dec 31 16:00:02 1969 | 2999
- Wed Dec 31 16:00:03 1969 | 3999
- Wed Dec 31 16:00:04 1969 | 4999
+ Wed Dec 31 16:00:00 1969 |  990
+ Wed Dec 31 16:00:01 1969 | 1990
+ Wed Dec 31 16:00:02 1969 | 2990
+ Wed Dec 31 16:00:03 1969 | 3990
+ Wed Dec 31 16:00:04 1969 | 4990
 (5 rows)
 
 --test variants of histogram
@@ -144,9 +146,9 @@ EXPLAIN (costs off) SELECT histogram(i, 1, 1000000, 2) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 1, 1000000, 2) FROM "test";
-      histogram      
----------------------
- {1,500000,499999,0}
+     histogram     
+-------------------
+ {1,50000,49999,0}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 1,1000001,10) FROM "test";
@@ -162,9 +164,9 @@ EXPLAIN (costs off) SELECT histogram(i, 1,1000001,10) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 1, 1000001, 10) FROM "test";
-                                 histogram                                  
-----------------------------------------------------------------------------
- {1,100000,100000,100000,100000,100000,100000,100000,100000,100000,99999,0}
+                            histogram                             
+------------------------------------------------------------------
+ {1,10000,10000,10000,10000,10000,10000,10000,10000,10000,9999,0}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 0,100000,5) FROM "test";
@@ -180,9 +182,9 @@ EXPLAIN (costs off) SELECT histogram(i, 0,100000,5) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 0, 100000, 5) FROM "test";
-                histogram                 
-------------------------------------------
- {0,20000,20000,20000,20000,20000,900000}
+             histogram              
+------------------------------------
+ {0,2000,2000,2000,2000,2000,90000}
 (1 row)
 
 EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
@@ -198,9 +200,9 @@ EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
 (7 rows)
 
 SELECT histogram(i, 10, 100000, 5) FROM "test";
-                 histogram                 
--------------------------------------------
- {10,19998,19998,19998,19998,19998,900000}
+             histogram              
+------------------------------------
+ {1,2000,2000,2000,2000,1999,90000}
 (1 row)
 
 -- test parallel ChunkAppend
@@ -247,9 +249,9 @@ SET max_parallel_workers_per_gather TO 2;
 (16 rows)
 
 SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
- count  
---------
- 600000
+ count 
+-------
+ 60000
 (1 row)
 
 -- test worker assignment
@@ -276,9 +278,9 @@ SELECT count(*) FROM "test" WHERE i >= 400000 AND length(version()) > 0;
 (16 rows)
 
 SELECT count(*) FROM "test" WHERE i < 600000 AND length(version()) > 0;
- count  
---------
- 600000
+ count 
+-------
+ 60000
 (1 row)
 
 -- test ChunkAppend with # workers < # childs
@@ -303,9 +305,9 @@ SET max_parallel_workers_per_gather TO 1;
 (14 rows)
 
 SELECT count(*) FROM "test" WHERE length(version()) > 0;
-  count  
----------
- 1000000
+ count  
+--------
+ 100000
 (1 row)
 
 -- test ChunkAppend with # workers > # childs
@@ -328,9 +330,9 @@ SET max_parallel_workers_per_gather TO 2;
 (12 rows)
 
 SELECT count(*) FROM "test" WHERE i >= 500000 AND length(version()) > 0;
- count  
---------
- 500000
+ count 
+-------
+ 50000
 (1 row)
 
 RESET max_parallel_workers_per_gather;

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -19,14 +19,16 @@ SELECT
 
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
---has to be big enough to force at least 2 workers below.
-INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1) AS x;
+INSERT INTO test SELECT x, x+0.1, _timescaledb_internal.to_timestamp(x*1000)  FROM generate_series(0,1000000-1,10) AS x;
 
 ANALYZE test;
+ALTER TABLE :CHUNK1 SET (parallel_workers=2);
+ALTER TABLE :CHUNK2 SET (parallel_workers=2);
 
 SET work_mem TO '50MB';
 SET force_parallel_mode = 'on';
 SET max_parallel_workers_per_gather = 4;
+SET parallel_setup_cost TO 0;
 
 EXPLAIN (costs off) SELECT first(i, j) FROM "test";
 SELECT first(i, j) FROM "test";


### PR DESCRIPTION
Since we can now set reloptions on chunks we don't have to rely on
data volume to trigger parallel plans.