### PR TITLE
Fix logic for BGW rescheduling

### DIFF
--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -425,6 +425,10 @@ ts_update_scheduled_jobs_list(List *cur_jobs_list, MemoryContext mctx)
 			cur_sjob->job = new_sjob->job;
 			*new_sjob = *cur_sjob;
 
+			/* reload the scheduling information from the job_stats */
+			if (cur_sjob->state == JOB_STATE_SCHEDULED)
+				scheduled_bgw_job_transition_state_to(new_sjob, JOB_STATE_SCHEDULED);
+
 			cur_ptr = lnext(cur_ptr);
 			new_ptr = lnext(new_ptr);
 		}

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -28,6 +28,8 @@ REVOKE EXECUTE ON FUNCTION get_constant_no_perms() FROM PUBLIC;
 \set WAIT_ON_JOB 0
 \set IMMEDIATELY_SET_UNTIL 1
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
+CREATE OR REPLACE FUNCTION ts_bgw_params_mock_wait_returns_immediately(new_val INTEGER) RETURNS VOID
+AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 -- Remove any default jobs, e.g., telemetry
 SELECT _timescaledb_internal.stop_background_workers();
  stop_background_workers 
@@ -37,12 +39,6 @@ SELECT _timescaledb_internal.stop_background_workers();
 
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
-SELECT _timescaledb_internal.start_background_workers();
- start_background_workers 
---------------------------
- t
-(1 row)
-
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE public.bgw_log(
     msg_no INT,
@@ -154,28 +150,161 @@ SELECT * FROM _timescaledb_config.bgw_job where id=:job_id;
 (1 row)
 
 -- job ran once, successfully
-SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
+SELECT job_id, next_start, last_finish, next_start-last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
     FROM _timescaledb_internal.bgw_job_stat
     where job_id=:job_id;
- job_id |          next_start          |          until_next          | last_run_success | total_runs | total_successes | total_failures | total_crashes 
---------+------------------------------+------------------------------+------------------+------------+-----------------+----------------+---------------
-   1000 | Sat Jan 01 04:00:00 2000 PST | Fri Dec 31 16:00:00 1999 PST | t                |          1 |               1 |              0 |             0
+ job_id |          next_start          |         last_finish          | until_next | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+------------------------------+------------------------------+------------+------------------+------------+-----------------+----------------+---------------
+   1000 | Sat Jan 01 04:00:00 2000 PST | Fri Dec 31 16:00:00 1999 PST | @ 12 hours | t                |          1 |               1 |              0 |             0
+(1 row)
+
+--clear log for next run of scheduler.
+TRUNCATE public.bgw_log;
+CREATE FUNCTION wait_for_timer_to_run(started_at INTEGER, spins INTEGER=:TEST_SPINWAIT_ITERS) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+	num_runs INTEGER;
+	message TEXT;
+BEGIN
+	select format('[TESTING] Wait until %%, started at %s', started_at) into message;
+	FOR i in 1..spins
+	LOOP
+	SELECT COUNT(*) from bgw_log where msg LIKE message INTO num_runs;
+	if (num_runs > 0) THEN
+		RETURN true;
+	ELSE
+        RAISE WARNING 'waiting';
+		PERFORM pg_sleep(0.1);
+	END IF;
+	END LOOP;
+	RETURN false;
+END
+$BODY$;
+CREATE FUNCTION wait_for_job_to_run(job_param_id INTEGER, expected_runs INTEGER, spins INTEGER=:TEST_SPINWAIT_ITERS) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+	num_runs INTEGER;
+BEGIN
+	FOR i in 1..spins
+	LOOP
+	SELECT total_successes FROM _timescaledb_internal.bgw_job_stat WHERE job_id=job_param_id INTO num_runs;
+	if (num_runs = expected_runs) THEN
+		RETURN true;
+    ELSEIF (num_runs > expected_runs) THEN
+        RAISE 'num_runs > expected';
+	ELSE
+		PERFORM pg_sleep(0.1);
+	END IF;
+	END LOOP;
+	RETURN false;
+END
+$BODY$;
+--make sure there is 1 job to start with
+SELECT wait_for_job_to_run(:job_id, 1);
+ wait_for_job_to_run 
+---------------------
+ t
+(1 row)
+
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_FOR_OTHER_TO_ADVANCE);
+ ts_bgw_params_mock_wait_returns_immediately 
+---------------------------------------------
+ 
+(1 row)
+
+--start the scheduler on 0 time
+SELECT ts_bgw_params_reset_time(0, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run(extract(epoch from interval '24 hour')::int * 1000, 0);
+ ts_bgw_db_scheduler_test_run 
+------------------------------
+ 
+(1 row)
+
+SELECT wait_for_timer_to_run(0);
+WARNING:  waiting
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+--advance to 12:00 so that it runs one more time; now we know the
+--scheduler has loaded up the job with the old schedule_interval
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '12 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_job_to_run(:job_id, 2);
+ wait_for_job_to_run 
+---------------------
+ t
+(1 row)
+
+--advance clock 1us to make the scheduler realize the job is done
+SELECT ts_bgw_params_reset_time((extract(epoch from interval '12 hour')::bigint * 1000000)+1, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
 (1 row)
 
 --alter the refresh interval and check if next_scheduled_run is altered
-ALTER VIEW test_continuous_agg_view SET(timescaledb.refresh_interval= '1h');
-SELECT view_name, 
-case when next_scheduled_run - now() > '59 min'::interval 
-      and  next_scheduled_run - now() < '60 min'::interval then 'Success'
-     else 'Fail'
-end 
- from 
-timescaledb_information.continuous_aggregate_stats;
-        view_name         |  case   
---------------------------+---------
- test_continuous_agg_view | Success
+ALTER VIEW test_continuous_agg_view SET(timescaledb.refresh_interval= '1m');
+SELECT job_id, next_start- last_finish as until_next, total_runs
+FROM _timescaledb_internal.bgw_job_stat
+WHERE job_id=:job_id;;
+ job_id | until_next | total_runs 
+--------+------------+------------
+   1000 | @ 1 min    |          2
 (1 row)
 
+--advance to 12:02, job should have run at 12:01
+SELECT ts_bgw_params_reset_time((extract(epoch from interval '12 hour')::bigint * 1000000)+(extract(epoch from interval '2 minute')::bigint * 1000000), true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_job_to_run(:job_id, 3);
+ wait_for_job_to_run 
+---------------------
+ t
+(1 row)
+
+--next run in 1 minute
+SELECT job_id, next_start-last_finish as until_next, total_runs
+FROM _timescaledb_internal.bgw_job_stat
+WHERE job_id=:job_id;
+ job_id | until_next | total_runs 
+--------+------------+------------
+   1000 | @ 1 min    |          3
+(1 row)
+
+--advance clock to quit scheduler
+SELECT ts_bgw_params_reset_time(extract(epoch from interval '25 hour')::bigint * 1000000, true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+select ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+ ts_bgw_db_scheduler_test_wait_for_scheduler_finish 
+----------------------------------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_ON_JOB);
+ ts_bgw_params_mock_wait_returns_immediately 
+---------------------------------------------
+ 
+(1 row)
+
+TRUNCATE public.bgw_log;
 -- data before 8
 SELECT * FROM test_continuous_agg_view ORDER BY 1;
  time_bucket | value 
@@ -212,10 +341,8 @@ SELECT * FROM sorted_bgw_log;
  msg_no | mock_time | application_name |                    msg                     
 --------+-----------+------------------+--------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
-      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
-(4 rows)
+(2 rows)
 
 -- job ran once, successfully
 SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -243,12 +370,10 @@ SELECT * FROM sorted_bgw_log;
  msg_no | mock_time | application_name |                     msg                      
 --------+-----------+------------------+----------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
       0 |     25000 | DB Scheduler     | [TESTING] Registered new background worker
       1 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
-(6 rows)
+(4 rows)
 
 -- job ran again, fast restart
 SELECT job_id, next_start, last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -277,14 +402,12 @@ SELECT * FROM sorted_bgw_log;
  msg_no | mock_time | application_name |                     msg                      
 --------+-----------+------------------+----------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
       0 |     25000 | DB Scheduler     | [TESTING] Registered new background worker
       1 |     25000 | DB Scheduler     | [TESTING] Wait until 50000, started at 25000
       0 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
       1 |     50000 | DB Scheduler     | [TESTING] Wait until 75000, started at 50000
-(8 rows)
+(6 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:job_id;
   id  |          application_name           |       job_type       | schedule_interval | max_runtime | max_retries | retry_period 


### PR DESCRIPTION
This fixes the logic for what happens when the next start time
is changed on the bgw job:

- When changing the schedule_interval, the new next start time
  is set to last_finish + new_schedule_interval instead of
  now() + new_schedule_interval. This makes it easier to test
  and is semantically more correct
- New logic is added in the scheduler to recalculate the
  scheduler's next start time
- Better tests are added

Fixes #1462