### PR TITLE
Fix gapfill treat_null_as_missing

### DIFF
--- a/src/chunk_append/explain.h
+++ b/src/chunk_append/explain.h
@@ -10,6 +10,6 @@
 #include <commands/explain.h>
 #include <nodes/execnodes.h>
 
-extern void chunk_append_explain(CustomScanState *node, List *ancestors, ExplainState *es);
+void chunk_append_explain(CustomScanState *node, List *ancestors, ExplainState *es);
 
 #endif /* TIMESCALEDB_CHUNK_APPEND_EXPLAIN_H */

--- a/src/chunk_append/planner.h
+++ b/src/chunk_append/planner.h
@@ -10,10 +10,10 @@
 #include <nodes/extensible.h>
 #include <nodes/relation.h>
 
-extern Plan *chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path,
-									  List *tlist, List *clauses, List *custom_plans);
-extern Scan *chunk_append_get_scan_plan(Plan *plan);
+Plan *chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path, List *tlist,
+							   List *clauses, List *custom_plans);
+Scan *chunk_append_get_scan_plan(Plan *plan);
 
-extern void _chunk_append_init(void);
+void _chunk_append_init(void);
 
 #endif /* TIMESCALEDB_CHUNK_APPEND_PLANNER_H */

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -173,7 +173,6 @@ BEGIN
 	if (num_runs > 0) THEN
 		RETURN true;
 	ELSE
-        RAISE WARNING 'waiting';
 		PERFORM pg_sleep(0.1);
 	END IF;
 	END LOOP;
@@ -226,7 +225,6 @@ SELECT ts_bgw_db_scheduler_test_run(extract(epoch from interval '24 hour')::int 
 (1 row)
 
 SELECT wait_for_timer_to_run(0);
-WARNING:  waiting
  wait_for_timer_to_run 
 -----------------------
  t

--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -833,6 +833,22 @@ GROUP BY 1 ORDER BY 1;
    50 |     6
 (6 rows)
 
+-- test locf with NULLs in resultset and treat_null_as_missing with resort
+SELECT
+  time_bucket_gapfill(10,time,0,50) AS time,
+  locf(min(value),treat_null_as_missing:=true) AS value
+FROM (values (10,9),(20,3),(30,NULL),(50,6)) v(time,value)
+GROUP BY 1 ORDER BY 1 DESC;
+ time | value 
+------+-------
+   50 |     6
+   40 |     3
+   30 |     3
+   20 |     3
+   10 |     9
+    0 |      
+(6 rows)
+
 -- test locf with constants
 SELECT
   time_bucket_gapfill(1,time,0,5),

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -134,7 +134,6 @@ BEGIN
 	if (num_runs > 0) THEN
 		RETURN true;
 	ELSE
-        RAISE WARNING 'waiting';
 		PERFORM pg_sleep(0.1);
 	END IF;
 	END LOOP;

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -525,6 +525,13 @@ SELECT
 FROM (values (10,9),(20,3),(30,NULL),(50,6)) v(time,value)
 GROUP BY 1 ORDER BY 1;
 
+-- test locf with NULLs in resultset and treat_null_as_missing with resort
+SELECT
+  time_bucket_gapfill(10,time,0,50) AS time,
+  locf(min(value),treat_null_as_missing:=true) AS value
+FROM (values (10,9),(20,3),(30,NULL),(50,6)) v(time,value)
+GROUP BY 1 ORDER BY 1 DESC;
+
 -- test locf with constants
 SELECT
   time_bucket_gapfill(1,time,0,5),


### PR DESCRIPTION
When locf was used with the treat_null_as_missing option and the
query ORDER BY did not match gapfill ordering the treat_null_as_missing
option was not working correctly because the values from orignal tuple
would be returned and not our modified ones.

Fixes #1466