### PR TITLE
Add next_start option to alter_job_schedule

### DIFF
--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -45,7 +45,9 @@ CREATE OR REPLACE FUNCTION alter_job_schedule(
     max_runtime INTERVAL = NULL,
     max_retries INTEGER = NULL,
     retry_period INTERVAL = NULL,
-    if_exists BOOL = FALSE)
-RETURNS TABLE (job_id INTEGER, schedule_interval INTERVAL, max_runtime INTERVAL, max_retries INTEGER, retry_period INTERVAL)
+    if_exists BOOL = FALSE,
+    next_start TIMESTAMPTZ = NULL
+)
+RETURNS TABLE (job_id INTEGER, schedule_interval INTERVAL, max_runtime INTERVAL, max_retries INTEGER, retry_period INTERVAL, next_start TIMESTAMPTZ)
 AS '@MODULE_PATHNAME@', 'ts_alter_job_schedule'
 LANGUAGE C VOLATILE;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -58,3 +58,5 @@ INSERT INTO _timescaledb_config.bgw_policy_drop_chunks
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_policy_drop_chunks', '');
 DROP TABLE _timescaledb_config.bgw_policy_drop_chunks_tmp;
 GRANT SELECT ON _timescaledb_config.bgw_policy_drop_chunks TO PUBLIC;
+
+DROP FUNCTION IF EXISTS alter_job_schedule(INTEGER, INTERVAL, INTERVAL, INTEGER, INTERVAL, BOOL);

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -771,7 +771,10 @@ bgw_job_tuple_update_by_id(TupleInfo *ti, void *const data)
 				DirectFunctionCall2(timestamptz_pl_interval,
 									TimestampTzGetDatum(stat->fd.last_finish),
 									IntervalPGetDatum(&updated_job->fd.schedule_interval)));
-			ts_bgw_job_stat_update_next_start(updated_job, next_start);
+			/* allow DT_NOBEGIN for next_start here through allow_unset=true in the case that
+			 * last_finish is DT_NOBEGIN,
+			 * This means the value is counted as unset which is what we want */
+			ts_bgw_job_stat_update_next_start(updated_job, next_start, true);
 		}
 		fd->schedule_interval = updated_job->fd.schedule_interval;
 	}

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -27,7 +27,10 @@ extern void ts_bgw_job_stat_mark_end(BgwJob *job, JobResult result);
 extern bool ts_bgw_job_stat_end_was_marked(BgwJobStat *jobstat);
 
 extern TSDLLEXPORT void ts_bgw_job_stat_set_next_start(BgwJob *job, TimestampTz next_start);
-extern TSDLLEXPORT bool ts_bgw_job_stat_update_next_start(BgwJob *job, TimestampTz next_start);
+extern TSDLLEXPORT bool ts_bgw_job_stat_update_next_start(BgwJob *job, TimestampTz next_start,
+														  bool allow_unset);
+
+extern TSDLLEXPORT void ts_bgw_job_stat_upsert_next_start(int32 bgw_job_id, TimestampTz next_start);
 
 extern bool ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
 

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -440,9 +440,9 @@ SELECT json_object_field(get_telemetry_report(always_display_report := true)::js
 (1 row)
 
 SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
-             alter_job_schedule              
----------------------------------------------
- (1001,"@ 1 sec","@ 5 mins",-1,"@ 12 hours")
+                  alter_job_schedule                   
+-------------------------------------------------------
+ (1001,"@ 1 sec","@ 5 mins",-1,"@ 12 hours",-infinity)
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -285,6 +285,28 @@ WHERE job_id=:job_id;
    1000 | @ 1 min    |          3
 (1 row)
 
+--change next run to be after 30s instead
+SELECT (next_start - '30s'::interval) AS "NEW_NEXT_START"
+FROM _timescaledb_internal.bgw_job_stat
+WHERE job_id=:job_id \gset
+SELECT alter_job_schedule(:job_id, next_start => :'NEW_NEXT_START');
+                         alter_job_schedule                         
+--------------------------------------------------------------------
+ (1000,"@ 1 min","@ 0",-1,"@ 1 min","Sat Jan 01 04:02:30 2000 PST")
+(1 row)
+
+SELECT ts_bgw_params_reset_time((extract(epoch from interval '12 hour')::bigint * 1000000)+(extract(epoch from interval '2 minute 30 seconds')::bigint * 1000000), true);
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_job_to_run(:job_id, 4);
+ wait_for_job_to_run 
+---------------------
+ t
+(1 row)
+
 --advance clock to quit scheduler
 SELECT ts_bgw_params_reset_time(extract(epoch from interval '25 hour')::bigint * 1000000, true);
  ts_bgw_params_reset_time 

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -776,73 +776,152 @@ select add_reorder_policy('test_table', 'test_table_time_idx') as job_id \gset
 
 -- No change
 select * from alter_job_schedule(:job_id);
- job_id | schedule_interval | max_runtime | max_retries | retry_period 
---------+-------------------+-------------+-------------+--------------
-   1014 | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | next_start 
+--------+-------------------+-------------+-------------+--------------+------------
+   1014 | @ 84 hours        | @ 0         |          -1 | @ 1 day      | -infinity
 (1 row)
 
 -- Changes expected
 select * from alter_job_schedule(:job_id, INTERVAL '3 years', INTERVAL '5 min', 5, INTERVAL '123 sec');
- job_id | schedule_interval | max_runtime | max_retries |  retry_period   
---------+-------------------+-------------+-------------+-----------------
-   1014 | @ 3 years         | @ 5 mins    |           5 | @ 2 mins 3 secs
+ job_id | schedule_interval | max_runtime | max_retries |  retry_period   | next_start 
+--------+-------------------+-------------+-------------+-----------------+------------
+   1014 | @ 3 years         | @ 5 mins    |           5 | @ 2 mins 3 secs | -infinity
 (1 row)
 
 select * from alter_job_schedule(:job_id, INTERVAL '123 years');
- job_id | schedule_interval | max_runtime | max_retries |  retry_period   
---------+-------------------+-------------+-------------+-----------------
-   1014 | @ 123 years       | @ 5 mins    |           5 | @ 2 mins 3 secs
+ job_id | schedule_interval | max_runtime | max_retries |  retry_period   | next_start 
+--------+-------------------+-------------+-------------+-----------------+------------
+   1014 | @ 123 years       | @ 5 mins    |           5 | @ 2 mins 3 secs | -infinity
 (1 row)
 
 select * from alter_job_schedule(:job_id, retry_period => INTERVAL '33 hours');
- job_id | schedule_interval | max_runtime | max_retries | retry_period 
---------+-------------------+-------------+-------------+--------------
-   1014 | @ 123 years       | @ 5 mins    |           5 | @ 33 hours
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | next_start 
+--------+-------------------+-------------+-------------+--------------+------------
+   1014 | @ 123 years       | @ 5 mins    |           5 | @ 33 hours   | -infinity
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_runtime => INTERVAL '456 sec');
- job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
---------+-------------------+------------------+-------------+--------------
-   1014 | @ 123 years       | @ 7 mins 36 secs |           5 | @ 33 hours
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 123 years       | @ 7 mins 36 secs |           5 | @ 33 hours   | -infinity
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => 0);
- job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
---------+-------------------+------------------+-------------+--------------
-   1014 | @ 123 years       | @ 7 mins 36 secs |           0 | @ 33 hours
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 123 years       | @ 7 mins 36 secs |           0 | @ 33 hours   | -infinity
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => -1);
- job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
---------+-------------------+------------------+-------------+--------------
-   1014 | @ 123 years       | @ 7 mins 36 secs |          -1 | @ 33 hours
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 123 years       | @ 7 mins 36 secs |          -1 | @ 33 hours   | -infinity
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => 20);
- job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
---------+-------------------+------------------+-------------+--------------
-   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours   | -infinity
 (1 row)
 
 -- No change
 select * from alter_job_schedule(:job_id, max_runtime => NULL);
- job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
---------+-------------------+------------------+-------------+--------------
-   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours   | -infinity
 (1 row)
 
 select * from alter_job_schedule(:job_id, max_retries => NULL);
- job_id | schedule_interval |   max_runtime    | max_retries | retry_period 
---------+-------------------+------------------+-------------+--------------
-   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 123 years       | @ 7 mins 36 secs |          20 | @ 33 hours   | -infinity
 (1 row)
 
+--change schedule_interval when bgw_job_stat does not exist
+select * from alter_job_schedule(:job_id, schedule_interval=>'1 min');
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 1 min           | @ 7 mins 36 secs |          20 | @ 33 hours   | -infinity
+(1 row)
+
+select count(*) = 0 from _timescaledb_internal.bgw_job_stat where job_id = :job_id;
+ ?column? 
+----------
+ t
+(1 row)
+
+--set next_start when bgw_job_stat does not exist
+select * from alter_job_schedule(:job_id, next_start=>'2001-01-01 01:01:01');
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period |          next_start          
+--------+-------------------+------------------+-------------+--------------+------------------------------
+   1014 | @ 1 min           | @ 7 mins 36 secs |          20 | @ 33 hours   | Mon Jan 01 01:01:01 2001 PST
+(1 row)
+
+--change schedule_interval when no last_finish set
+select * from alter_job_schedule(:job_id, schedule_interval=>'10 min');
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 10 mins         | @ 7 mins 36 secs |          20 | @ 33 hours   | -infinity
+(1 row)
+
+--next_start overrides any schedule_interval changes
+select * from alter_job_schedule(:job_id, schedule_interval=>'20 min', next_start=>'2002-01-01 01:01:01');
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period |          next_start          
+--------+-------------------+------------------+-------------+--------------+------------------------------
+   1014 | @ 20 mins         | @ 7 mins 36 secs |          20 | @ 33 hours   | Tue Jan 01 01:01:01 2002 PST
+(1 row)
+
+--set the last_finish manually
+\c :TEST_DBNAME :ROLE_SUPERUSER
+UPDATE _timescaledb_internal.bgw_job_stat SET last_finish = '2003-01-01:01:01:01' WHERE job_id = :job_id;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+--not changing the interval doesn't change the next_start
+select * from alter_job_schedule(:job_id, schedule_interval=>'20 min');
+WARNING:  Timescale License expired
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period |          next_start          
+--------+-------------------+------------------+-------------+--------------+------------------------------
+   1014 | @ 20 mins         | @ 7 mins 36 secs |          20 | @ 33 hours   | Tue Jan 01 01:01:01 2002 PST
+(1 row)
+
+--changing the interval changes next_start
+select * from alter_job_schedule(:job_id, schedule_interval=>'30 min');
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period |          next_start          
+--------+-------------------+------------------+-------------+--------------+------------------------------
+   1014 | @ 30 mins         | @ 7 mins 36 secs |          20 | @ 33 hours   | Wed Jan 01 01:31:01 2003 PST
+(1 row)
+
+--explicit next start overrides.
+select * from alter_job_schedule(:job_id, schedule_interval=>'40 min', next_start=>'2004-01-01 01:01:01');
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period |          next_start          
+--------+-------------------+------------------+-------------+--------------+------------------------------
+   1014 | @ 40 mins         | @ 7 mins 36 secs |          20 | @ 33 hours   | Thu Jan 01 01:01:01 2004 PST
+(1 row)
+
+--test pausing
+select * from alter_job_schedule(:job_id, next_start=>'infinity');
+ job_id | schedule_interval |   max_runtime    | max_retries | retry_period | next_start 
+--------+-------------------+------------------+-------------+--------------+------------
+   1014 | @ 40 mins         | @ 7 mins 36 secs |          20 | @ 33 hours   | infinity
+(1 row)
+
+--test that you can use now() to unpause
+select next_start = now() from alter_job_schedule(:job_id, next_start=>now());
+ ?column? 
+----------
+ t
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- negative infinity disallowed (used as special value)
+select * from alter_job_schedule(:job_id, next_start=>'-infinity');
+ERROR:  cannot set next start to -infinity
+\set ON_ERROR_STOP 1
 -- Check if_exists boolean works correctly
 select * from alter_job_schedule(1234, if_exists => TRUE);
 NOTICE:  cannot alter policy schedule, policy #1234 not found, skipping
- job_id | schedule_interval | max_runtime | max_retries | retry_period 
---------+-------------------+-------------+-------------+--------------
-        |                   |             |             | 
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | next_start 
+--------+-------------------+-------------+-------------+--------------+------------
+        |                   |             |             |              | 
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -868,7 +947,7 @@ ERROR:  cannot execute an enterprise function with an invalid enterprise license
 select remove_drop_chunks_policy('test_table');
 ERROR:  cannot execute an enterprise function with an invalid enterprise license
 select alter_job_schedule(12345);
-ERROR:  cannot execute an enterprise function with an invalid enterprise license
+ERROR:  cannot alter policy schedule, policy #12345 not found
 \set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_SUPERUSER
 select add_reorder_policy('test_table', 'test_table_time_idx') as reorder_job_id \gset


### PR DESCRIPTION
Add the option to set the next start time on a job in the
alter job schedule function. This also adds the ability
to pause jobs by setting next_start to 'infinity'

Also fix the enterprise licence check to only activate for
enterprise jobs.