### PR TITLE
Set default retry_period for jobs to 5 minutes

### DIFF
--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -26,36 +26,15 @@
 
 /* Default scheduled interval for drop_chunks jobs is currently 1 day (24 hours) */
 #define DEFAULT_SCHEDULE_INTERVAL                                                                  \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(1),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("1 day"), InvalidOid, -1))
 /* Default max runtime for a drop_chunks job should not be very long. Right now set to 5 minutes */
 #define DEFAULT_MAX_RUNTIME                                                                        \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(5),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("5 min"), InvalidOid, -1))
 /* Right now, there is an infinite number of retries for drop_chunks jobs */
 #define DEFAULT_MAX_RETRIES -1
-/* Default retry period for drop_chunks_jobs is currently 12 hours */
+/* Default retry period for drop_chunks_jobs is currently 5 minutes */
 #define DEFAULT_RETRY_PERIOD                                                                       \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(12),                                       \
-										  Int32GetDatum(0),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("5 min"), InvalidOid, -1))
 
 Datum
 drop_chunks_add_policy(PG_FUNCTION_ARGS)

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -32,36 +32,15 @@
  * the default is 4 days, which is approximately 1/2 of the default chunk size, 7 days.
  */
 #define DEFAULT_SCHEDULE_INTERVAL                                                                  \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(4),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("4 days"), InvalidOid, -1))
 /* Default max runtime for a reorder job is unlimited for now */
 #define DEFAULT_MAX_RUNTIME                                                                        \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("0"), InvalidOid, -1))
 /* Right now, there is an infinite number of retries for reorder jobs */
 #define DEFAULT_MAX_RETRIES -1
-/* Default retry period for reorder_jobs is currently 1 day */
+/* Default retry period for reorder_jobs is currently 5 minutes */
 #define DEFAULT_RETRY_PERIOD                                                                       \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(1),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("5 min"), InvalidOid, -1))
 
 static void
 check_valid_index(Hypertable *ht, Name index_name)

--- a/tsl/src/continuous_aggs/job.c
+++ b/tsl/src/continuous_aggs/job.c
@@ -15,24 +15,10 @@
 
 /* DEFAULT_SCHEDULE_INTERVAL 12 hours */
 #define DEFAULT_SCHEDULE_INTERVAL                                                                  \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(12),                                       \
-										  Int32GetDatum(0),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("12 hours"), InvalidOid, -1))
 /* Default max runtime for a continuous aggregate jobs is unlimited for now */
 #define DEFAULT_MAX_RUNTIME                                                                        \
-	DatumGetIntervalP(DirectFunctionCall7(make_interval,                                           \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Int32GetDatum(0),                                        \
-										  Float8GetDatum(0)))
+	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("0"), InvalidOid, -1))
 /* Right now, there is an infinite number of retries for continuous aggregate jobs */
 #define DEFAULT_MAX_RETRIES -1
 

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -72,7 +72,7 @@ select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_i
 select * from _timescaledb_config.bgw_job where job_type IN ('reorder');
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -123,7 +123,7 @@ select * from _timescaledb_config.bgw_policy_reorder where job_id=:reorder_job_i
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 -- no stats
@@ -159,7 +159,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 -- job ran once, successfully
@@ -199,7 +199,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 -- two runs
@@ -243,7 +243,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 SELECT *
@@ -287,7 +287,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 SELECT *
@@ -313,7 +313,7 @@ SELECT indexrelid::regclass, indisclustered
 SELECT * FROM timescaledb_information.reorder_policies;
      hypertable     |    hypertable_index_name    | job_id | schedule_interval | max_runtime | max_retries | retry_period 
 --------------------+-----------------------------+--------+-------------------+-------------+-------------+--------------
- test_reorder_table | test_reorder_table_time_idx |   1000 | @ 4 days          | @ 0         |          -1 | @ 1 day
+ test_reorder_table | test_reorder_table_time_idx |   1000 | @ 4 days          | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;
@@ -440,9 +440,9 @@ SELECT json_object_field(get_telemetry_report(always_display_report := true)::js
 (1 row)
 
 SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
-                  alter_job_schedule                   
--------------------------------------------------------
- (1001,"@ 1 sec","@ 5 mins",-1,"@ 12 hours",-infinity)
+                 alter_job_schedule                  
+-----------------------------------------------------
+ (1001,"@ 1 sec","@ 5 mins",-1,"@ 5 mins",-infinity)
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
@@ -454,7 +454,7 @@ select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chun
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins
 (1 row)
 
 -- no stats
@@ -493,7 +493,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins
 (1 row)
 
 -- job ran once, successfully
@@ -532,7 +532,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins
 (1 row)
 
 -- still only 1 run
@@ -584,7 +584,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins
 (1 row)
 
 -- 2 runs
@@ -608,7 +608,7 @@ SELECT show_chunks('test_drop_chunks_table');
 SELECT * FROM timescaledb_information.drop_chunks_policies;
        hypertable       |   older_than    | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
 ------------------------+-----------------+---------+--------+-------------------+-------------+-------------+--------------+-----------------------------
- test_drop_chunks_table | (t,"@ 4 mons",) | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours   | f
+ test_drop_chunks_table | (t,"@ 4 mons",) | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | f
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;
@@ -656,7 +656,7 @@ SELECT * FROM sorted_bgw_log;
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 12 hours
+ 1001 | Drop Chunks Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins
 (1 row)
 
 -- should now have a failure

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -106,8 +106,8 @@ select add_reorder_policy('test_table2', 'test_table2_time_idx');
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks', 'reorder');
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
- 1001 | Reorder Background Job | reorder  | @ 12 hours        | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins
+ 1001 | Reorder Background Job | reorder  | @ 12 hours        | @ 0         |          -1 | @ 5 mins
 (2 rows)
 
 DROP TABLE test_table2;
@@ -115,7 +115,7 @@ DROP TABLE test_table2;
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks', 'reorder');
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 -- Error whenever incorrect arguments are applied (must have table and interval)
@@ -497,8 +497,8 @@ select * from _timescaledb_config.bgw_job;
   id  |      application_name      |                job_type                | schedule_interval |   max_runtime   | max_retries | retry_period 
 ------+----------------------------+----------------------------------------+-------------------+-----------------+-------------+--------------
     1 | Telemetry Reporter         | telemetry_and_version_check_if_enabled | @ 24 hours        | @ 1 min 40 secs |          -1 | @ 1 hour
- 1007 | Drop Chunks Background Job | drop_chunks                            | @ 1 day           | @ 5 mins        |          -1 | @ 12 hours
- 1008 | Reorder Background Job     | reorder                                | @ 84 hours        | @ 0             |          -1 | @ 1 day
+ 1007 | Drop Chunks Background Job | drop_chunks                            | @ 1 day           | @ 5 mins        |          -1 | @ 5 mins
+ 1008 | Reorder Background Job     | reorder                                | @ 84 hours        | @ 0             |          -1 | @ 5 mins
 (3 rows)
 
 DROP TABLE test_table;
@@ -569,8 +569,8 @@ select add_drop_chunks_policy('test_table2', INTERVAL '1 days');
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1009 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
- 1010 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
+ 1009 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins
+ 1010 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins
 (2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
@@ -585,7 +585,7 @@ DROP TABLE test_table_int;
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1010 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
+ 1010 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
@@ -664,7 +664,7 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 select * from _timescaledb_config.bgw_job where job_type='reorder';
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 -- Deleting a chunk that has nothing to do with the job should do nothing
@@ -680,7 +680,7 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 select * from _timescaledb_config.bgw_job where job_type='reorder';
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 -- Dropping the hypertable should drop the chunk, which should drop the reorder policy
@@ -726,8 +726,8 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 select * from _timescaledb_config.bgw_job where job_type in ('drop_chunks', 'reorder');
   id  |      application_name      |  job_type   | schedule_interval | max_runtime | max_retries | retry_period 
 ------+----------------------------+-------------+-------------------+-------------+-------------+--------------
- 1012 | Reorder Background Job     | reorder     | @ 84 hours        | @ 0         |          -1 | @ 1 day
- 1013 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 12 hours
+ 1012 | Reorder Background Job     | reorder     | @ 84 hours        | @ 0         |          -1 | @ 5 mins
+ 1013 | Drop Chunks Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins
 (2 rows)
 
 -- Dropping the drop_chunks job should not affect the chunk_stats row
@@ -746,7 +746,7 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 select * from _timescaledb_config.bgw_job where job_type in ('drop_chunks', 'reorder');
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1012 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1012 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 select remove_reorder_policy('test_table');
@@ -771,14 +771,14 @@ select add_reorder_policy('test_table', 'test_table_time_idx') as job_id \gset
  select * from _timescaledb_config.bgw_job where id=:job_id;
   id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period 
 ------+------------------------+----------+-------------------+-------------+-------------+--------------
- 1014 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 1 day
+ 1014 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins
 (1 row)
 
 -- No change
 select * from alter_job_schedule(:job_id);
  job_id | schedule_interval | max_runtime | max_retries | retry_period | next_start 
 --------+-------------------+-------------+-------------+--------------+------------
-   1014 | @ 84 hours        | @ 0         |          -1 | @ 1 day      | -infinity
+   1014 | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | -infinity
 (1 row)
 
 -- Changes expected


### PR DESCRIPTION
The default retry_period for jobs was set too high, causing jobs
that failed because of lack of workers to be restarted too infrequently,
this sets it significantly lower, to 5 minutes, though exponential
backoff will cause that to be larger as multiple failures stack up.