### PR TITLE
Add last_successful_finish to bgw_job_stats

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -180,6 +180,7 @@ CREATE TABLE IF NOT EXISTS _timescaledb_internal.bgw_job_stat (
     last_start              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_finish             TIMESTAMPTZ NOT NULL,
     next_start              TIMESTAMPTZ NOT NULL,
+    last_successful_finish  TIMESTAMPTZ NOT NULL,
     last_run_success        BOOL        NOT NULL,
     total_runs              BIGINT      NOT NULL,
     total_duration          INTERVAL    NOT NULL,
@@ -275,7 +276,7 @@ CREATE INDEX continuous_aggs_hypertable_invalidation_log_idx
 
 -- per cagg copy of invalidation log
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_aggs_materialization_invalidation_log(
-    materialization_id INTEGER 
+    materialization_id INTEGER
         REFERENCES _timescaledb_catalog.continuous_agg(mat_hypertable_id)
         ON DELETE CASCADE,
     lowest_modified_value BIGINT NOT NULL,

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -44,7 +44,7 @@ CREATE OR REPLACE VIEW timescaledb_information.reorder_policies as
     INNER JOIN _timescaledb_config.bgw_job j ON p.job_id = j.id;
 
 CREATE OR REPLACE VIEW timescaledb_information.policy_stats as
-  SELECT format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as hypertable, p.job_id, j.job_type, js.last_run_success, js.last_finish, js.last_start, js.next_start,
+  SELECT format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as hypertable, p.job_id, j.job_type, js.last_run_success, js.last_finish, js.last_successful_finish, js.last_start, js.next_start,
     js.total_runs, js.total_failures
   FROM (SELECT job_id, hypertable_id FROM _timescaledb_config.bgw_policy_reorder
         UNION SELECT job_id, hypertable_id FROM _timescaledb_config.bgw_policy_drop_chunks) p
@@ -115,6 +115,7 @@ CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregate_stats as
     END AS invalidation_threshold,
     cagg.job_id as job_id,
     bgw_job_stat.last_start as last_run_started_at,
+    bgw_job_stat.last_successful_finish as last_successful_finish,
     CASE when bgw_job_stat.last_run_success = 't' then 'Success'
          when bgw_job_stat.last_run_success = 'f' then 'Failed'
     END AS last_run_status,

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -255,6 +255,7 @@ bgw_job_stat_tuple_mark_end(TupleInfo *ti, void *const data)
 	{
 		fd->total_success++;
 		fd->consecutive_failures = 0;
+		fd->last_successful_finish = fd->last_finish;
 		/* Mark the next start at the end if the job itself hasn't */
 		if (!bgw_job_stat_next_start_was_set(fd))
 			fd->next_start = calculate_next_start_on_success(fd->last_finish, result_ctx->job);
@@ -316,6 +317,8 @@ bgw_job_stat_insert_relation(Relation rel, int32 bgw_job_id, bool mark_start,
 			TimestampGetDatum(DT_NOBEGIN);
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_last_finish)] = TimestampGetDatum(DT_NOBEGIN);
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_next_start)] = TimestampGetDatum(next_start);
+	values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_last_successful_finish)] =
+		TimestampGetDatum(DT_NOBEGIN);
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_total_runs)] =
 		Int64GetDatum((mark_start ? 1 : 0));
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_stat_total_duration)] =

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -552,6 +552,7 @@ enum Anum_bgw_job_stat
 	Anum_bgw_job_stat_last_start,
 	Anum_bgw_job_stat_last_finish,
 	Anum_bgw_job_stat_next_start,
+	Anum_bgw_job_stat_last_successful_finish,
 	Anum_bgw_job_stat_last_run_success,
 	Anum_bgw_job_stat_total_runs,
 	Anum_bgw_job_stat_total_duration,
@@ -571,6 +572,7 @@ typedef struct FormData_bgw_job_stat
 	TimestampTz last_start;
 	TimestampTz last_finish;
 	TimestampTz next_start;
+	TimestampTz last_successful_finish;
 	bool last_run_success;
 	int64 total_runs;
 	Interval total_duration;

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -95,8 +95,8 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50);
 
 -- empty
 SELECT * FROM _timescaledb_internal.bgw_job_stat;
- job_id | last_start | last_finish | next_start | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
---------+------------+-------------+------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+ job_id | last_start | last_finish | next_start | last_successful_finish | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+------------+-------------+------------+------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
 (0 rows)
 
 -- empty
@@ -266,6 +266,12 @@ SELECT * FROM sorted_bgw_log;
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
       1 |         0 | test_job_2       | Error job 2
 (3 rows)
+
+SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_internal.bgw_job_stat;
+         last_finish          | last_successful_finish | last_run_success 
+------------------------------+------------------------+------------------
+ Fri Dec 31 16:00:00 1999 PST | -infinity              | f
+(1 row)
 
 --Scheduler runs the job again, sees another error, and increases the wait time
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(125);
@@ -1125,9 +1131,9 @@ SELECT wait_for_job_1_to_run(2);
 (1 row)
 
 select * from _timescaledb_internal.bgw_job_stat;
- job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
---------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
-   1026 | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.25 1999 PST | t                |          2 | @ 0            |               2 |              0 |             0 |                    0 |                   0
+ job_id |           last_start            |           last_finish           |           next_start            |     last_successful_finish      | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1026 | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.25 1999 PST | Fri Dec 31 16:00:00.15 1999 PST | t                |          2 | @ 0            |               2 |              0 |             0 |                    0 |                   0
 (1 row)
 
 SELECT delete_job(x.id) FROM (select * from _timescaledb_config.bgw_job) x;
@@ -1248,9 +1254,9 @@ SELECT * FROM sorted_bgw_log;
 (16 rows)
 
 select * from _timescaledb_internal.bgw_job_stat;
- job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
---------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
-   1027 | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.49 1999 PST | t                |          2 | @ 0            |               2 |              0 |             0 |                    0 |                   0
+ job_id |           last_start            |           last_finish           |           next_start            |     last_successful_finish      | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1027 | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.48 1999 PST | Fri Dec 31 16:00:00.49 1999 PST | Fri Dec 31 16:00:00.48 1999 PST | t                |          2 | @ 0            |               2 |              0 |             0 |                    0 |                   0
 (1 row)
 
 SELECT * FROM insert_job(NULL,NULL,NULL,NULL,NULL,NULL);

--- a/test/sql/bgw_db_scheduler.sql
+++ b/test/sql/bgw_db_scheduler.sql
@@ -159,6 +159,8 @@ SELECT job_id, next_start-last_finish as until_next, last_run_success, total_run
 FROM _timescaledb_internal.bgw_job_stat;
 SELECT * FROM sorted_bgw_log;
 
+SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_internal.bgw_job_stat;
+
 --Scheduler runs the job again, sees another error, and increases the wait time
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(125);
 SELECT job_id, next_start-last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -70,8 +70,8 @@ SELECT * FROM timescaledb_information.reorder_policies;
 (0 rows)
 
 SELECT * FROM timescaledb_information.policy_stats;
- hypertable | job_id | job_type | last_run_success | last_finish | last_start | next_start | total_runs | total_failures 
-------------+--------+----------+------------------+-------------+------------+------------+------------+----------------
+ hypertable | job_id | job_type | last_run_success | last_finish | last_successful_finish | last_start | next_start | total_runs | total_failures 
+------------+--------+----------+------------------+-------------+------------------------+------------+------------+------------+----------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -249,9 +249,9 @@ SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
 SELECT *
     FROM _timescaledb_internal.bgw_job_stat
     where job_id=:reorder_job_id;
- job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
---------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
-   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST | t                |          3 | @ 0            |               3 |              0 |             0 |                    0 |                   0
+ job_id |           last_start            |           last_finish           |           next_start            |     last_successful_finish      | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST | Fri Dec 31 16:00:00.05 1999 PST | t                |          3 | @ 0            |               3 |              0 |             0 |                    0 |                   0
 (1 row)
 
 -- three chunks clustered
@@ -293,9 +293,9 @@ SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
 SELECT *
     FROM _timescaledb_internal.bgw_job_stat
     where job_id=:reorder_job_id;
- job_id |           last_start            |           last_finish           |           next_start            | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
---------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
-   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST | t                |          3 | @ 0            |               3 |              0 |             0 |                    0 |                   0
+ job_id |           last_start            |           last_finish           |           next_start            |     last_successful_finish      | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST | Fri Dec 31 16:00:00.05 1999 PST | t                |          3 | @ 0            |               3 |              0 |             0 |                    0 |                   0
 (1 row)
 
 -- still have 3 chunks clustered
@@ -317,9 +317,9 @@ SELECT * FROM timescaledb_information.reorder_policies;
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;
-     hypertable     | job_id | job_type | last_run_success |           last_finish           |           last_start            |           next_start            | total_runs | total_failures 
---------------------+--------+----------+------------------+---------------------------------+---------------------------------+---------------------------------+------------+----------------
- test_reorder_table |   1000 | reorder  | t                | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST |          3 |              0
+     hypertable     | job_id | job_type | last_run_success |           last_finish           |     last_successful_finish      |           last_start            |           next_start            | total_runs | total_failures 
+--------------------+--------+----------+------------------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+------------+----------------
+ test_reorder_table |   1000 | reorder  | t                | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Tue Jan 04 16:00:00.05 2000 PST |          3 |              0
 (1 row)
 
 -- test deleting the policy
@@ -612,9 +612,9 @@ SELECT * FROM timescaledb_information.drop_chunks_policies;
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;
-       hypertable       | job_id |  job_type   | last_run_success |         last_finish          |          last_start          |          next_start          | total_runs | total_failures 
-------------------------+--------+-------------+------------------+------------------------------+------------------------------+------------------------------+------------+----------------
- test_drop_chunks_table |   1001 | drop_chunks | t                | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:02 1999 PST |          2 |              0
+       hypertable       | job_id |  job_type   | last_run_success |         last_finish          |    last_successful_finish    |          last_start          |          next_start          | total_runs | total_failures 
+------------------------+--------+-------------+------------------+------------------------------+------------------------------+------------------------------+------------------------------+------------+----------------
+ test_drop_chunks_table |   1001 | drop_chunks | t                | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:02 1999 PST |          2 |              0
 (1 row)
 
 -- continuous aggregate blocks drop_chunks

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -64,8 +64,8 @@ SELECT * FROM _timescaledb_config.bgw_job;
 (0 rows)
 
 SELECT * FROM timescaledb_information.policy_stats;
- hypertable | job_id | job_type | last_run_success | last_finish | last_start | next_start | total_runs | total_failures 
-------------+--------+----------+------------------+-------------+------------+------------+------------+----------------
+ hypertable | job_id | job_type | last_run_success | last_finish | last_successful_finish | last_start | next_start | total_runs | total_failures 
+------------+--------+----------+------------------+-------------+------------------------+------------+------------+------------+----------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_agg;

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -99,6 +99,7 @@ completed_threshold    | Sun Dec 30 22:00:00 2018 PST
 invalidation_threshold | Sun Dec 30 22:00:00 2018 PST
 job_id                 | 1000
 last_run_started_at    | 
+last_successful_finish | 
 last_run_status        | 
 job_status             | 
 last_run_duration      | 


### PR DESCRIPTION
This allows people to better monitor the bgw job health. It
indicates when the last time the job made progress was.