### PR TITLE
Fix negative array index access in ChunkAppend parallel worker assignment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,6 +72,8 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "log_directory = 'pg_log'"
 
+    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "log_line_prefix = '%u [%p] %d '"
+
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "max_worker_processes=16"
 
     Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "autovacuum=false"

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -436,7 +436,12 @@ post_analyze_hook(ParseState *pstate, Query *query)
 					Oid db_oid = get_database_oid(stmt->subname, stmt->missing_ok);
 
 					if (OidIsValid(db_oid))
-						ts_bgw_message_send_and_wait(RESTART, db_oid);
+					{
+						ts_bgw_message_send_and_wait(STOP, db_oid);
+						ereport(WARNING,
+								(errmsg("You need to manually restart any running "
+										"background workers after this command.")));
+					}
 				}
 				break;
 			default:

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -607,12 +607,7 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-SELECT pg_sleep(0.001);
- pg_sleep 
-----------
- 
-(1 row)
-
+\c :TEST_DBNAME :ROLE_SUPERUSER
 SHOW timescaledb.shutdown_bgw_scheduler;
  timescaledb.shutdown_bgw_scheduler 
 ------------------------------------
@@ -638,12 +633,7 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-SELECT pg_sleep(0.001);
- pg_sleep 
-----------
- 
-(1 row)
-
+\c :TEST_DBNAME :ROLE_SUPERUSER
 SHOW timescaledb.shutdown_bgw_scheduler;
  timescaledb.shutdown_bgw_scheduler 
 ------------------------------------

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -529,6 +529,7 @@ SELECT wait_for_bgw_scheduler('db_rename_test');
 (1 row)
 
 ALTER DATABASE db_rename_test RENAME TO db_rename_test2;
+WARNING:  You need to manually restart any running background workers after this command.
 DROP DATABASE db_rename_test2;
 -- test create database with timescaledb database as template
 SELECT wait_for_bgw_scheduler(:'TEST_DBNAME');

--- a/test/postgresql.conf
+++ b/test/postgresql.conf
@@ -6,4 +6,4 @@ timescaledb.telemetry_level=off
 timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'
 timescaledb.last_tuned_version='0.0.1'
 timescaledb_telemetry.cloud='ci'
-log_line_prefix='%u [%p] '
+log_line_prefix='%u [%p] %d '

--- a/test/sql/bgw_db_scheduler.sql
+++ b/test/sql/bgw_db_scheduler.sql
@@ -270,7 +270,7 @@ SHOW timescaledb.shutdown_bgw_scheduler;
 
 ALTER SYSTEM SET timescaledb.shutdown_bgw_scheduler TO 'on';
 SELECT pg_reload_conf();
-SELECT pg_sleep(0.001);
+\c :TEST_DBNAME :ROLE_SUPERUSER
 SHOW timescaledb.shutdown_bgw_scheduler;
 
 SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
@@ -279,7 +279,7 @@ SELECT * FROM sorted_bgw_log;
 
 ALTER SYSTEM RESET timescaledb.shutdown_bgw_scheduler;
 SELECT pg_reload_conf();
-SELECT pg_sleep(0.001);
+\c :TEST_DBNAME :ROLE_SUPERUSER
 SHOW timescaledb.shutdown_bgw_scheduler;
 
 SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_ON_JOB);

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -176,8 +176,11 @@ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(PG_FUNCTION_ARGS)
 
 	worker_handle = start_test_scheduler(params);
 
-	Assert(BGWH_STARTED == WaitForBackgroundWorkerStartup(worker_handle, &pid));
-	Assert(BGWH_STOPPED == WaitForBackgroundWorkerShutdown(worker_handle));
+	if (worker_handle != NULL)
+	{
+		Assert(BGWH_STARTED == WaitForBackgroundWorkerStartup(worker_handle, &pid));
+		Assert(BGWH_STOPPED == WaitForBackgroundWorkerShutdown(worker_handle));
+	}
 
 	PG_RETURN_VOID();
 }
@@ -203,7 +206,10 @@ ts_bgw_db_scheduler_test_run(PG_FUNCTION_ARGS)
 extern Datum
 ts_bgw_db_scheduler_test_wait_for_scheduler_finish(PG_FUNCTION_ARGS)
 {
-	Assert(BGWH_STOPPED == WaitForBackgroundWorkerShutdown(current_handle));
+	if (current_handle != NULL)
+	{
+		Assert(BGWH_STOPPED == WaitForBackgroundWorkerShutdown(current_handle));
+	}
 	PG_RETURN_VOID();
 }
 

--- a/tsl/test/postgresql.conf
+++ b/tsl/test/postgresql.conf
@@ -4,3 +4,4 @@ autovacuum=false
 timescaledb.telemetry_level=off
 # when changing this, also update the one in appveyor.yml
 timescaledb.license_key='E1eyJlbmRfdGltZSI6IjIwMTgtMTAtMDEgKzAwMDAiLCAic3RhcnRfdGltZSI6IjIwMTgtMDktMDEgKzAwMDAiLCAiaWQiOiI0OTBGQjI2MC1BMjkyLTRBRDktOUFBMi0wMzYwODM1NzkxQjgiLCAia2luZCI6InRyaWFsIn0K'
+log_line_prefix='%u [%p] %d '


### PR DESCRIPTION
When all subplans are excluded during runtime exclusion negative
array index access might be possible on the ChunkAppend finished
state. This patch fixes the check for a valid subplan index.