### PR TITLE
Fix overflow in gapfill's interpolate

### DIFF
--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -725,7 +725,7 @@ SELECT t1.*,t2.m FROM
 SELECT t1.*,t2.m FROM
 (
   SELECT
-    time_bucket_gapfill(1,time,0,5) as time, 
+    time_bucket_gapfill(1,time,0,5) as time,
     color,
     locf(min(value)) as locf
   FROM
@@ -1083,10 +1083,10 @@ GROUP BY 1 ORDER BY 1;
  time | smallint | int | bigint | float4 | float8 
 ------+----------+-----+--------+--------+--------
     0 |       -3 |  -3 |     -3 |     -3 |     -3
-   10 |       -1 |  -1 |     -1 |   -1.8 |   -1.8
-   20 |        0 |   0 |      0 |   -0.6 |   -0.6
-   30 |        0 |   0 |      0 |    0.6 |    0.6
-   40 |        1 |   1 |      1 |    1.8 |    1.8
+   10 |       -2 |  -2 |     -2 |   -1.8 |   -1.8
+   20 |       -1 |  -1 |     -1 |   -0.6 |   -0.6
+   30 |        1 |   1 |      1 |    0.6 |    0.6
+   40 |        2 |   2 |      2 |    1.8 |    1.8
    50 |        3 |   3 |      3 |      3 |      3
 (6 rows)
 
@@ -2682,4 +2682,27 @@ GROUP BY 1,device_id;
     3 | Device 2
     4 | Device 2
 (10 rows)
+
+--test interpolation with big diifferences in values (test overflows in calculations)
+--we use the biggest possible difference in time(x) and the value(y).
+--For bigints we also test values of smaller than bigintmax/min to avoid
+--the symmetry where x=y (which catches more errors)
+SELECT  9223372036854775807 as big_int_max \gset
+SELECT -9223372036854775808	 as big_int_min \gset
+SELECT
+  time_bucket_gapfill(1,time,0,1) AS time,
+  interpolate(min(s)) AS "smallint",
+  interpolate(min(i)) AS "int",
+  interpolate(min(b)) AS "bigint",
+  interpolate(min(b2)) AS "bigint2",
+  interpolate(min(d)) AS "double"
+FROM (values (:big_int_min,(-32768)::smallint,(-2147483648)::int,:big_int_min,-2147483648::bigint, '-Infinity'::double precision),
+             (:big_int_max, 32767::smallint, 2147483647::int,:big_int_max, 2147483647::bigint, 'Infinity'::double precision)) v(time,s,i,b,b2,d)
+GROUP BY 1 ORDER BY 1;
+         time         | smallint |     int     |        bigint        |   bigint2   |  double   
+----------------------+----------+-------------+----------------------+-------------+-----------
+ -9223372036854775808 |   -32768 | -2147483648 | -9223372036854775808 | -2147483648 | -Infinity
+                    0 |        0 |           0 |                    0 |           0 |  Infinity
+  9223372036854775807 |    32767 |  2147483647 |  9223372036854775807 |  2147483647 |  Infinity
+(3 rows)
 


### PR DESCRIPTION
All integer types must use numeric-based interpolation calculations
since they are multiplied by int64 and this could cause an overflow.
numerics also interpolate better because the answer is rounded and not
truncated. We can't use float8 because that doesn't handle really big
ints exactly. We can't use the Postgres INT128 implementation because
it doesn't support division.

In the future we can optimize this for cases where overflow doesn't
occur.

Fixes #1491.