### PR TITLE
Fix bug with histogram function in parallel

### DIFF
--- a/src/histogram.c
+++ b/src/histogram.c
@@ -119,16 +119,18 @@ ts_hist_combinefunc(PG_FUNCTION_ARGS)
 		elog(ERROR, "ts_hist_combinefunc called in non-aggregate context");
 	}
 
-	if (state2 == NULL)
+	if (state1 == NULL && state2 == NULL)
+	{
+		PG_RETURN_NULL();
+	}
+	else if (state2 == NULL)
 	{
 		result = copy_state(aggcontext, state1);
 	}
-
 	else if (state1 == NULL)
 	{
 		result = copy_state(aggcontext, state2);
 	}
-
 	else
 	{
 		Size i;

--- a/test/expected/parallel-10.out
+++ b/test/expected/parallel-10.out
@@ -205,6 +205,26 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
  {1,2000,2000,2000,2000,1999,90000}
 (1 row)
 
+EXPLAIN (costs off) SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk
+                           Filter: ((i)::double precision = '-1'::double precision)
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk
+                           Filter: ((i)::double precision = '-1'::double precision)
+(9 rows)
+
+SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+ histogram 
+-----------
+ 
+(1 row)
+
 -- test parallel ChunkAppend
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
                                     QUERY PLAN                                    

--- a/test/expected/parallel-11.out
+++ b/test/expected/parallel-11.out
@@ -203,6 +203,26 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
  {1,2000,2000,2000,2000,1999,90000}
 (1 row)
 
+EXPLAIN (costs off) SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Parallel Append
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk
+                           Filter: ((i)::double precision = '-1'::double precision)
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk
+                           Filter: ((i)::double precision = '-1'::double precision)
+(9 rows)
+
+SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+ histogram 
+-----------
+ 
+(1 row)
+
 -- test parallel ChunkAppend
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
                                     QUERY PLAN                                    

--- a/test/expected/parallel-9.6.out
+++ b/test/expected/parallel-9.6.out
@@ -205,6 +205,26 @@ SELECT histogram(i, 10, 100000, 5) FROM "test";
  {1,2000,2000,2000,2000,1999,90000}
 (1 row)
 
+EXPLAIN (costs off) SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate
+   ->  Gather
+         Workers Planned: 2
+         ->  Partial Aggregate
+               ->  Append
+                     ->  Parallel Seq Scan on _hyper_1_1_chunk
+                           Filter: ((i)::double precision = '-1'::double precision)
+                     ->  Parallel Seq Scan on _hyper_1_2_chunk
+                           Filter: ((i)::double precision = '-1'::double precision)
+(9 rows)
+
+SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+ histogram 
+-----------
+ 
+(1 row)
+
 -- test parallel ChunkAppend
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
                           QUERY PLAN                          

--- a/test/sql/parallel.sql.in
+++ b/test/sql/parallel.sql.in
@@ -70,6 +70,9 @@ SELECT histogram(i, 0, 100000, 5) FROM "test";
 EXPLAIN (costs off) SELECT histogram(i, 10,100000,5) FROM "test";
 SELECT histogram(i, 10, 100000, 5) FROM "test";
 
+EXPLAIN (costs off) SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+SELECT histogram(NULL, 10,100000,5) FROM "test" WHERE  i = coalesce(-1,j); 
+
 -- test parallel ChunkAppend
 :PREFIX SELECT i FROM "test" WHERE length(version()) > 0;
 


### PR DESCRIPTION
Histogram's combine function threw a segfault if both state1
and state2 were NULL. I could only reproduce this case in
PG 10. Add a tests that hits this with PG 10.4

Fixes #1490