### PR TITLE
Use Postgres linker flags when linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,34 @@
 cmake_minimum_required(VERSION 3.4)
 include(CheckCCompilerFlag)
 
+# Function to call pg_config and extract values.
+#
+function(GET_PG_CONFIG var)
+  set(_temp)
+
+  # Only call pg_config if the variable didn't already have a value.
+  if(NOT ${var})
+    execute_process(
+      COMMAND ${PG_CONFIG} ${ARGN}
+      OUTPUT_VARIABLE _temp
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+
+  
+  # On Windows, fields that are not recorded will be given the value
+  # "not recorded", so we translate this into <var>-NOTFOUND to make
+  # it undefined.
+  #
+  # It will then also show as, e.g., "PG_LDFLAGS-NOTFOUND" in any
+  # string interpolation, making it obvious that it is an undefined
+  # CMake variable.
+  if(${_temp} STREQUAL "not recorded")
+    set(_temp ${var}-NOTFOUND)
+  endif()
+
+  set(${var} ${_temp} PARENT_SCOPE)
+endfunction()
+
 configure_file("version.config" "version.config" COPYONLY)
 file(READ version.config VERSION_CONFIG)
 set(VERSION_REGEX "version[\t ]*=[\t ]*([0-9]+\\.[0-9]+\\.*[0-9]*)([-]([a-z]+[0-9]*))*\r?\nupdate_from_version[\t ]*=[\t ]*([0-9]+\\.[0-9]+\\.*[0-9]*)([-]([a-z]+[0-9]*))*(\r?\n)*$")
@@ -202,58 +230,16 @@ if ((${PG_VERSION} VERSION_LESS "9.6")
 endif ()
 
 # Get PostgreSQL configuration from pg_config
-if (NOT PG_INCLUDEDIR)
-  execute_process(
-    COMMAND ${PG_CONFIG} --includedir
-    OUTPUT_VARIABLE PG_INCLUDEDIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif ()
-if (NOT PG_INCLUDEDIR_SERVER)
-  execute_process(
-    COMMAND ${PG_CONFIG} --includedir-server
-    OUTPUT_VARIABLE PG_INCLUDEDIR_SERVER
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif ()
-if (NOT PG_LIBDIR)
-  execute_process(
-    COMMAND ${PG_CONFIG} --libdir
-    OUTPUT_VARIABLE PG_LIBDIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif ()
-if (NOT PG_PKGLIBDIR)
-  execute_process(
-    COMMAND ${PG_CONFIG} --pkglibdir
-    OUTPUT_VARIABLE PG_PKGLIBDIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif ()
-if (NOT PG_SHAREDIR)
-  execute_process(
-    COMMAND ${PG_CONFIG} --sharedir
-    OUTPUT_VARIABLE PG_SHAREDIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif ()
-if (NOT PG_BINDIR)
-  execute_process(
-    COMMAND ${PG_CONFIG} --bindir
-    OUTPUT_VARIABLE PG_BINDIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif ()
-execute_process(
-  COMMAND ${PG_CONFIG} --cppflags
-  OUTPUT_VARIABLE PG_CPPFLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-  COMMAND ${PG_CONFIG} --cflags
-  OUTPUT_VARIABLE PG_CFLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-  COMMAND ${PG_CONFIG} --ldflags
-  OUTPUT_VARIABLE PG_LDFLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(
-  COMMAND ${PG_CONFIG} --libs
-  OUTPUT_VARIABLE PG_LIBS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+get_pg_config(PG_INCLUDEDIR --includedir)
+get_pg_config(PG_INCLUDEDIR_SERVER --includedir-server)
+get_pg_config(PG_LIBDIR --libdir)
+get_pg_config(PG_PKGLIBDIR --pkglibdir)
+get_pg_config(PG_SHAREDIR --sharedir)
+get_pg_config(PG_BINDIR --bindir)
+get_pg_config(PG_CPPFLAGS --cppflags)
+get_pg_config(PG_CFLAGS --cflags)
+get_pg_config(PG_LDFLAGS --ldflags)
+get_pg_config(PG_LIBS --libs)
 
 find_path(PG_SOURCE_DIR
   src/include/pg_config.h.in

--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -3,22 +3,27 @@ if(NOT USE_DEFAULT_VISIBILITY)
   set(CMAKE_C_VISIBILITY_PRESET "hidden")
 endif()
 
-if (UNIX)
+if(UNIX)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${PG_LIBDIR}")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -L${PG_LIBDIR}")
   set(CMAKE_C_FLAGS "${PG_CFLAGS} ${CMAKE_C_FLAGS}")
   set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${PG_CPPFLAGS}")
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
-endif (UNIX)
-
-if (APPLE)
+elseif(APPLE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -multiply_defined suppress")
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -multiply_defined suppress -Wl,-undefined,dynamic_lookup -Wl,-dead_strip_dylibs -bundle_loader ${PG_BINDIR}/postgres")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -multiply_defined suppress -Wl,-undefined,dynamic_lookup -bundle_loader ${PG_BINDIR}/postgres")
 elseif (WIN32)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /MANIFEST:NO")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /MANIFEST:NO")
-endif (APPLE)
+endif()
+
+# PG_LDFLAGS can have strange values if not found, so we just add the
+# flags if they are defined.
+if(PG_LDFLAGS)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${PG_LDFLAGS}")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${PG_LDFLAGS}")
+endif()
 
 if(APACHE_ONLY)
   add_definitions(-DAPACHE_ONLY)

--- a/tsl/src/build-defs.cmake
+++ b/tsl/src/build-defs.cmake
@@ -8,15 +8,20 @@ if (UNIX)
   set(CMAKE_C_FLAGS "${PG_CFLAGS} ${CMAKE_C_FLAGS}")
   set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${PG_CPPFLAGS}")
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
-endif (UNIX)
-
-if (APPLE)
+elseif(APPLE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -multiply_defined suppress")
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -multiply_defined suppress -Wl,-undefined,dynamic_lookup -Wl,-dead_strip_dylibs -bundle_loader ${PG_BINDIR}/postgres")
-elseif (WIN32)
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -multiply_defined suppress -Wl,-undefined,dynamic_lookup -bundle_loader ${PG_BINDIR}/postgres")
+elseif(WIN32)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /MANIFEST:NO")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /MANIFEST:NO")
-endif (APPLE)
+endif()
+
+# PG_LDFLAGS can have strange values if not found, so we just add the
+# flags if they are defined.
+if(PG_LDFLAGS)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${PG_LDFLAGS}")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${PG_LDFLAGS}")
+endif()
 
 include_directories(
   ${PROJECT_SOURCE_DIR}/src


### PR DESCRIPTION
When linking the extensions as shared libraries, the linker flags from
`pg_config` is not used. This means that if `PG_PATH` is provided and
refer to a locally compiled Postgres installation, shared libraries
from that installation will not be used. Instead any default-installed
version of Postgres will be used.

This commit adds `PG_LDFLAGS` to `CMAKE_SHARED_LINKER_FLAGS` and
`CMAKE_MODULE_LINKER_FLAGS`.

To handle that Windows set some fields to "not recorded" when they are
not available, it introduces a CMake function `get_pg_config` that will
replace it with `<var>-NOTFOUND` so that it is treated as undefined by
CMake.
