### PR TITLE
Add constraint aware tests for compression

### DIFF
--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -7426,6 +7426,13 @@ NOTICE:  adding index _compressed_hypertable_16_device_id__ts_meta_sequence_num_
 NOTICE:  adding index _compressed_hypertable_16_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT time, device_id, 0, device_id FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-15 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) ;
+INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz,'2018-01-20 11:55:00+0','10s') , 4, 5, generate_series(1,5,1) ;
+INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT now(), generate_series(4,7,1), 5, generate_series(1,5,1) ;
+-- misisng values device_id = 7
+CREATE TABLE device_tbl(device_id int, descr text);
+INSERT into device_tbl select generate_series(1, 6,1), 'devicex';
+INSERT into device_tbl select  8, 'device8';
+analyze device_tbl;
 -- run queries on uncompressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
@@ -7442,7 +7449,9 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_15_1438_chunk
  _timescaledb_internal._hyper_15_1439_chunk
  _timescaledb_internal._hyper_15_1440_chunk
-(3 rows)
+ _timescaledb_internal._hyper_15_1441_chunk
+ _timescaledb_internal._hyper_15_1442_chunk
+(5 rows)
 
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
@@ -7491,7 +7500,7 @@ WHERE ht.table_name = 'metrics_ordered_idx2'
 ORDER BY c.id;
                compress_chunk               
 --------------------------------------------
- _timescaledb_internal._hyper_17_1444_chunk
+ _timescaledb_internal._hyper_17_1448_chunk
 (1 row)
 
 --all queries have only prefix of compress_orderby in ORDER BY clause
@@ -7502,8 +7511,8 @@ ORDER BY c.id;
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
          Order: metrics_ordered_idx2."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk (actual rows=10 loops=1)
-               ->  Index Scan Backward using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1445_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
+               ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 3)
                      Filter: (device_id_peer = 3)
 (7 rows)
@@ -7514,8 +7523,8 @@ ORDER BY c.id;
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
          Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk (actual rows=10 loops=1)
-               ->  Index Scan Backward using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1445_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
+               ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 3)
                      Filter: (device_id_peer = 3)
 (7 rows)
@@ -7525,11 +7534,11 @@ ORDER BY c.id;
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_17_1444_chunk."time" DESC, _hyper_17_1444_chunk.v0 DESC
+         Sort Key: _hyper_17_1448_chunk."time" DESC, _hyper_17_1448_chunk.v0 DESC
          Sort Method: top-N heapsort 
          ->  Append (actual rows=4291 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1445_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=4291 loops=1)
+                     ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
                            Index Cond: (device_id_peer = 3)
                            Filter: (device_id = 3)
 (9 rows)
@@ -7540,15 +7549,15 @@ ORDER BY c.id;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=4291 loops=1)
    ->  Append (actual rows=4291 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk d (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1445_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk d (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
    ->  Subquery Scan on m (actual rows=1 loops=4291)
          Filter: (d.device_id_peer = m.device_id_peer)
          ->  Limit (actual rows=1 loops=4291)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
                      Order: m_1."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk m_2 (actual rows=1 loops=4291)
-                           ->  Index Scan Backward using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1445_chunk compress_hyper_18_1445_chunk_1 (actual rows=1 loops=4291)
+                     ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk m_2 (actual rows=1 loops=4291)
+                           ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk compress_hyper_18_1449_chunk_1 (actual rows=1 loops=4291)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
 (13 rows)
@@ -7566,20 +7575,24 @@ SET work_mem TO '50MB';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
-   Sort Key: _hyper_15_1440_chunk."time", _hyper_15_1440_chunk.device_id, _hyper_15_1440_chunk.device_id_peer, _hyper_15_1440_chunk.v0
+   Sort Key: _hyper_15_1442_chunk."time", _hyper_15_1442_chunk.device_id, _hyper_15_1442_chunk.device_id_peer, _hyper_15_1442_chunk.v0
    Sort Method: quicksort 
    ->  Limit (actual rows=10 loops=1)
          ->  Sort (actual rows=10 loops=1)
-               Sort Key: _hyper_15_1440_chunk."time" DESC
+               Sort Key: _hyper_15_1442_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Append (actual rows=8611 loops=1)
+               ->  Append (actual rows=12907 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (actual rows=2880 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1442_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1441_chunk (actual rows=5 loops=1)
-(14 rows)
+                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
+(18 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10) as q order by 1, 2, 3, 4;
@@ -7591,85 +7604,337 @@ SET work_mem TO '50MB';
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
                ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=1 loops=1)
+                     ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=1 loops=1)
                            Index Cond: (device_id = 3)
                            Filter: (device_id_peer = 3)
                ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1442_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (never executed)
                            Index Cond: (device_id = 3)
                            Filter: (device_id_peer = 3)
                ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1441_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (never executed)
                            Index Cond: (device_id = 3)
                            Filter: (device_id_peer = 3)
-(18 rows)
+(26 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                       QUERY PLAN                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
    ->  Nested Loop (actual rows=4291 loops=1)
-         ->  Merge Append (actual rows=8611 loops=1)
+         ->  Merge Append (actual rows=12907 loops=1)
                Sort Key: d.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-                     ->  Index Scan using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1441_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-                     ->  Index Scan using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1442_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
                      ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-         ->  Subquery Scan on m (actual rows=0 loops=8611)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
+                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
+                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
+                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+         ->  Subquery Scan on m (actual rows=0 loops=12907)
                Filter: (d.device_id_peer = m.device_id_peer)
                Rows Removed by Filter: 0
-               ->  Limit (actual rows=1 loops=8611)
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=1 loops=8611)
+               ->  Limit (actual rows=0 loops=12907)
+                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
                            Order: m_1."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_2 (actual rows=1 loops=8611)
-                                 ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=1 loops=8611)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
+                                 ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
                                        Index Cond: (device_id_peer = 3)
                                        Filter: (device_id = d.device_id)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_3 (actual rows=0 loops=3456)
-                                 ->  Index Scan Backward using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1442_chunk compress_hyper_16_1442_chunk_1 (actual rows=0 loops=3456)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
+                                 ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
                                        Index Cond: (device_id_peer = 3)
                                        Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_4 (actual rows=0 loops=3456)
-                                 ->  Index Scan Backward using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1441_chunk compress_hyper_16_1441_chunk_1 (actual rows=0 loops=3456)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
+                                 ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
                                        Index Cond: (device_id_peer = 3)
                                        Filter: (device_id = d.device_id)
-(29 rows)
+                                       Rows Removed by Filter: 3
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
+                                 ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
+                                 ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+(41 rows)
 
 :PREFIX SELECT d.device_id, m.time,  m.time
 FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=4291 loops=1)
-   ->  Append (actual rows=8611 loops=1)
+   ->  Append (actual rows=12907 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1441_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-               ->  Index Scan using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1442_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
                ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-   ->  Subquery Scan on m (actual rows=0 loops=8611)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
+               ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
+               ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+   ->  Subquery Scan on m (actual rows=0 loops=12907)
          Filter: (d.device_id_peer = m.device_id_peer)
          Rows Removed by Filter: 0
-         ->  Limit (actual rows=1 loops=8611)
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=1 loops=8611)
+         ->  Limit (actual rows=0 loops=12907)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
                      Order: m_1."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_2 (actual rows=1 loops=8611)
-                           ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=1 loops=8611)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
+                           ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
-                                 Rows Removed by Filter: 2
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_3 (actual rows=0 loops=3456)
-                           ->  Index Scan Backward using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1442_chunk compress_hyper_16_1442_chunk_1 (actual rows=0 loops=3456)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
+                           ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_4 (actual rows=0 loops=3456)
-                           ->  Index Scan Backward using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1441_chunk compress_hyper_16_1441_chunk_1 (actual rows=0 loops=3456)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
+                           ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
-(27 rows)
+                                 Rows Removed by Filter: 3
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
+                           ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
+                           ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+(39 rows)
 
 set enable_seqscan = true;
+\ir include/transparent_decompression_constraintaware.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--- TEST for constraint aware append  ------------
+--should select only newly added chunk --
+set timescaledb.enable_chunk_append to false;
+:PREFIX select * from ( SELECT * FROM metrics_ordered_idx where time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: metrics_ordered_idx."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 2
+                     ->  Append (actual rows=4296 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
+
+-- DecompressChunk path because segmentby columns have equality constraints
+:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 4 AND device_id_peer = 5 and time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10) as q  order by 1, 2, 3, 4;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=10 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 2
+               ->  Merge Append (actual rows=10 loops=1)
+                     Sort Key: _hyper_15_1441_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=9 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_16_1446_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=1 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_16_1447_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                                       Rows Removed by Filter: 4
+(24 rows)
+
+:PREFIX SELECT m.device_id, d.v0, count(*)
+FROM metrics_ordered_idx d , metrics_ordered_idx m
+WHERE m.device_id = d.device_id AND m.device_id_peer = 5
+and m.time = d.time and m.time > '2002-01-01' and m.time < now()
+AND m.device_id_peer = d.device_id_peer
+group by m.device_id, d.v0 order by 1,2 ,3;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=9 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=9 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Hash Join (actual rows=4295 loops=1)
+               Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 2
+                     ->  Append (actual rows=4296 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_1 (actual rows=4291 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_2 (actual rows=5 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+               ->  Hash (actual rows=4295 loops=1)
+                     Buckets: 8192 (originally 2048)  Batches: 1 (originally 1) 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 2
+                           ->  Append (actual rows=4296 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_1 (actual rows=4291 loops=1)
+                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                       ->  Seq Scan on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=5 loops=1)
+                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=5 loops=1)
+                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=5 loops=1)
+                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+(33 rows)
+
+--query with no results --
+:PREFIX SELECT m.device_id, d.v0, count(*) 
+FROM metrics_ordered_idx d , metrics_ordered_idx m 
+WHERE m.time = d.time and  m.time > now()
+group by m.device_id, d.v0 order by 1,2 ,3;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Merge Join (actual rows=0 loops=1)
+               Merge Cond: (d."time" = m."time")
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: d."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 1
+                           ->  Append (actual rows=0 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_1 (actual rows=0 loops=1)
+                                       Filter: ("time" > now())
+                                       Rows Removed by Filter: 5
+                                       ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+               ->  Sort (never executed)
+                     Sort Key: m."time"
+                     ->  Custom Scan (ConstraintAwareAppend) (never executed)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 1
+                           ->  Append (never executed)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (never executed)
+                                       Filter: ("time" > now())
+                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (never executed)
+(27 rows)
+
+--query with all chunks but 1 excluded at plan time --
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d, metrics_ordered_idx m 
+WHERE m.device_id = d.device_id 
+and m.time > '2019-01-01' and m.time < now()
+order by m.v0;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=3 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=5 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 1
+               ->  Append (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (actual rows=5 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+(16 rows)
+
+-- no matches in metrics_ordered_idx but one row in device_tbl
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d LEFT OUTER JOIN  metrics_ordered_idx m 
+ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
+WHERE d.device_id = 8 
+order by m.v0;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Nested Loop Left Join (actual rows=1 loops=1)
+         Join Filter: (m.device_id = d.device_id)
+         ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
+               Filter: (device_id = 8)
+               Rows Removed by Filter: 6
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 1
+               ->  Append (actual rows=0 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (actual rows=0 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                                 Rows Removed by Filter: 5
+(17 rows)
+
+-- no matches in device_tbl but 1 row in metrics_ordered_idx
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d FULL OUTER JOIN  metrics_ordered_idx m 
+ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
+WHERE m.device_id = 7 
+order by m.v0;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Left Join (actual rows=1 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < now()))
+         ->  Append (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 4
+         ->  Hash (actual rows=0 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
+                     Filter: (device_id = 7)
+                     Rows Removed by Filter: 7
+(16 rows)
+
+set timescaledb.enable_chunk_append to true;

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -7552,6 +7552,13 @@ NOTICE:  adding index _compressed_hypertable_16_device_id__ts_meta_sequence_num_
 NOTICE:  adding index _compressed_hypertable_16_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT time, device_id, 0, device_id FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-15 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) ;
+INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz,'2018-01-20 11:55:00+0','10s') , 4, 5, generate_series(1,5,1) ;
+INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT now(), generate_series(4,7,1), 5, generate_series(1,5,1) ;
+-- misisng values device_id = 7
+CREATE TABLE device_tbl(device_id int, descr text);
+INSERT into device_tbl select generate_series(1, 6,1), 'devicex';
+INSERT into device_tbl select  8, 'device8';
+analyze device_tbl;
 -- run queries on uncompressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
@@ -7568,7 +7575,9 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_15_1438_chunk
  _timescaledb_internal._hyper_15_1439_chunk
  _timescaledb_internal._hyper_15_1440_chunk
-(3 rows)
+ _timescaledb_internal._hyper_15_1441_chunk
+ _timescaledb_internal._hyper_15_1442_chunk
+(5 rows)
 
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
@@ -7617,7 +7626,7 @@ WHERE ht.table_name = 'metrics_ordered_idx2'
 ORDER BY c.id;
                compress_chunk               
 --------------------------------------------
- _timescaledb_internal._hyper_17_1444_chunk
+ _timescaledb_internal._hyper_17_1448_chunk
 (1 row)
 
 --all queries have only prefix of compress_orderby in ORDER BY clause
@@ -7628,8 +7637,8 @@ ORDER BY c.id;
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
          Order: metrics_ordered_idx2."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk (actual rows=10 loops=1)
-               ->  Index Scan Backward using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1445_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
+               ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 3)
                      Filter: (device_id_peer = 3)
 (7 rows)
@@ -7640,8 +7649,8 @@ ORDER BY c.id;
  Limit (actual rows=10 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
          Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk (actual rows=10 loops=1)
-               ->  Index Scan Backward using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1445_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
+               ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
                      Index Cond: (device_id = 3)
                      Filter: (device_id_peer = 3)
 (7 rows)
@@ -7651,11 +7660,11 @@ ORDER BY c.id;
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_17_1444_chunk."time" DESC, _hyper_17_1444_chunk.v0 DESC
+         Sort Key: _hyper_17_1448_chunk."time" DESC, _hyper_17_1448_chunk.v0 DESC
          Sort Method: top-N heapsort 
          ->  Append (actual rows=4291 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1445_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=4291 loops=1)
+                     ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
                            Index Cond: (device_id_peer = 3)
                            Filter: (device_id = 3)
 (9 rows)
@@ -7666,15 +7675,15 @@ ORDER BY c.id;
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=4291 loops=1)
    ->  Append (actual rows=4291 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk d (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1445_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk d (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
    ->  Subquery Scan on m (actual rows=1 loops=4291)
          Filter: (d.device_id_peer = m.device_id_peer)
          ->  Limit (actual rows=1 loops=4291)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
                      Order: m_1."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_17_1444_chunk m_2 (actual rows=1 loops=4291)
-                           ->  Index Scan Backward using compress_hyper_18_1445_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1445_chunk compress_hyper_18_1445_chunk_1 (actual rows=1 loops=4291)
+                     ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk m_2 (actual rows=1 loops=4291)
+                           ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk compress_hyper_18_1449_chunk_1 (actual rows=1 loops=4291)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
 (13 rows)
@@ -7692,20 +7701,24 @@ SET work_mem TO '50MB';
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
-   Sort Key: _hyper_15_1440_chunk."time", _hyper_15_1440_chunk.device_id, _hyper_15_1440_chunk.device_id_peer, _hyper_15_1440_chunk.v0
+   Sort Key: _hyper_15_1442_chunk."time", _hyper_15_1442_chunk.device_id, _hyper_15_1442_chunk.device_id_peer, _hyper_15_1442_chunk.v0
    Sort Method: quicksort 
    ->  Limit (actual rows=10 loops=1)
          ->  Sort (actual rows=10 loops=1)
-               Sort Key: _hyper_15_1440_chunk."time" DESC
+               Sort Key: _hyper_15_1442_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Append (actual rows=8611 loops=1)
+               ->  Append (actual rows=12907 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (actual rows=2880 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1442_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1441_chunk (actual rows=5 loops=1)
-(14 rows)
+                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
+(18 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10) as q order by 1, 2, 3, 4;
@@ -7717,85 +7730,337 @@ SET work_mem TO '50MB';
    ->  Limit (actual rows=10 loops=1)
          ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
                Order: metrics_ordered_idx."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
                ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=1 loops=1)
+                     ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=1 loops=1)
                            Index Cond: (device_id = 3)
                            Filter: (device_id_peer = 3)
                ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1442_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (never executed)
                            Index Cond: (device_id = 3)
                            Filter: (device_id_peer = 3)
                ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1441_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (never executed)
                            Index Cond: (device_id = 3)
                            Filter: (device_id_peer = 3)
-(18 rows)
+(26 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                       QUERY PLAN                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                        QUERY PLAN                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=1 loops=1)
    ->  Nested Loop (actual rows=4291 loops=1)
-         ->  Merge Append (actual rows=8611 loops=1)
+         ->  Merge Append (actual rows=12907 loops=1)
                Sort Key: d.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-                     ->  Index Scan using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1441_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-                     ->  Index Scan using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1442_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
                      ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-         ->  Subquery Scan on m (actual rows=0 loops=8611)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
+                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
+                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
+                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+         ->  Subquery Scan on m (actual rows=0 loops=12907)
                Filter: (d.device_id_peer = m.device_id_peer)
                Rows Removed by Filter: 0
-               ->  Limit (actual rows=1 loops=8611)
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=1 loops=8611)
+               ->  Limit (actual rows=0 loops=12907)
+                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
                            Order: m_1."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_2 (actual rows=1 loops=8611)
-                                 ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=1 loops=8611)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
+                                 ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
                                        Index Cond: (device_id_peer = 3)
                                        Filter: (device_id = d.device_id)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_3 (actual rows=0 loops=3456)
-                                 ->  Index Scan Backward using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1442_chunk compress_hyper_16_1442_chunk_1 (actual rows=0 loops=3456)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
+                                 ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
                                        Index Cond: (device_id_peer = 3)
                                        Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_4 (actual rows=0 loops=3456)
-                                 ->  Index Scan Backward using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1441_chunk compress_hyper_16_1441_chunk_1 (actual rows=0 loops=3456)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
+                                 ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
                                        Index Cond: (device_id_peer = 3)
                                        Filter: (device_id = d.device_id)
-(29 rows)
+                                       Rows Removed by Filter: 3
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
+                                 ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
+                                 ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+(41 rows)
 
 :PREFIX SELECT d.device_id, m.time,  m.time
 FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=4291 loops=1)
-   ->  Append (actual rows=8611 loops=1)
+   ->  Append (actual rows=12907 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1441_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-               ->  Index Scan using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1442_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
                ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-   ->  Subquery Scan on m (actual rows=0 loops=8611)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
+               ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
+               ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+   ->  Subquery Scan on m (actual rows=0 loops=12907)
          Filter: (d.device_id_peer = m.device_id_peer)
          Rows Removed by Filter: 0
-         ->  Limit (actual rows=1 loops=8611)
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=1 loops=8611)
+         ->  Limit (actual rows=0 loops=12907)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
                      Order: m_1."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_2 (actual rows=1 loops=8611)
-                           ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=1 loops=8611)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
+                           ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
-                                 Rows Removed by Filter: 2
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_3 (actual rows=0 loops=3456)
-                           ->  Index Scan Backward using compress_hyper_16_1442_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1442_chunk compress_hyper_16_1442_chunk_1 (actual rows=0 loops=3456)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
+                           ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_4 (actual rows=0 loops=3456)
-                           ->  Index Scan Backward using compress_hyper_16_1441_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1441_chunk compress_hyper_16_1441_chunk_1 (actual rows=0 loops=3456)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
+                           ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
                                  Index Cond: (device_id_peer = 3)
                                  Filter: (device_id = d.device_id)
-(27 rows)
+                                 Rows Removed by Filter: 3
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
+                           ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
+                           ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+(39 rows)
 
 set enable_seqscan = true;
+\ir include/transparent_decompression_constraintaware.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--- TEST for constraint aware append  ------------
+--should select only newly added chunk --
+set timescaledb.enable_chunk_append to false;
+:PREFIX select * from ( SELECT * FROM metrics_ordered_idx where time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: metrics_ordered_idx."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 2
+                     ->  Append (actual rows=4296 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
+
+-- DecompressChunk path because segmentby columns have equality constraints
+:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 4 AND device_id_peer = 5 and time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10) as q  order by 1, 2, 3, 4;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=10 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 2
+               ->  Merge Append (actual rows=10 loops=1)
+                     Sort Key: _hyper_15_1441_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=9 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_16_1446_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=1 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_16_1447_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                                       Rows Removed by Filter: 4
+(24 rows)
+
+:PREFIX SELECT m.device_id, d.v0, count(*)
+FROM metrics_ordered_idx d , metrics_ordered_idx m
+WHERE m.device_id = d.device_id AND m.device_id_peer = 5
+and m.time = d.time and m.time > '2002-01-01' and m.time < now()
+AND m.device_id_peer = d.device_id_peer
+group by m.device_id, d.v0 order by 1,2 ,3;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=9 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=9 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Hash Join (actual rows=4295 loops=1)
+               Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 2
+                     ->  Append (actual rows=4296 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_1 (actual rows=4291 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_2 (actual rows=5 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+               ->  Hash (actual rows=4295 loops=1)
+                     Buckets: 8192 (originally 2048)  Batches: 1 (originally 1) 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 2
+                           ->  Append (actual rows=4296 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_1 (actual rows=4291 loops=1)
+                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                       ->  Seq Scan on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=5 loops=1)
+                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=5 loops=1)
+                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=5 loops=1)
+                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
+(33 rows)
+
+--query with no results --
+:PREFIX SELECT m.device_id, d.v0, count(*) 
+FROM metrics_ordered_idx d , metrics_ordered_idx m 
+WHERE m.time = d.time and  m.time > now()
+group by m.device_id, d.v0 order by 1,2 ,3;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Merge Join (actual rows=0 loops=1)
+               Merge Cond: (d."time" = m."time")
+               ->  Sort (actual rows=0 loops=1)
+                     Sort Key: d."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 1
+                           ->  Append (actual rows=0 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_1 (actual rows=0 loops=1)
+                                       Filter: ("time" > now())
+                                       Rows Removed by Filter: 5
+                                       ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+               ->  Sort (never executed)
+                     Sort Key: m."time"
+                     ->  Custom Scan (ConstraintAwareAppend) (never executed)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 1
+                           ->  Append (never executed)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (never executed)
+                                       Filter: ("time" > now())
+                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (never executed)
+(27 rows)
+
+--query with all chunks but 1 excluded at plan time --
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d, metrics_ordered_idx m 
+WHERE m.device_id = d.device_id 
+and m.time > '2019-01-01' and m.time < now()
+order by m.v0;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=3 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=5 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 1
+               ->  Append (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (actual rows=5 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+         ->  Hash (actual rows=7 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+(16 rows)
+
+-- no matches in metrics_ordered_idx but one row in device_tbl
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d LEFT OUTER JOIN  metrics_ordered_idx m 
+ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
+WHERE d.device_id = 8 
+order by m.v0;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Nested Loop Left Join (actual rows=1 loops=1)
+         Join Filter: (m.device_id = d.device_id)
+         ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
+               Filter: (device_id = 8)
+               Rows Removed by Filter: 6
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 1
+               ->  Append (actual rows=0 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (actual rows=0 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
+                                 Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                                 Rows Removed by Filter: 5
+(17 rows)
+
+-- no matches in device_tbl but 1 row in metrics_ordered_idx
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d FULL OUTER JOIN  metrics_ordered_idx m 
+ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
+WHERE m.device_id = 7 
+order by m.v0;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Left Join (actual rows=1 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < now()))
+         ->  Append (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 4
+         ->  Hash (actual rows=0 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
+                     Filter: (device_id = 7)
+                     Rows Removed by Filter: 7
+(16 rows)
+
+set timescaledb.enable_chunk_append to true;

--- a/tsl/test/sql/include/transparent_decompression_constraintaware.sql
+++ b/tsl/test/sql/include/transparent_decompression_constraintaware.sql
@@ -1,0 +1,48 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+--- TEST for constraint aware append  ------------
+--should select only newly added chunk --
+set timescaledb.enable_chunk_append to false;
+:PREFIX select * from ( SELECT * FROM metrics_ordered_idx where time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
+
+-- DecompressChunk path because segmentby columns have equality constraints
+:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 4 AND device_id_peer = 5 and time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10) as q  order by 1, 2, 3, 4;
+
+:PREFIX SELECT m.device_id, d.v0, count(*)
+FROM metrics_ordered_idx d , metrics_ordered_idx m
+WHERE m.device_id = d.device_id AND m.device_id_peer = 5
+and m.time = d.time and m.time > '2002-01-01' and m.time < now()
+AND m.device_id_peer = d.device_id_peer
+group by m.device_id, d.v0 order by 1,2 ,3;
+
+--query with no results --
+:PREFIX SELECT m.device_id, d.v0, count(*) 
+FROM metrics_ordered_idx d , metrics_ordered_idx m 
+WHERE m.time = d.time and  m.time > now()
+group by m.device_id, d.v0 order by 1,2 ,3;
+
+--query with all chunks but 1 excluded at plan time --
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d, metrics_ordered_idx m 
+WHERE m.device_id = d.device_id 
+and m.time > '2019-01-01' and m.time < now()
+order by m.v0;
+
+-- no matches in metrics_ordered_idx but one row in device_tbl
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d LEFT OUTER JOIN  metrics_ordered_idx m 
+ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
+WHERE d.device_id = 8 
+order by m.v0;
+
+-- no matches in device_tbl but 1 row in metrics_ordered_idx
+:PREFIX SELECT d.*, m.* 
+FROM device_tbl d FULL OUTER JOIN  metrics_ordered_idx m 
+ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
+WHERE m.device_id = 7 
+order by m.v0;
+
+
+set timescaledb.enable_chunk_append to true;

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -146,6 +146,14 @@ SELECT create_hypertable('metrics_ordered_idx','time', chunk_time_interval=>'2da
 ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby='time ASC',timescaledb.compress_segmentby='device_id,device_id_peer');
 INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT time, device_id, 0, device_id FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-15 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
 INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) ;
+INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz,'2018-01-20 11:55:00+0','10s') , 4, 5, generate_series(1,5,1) ;
+INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT now(), generate_series(4,7,1), 5, generate_series(1,5,1) ;
+
+-- misisng values device_id = 7
+CREATE TABLE device_tbl(device_id int, descr text);
+INSERT into device_tbl select generate_series(1, 6,1), 'devicex';
+INSERT into device_tbl select  8, 'device8';
+analyze device_tbl;
 
 -- run queries on uncompressed hypertable and store result
 \set PREFIX ''
@@ -154,6 +162,7 @@ INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generat
 SET client_min_messages TO error;
 \o :TEST_RESULTS_UNCOMPRESSED_IDX
 \ir include/transparent_decompression_ordered_index.sql
+\ir include/transparent_decompression_constraintaware.sql
 \o
 RESET client_min_messages;
 \set ECHO all
@@ -174,6 +183,7 @@ SET client_min_messages TO error;
 set enable_seqscan = false;
 \o :TEST_RESULTS_COMPRESSED_IDX
 \ir include/transparent_decompression_ordered_index.sql
+\ir include/transparent_decompression_constraintaware.sql
 set enable_seqscan = true;
 \o
 RESET client_min_messages;
@@ -204,3 +214,4 @@ set enable_seqscan = false;
 set enable_seqscan = false;
 \ir include/transparent_decompression_ordered_index.sql
 set enable_seqscan = true;
+\ir include/transparent_decompression_constraintaware.sql


### PR DESCRIPTION
1. This commit introduces changes to expected plan output due
to the addition of new chunks to metrics_ordered_idx.
2. Add tests for constraint aware appends on compressed
tables.