### PR TITLE
Fix failure with custom type test

### DIFF
--- a/test/expected/custom_type.out
+++ b/test/expected/custom_type.out
@@ -23,10 +23,7 @@ CREATE TYPE customtype (
  OUTPUT = customtype_out,
  RECEIVE = customtype_recv,
  SEND = customtype_send,
- INTERNALLENGTH = 8,
- PASSEDBYVALUE,
- ALIGNMENT = double,
- STORAGE = plain
+ LIKE = TIMESTAMPTZ
 );
 CREATE CAST (customtype AS bigint)
 WITHOUT FUNCTION AS ASSIGNMENT;

--- a/test/sql/custom_type.sql
+++ b/test/sql/custom_type.sql
@@ -23,10 +23,7 @@ CREATE TYPE customtype (
  OUTPUT = customtype_out,
  RECEIVE = customtype_recv,
  SEND = customtype_send,
- INTERNALLENGTH = 8,
- PASSEDBYVALUE,
- ALIGNMENT = double,
- STORAGE = plain
+ LIKE = TIMESTAMPTZ
 );
 
 CREATE CAST (customtype AS bigint)


### PR DESCRIPTION
Fix tests that fail like so:
test=# CREATE CAST (customtype AS bigint)
test-# WITHOUT FUNCTION AS ASSIGNMENT;
ERROR:  source and target data types are not physically compatible