### PR TITLE
Set active snapshots in multi-xact index create

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1673,10 +1673,12 @@ process_index_chunk_multitransaction(int32 hypertable_id, Oid chunk_relid, void 
 
 	/* Start a new transaction for each relation. */
 	StartTransactionCommand();
+	PushActiveSnapshot(GetTransactionSnapshot());
 
 #ifdef DEBUG
 	if (info->extended_options.max_chunks == 0)
 	{
+		PopActiveSnapshot();
 		CommitTransactionCommand();
 		return;
 	}
@@ -1751,6 +1753,7 @@ process_index_chunk_multitransaction(int32 hypertable_id, Oid chunk_relid, void 
 
 	ts_catalog_restore_user(&sec_ctx);
 
+	PopActiveSnapshot();
 	CommitTransactionCommand();
 }
 


### PR DESCRIPTION
Set active snapshots when creating txns during index
create with timescaledb.transaction_per_chunk. This
is needed for some index types like `bloom`.

Tests not added since we don't want dependencies on contrib modules
like bloom.

Fixes #1521.