### PR TITLE
Fix CMake condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ function(GET_PG_CONFIG var)
   # It will then also show as, e.g., "PG_LDFLAGS-NOTFOUND" in any
   # string interpolation, making it obvious that it is an undefined
   # CMake variable.
-  if(${_temp} STREQUAL "not recorded")
+  if("${_temp}" STREQUAL "not recorded")
     set(_temp ${var}-NOTFOUND)
   endif()
 


### PR DESCRIPTION
In some cases _temp variable will not be set due to pg_config not
returning any output for a specific flag. This will result in an
error when doing comparison using STREQUAL. Wrapping variable in
double quotes fixes the problem.