### PR TITLE
Make continuous agg relative to now()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 1.6
+
+The semantics of the refresh_lag parameter for continuous aggregates has 
+been changed to be relative to the current timestamp instead of the maximum
+value in the table. This change requires that an integer_now func be set on
+hypertables with integer-based time columns to use continuous aggregates on
+this table.
+
 ## 1.5.1 (2019-11-12)
 
 This maintenance release contains bugfixes since the 1.5.0 release. We deem it low

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,24 @@
+DO
+$BODY$
+DECLARE
+    hypertable_name TEXT;
+BEGIN
+    SELECT first_dim.schema_name || '.' || first_dim.table_name
+    FROM _timescaledb_catalog.continuous_agg ca
+    INNER JOIN LATERAL (
+        SELECT dim.*, h.*
+        FROM _timescaledb_catalog.hypertable h
+        INNER JOIN _timescaledb_catalog.dimension dim ON (dim.hypertable_id = h.id)
+        WHERE ca.raw_hypertable_id = h.id
+        ORDER by dim.id ASC
+        LIMIT 1
+    ) first_dim ON true
+    WHERE first_dim.column_type IN (REGTYPE 'int2', REGTYPE 'int4', REGTYPE 'int8')
+    AND (first_dim.integer_now_func_schema IS NULL OR first_dim.integer_now_func IS NULL)
+    INTO hypertable_name;
+
+    IF hypertable_name is not null AND (current_setting('timescaledb.ignore_update_errors', true) is null OR current_setting('timescaledb.ignore_update_errors', true) != 'on') THEN
+        RAISE 'The continuous aggregate on hypertable "%" will break unless an integer_now func is set using set_integer_now_func().', hypertable_name;
+    END IF;
+END
+$BODY$;

--- a/src/guc.c
+++ b/src/guc.c
@@ -55,6 +55,7 @@ char *ts_telemetry_cloud = NULL;
 
 #ifdef TS_DEBUG
 bool ts_shutdown_bgw = false;
+char *ts_current_timestamp_mock = "";
 #endif
 
 static void
@@ -278,6 +279,17 @@ _guc_init(void)
 							 /* check_hook= */ NULL,
 							 /* assign_hook= */ NULL,
 							 /* show_hook= */ NULL);
+
+	DefineCustomStringVariable(/* name= */ "timescaledb.current_timestamp_mock",
+							   /* short_dec= */ "set the current timestamp",
+							   /* long_dec= */ "this is for debugging purposes",
+							   /* valueAddr= */ &ts_current_timestamp_mock,
+							   /* bootValue= */ false,
+							   /* context= */ PGC_USERSET,
+							   /* flags= */ 0,
+							   /* check_hook= */ NULL,
+							   /* assign_hook= */ NULL,
+							   /* show_hook= */ NULL);
 #endif
 }
 

--- a/src/guc.h
+++ b/src/guc.h
@@ -31,6 +31,7 @@ extern char *ts_telemetry_cloud;
 
 #ifdef TS_DEBUG
 extern bool ts_shutdown_bgw;
+extern char *ts_current_timestamp_mock;
 #else
 #define ts_shutdown_bgw false
 #endif

--- a/src/interval.h
+++ b/src/interval.h
@@ -20,5 +20,6 @@ TSDLLEXPORT HeapTuple ts_interval_form_heaptuple(FormData_ts_interval *invl);
 TSDLLEXPORT bool ts_interval_equal(FormData_ts_interval *invl1, FormData_ts_interval *invl2);
 TSDLLEXPORT void ts_interval_now_func_validate(Oid now_func_oid, Oid open_dim_type);
 TSDLLEXPORT Datum ts_interval_subtract_from_now(FormData_ts_interval *invl, Dimension *open_dim);
+TSDLLEXPORT int64 ts_get_now_internal(Dimension *open_dim);
 
 #endif /* TIMESCALEDB_INTERVAL */

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -440,7 +440,7 @@ SELECT count(*) FROM _timescaledb_catalog.hypertable hypertable;
 ROLLBACK;
 DROP VIEW dependent_1;
 --create a cont agg view on the ht as well then the drop should nuke everything
---TODO put back when cont aggs work
+SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
 CREATE VIEW test1_cont_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -42,6 +42,13 @@ insert into foo values( 1 , 14 , 20);
 insert into foo values( 2 , 14 , 20);
 insert into foo values( 2 , 15 , 20);
 insert into foo values( 2 , 16 , 20);
+CREATE OR REPLACE FUNCTION integer_now_foo() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(a), 0) FROM foo $$;
+SELECT set_integer_now_func('foo', 'integer_now_foo');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 create or replace view mat_m1( a, countb )
 WITH ( timescaledb.continuous)
 as
@@ -753,6 +760,7 @@ FROM _timescaledb_catalog.continuous_agg ca
 INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_drop_test;
 INFO:  new materialization range for public.conditions larger than allowed in one run, truncating (time column timec) (1546041600000000)
 INFO:  new materialization range for public.conditions (time column timec) (1542758400000000)
@@ -939,6 +947,13 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  conditions
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_conditions() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_conditions');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 create or replace view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '500', timescaledb.refresh_interval = '2h')
 as
@@ -992,6 +1007,13 @@ NOTICE:  adding not-null constraint to column "time"
  (24,public,space_table,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_space_table() returns BIGINT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), BIGINT '0') FROM space_table $$;
+SELECT set_integer_now_func('space_table', 'integer_now_space_table');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW space_view
 WITH (timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.refresh_interval = '72h')
 AS SELECT time_bucket('4', time), COUNT(data)
@@ -1038,7 +1060,7 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 
 INSERT INTO space_table VALUES (3, 2, 1);
 REFRESH MATERIALIZED VIEW space_view;
-INFO:  new materialization range not found for public.space_table (time column time): no new data
+INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold (12)
 INFO:  materializing continuous aggregate public.space_view: no new range to materialize
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
@@ -1059,7 +1081,7 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 
 INSERT INTO space_table VALUES (2, 3, 1);
 REFRESH MATERIALIZED VIEW space_view;
-INFO:  new materialization range not found for public.space_table (time column time): no new data
+INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold (12)
 INFO:  materializing continuous aggregate public.space_view: no new range to materialize
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
@@ -1122,6 +1144,13 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  table_name 
 ------------
  conditions
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_conditions() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_conditions');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 insert into conditions

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -82,6 +82,13 @@ NOTICE:  adding not-null constraint to column "time"
  (1,public,test_continuous_agg_table,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM test_continuous_agg_table $$;
+SELECT set_integer_now_func('test_continuous_agg_table', 'integer_now_test');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW test_continuous_agg_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('2', time), SUM(data) as value
@@ -520,6 +527,13 @@ NOTICE:  adding not-null constraint to column "time"
                create_hypertable                
 ------------------------------------------------
  (5,public,test_continuous_agg_table_w_grant,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM test_continuous_agg_table_w_grant $$;
+SELECT set_integer_now_func('test_continuous_agg_table_w_grant', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 GRANT SELECT, TRIGGER ON test_continuous_agg_table_w_grant TO public;

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -211,6 +211,13 @@ CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_id
     FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10) \gset
 NOTICE:  adding not-null constraint to column "time"
+CREATE OR REPLACE FUNCTION integer_now_test() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table $$;
+SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
@@ -358,6 +365,13 @@ CREATE TABLE drop_chunks_table_u(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_u_id
     FROM create_hypertable('drop_chunks_table_u', 'time', chunk_time_interval => 7) \gset
 NOTICE:  adding not-null constraint to column "time"
+CREATE OR REPLACE FUNCTION integer_now_test1() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table_u $$;
+SELECT set_integer_now_func('drop_chunks_table_u', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
@@ -527,6 +541,7 @@ NOTICE:  adding index _materialized_hypertable_10_const_time_idx ON _timescaledb
 NOTICE:  adding index _materialized_hypertable_10_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(numeric, time)
 NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(case, time)
 NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
+SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
 INFO:  new materialization range for public.metrics (time column time) (947289600000000)
 INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -211,6 +211,13 @@ CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_id
     FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10) \gset
 NOTICE:  adding not-null constraint to column "time"
+CREATE OR REPLACE FUNCTION integer_now_test() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table $$;
+SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
@@ -358,6 +365,13 @@ CREATE TABLE drop_chunks_table_u(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_u_id
     FROM create_hypertable('drop_chunks_table_u', 'time', chunk_time_interval => 7) \gset
 NOTICE:  adding not-null constraint to column "time"
+CREATE OR REPLACE FUNCTION integer_now_test1() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table_u $$;
+SELECT set_integer_now_func('drop_chunks_table_u', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
@@ -527,6 +541,7 @@ NOTICE:  adding index _materialized_hypertable_10_const_time_idx ON _timescaledb
 NOTICE:  adding index _materialized_hypertable_10_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(numeric, time)
 NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(case, time)
 NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
+SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
 INFO:  new materialization range for public.metrics (time column time) (947289600000000)
 INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -211,6 +211,13 @@ CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_id
     FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10) \gset
 NOTICE:  adding not-null constraint to column "time"
+CREATE OR REPLACE FUNCTION integer_now_test() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table $$;
+SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
@@ -358,6 +365,13 @@ CREATE TABLE drop_chunks_table_u(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_u_id
     FROM create_hypertable('drop_chunks_table_u', 'time', chunk_time_interval => 7) \gset
 NOTICE:  adding not-null constraint to column "time"
+CREATE OR REPLACE FUNCTION integer_now_test1() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table_u $$;
+SELECT set_integer_now_func('drop_chunks_table_u', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
@@ -527,6 +541,7 @@ NOTICE:  adding index _materialized_hypertable_10_const_time_idx ON _timescaledb
 NOTICE:  adding index _materialized_hypertable_10_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(numeric, time)
 NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(case, time)
 NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
+SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
 INFO:  new materialization range for public.metrics (time column time) (947289600000000)
 INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -107,9 +107,10 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_AFTER;
 NOTICE:  adding index _materialized_hypertable_4_location_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(location, bucket)
 --materialize mat_before
+SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_before;
-INFO:  new materialization range for public.conditions_before (time column timec) (1548633600000000)
-INFO:  materializing continuous aggregate public.mat_before: new range up to 1548633600000000
+INFO:  new materialization range for public.conditions_before (time column timec) (1551052800000000)
+INFO:  materializing continuous aggregate public.mat_before: new range up to 1551052800000000
 SELECT count(*) FROM conditions_before;
  count 
 -------
@@ -190,9 +191,10 @@ DROP VIEW mat_after;
 ERROR:  dropping a continous aggregate requires using CASCADE
 \set ON_ERROR_STOP 1
 --materialize mat_after
+SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_after;
-INFO:  new materialization range for public.conditions_after (time column timec) (1548633600000000)
-INFO:  materializing continuous aggregate public.mat_after: new range up to 1548633600000000
+INFO:  new materialization range for public.conditions_after (time column timec) (1551052800000000)
+INFO:  materializing continuous aggregate public.mat_after: new range up to 1551052800000000
 SELECT count(*) FROM mat_after;
  count 
 -------

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -320,6 +320,13 @@ NOTICE:  adding not-null constraint to column "a"
  rowsec_tab
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(a), 0)::bigint FROM rowsec_tab $$;
+SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
 create  view mat_m1 WITH ( timescaledb.continuous)
@@ -405,6 +412,13 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  table_name 
 ------------
  conditions
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test_s() returns smallint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0)::smallint FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_test_s');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 \set ON_ERROR_STOP 0

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -680,9 +680,11 @@ SELECT materialization_id, _timescaledb_internal.to_timestamp(watermark)
 --------------------+--------------
 (0 rows)
 
+SET timescaledb.current_timestamp_mock = '2019-02-02 5:00 UTC';
 REFRESH MATERIALIZED VIEW test_t_mat_view;
-INFO:  new materialization range for public.continuous_agg_test_t (time column time) (1549072800000000)
-INFO:  materializing continuous aggregate public.test_t_mat_view: new range up to 1549072800000000
+INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549072800000000)
+INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize
+INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME" ORDER BY 1;
  time_bucket | agg_2_2 | chunk_id 
 -------------+---------+----------
@@ -694,24 +696,21 @@ SELECT * FROM test_t_mat_view ORDER BY 1;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_completed_threshold;
- materialization_id |    watermark     
---------------------+------------------
-                  6 | 1549072800000000
-(1 row)
+ materialization_id | watermark 
+--------------------+-----------
+(0 rows)
 
 SELECT materialization_id, _timescaledb_internal.to_timestamp(watermark)
     FROM _timescaledb_catalog.continuous_aggs_completed_threshold
     WHERE materialization_id = :mat_hypertable_id;
- materialization_id |      to_timestamp      
---------------------+------------------------
-                  6 | 2019-02-02 02:00:00+00
-(1 row)
+ materialization_id | to_timestamp 
+--------------------+--------------
+(0 rows)
 
 SELECT hypertable_id, _timescaledb_internal.to_timestamp(watermark) FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id |      to_timestamp      
----------------+------------------------
-             5 | 2019-02-02 02:00:00+00
-(1 row)
+ hypertable_id | to_timestamp 
+---------------+--------------
+(0 rows)
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;
 INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549072800000000)
@@ -728,26 +727,24 @@ SELECT * FROM test_t_mat_view ORDER BY 1;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_completed_threshold;
- materialization_id |    watermark     
---------------------+------------------
-                  6 | 1549072800000000
-(1 row)
+ materialization_id | watermark 
+--------------------+-----------
+(0 rows)
 
 SELECT materialization_id, _timescaledb_internal.to_timestamp(watermark)
     FROM _timescaledb_catalog.continuous_aggs_completed_threshold
     WHERE materialization_id = :mat_hypertable_id;
- materialization_id |      to_timestamp      
---------------------+------------------------
-                  6 | 2019-02-02 02:00:00+00
-(1 row)
+ materialization_id | to_timestamp 
+--------------------+--------------
+(0 rows)
 
 SELECT hypertable_id, _timescaledb_internal.to_timestamp(watermark) FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id |      to_timestamp      
----------------+------------------------
-             5 | 2019-02-02 02:00:00+00
-(1 row)
+ hypertable_id | to_timestamp 
+---------------+--------------
+(0 rows)
 
--- increase the last timestamp, so we actually materialize
+-- increase the current timestamp, so we actually materialize
+SET timescaledb.current_timestamp_mock = '2019-02-02 7:00 UTC';
 INSERT INTO continuous_agg_test_t VALUES ('2019-02-02 7:00 UTC', 1);
 SELECT * FROM continuous_agg_test_t ORDER BY 1;
           time          | data 
@@ -832,6 +829,13 @@ NOTICE:  adding not-null constraint to column "time"
  (7,public,continuous_agg_extreme,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_continuous_agg_extreme() returns BIGINT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), BIGINT '-9223372036854775808') FROM continuous_agg_extreme $$;
+SELECT set_integer_now_func('continuous_agg_extreme', 'integer_now_continuous_agg_extreme');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 -- TODO we should be able to use time_bucket(5, ...) (note lack of '), but that is currently not
 --      recognized as a constant
 CREATE VIEW extreme_view
@@ -847,7 +851,7 @@ CREATE TRIGGER continuous_agg_insert_trigger
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE raw_hypertable_id=:raw_table_id \gset
 -- EMPTY table should be a nop
 REFRESH MATERIALIZED VIEW extreme_view;
-INFO:  new materialization range not found for public.continuous_agg_extreme (time column time): no new data
+INFO:  new materialization range not found for public.continuous_agg_extreme (time column time): not enough data in table (-9223372036854775808)
 INFO:  materializing continuous aggregate public.extreme_view: no new range to materialize
 INFO:  materializing continuous aggregate public.extreme_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM extreme_view;
@@ -977,6 +981,13 @@ NOTICE:  adding not-null constraint to column "time"
  (9,public,continuous_agg_negative,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_continuous_agg_negative() returns BIGINT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), BIGINT '-9223372036854775808') FROM continuous_agg_negative $$;
+SELECT set_integer_now_func('continuous_agg_negative', 'integer_now_continuous_agg_negative');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW negative_view_5
     WITH (timescaledb.continuous, timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('5', time), COUNT(data) as value
@@ -1012,7 +1023,7 @@ SELECT * FROM negative_view_5 ORDER BY 1;
 -- bucket is finished as normal with the additional value
 INSERT INTO continuous_agg_negative VALUES (14, 14);
 REFRESH MATERIALIZED VIEW negative_view_5;
-INFO:  new materialization range not found for public.continuous_agg_negative (time column time): no new data
+INFO:  new materialization range not found for public.continuous_agg_negative (time column time): not enough new data past completion threshold (15)
 INFO:  materializing continuous aggregate public.negative_view_5: no new range to materialize
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
@@ -1022,6 +1033,30 @@ SELECT * FROM negative_view_5 ORDER BY 1;
           10 |     5
 (3 rows)
 
+--inserting a really large value does not work because of max_interval_per_job
+INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
+SET client_min_messages TO error;
+REFRESH MATERIALIZED VIEW negative_view_5;
+INFO:  new materialization range for public.continuous_agg_negative larger than allowed in one run, truncating (time column time) (9223372036854775805)
+INFO:  new materialization range for public.continuous_agg_negative (time column time) (115)
+INFO:  materializing continuous aggregate public.negative_view_5: new range up to 115
+RESET client_min_messages;
+SELECT * FROM negative_view_5 ORDER BY 1;
+ time_bucket | value 
+-------------+-------
+           0 |     5
+           5 |     5
+          10 |     5
+(3 rows)
+
+DROP VIEW negative_view_5 CASCADE;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_10_27_chunk
+TRUNCATE continuous_agg_negative;
+CREATE VIEW negative_view_5
+            WITH (timescaledb.continuous, timescaledb.refresh_lag='-2')
+AS SELECT time_bucket('5', time), COUNT(data) as value
+   FROM continuous_agg_negative
+   GROUP BY 1;
 -- we can handle values near max
 INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
 SET client_min_messages TO error;
@@ -1032,11 +1067,8 @@ RESET client_min_messages;
 SELECT * FROM negative_view_5 ORDER BY 1;
      time_bucket     | value 
 ---------------------+-------
-                   0 |     5
-                   5 |     5
-                  10 |     5
  9223372036854775800 |     1
-(4 rows)
+(1 row)
 
 -- even when the subrtraction would make a completion time greater than max
 INSERT INTO continuous_agg_negative VALUES (:big_int_max-1, 201);
@@ -1049,22 +1081,26 @@ RESET client_min_messages;
 SELECT * FROM negative_view_5 ORDER BY 1;
      time_bucket     | value 
 ---------------------+-------
-                   0 |     5
-                   5 |     5
-                  10 |     5
  9223372036854775800 |     1
-(4 rows)
+(1 row)
 
 DROP TABLE continuous_agg_negative CASCADE;
 NOTICE:  drop cascades to 2 other objects
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_11_30_chunk
 -- max_interval_per_job tests
 CREATE TABLE continuous_agg_max_mat(time BIGINT, data BIGINT);
 SELECT create_hypertable('continuous_agg_max_mat', 'time', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
- (11,public,continuous_agg_max_mat,t)
+ (12,public,continuous_agg_max_mat,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_continuous_agg_max_mat() returns BIGINT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), BIGINT '-9223372036854775808') FROM continuous_agg_max_mat $$;
+SELECT set_integer_now_func('continuous_agg_max_mat', 'integer_now_continuous_agg_max_mat');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 -- only allow two time_buckets per run
@@ -1117,7 +1153,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 (6 rows)
 
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): no new data
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM max_mat_view ORDER BY 1;
@@ -1137,7 +1173,7 @@ SELECT create_hypertable('continuous_agg_max_mat_t', 'time');
 NOTICE:  adding not-null constraint to column "time"
            create_hypertable            
 ----------------------------------------
- (13,public,continuous_agg_max_mat_t,t)
+ (14,public,continuous_agg_max_mat_t,t)
 (1 row)
 
 -- only allow two time_buckets per run
@@ -1149,6 +1185,7 @@ CREATE VIEW max_mat_view_t
 INSERT INTO continuous_agg_max_mat_t
     SELECT i, i FROM
         generate_series('2019-09-09 1:00'::TIMESTAMPTZ, '2019-09-09 10:00', '1 hour') AS i;
+SET timescaledb.current_timestamp_mock = '2019-09-09 10:00 UTC';
 -- first run create two materializations
 REFRESH MATERIALIZED VIEW max_mat_view_t;
 INFO:  new materialization range for public.continuous_agg_max_mat_t larger than allowed in one run, truncating (time column time) (1568030400000000)
@@ -1192,7 +1229,7 @@ SELECT * FROM max_mat_view_t ORDER BY 1;
 (6 rows)
 
 REFRESH MATERIALIZED VIEW max_mat_view_t;
-INFO:  new materialization range not found for public.continuous_agg_max_mat_t (time column time): no new data
+INFO:  new materialization range not found for public.continuous_agg_max_mat_t (time column time): not enough new data past completion threshold (1568030400000000)
 INFO:  materializing continuous aggregate public.max_mat_view_t: no new range to materialize
 INFO:  materializing continuous aggregate public.max_mat_view_t: no new range to materialize or invalidations found, exiting early
 SELECT * FROM max_mat_view_t ORDER BY 1;
@@ -1212,7 +1249,7 @@ SELECT create_hypertable('continuous_agg_max_mat_timestamp', 'time');
 NOTICE:  adding not-null constraint to column "time"
                create_hypertable                
 ------------------------------------------------
- (15,public,continuous_agg_max_mat_timestamp,t)
+ (16,public,continuous_agg_max_mat_timestamp,t)
 (1 row)
 
 CREATE VIEW max_mat_view_timestamp
@@ -1243,7 +1280,7 @@ SELECT create_hypertable('continuous_agg_max_mat_date', 'time');
 NOTICE:  adding not-null constraint to column "time"
              create_hypertable             
 -------------------------------------------
- (17,public,continuous_agg_max_mat_date,t)
+ (18,public,continuous_agg_max_mat_date,t)
 (1 row)
 
 CREATE VIEW max_mat_view_date
@@ -1253,6 +1290,8 @@ CREATE VIEW max_mat_view_date
         GROUP BY 1;
 INSERT INTO continuous_agg_max_mat_date
     SELECT generate_series('2019-09-01'::DATE, '2019-09-010 10:00', '1 day');
+SET timescaledb.current_timestamp_mock = '2019-09-09 01:00 UTC';
+--SET timescaledb.current_timestamp_mock = '2019-09-09 01:01:01 UTC';
 -- first materializes everything
 REFRESH MATERIALIZED VIEW max_mat_view_date;
 INFO:  new materialization range for public.continuous_agg_max_mat_date (time column time) (1568592000000000)
@@ -1269,10 +1308,10 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_statu
     FROM timescaledb_information.continuous_aggregate_stats ORDER BY 1;
        view_name        |  completed_threshold   | invalidation_threshold | job_id | job_status | last_run_duration 
 ------------------------+------------------------+------------------------+--------+------------+-------------------
- max_mat_view           | 12                     | 12                     |   1003 |            | 
- max_mat_view_t         | 2019-09-09 12:00:00+00 | 2019-09-09 12:00:00+00 |   1004 |            | 
- max_mat_view_timestamp | 2019-09-09 12:00:00    | 2019-09-09 12:00:00    |   1005 |            | 
- max_mat_view_date      | 2019-09-16             | 2019-09-16             |   1006 |            | 
+ max_mat_view           | 12                     | 12                     |   1004 |            | 
+ max_mat_view_t         | 2019-09-09 12:00:00+00 | 2019-09-09 12:00:00+00 |   1005 |            | 
+ max_mat_view_timestamp | 2019-09-09 12:00:00    | 2019-09-09 12:00:00    |   1006 |            | 
+ max_mat_view_date      | 2019-09-16             | 2019-09-16             |   1007 |            | 
 (4 rows)
 
 SELECT view_name, refresh_lag, max_interval_per_job
@@ -1290,10 +1329,10 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_statu
     FROM timescaledb_information.continuous_aggregate_stats ORDER BY 1;
        view_name        |  completed_threshold   | invalidation_threshold | job_id | job_status | last_run_duration 
 ------------------------+------------------------+------------------------+--------+------------+-------------------
- max_mat_view           | 12                     | 12                     |   1003 |            | 
- max_mat_view_t         | 2019-09-09 07:00:00-05 | 2019-09-09 07:00:00-05 |   1004 |            | 
- max_mat_view_timestamp | 2019-09-09 12:00:00    | 2019-09-09 12:00:00    |   1005 |            | 
- max_mat_view_date      | 2019-09-16             | 2019-09-16             |   1006 |            | 
+ max_mat_view           | 12                     | 12                     |   1004 |            | 
+ max_mat_view_t         | 2019-09-09 07:00:00-05 | 2019-09-09 07:00:00-05 |   1005 |            | 
+ max_mat_view_timestamp | 2019-09-09 12:00:00    | 2019-09-09 12:00:00    |   1006 |            | 
+ max_mat_view_date      | 2019-09-16             | 2019-09-16             |   1007 |            | 
 (4 rows)
 
 SELECT view_name, refresh_lag, max_interval_per_job

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -19,6 +19,13 @@ NOTICE:  adding not-null constraint to column "timeval"
  (1,public,continuous_agg_test,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timeval), 0) FROM continuous_agg_test $$;
+SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 INSERT INTO continuous_agg_test VALUES
     (10, - 4, 1), (11, - 3, 5), (12, - 3, 7), (13, - 3, 9), (14,-4, 11),
     (15, -4, 22), (16, -4, 23);
@@ -119,7 +126,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): no new data
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
 INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
 select * from cagg_1 order by 1;
  timed | cnt 
@@ -166,7 +173,7 @@ order by 1,2 ;
 (5 rows)
 
 refresh materialized view cagg_2;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): no new data
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
 INFO:  materializing continuous aggregate public.cagg_2: no new range to materialize
 select * from cagg_2 order by 1, 2;
  timed | grp | maxval 
@@ -195,7 +202,7 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
 (1 row)
 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): no new data
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
 INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
 select count(*) from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
  count 
@@ -249,6 +256,13 @@ NOTICE:  adding not-null constraint to column "timeval"
  (4,public,continuous_agg_test,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timeval), 0) FROM continuous_agg_test $$;
+SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 INSERT INTO continuous_agg_test VALUES
     (10, - 4, 1), (11, - 3, 5), (12, - 3, 7), (13, - 3, 9), (14,-4, 11),
     (15, -4, 22), (16, -4, 23);
@@ -289,7 +303,7 @@ select * from cagg_2 order by 1;
 --this insert will be processed only by cagg_1 and copied over to cagg_2
 insert into continuous_agg_test values( 14, -2, 100); 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): no new data
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
 INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
 select * from cagg_1 order by 1;
  timed | cnt 
@@ -363,7 +377,7 @@ select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log o
 (2 rows)
 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): no new data
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (20)
 INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
 select * from cagg_1 where timed = 18 ;
  timed | cnt 

--- a/tsl/test/expected/continuous_aggs_permissions-10.out
+++ b/tsl/test/expected/continuous_aggs_permissions-10.out
@@ -28,6 +28,13 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  conditions
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 create or replace view mat_refresh_test
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as
@@ -63,6 +70,13 @@ select table_name from create_hypertable('conditions_for_perm_check', 'timec', c
  conditions_for_perm_check
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check $$;
+SELECT set_integer_now_func('conditions_for_perm_check', 'integer_now_test2');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE TABLE conditions_for_perm_check_w_grant (
       timec       INT       NOT NULL,
       location    TEXT              NOT NULL,
@@ -76,6 +90,13 @@ select table_name from create_hypertable('conditions_for_perm_check_w_grant', 't
             table_name             
 -----------------------------------
  conditions_for_perm_check_w_grant
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check_w_grant $$;
+SELECT set_integer_now_func('conditions_for_perm_check_w_grant', 'integer_now_test3');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 GRANT SELECT, TRIGGER ON conditions_for_perm_check_w_grant TO public;

--- a/tsl/test/expected/continuous_aggs_permissions-11.out
+++ b/tsl/test/expected/continuous_aggs_permissions-11.out
@@ -28,6 +28,13 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  conditions
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 create or replace view mat_refresh_test
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as
@@ -63,6 +70,13 @@ select table_name from create_hypertable('conditions_for_perm_check', 'timec', c
  conditions_for_perm_check
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check $$;
+SELECT set_integer_now_func('conditions_for_perm_check', 'integer_now_test2');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE TABLE conditions_for_perm_check_w_grant (
       timec       INT       NOT NULL,
       location    TEXT              NOT NULL,
@@ -76,6 +90,13 @@ select table_name from create_hypertable('conditions_for_perm_check_w_grant', 't
             table_name             
 -----------------------------------
  conditions_for_perm_check_w_grant
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check_w_grant $$;
+SELECT set_integer_now_func('conditions_for_perm_check_w_grant', 'integer_now_test3');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 GRANT SELECT, TRIGGER ON conditions_for_perm_check_w_grant TO public;

--- a/tsl/test/expected/continuous_aggs_permissions-9.6.out
+++ b/tsl/test/expected/continuous_aggs_permissions-9.6.out
@@ -28,6 +28,13 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
  conditions
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 create or replace view mat_refresh_test
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as
@@ -63,6 +70,13 @@ select table_name from create_hypertable('conditions_for_perm_check', 'timec', c
  conditions_for_perm_check
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check $$;
+SELECT set_integer_now_func('conditions_for_perm_check', 'integer_now_test2');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE TABLE conditions_for_perm_check_w_grant (
       timec       INT       NOT NULL,
       location    TEXT              NOT NULL,
@@ -76,6 +90,13 @@ select table_name from create_hypertable('conditions_for_perm_check_w_grant', 't
             table_name             
 -----------------------------------
  conditions_for_perm_check_w_grant
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check_w_grant $$;
+SELECT set_integer_now_func('conditions_for_perm_check_w_grant', 'integer_now_test3');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 GRANT SELECT, TRIGGER ON conditions_for_perm_check_w_grant TO public;

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -54,6 +54,7 @@ SELECT * FROM device_summary;
 --Normally, the continuous view will be updated automatically on a schedule but, you can also do it manually.
 --We alter max_interval_per_job too since we are not using background workers
 ALTER VIEW device_summary SET (timescaledb.max_interval_per_job = '60 day');
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW device_summary;
 INFO:  new materialization range for public.device_readings (time column observation_time) (1546236000000000)
 INFO:  materializing continuous aggregate public.device_summary: new range up to 1546236000000000
@@ -193,8 +194,9 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
  Sun Dec 30 13:00:00 2018 PST | device_1  | 1546175700 |          1800
 (1 row)
 
+SET timescaledb.current_timestamp_mock = 'Sun Dec 30 13:01:00 2018 PST';
 REFRESH MATERIALIZED VIEW device_summary;
-INFO:  new materialization range not found for public.device_readings (time column observation_time): no new data
+INFO:  new materialization range not found for public.device_readings (time column observation_time): not enough new data past completion threshold (1546207200000000)
 INFO:  materializing continuous aggregate public.device_summary: no new range to materialize
 --But is reflected after.
 SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 30 13:00:00 2018 PST';
@@ -262,7 +264,7 @@ FROM
 GROUP BY bucket, device_id;
 NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 REFRESH MATERIALIZED VIEW device_summary;
-INFO:  new materialization range for public.device_readings larger than allowed in one run, truncating (time column observation_time) (1546236000000000)
+INFO:  new materialization range for public.device_readings larger than allowed in one run, truncating (time column observation_time) (1546196400000000)
 INFO:  new materialization range for public.device_readings (time column observation_time) (1543723200000000)
 INFO:  materializing continuous aggregate public.device_summary: new range up to 1543723200000000
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -18,6 +18,13 @@ NOTICE:  adding not-null constraint to column "time"
  (1,public,continuous_agg_test,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM continuous_agg_test $$;
+SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 -- watermark tabels start out empty
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
@@ -206,6 +213,13 @@ NOTICE:  adding not-null constraint to column "time"
  (2,public,ca_inval_test,t)
 (1 row)
 
+CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ca_inval_test $$;
+SELECT set_integer_now_func('ca_inval_test', 'integer_now_test2');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 CREATE VIEW cit_view
     WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
     AS SELECT time_bucket('5', time), COUNT(time)
@@ -291,6 +305,13 @@ NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
  (4,public,ts_continuous_test,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ts_continuous_test $$;
+SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test3');
+ set_integer_now_func 
+----------------------
+ 
 (1 row)
 
 INSERT INTO ts_continuous_test SELECT i, i FROM

--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -47,10 +47,10 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
@@ -129,10 +129,10 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -2316,9 +2316,10 @@ DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------
@@ -5615,9 +5616,10 @@ DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -47,10 +47,10 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
@@ -129,10 +129,10 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -2426,9 +2426,10 @@ DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------
@@ -5739,9 +5740,10 @@ DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:283: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:283: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------

--- a/tsl/test/isolation/expected/continuous_aggs_multi.out
+++ b/tsl/test/isolation/expected/continuous_aggs_multi.out
@@ -33,13 +33,13 @@ lock_mattable
                
 step I1: INSERT INTO ts_continuous_test SELECT 0, i*10 FROM (SELECT generate_series(0, 10) AS i) AS i;
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1; <waiting ...>
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): no new data
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (35)
 INFO:  materializing continuous aggregate public.continuous_view_2: no new range to materialize
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 step Refresh2: <... completed>
 step UnlockMat1: ROLLBACK;
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): no new data
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (30)
 INFO:  materializing continuous aggregate public.continuous_view_1: no new range to materialize
 step Refresh1: <... completed>
 step Refresh1_sel: select * from continuous_view_1 where bkt = 0 or bkt > 30

--- a/tsl/test/isolation/specs/continuous_aggs_insert.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_insert.spec
@@ -4,6 +4,8 @@ setup
     SELECT _timescaledb_internal.stop_background_workers();
     CREATE TABLE ts_continuous_test(time INTEGER, location INTEGER);
     SELECT create_hypertable('ts_continuous_test', 'time', chunk_time_interval => 10);
+    CREATE OR REPLACE FUNCTION integer_now_test() returns INT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ts_continuous_test $$;
+    SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test');
     INSERT INTO ts_continuous_test SELECT i, i FROM
         (SELECT generate_series(0, 29) AS i) AS i;
     CREATE VIEW continuous_view

--- a/tsl/test/isolation/specs/continuous_aggs_multi.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_multi.spec
@@ -4,6 +4,8 @@ setup
     SELECT _timescaledb_internal.stop_background_workers();
     CREATE TABLE ts_continuous_test(time INTEGER, val INTEGER);
     SELECT create_hypertable('ts_continuous_test', 'time', chunk_time_interval => 10);
+    CREATE OR REPLACE FUNCTION integer_now_test() returns INT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ts_continuous_test $$;
+    SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test');
     INSERT INTO ts_continuous_test SELECT i, i FROM
         (SELECT generate_series(0, 29) AS i) AS i;
     CREATE VIEW continuous_view_1( bkt, cnt)

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -303,7 +303,7 @@ DROP VIEW dependent_1;
 
 
 --create a cont agg view on the ht as well then the drop should nuke everything
---TODO put back when cont aggs work
+SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
 CREATE VIEW test1_cont_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -74,6 +74,8 @@ SELECT * FROM _timescaledb_catalog.continuous_agg;
 
 CREATE TABLE test_continuous_agg_table(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table', 'time', chunk_time_interval => 10);
+CREATE OR REPLACE FUNCTION integer_now_test() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM test_continuous_agg_table $$;
+SELECT set_integer_now_func('test_continuous_agg_table', 'integer_now_test');
 CREATE VIEW test_continuous_agg_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('2', time), SUM(data) as value
@@ -307,6 +309,8 @@ SELECT job_id, next_start, last_finish as until_next, last_run_success, total_ru
 --
 CREATE TABLE test_continuous_agg_table_w_grant(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table_w_grant', 'time', chunk_time_interval => 10);
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM test_continuous_agg_table_w_grant $$;
+SELECT set_integer_now_func('test_continuous_agg_table_w_grant', 'integer_now_test1');
 GRANT SELECT, TRIGGER ON test_continuous_agg_table_w_grant TO public;
 INSERT INTO test_continuous_agg_table_w_grant
     SELECT i, i FROM

--- a/tsl/test/sql/continuous_aggs_ddl.sql.in
+++ b/tsl/test/sql/continuous_aggs_ddl.sql.in
@@ -156,6 +156,9 @@ CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_id
     FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10) \gset
 
+CREATE OR REPLACE FUNCTION integer_now_test() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table $$;
+SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test');
+
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
@@ -227,6 +230,9 @@ DROP TABLE drop_chunks_table CASCADE;
 CREATE TABLE drop_chunks_table_u(time BIGINT, data INTEGER);
 SELECT hypertable_id AS drop_chunks_table_u_id
     FROM create_hypertable('drop_chunks_table_u', 'time', chunk_time_interval => 7) \gset
+
+CREATE OR REPLACE FUNCTION integer_now_test1() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table_u $$;
+SELECT set_integer_now_func('drop_chunks_table_u', 'integer_now_test1');
 
 CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('3', time), COUNT(data)
@@ -336,6 +342,7 @@ SELECT
 FROM metrics
 GROUP BY 1;
 
+SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
 

--- a/tsl/test/sql/continuous_aggs_dump.sql
+++ b/tsl/test/sql/continuous_aggs_dump.sql
@@ -103,6 +103,7 @@ AS :QUERY_AFTER;
 
 --materialize mat_before
 
+SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_before;
 
 SELECT count(*) FROM conditions_before;
@@ -146,6 +147,7 @@ DROP VIEW mat_after;
 \set ON_ERROR_STOP 1
 
 --materialize mat_after
+SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_after;
 SELECT count(*) FROM mat_after;
 

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -317,6 +317,8 @@ group by time_bucket('1week', timec), test_stablefunc(humidity::int);
 -- row security on table
 create table rowsec_tab( a bigint, b integer, c integer);
 select table_name from create_hypertable( 'rowsec_tab', 'a', chunk_time_interval=>10);
+CREATE OR REPLACE FUNCTION integer_now_test() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(a), 0)::bigint FROM rowsec_tab $$;
+SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
 
@@ -397,6 +399,8 @@ CREATE TABLE conditions (
     );
 
 select table_name from create_hypertable( 'conditions', 'timec', chunk_time_interval=> 100);
+CREATE OR REPLACE FUNCTION integer_now_test_s() returns smallint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0)::smallint FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_test_s');
 
 \set ON_ERROR_STOP 0
 create or replace view mat_with_test( timec, minl, sumt , sumh)

--- a/tsl/test/sql/continuous_aggs_multi.sql
+++ b/tsl/test/sql/continuous_aggs_multi.sql
@@ -13,7 +13,8 @@ SELECT _timescaledb_internal.stop_background_workers();
 
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);
 select create_hypertable('continuous_agg_test', 'timeval', chunk_time_interval=> 2);
-
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timeval), 0) FROM continuous_agg_test $$;
+SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
 
 INSERT INTO continuous_agg_test VALUES
     (10, - 4, 1), (11, - 3, 5), (12, - 3, 7), (13, - 3, 9), (14,-4, 11),
@@ -98,6 +99,9 @@ select view_name from timescaledb_information.continuous_aggregates;
 -- they do not meet materialization invalidation threshold for cagg2.
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);
 select create_hypertable('continuous_agg_test', 'timeval', chunk_time_interval=> 2);
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timeval), 0) FROM continuous_agg_test $$;
+SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
+
 
 INSERT INTO continuous_agg_test VALUES
     (10, - 4, 1), (11, - 3, 5), (12, - 3, 7), (13, - 3, 9), (14,-4, 11),

--- a/tsl/test/sql/continuous_aggs_permissions.sql.in
+++ b/tsl/test/sql/continuous_aggs_permissions.sql.in
@@ -23,6 +23,9 @@ CREATE TABLE conditions (
     );
 
 select table_name from create_hypertable( 'conditions', 'timec', chunk_time_interval=> 100);
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_test1');
+
 
 create or replace view mat_refresh_test
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
@@ -58,6 +61,8 @@ CREATE TABLE conditions_for_perm_check (
     );
 
 select table_name from create_hypertable('conditions_for_perm_check', 'timec', chunk_time_interval=> 100);
+CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check $$;
+SELECT set_integer_now_func('conditions_for_perm_check', 'integer_now_test2');
 
 CREATE TABLE conditions_for_perm_check_w_grant (
       timec       INT       NOT NULL,
@@ -70,7 +75,8 @@ CREATE TABLE conditions_for_perm_check_w_grant (
     );
 
 select table_name from create_hypertable('conditions_for_perm_check_w_grant', 'timec', chunk_time_interval=> 100);
-
+CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions_for_perm_check_w_grant $$;
+SELECT set_integer_now_func('conditions_for_perm_check_w_grant', 'integer_now_test3');
 
 GRANT SELECT, TRIGGER ON conditions_for_perm_check_w_grant TO public;
 

--- a/tsl/test/sql/continuous_aggs_usage.sql
+++ b/tsl/test/sql/continuous_aggs_usage.sql
@@ -47,6 +47,7 @@ SELECT * FROM device_summary;
 --Normally, the continuous view will be updated automatically on a schedule but, you can also do it manually.
 --We alter max_interval_per_job too since we are not using background workers
 ALTER VIEW device_summary SET (timescaledb.max_interval_per_job = '60 day');
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW device_summary;
 
 --Now you can run selects over your view as normal
@@ -108,6 +109,7 @@ INSERT INTO device_readings VALUES ('Sun Dec 30 13:01:00 2018 PST', 'device_1', 
 
 --Change not reflected before materializer runs.
 SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 30 13:00:00 2018 PST';
+SET timescaledb.current_timestamp_mock = 'Sun Dec 30 13:01:00 2018 PST';
 REFRESH MATERIALIZED VIEW device_summary;
 --But is reflected after.
 SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 30 13:00:00 2018 PST';

--- a/tsl/test/sql/continuous_aggs_watermark.sql
+++ b/tsl/test/sql/continuous_aggs_watermark.sql
@@ -9,7 +9,8 @@ SELECT _timescaledb_internal.stop_background_workers();
 
 CREATE TABLE continuous_agg_test(time int, data int);
 select create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);
-
+CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM continuous_agg_test $$;
+SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
 
 -- watermark tabels start out empty
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
@@ -98,6 +99,9 @@ TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 -- CREATE VIEW creates the invalidation trigger correctly
 CREATE TABLE ca_inval_test(time int);
 SELECT create_hypertable('ca_inval_test', 'time', chunk_time_interval=> 10);
+CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ca_inval_test $$;
+SELECT set_integer_now_func('ca_inval_test', 'integer_now_test2');
+
 CREATE VIEW cit_view
     WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
     AS SELECT time_bucket('5', time), COUNT(time)
@@ -150,6 +154,8 @@ TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 -- the view was created
 CREATE TABLE ts_continuous_test(time INTEGER, location INTEGER);
     SELECT create_hypertable('ts_continuous_test', 'time', chunk_time_interval => 10);
+CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ts_continuous_test $$;
+SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test3');
 INSERT INTO ts_continuous_test SELECT i, i FROM
     (SELECT generate_series(0, 29) AS i) AS i;
 CREATE VIEW continuous_view

--- a/tsl/test/sql/include/transparent_decompression_query.sql
+++ b/tsl/test/sql/include/transparent_decompression_query.sql
@@ -280,6 +280,7 @@ DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
 DROP VIEW cagg_test CASCADE;


### PR DESCRIPTION
Previously, refresh_lag in continuous aggs was calculated
relative to the maximum timestamp in the table. Change the
semantics so that it is relative to now(). This is more
intuitive.

Requires an integer_now function applied to hypertables
with integer-based time dimensions.