### PR TITLE
Use function cache to check for valid bucketing functions

### DIFF
--- a/src/func_cache.h
+++ b/src/func_cache.h
@@ -7,6 +7,10 @@
 #define TIMESCALEDB_FUNC_CACHE_H
 
 #include <postgres.h>
+#include <nodes/primnodes.h>
+#include <nodes/relation.h>
+
+#include "export.h"
 
 #define FUNC_CACHE_MAX_FUNC_ARGS 10
 
@@ -24,7 +28,7 @@ typedef struct FuncInfo
 	sort_transform_func sort_transform;
 } FuncInfo;
 
-extern FuncInfo *ts_func_cache_get(Oid funcid);
-extern FuncInfo *ts_func_cache_get_bucketing_func(Oid funcid);
+extern TSDLLEXPORT FuncInfo *ts_func_cache_get(Oid funcid);
+extern TSDLLEXPORT FuncInfo *ts_func_cache_get_bucketing_func(Oid funcid);
 
 #endif /* TIMESCALEDB_FUNC_CACHE_H */

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -65,7 +65,7 @@ ERROR:  SELECT query for continuous aggregate should have at least 1 aggregate f
 create  view mat_m1 WITH ( timescaledb.continuous)
 as
 select count(*) from conditions group by location;
-ERROR:  time_bucket function missing from GROUP BY clause for continuous aggregate query
+ERROR:  no valid bucketing function found for continuous aggregate query
 -- with valid query in a CTE
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
@@ -128,7 +128,7 @@ AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location;
-ERROR:  time_bucket function for continuous aggregate query cannot use optional arguments
+ERROR:  no valid bucketing function found for continuous aggregate query
 --time_bucket using non-const for first argument
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS


### PR DESCRIPTION
Refactor the continuous aggregate validation to use our function cache
to check for bucketing function. This simplifies the code and allows
adding support for other bucketing functions like date_trunc later on.