### PR TITLE
Apply max_interval_per_job to invalidations

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -284,7 +284,7 @@ _guc_init(void)
 							   /* short_dec= */ "set the current timestamp",
 							   /* long_dec= */ "this is for debugging purposes",
 							   /* valueAddr= */ &ts_current_timestamp_mock,
-							   /* bootValue= */ false,
+							   /* bootValue= */ NULL,
 							   /* context= */ PGC_USERSET,
 							   /* flags= */ 0,
 							   /* check_hook= */ NULL,

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -23,10 +23,12 @@ typedef struct Invalidation
 } Invalidation;
 
 int64 invalidation_threshold_get(int32 raw_hypertable_id);
+int64 continuous_agg_completed_threshold_get(int32 materialization_id);
 bool continuous_agg_materialize(int32 materialization_id, bool verbose);
 void continuous_agg_execute_materialization(int64 bucket_width, int32 hypertable_id,
 											int32 materialization_id, SchemaAndName partial_view,
-											List *invalidations,
+											int64 invalidation_range_start,
+											int64 invalidation_range_end,
 											int64 materialization_invalidation_threshold);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H */

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -447,7 +447,7 @@ AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    GROUP BY 1;
 REFRESH MATERIALIZED VIEW test1_cont_view;
 INFO:  new materialization range for public.test1 (time column Time) (1522216800000000)
-INFO:  materializing continuous aggregate public.test1_cont_view: new range up to 1522216800000000
+INFO:  materializing continuous aggregate public.test1_cont_view: nothing to invalidate, new range up to 1522216800000000
 SELECT count(*) FROM test1_cont_view;
  count 
 -------

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -764,7 +764,7 @@ SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_drop_test;
 INFO:  new materialization range for public.conditions larger than allowed in one run, truncating (time column timec) (1546041600000000)
 INFO:  new materialization range for public.conditions (time column timec) (1542758400000000)
-INFO:  materializing continuous aggregate public.mat_drop_test: new range up to 1542758400000000
+INFO:  materializing continuous aggregate public.mat_drop_test: nothing to invalidate, new range up to 1542758400000000
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 --force invalidation
 insert into conditions
@@ -1040,7 +1040,7 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 
 REFRESH MATERIALIZED VIEW space_view;
 INFO:  new materialization range for public.space_table (time column time) (12)
-INFO:  materializing continuous aggregate public.space_view: new range up to 12
+INFO:  materializing continuous aggregate public.space_view: nothing to invalidate, new range up to 12
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
 -------------+-------
@@ -1061,7 +1061,7 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 INSERT INTO space_table VALUES (3, 2, 1);
 REFRESH MATERIALIZED VIEW space_view;
 INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold (12)
-INFO:  materializing continuous aggregate public.space_view: no new range to materialize
+INFO:  materializing continuous aggregate public.space_view: processing invalidations, no new range
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
 -------------+-------
@@ -1082,7 +1082,7 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 INSERT INTO space_table VALUES (2, 3, 1);
 REFRESH MATERIALIZED VIEW space_view;
 INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold (12)
-INFO:  materializing continuous aggregate public.space_view: no new range to materialize
+INFO:  materializing continuous aggregate public.space_view: processing invalidations, no new range
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
 -------------+-------
@@ -1163,7 +1163,7 @@ from conditions
 group by time_bucket(100, timec);
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 INFO:  new materialization range for public.conditions (time column timec) (400)
-INFO:  materializing continuous aggregate public.mat_ffunc_test: new range up to 400
+INFO:  materializing continuous aggregate public.mat_ffunc_test: nothing to invalidate, new range up to 400
 SELECT * FROM mat_ffunc_test;
 WARNING:  type integer text
 WARNING:  type integer text
@@ -1185,7 +1185,7 @@ from conditions
 group by time_bucket(100, timec);
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 INFO:  new materialization range for public.conditions (time column timec) (400)
-INFO:  materializing continuous aggregate public.mat_ffunc_test: new range up to 400
+INFO:  materializing continuous aggregate public.mat_ffunc_test: nothing to invalidate, new range up to 400
 SELECT * FROM mat_ffunc_test;
 WARNING:  type integer bigint
 WARNING:  type integer bigint
@@ -1211,7 +1211,7 @@ insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 INFO:  new materialization range for public.conditions (time column timec) (400)
-INFO:  materializing continuous aggregate public.mat_refresh_test: new range up to 400
+INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 400
 SELECT * FROM mat_refresh_test order by 1,2 ;
  location | max 
 ----------+-----

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -232,7 +232,7 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 29) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  new materialization range for public.drop_chunks_table (time column time) (15)
-INFO:  materializing continuous aggregate public.drop_chunks_view: new range up to 15
+INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
 -------
@@ -386,7 +386,7 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
 INSERT INTO drop_chunks_table_u SELECT i, i FROM generate_series(0, 21) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  new materialization range for public.drop_chunks_table_u (time column time) (15)
-INFO:  materializing continuous aggregate public.drop_chunks_view: new range up to 15
+INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table_u') AS c;
  count 
 -------
@@ -544,7 +544,7 @@ NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescal
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
 INFO:  new materialization range for public.metrics (time column time) (947289600000000)
-INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000
+INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to 947289600000000
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
 ------------------------------+-------+---------+----------------------------------------------+------+----------+------+------

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -232,7 +232,7 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 29) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  new materialization range for public.drop_chunks_table (time column time) (15)
-INFO:  materializing continuous aggregate public.drop_chunks_view: new range up to 15
+INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
 -------
@@ -386,7 +386,7 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
 INSERT INTO drop_chunks_table_u SELECT i, i FROM generate_series(0, 21) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  new materialization range for public.drop_chunks_table_u (time column time) (15)
-INFO:  materializing continuous aggregate public.drop_chunks_view: new range up to 15
+INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table_u') AS c;
  count 
 -------
@@ -544,7 +544,7 @@ NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescal
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
 INFO:  new materialization range for public.metrics (time column time) (947289600000000)
-INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000
+INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to 947289600000000
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
 ------------------------------+-------+---------+----------------------------------------------+------+----------+------+------

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -232,7 +232,7 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 29) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  new materialization range for public.drop_chunks_table (time column time) (15)
-INFO:  materializing continuous aggregate public.drop_chunks_view: new range up to 15
+INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
 -------
@@ -386,7 +386,7 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
 INSERT INTO drop_chunks_table_u SELECT i, i FROM generate_series(0, 21) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  new materialization range for public.drop_chunks_table_u (time column time) (15)
-INFO:  materializing continuous aggregate public.drop_chunks_view: new range up to 15
+INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table_u') AS c;
  count 
 -------
@@ -544,7 +544,7 @@ NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescal
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
 INFO:  new materialization range for public.metrics (time column time) (947289600000000)
-INFO:  materializing continuous aggregate public.cagg_expr: new range up to 947289600000000
+INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to 947289600000000
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
 ------------------------------+-------+---------+----------------------------------------------+------+----------+------+------

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -110,7 +110,7 @@ NOTICE:  adding index _materialized_hypertable_4_location_bucket_idx ON _timesca
 SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_before;
 INFO:  new materialization range for public.conditions_before (time column timec) (1551052800000000)
-INFO:  materializing continuous aggregate public.mat_before: new range up to 1551052800000000
+INFO:  materializing continuous aggregate public.mat_before: nothing to invalidate, new range up to 1551052800000000
 SELECT count(*) FROM conditions_before;
  count 
 -------
@@ -194,7 +194,7 @@ ERROR:  dropping a continous aggregate requires using CASCADE
 SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_after;
 INFO:  new materialization range for public.conditions_after (time column timec) (1551052800000000)
-INFO:  materializing continuous aggregate public.mat_after: new range up to 1551052800000000
+INFO:  materializing continuous aggregate public.mat_after: nothing to invalidate, new range up to 1551052800000000
 SELECT count(*) FROM mat_after;
  count 
 -------

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -268,7 +268,7 @@ SELECT  9223372036854775807 as big_int_max \gset
 SELECT -9223372036854775808	 as big_int_min \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DELETE FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold WHERE hypertable_id = 1;
-INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, :big_int_max);
+INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (1, :big_int_max-1);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 INSERT INTO continuous_agg_test VALUES
     (:big_int_max - 4, 1), (:big_int_max - 3, 5), (:big_int_max - 2, 7), (:big_int_max - 1, 9), (:big_int_max, 11),
@@ -303,7 +303,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_completed_threshold;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id |      watermark      
 ---------------+---------------------
-             1 | 9223372036854775807
+             1 | 9223372036854775806
 (1 row)
 
 -- test invalidations
@@ -337,7 +337,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_completed_threshold;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id |      watermark      
 ---------------+---------------------
-             1 | 9223372036854775807
+             1 | 9223372036854775806
 (1 row)
 
 SET client_min_messages TO error;
@@ -371,7 +371,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_completed_threshold;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id |      watermark      
 ---------------+---------------------
-             1 | 9223372036854775807
+             1 | 9223372036854775806
 (1 row)
 
 TRUNCATE materialization;
@@ -463,7 +463,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_completed_threshold;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id |      watermark      
 ---------------+---------------------
-             1 | 9223372036854775807
+             1 | 9223372036854775806
 (1 row)
 
 DROP TABLE materialization;
@@ -683,7 +683,7 @@ SELECT materialization_id, _timescaledb_internal.to_timestamp(watermark)
 SET timescaledb.current_timestamp_mock = '2019-02-02 5:00 UTC';
 REFRESH MATERIALIZED VIEW test_t_mat_view;
 INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549072800000000)
-INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize
+INFO:  materializing continuous aggregate public.test_t_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME" ORDER BY 1;
  time_bucket | agg_2_2 | chunk_id 
@@ -714,7 +714,7 @@ SELECT hypertable_id, _timescaledb_internal.to_timestamp(watermark) FROM _timesc
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;
 INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549072800000000)
-INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize
+INFO:  materializing continuous aggregate public.test_t_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME" ORDER BY 1;
  time_bucket | agg_2_2 | chunk_id 
@@ -758,7 +758,7 @@ SELECT * FROM continuous_agg_test_t ORDER BY 1;
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;
 INFO:  new materialization range for public.continuous_agg_test_t (time column time) (1549080000000000)
-INFO:  materializing continuous aggregate public.test_t_mat_view: new range up to 1549080000000000
+INFO:  materializing continuous aggregate public.test_t_mat_view: nothing to invalidate, new range up to 1549080000000000
 SELECT * FROM test_t_mat_view ORDER BY 1;
       time_bucket       | value 
 ------------------------+-------
@@ -793,7 +793,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;
 INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549080000000000)
-INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize
+INFO:  materializing continuous aggregate public.test_t_mat_view: processing invalidations, no new range
 SELECT * FROM test_t_mat_view ORDER BY 1;
       time_bucket       | value 
 ------------------------+-------
@@ -851,8 +851,8 @@ CREATE TRIGGER continuous_agg_insert_trigger
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE raw_hypertable_id=:raw_table_id \gset
 -- EMPTY table should be a nop
 REFRESH MATERIALIZED VIEW extreme_view;
-INFO:  new materialization range not found for public.continuous_agg_extreme (time column time): not enough data in table (-9223372036854775808)
-INFO:  materializing continuous aggregate public.extreme_view: no new range to materialize
+INFO:  new materialization range not found for public.continuous_agg_extreme (time column time): no data in table
+INFO:  materializing continuous aggregate public.extreme_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.extreme_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM extreme_view;
  time_bucket | value 
@@ -878,7 +878,7 @@ INSERT INTO continuous_agg_extreme VALUES
     (:big_int_min,   1);
 REFRESH MATERIALIZED VIEW extreme_view;
 INFO:  new materialization range not found for public.continuous_agg_extreme (time column time): not enough data in table (-9223372036854775808)
-INFO:  materializing continuous aggregate public.extreme_view: no new range to materialize
+INFO:  materializing continuous aggregate public.extreme_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.extreme_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM extreme_view;
  time_bucket | value 
@@ -904,7 +904,7 @@ INSERT INTO continuous_agg_extreme VALUES
     (:big_int_min+10, 11);
 REFRESH MATERIALIZED VIEW extreme_view;
 INFO:  new materialization range for public.continuous_agg_extreme (time column time) (-9223372036854775800)
-INFO:  materializing continuous aggregate public.extreme_view: new range up to -9223372036854775800
+INFO:  materializing continuous aggregate public.extreme_view: nothing to invalidate, new range up to -9223372036854775800
 SELECT * FROM extreme_view;
      time_bucket      | value 
 ----------------------+-------
@@ -939,7 +939,7 @@ INSERT INTO continuous_agg_extreme VALUES
     (:big_int_max,   :big_int_max);
 REFRESH MATERIALIZED VIEW extreme_view;
 INFO:  new materialization range for public.continuous_agg_extreme (time column time) (9223372036854775805)
-INFO:  materializing continuous aggregate public.extreme_view: new range up to 9223372036854775805
+INFO:  materializing continuous aggregate public.extreme_view: nothing to invalidate, new range up to 9223372036854775805
 SELECT * FROM extreme_view ORDER BY 1;
      time_bucket      | value 
 ----------------------+-------
@@ -998,7 +998,7 @@ INSERT INTO continuous_agg_negative
     SELECT i, i FROM generate_series(0, 11) AS i;
 REFRESH MATERIALIZED VIEW negative_view_5;
 INFO:  new materialization range for public.continuous_agg_negative (time column time) (10)
-INFO:  materializing continuous aggregate public.negative_view_5: new range up to 10
+INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 10
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
 -------------+-------
@@ -1011,7 +1011,7 @@ SELECT * FROM negative_view_5 ORDER BY 1;
 INSERT INTO continuous_agg_negative VALUES (12, 12), (13, 13);
 REFRESH MATERIALIZED VIEW negative_view_5;
 INFO:  new materialization range for public.continuous_agg_negative (time column time) (15)
-INFO:  materializing continuous aggregate public.negative_view_5: new range up to 15
+INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 15
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
 -------------+-------
@@ -1024,7 +1024,7 @@ SELECT * FROM negative_view_5 ORDER BY 1;
 INSERT INTO continuous_agg_negative VALUES (14, 14);
 REFRESH MATERIALIZED VIEW negative_view_5;
 INFO:  new materialization range not found for public.continuous_agg_negative (time column time): not enough new data past completion threshold (15)
-INFO:  materializing continuous aggregate public.negative_view_5: no new range to materialize
+INFO:  materializing continuous aggregate public.negative_view_5: processing invalidations, no new range
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
 -------------+-------
@@ -1039,7 +1039,7 @@ SET client_min_messages TO error;
 REFRESH MATERIALIZED VIEW negative_view_5;
 INFO:  new materialization range for public.continuous_agg_negative larger than allowed in one run, truncating (time column time) (9223372036854775805)
 INFO:  new materialization range for public.continuous_agg_negative (time column time) (115)
-INFO:  materializing continuous aggregate public.negative_view_5: new range up to 115
+INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 115
 RESET client_min_messages;
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
@@ -1062,7 +1062,7 @@ INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
 SET client_min_messages TO error;
 REFRESH MATERIALIZED VIEW negative_view_5;
 INFO:  new materialization range for public.continuous_agg_negative (time column time) (9223372036854775805)
-INFO:  materializing continuous aggregate public.negative_view_5: new range up to 9223372036854775805
+INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 9223372036854775805
 RESET client_min_messages;
 SELECT * FROM negative_view_5 ORDER BY 1;
      time_bucket     | value 
@@ -1075,7 +1075,7 @@ INSERT INTO continuous_agg_negative VALUES (:big_int_max-1, 201);
 SET client_min_messages TO error;
 REFRESH MATERIALIZED VIEW negative_view_5;
 INFO:  new materialization range not found for public.continuous_agg_negative (time column time): not enough new data past completion threshold (9223372036854775805)
-INFO:  materializing continuous aggregate public.negative_view_5: no new range to materialize
+INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.negative_view_5: no new range to materialize or invalidations found, exiting early
 RESET client_min_messages;
 SELECT * FROM negative_view_5 ORDER BY 1;
@@ -1114,7 +1114,7 @@ INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 10) AS i;
 REFRESH MATERIALIZED VIEW max_mat_view;
 INFO:  new materialization range for public.continuous_agg_max_mat larger than allowed in one run, truncating (time column time) (12)
 INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (4)
-INFO:  materializing continuous aggregate public.max_mat_view: new range up to 4
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, new range up to 4
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
@@ -1127,7 +1127,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 REFRESH MATERIALIZED VIEW max_mat_view;
 INFO:  new materialization range for public.continuous_agg_max_mat larger than allowed in one run, truncating (time column time) (12)
 INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (8)
-INFO:  materializing continuous aggregate public.max_mat_view: new range up to 8
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, new range up to 8
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
@@ -1140,7 +1140,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 REFRESH MATERIALIZED VIEW max_mat_view;
 INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (12)
-INFO:  materializing continuous aggregate public.max_mat_view: new range up to 12
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, new range up to 12
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
 -------------+-------
@@ -1154,7 +1154,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 REFRESH MATERIALIZED VIEW max_mat_view;
 INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
-INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
@@ -1167,6 +1167,127 @@ SELECT * FROM max_mat_view ORDER BY 1;
           10 |     1
 (6 rows)
 
+--one invalidation covered by max_interval refreshed right away
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 3) AS i;
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+SELECT * FROM max_mat_view ORDER BY 1;
+ time_bucket | value 
+-------------+-------
+           0 |     4
+           2 |     4
+           4 |     2
+           6 |     2
+           8 |     2
+          10 |     1
+(6 rows)
+
+--nothing to do
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
+INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
+--one invalidation too big for max_interval will be split
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 6) AS i;
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+SELECT * FROM max_mat_view ORDER BY 1;
+ time_bucket | value 
+-------------+-------
+           0 |     6
+           2 |     6
+           4 |     4
+           6 |     3
+           8 |     2
+          10 |     1
+(6 rows)
+
+--nothing to do
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
+INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
+--many invalidation too big for max_interval will be split
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 1) AS i;
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(2, 3) AS i;
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(4, 5) AS i;
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
+SELECT * FROM max_mat_view ORDER BY 1;
+ time_bucket | value 
+-------------+-------
+           0 |     8
+           2 |     8
+           4 |     6
+           6 |     3
+           8 |     2
+          10 |     1
+(6 rows)
+
+--nothing to do
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
+INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
+--one invalidation + new entries  requires two refreshes if the refresh budget taken up by invalidation
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 3) AS i;
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(11, 12) AS i;
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (14)
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, new range up to 14
+SELECT * FROM max_mat_view ORDER BY 1;
+ time_bucket | value 
+-------------+-------
+           0 |    10
+           2 |    10
+           4 |     6
+           6 |     3
+           8 |     2
+          10 |     2
+          12 |     1
+(7 rows)
+
+--nothing to do
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (14)
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
+INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
+--one invalidation + new entries  done in one refresh if the refresh budget allows
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 1) AS i;
+INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(14, 15) AS i;
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (16)
+INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, new range up to 16
+SELECT * FROM max_mat_view ORDER BY 1;
+ time_bucket | value 
+-------------+-------
+           0 |    12
+           2 |    10
+           4 |     6
+           6 |     3
+           8 |     2
+          10 |     2
+          12 |     1
+          14 |     2
+(8 rows)
+
+--nothing to do.
+REFRESH MATERIALIZED VIEW max_mat_view;
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (16)
+INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
+INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 -- time type
 CREATE TABLE continuous_agg_max_mat_t(time TIMESTAMPTZ, data TIMESTAMPTZ);
 SELECT create_hypertable('continuous_agg_max_mat_t', 'time');
@@ -1190,7 +1311,7 @@ SET timescaledb.current_timestamp_mock = '2019-09-09 10:00 UTC';
 REFRESH MATERIALIZED VIEW max_mat_view_t;
 INFO:  new materialization range for public.continuous_agg_max_mat_t larger than allowed in one run, truncating (time column time) (1568030400000000)
 INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) (1568001600000000)
-INFO:  materializing continuous aggregate public.max_mat_view_t: new range up to 1568001600000000
+INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 1568001600000000
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view_t ORDER BY 1;
       time_bucket       | value 
@@ -1203,7 +1324,7 @@ SELECT * FROM max_mat_view_t ORDER BY 1;
 REFRESH MATERIALIZED VIEW max_mat_view_t;
 INFO:  new materialization range for public.continuous_agg_max_mat_t larger than allowed in one run, truncating (time column time) (1568030400000000)
 INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) (1568016000000000)
-INFO:  materializing continuous aggregate public.max_mat_view_t: new range up to 1568016000000000
+INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 1568016000000000
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view_t ORDER BY 1;
       time_bucket       | value 
@@ -1216,7 +1337,7 @@ SELECT * FROM max_mat_view_t ORDER BY 1;
 
 REFRESH MATERIALIZED VIEW max_mat_view_t;
 INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) (1568030400000000)
-INFO:  materializing continuous aggregate public.max_mat_view_t: new range up to 1568030400000000
+INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 1568030400000000
 SELECT * FROM max_mat_view_t ORDER BY 1;
       time_bucket       | value 
 ------------------------+-------
@@ -1230,7 +1351,7 @@ SELECT * FROM max_mat_view_t ORDER BY 1;
 
 REFRESH MATERIALIZED VIEW max_mat_view_t;
 INFO:  new materialization range not found for public.continuous_agg_max_mat_t (time column time): not enough new data past completion threshold (1568030400000000)
-INFO:  materializing continuous aggregate public.max_mat_view_t: no new range to materialize
+INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view_t: no new range to materialize or invalidations found, exiting early
 SELECT * FROM max_mat_view_t ORDER BY 1;
       time_bucket       | value 
@@ -1262,7 +1383,7 @@ INSERT INTO continuous_agg_max_mat_timestamp
 -- first materializes everything
 REFRESH MATERIALIZED VIEW max_mat_view_timestamp;
 INFO:  new materialization range for public.continuous_agg_max_mat_timestamp (time column time) (1568030400000000)
-INFO:  materializing continuous aggregate public.max_mat_view_timestamp: new range up to 1568030400000000
+INFO:  materializing continuous aggregate public.max_mat_view_timestamp: nothing to invalidate, new range up to 1568030400000000
 SELECT * FROM max_mat_view_timestamp ORDER BY 1;
      time_bucket     
 ---------------------
@@ -1295,7 +1416,7 @@ SET timescaledb.current_timestamp_mock = '2019-09-09 01:00 UTC';
 -- first materializes everything
 REFRESH MATERIALIZED VIEW max_mat_view_date;
 INFO:  new materialization range for public.continuous_agg_max_mat_date (time column time) (1568592000000000)
-INFO:  materializing continuous aggregate public.max_mat_view_date: new range up to 1568592000000000
+INFO:  materializing continuous aggregate public.max_mat_view_date: nothing to invalidate, new range up to 1568592000000000
 SELECT * FROM max_mat_view_date ORDER BY 1;
  time_bucket 
 -------------
@@ -1308,7 +1429,7 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_statu
     FROM timescaledb_information.continuous_aggregate_stats ORDER BY 1;
        view_name        |  completed_threshold   | invalidation_threshold | job_id | job_status | last_run_duration 
 ------------------------+------------------------+------------------------+--------+------------+-------------------
- max_mat_view           | 12                     | 12                     |   1004 |            | 
+ max_mat_view           | 16                     | 16                     |   1004 |            | 
  max_mat_view_t         | 2019-09-09 12:00:00+00 | 2019-09-09 12:00:00+00 |   1005 |            | 
  max_mat_view_timestamp | 2019-09-09 12:00:00    | 2019-09-09 12:00:00    |   1006 |            | 
  max_mat_view_date      | 2019-09-16             | 2019-09-16             |   1007 |            | 
@@ -1329,7 +1450,7 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_statu
     FROM timescaledb_information.continuous_aggregate_stats ORDER BY 1;
        view_name        |  completed_threshold   | invalidation_threshold | job_id | job_status | last_run_duration 
 ------------------------+------------------------+------------------------+--------+------------+-------------------
- max_mat_view           | 12                     | 12                     |   1004 |            | 
+ max_mat_view           | 16                     | 16                     |   1004 |            | 
  max_mat_view_t         | 2019-09-09 07:00:00-05 | 2019-09-09 07:00:00-05 |   1005 |            | 
  max_mat_view_timestamp | 2019-09-09 12:00:00    | 2019-09-09 12:00:00    |   1006 |            | 
  max_mat_view_date      | 2019-09-16             | 2019-09-16             |   1007 |            | 

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -55,7 +55,7 @@ from timescaledb_information.continuous_aggregates;
 --TEST1: cagg_1 is materialized, not cagg_2.
 refresh materialized view cagg_1;
 INFO:  new materialization range for public.continuous_agg_test (time column timeval) (18)
-INFO:  materializing continuous aggregate public.cagg_1: new range up to 18
+INFO:  materializing continuous aggregate public.cagg_1: nothing to invalidate, new range up to 18
 select * from cagg_1 order by 1;
  timed | cnt 
 -------+-----
@@ -84,7 +84,7 @@ select * from cagg_2 order by 1,2;
 
 refresh materialized view cagg_2;
 INFO:  new materialization range for public.continuous_agg_test (time column timeval) (18)
-INFO:  materializing continuous aggregate public.cagg_2: new range up to 18
+INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, new range up to 18
 select * from cagg_2 order by 1,2;
  timed | grp | maxval 
 -------+-----+--------
@@ -127,7 +127,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 
 refresh materialized view cagg_1;
 INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
-INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
+INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select * from cagg_1 order by 1;
  timed | cnt 
 -------+-----
@@ -174,7 +174,7 @@ order by 1,2 ;
 
 refresh materialized view cagg_2;
 INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
-INFO:  materializing continuous aggregate public.cagg_2: no new range to materialize
+INFO:  materializing continuous aggregate public.cagg_2: processing invalidations, no new range
 select * from cagg_2 order by 1, 2;
  timed | grp | maxval 
 -------+-----+--------
@@ -203,7 +203,7 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
 
 refresh materialized view cagg_1;
 INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
-INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
+INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select count(*) from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
  count 
 -------
@@ -280,7 +280,7 @@ AS
     GROUP BY 1;
 refresh materialized view cagg_1;
 INFO:  new materialization range for public.continuous_agg_test (time column timeval) (18)
-INFO:  materializing continuous aggregate public.cagg_1: new range up to 18
+INFO:  materializing continuous aggregate public.cagg_1: nothing to invalidate, new range up to 18
 select * from cagg_1 order by 1;
  timed | cnt 
 -------+-----
@@ -292,7 +292,7 @@ select * from cagg_1 order by 1;
 
 refresh materialized view cagg_2;
 INFO:  new materialization range for public.continuous_agg_test (time column timeval) (14)
-INFO:  materializing continuous aggregate public.cagg_2: new range up to 14
+INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, new range up to 14
 select * from cagg_2 order by 1;
  timed | maxval 
 -------+--------
@@ -304,7 +304,7 @@ select * from cagg_2 order by 1;
 insert into continuous_agg_test values( 14, -2, 100); 
 refresh materialized view cagg_1;
 INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
-INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
+INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select * from cagg_1 order by 1;
  timed | cnt 
 -------+-----
@@ -316,7 +316,7 @@ select * from cagg_1 order by 1;
 
 refresh materialized view cagg_2;
 INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (14)
-INFO:  materializing continuous aggregate public.cagg_2: no new range to materialize
+INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.cagg_2: no new range to materialize or invalidations found, exiting early
 select * from cagg_2 order by 1;
  timed | maxval 
@@ -335,8 +335,7 @@ select * from _timescaledb_catalog.continuous_aggs_invalidation_threshold order 
 select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
  materialization_id | lowest_modified_value | greatest_modified_value 
 --------------------+-----------------------+-------------------------
-                  6 |                    14 |                      14
-(1 row)
+(0 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 --this insert will be processed only by cagg_1 and cagg_2 will process the previous
@@ -344,7 +343,7 @@ select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_
 insert into continuous_agg_test values( 18, -2, 200); 
 refresh materialized view cagg_1;
 INFO:  new materialization range for public.continuous_agg_test (time column timeval) (20)
-INFO:  materializing continuous aggregate public.cagg_1: new range up to 20
+INFO:  materializing continuous aggregate public.cagg_1: nothing to invalidate, new range up to 20
 select * from cagg_1 order by 1;
  timed | cnt 
 -------+-----
@@ -357,7 +356,7 @@ select * from cagg_1 order by 1;
 
 refresh materialized view cagg_2;
 INFO:  new materialization range for public.continuous_agg_test (time column timeval) (16)
-INFO:  materializing continuous aggregate public.cagg_2: new range up to 16
+INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, new range up to 16
 select * from cagg_2 order by 1;
  timed | maxval 
 -------+--------
@@ -378,7 +377,7 @@ select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log o
 
 refresh materialized view cagg_1;
 INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (20)
-INFO:  materializing continuous aggregate public.cagg_1: no new range to materialize
+INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select * from cagg_1 where timed = 18 ;
  timed | cnt 
 -------+-----

--- a/tsl/test/expected/continuous_aggs_permissions-10.out
+++ b/tsl/test/expected/continuous_aggs_permissions-10.out
@@ -46,7 +46,7 @@ insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW  mat_refresh_test;
 INFO:  new materialization range for public.conditions (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_refresh_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 200
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT materialization_hypertable FROM timescaledb_information.continuous_aggregates  WHERE view_name = 'mat_refresh_test'::regclass \gset 
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_refresh_test' \gset
@@ -160,7 +160,7 @@ NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_perm_view_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
 --can create a mat view on something with select and trigger grants
@@ -173,7 +173,7 @@ group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_perm_view_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 SELECT * FROM mat_perm_view_test;
  location | max 
 ----------+-----

--- a/tsl/test/expected/continuous_aggs_permissions-11.out
+++ b/tsl/test/expected/continuous_aggs_permissions-11.out
@@ -46,7 +46,7 @@ insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW  mat_refresh_test;
 INFO:  new materialization range for public.conditions (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_refresh_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 200
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT materialization_hypertable FROM timescaledb_information.continuous_aggregates  WHERE view_name = 'mat_refresh_test'::regclass \gset 
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_refresh_test' \gset
@@ -160,7 +160,7 @@ NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_perm_view_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
 --can create a mat view on something with select and trigger grants
@@ -173,7 +173,7 @@ group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_perm_view_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 SELECT * FROM mat_perm_view_test;
  location | max 
 ----------+-----

--- a/tsl/test/expected/continuous_aggs_permissions-9.6.out
+++ b/tsl/test/expected/continuous_aggs_permissions-9.6.out
@@ -46,7 +46,7 @@ insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW  mat_refresh_test;
 INFO:  new materialization range for public.conditions (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_refresh_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 200
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT materialization_hypertable FROM timescaledb_information.continuous_aggregates  WHERE view_name = 'mat_refresh_test'::regclass \gset 
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_refresh_test' \gset
@@ -160,7 +160,7 @@ NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_perm_view_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
 --can create a mat view on something with select and trigger grants
@@ -173,7 +173,7 @@ group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
-INFO:  materializing continuous aggregate public.mat_perm_view_test: new range up to 200
+INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 SELECT * FROM mat_perm_view_test;
  location | max 
 ----------+-----

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -57,7 +57,7 @@ ALTER VIEW device_summary SET (timescaledb.max_interval_per_job = '60 day');
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW device_summary;
 INFO:  new materialization range for public.device_readings (time column observation_time) (1546236000000000)
-INFO:  materializing continuous aggregate public.device_summary: new range up to 1546236000000000
+INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to 1546236000000000
 --Now you can run selects over your view as normal
 SELECT * FROM device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, device_id LIMIT 10;
             bucket            | device_id | metric_avg | metric_spread 
@@ -162,7 +162,7 @@ SELECT max(bucket) FROM device_summary;
 ALTER VIEW device_summary SET (timescaledb.refresh_lag = '-1 hour');
 REFRESH MATERIALIZED VIEW device_summary;
 INFO:  new materialization range for public.device_readings (time column observation_time) (1546246800000000)
-INFO:  materializing continuous aggregate public.device_summary: new range up to 1546246800000000
+INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to 1546246800000000
 SELECT max(observation_time) FROM device_readings;
              max              
 ------------------------------
@@ -197,7 +197,7 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 SET timescaledb.current_timestamp_mock = 'Sun Dec 30 13:01:00 2018 PST';
 REFRESH MATERIALIZED VIEW device_summary;
 INFO:  new materialization range not found for public.device_readings (time column observation_time): not enough new data past completion threshold (1546207200000000)
-INFO:  materializing continuous aggregate public.device_summary: no new range to materialize
+INFO:  materializing continuous aggregate public.device_summary: processing invalidations, no new range
 --But is reflected after.
 SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 30 13:00:00 2018 PST';
             bucket            | device_id |    metric_avg    | metric_spread 
@@ -266,7 +266,7 @@ NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timesc
 REFRESH MATERIALIZED VIEW device_summary;
 INFO:  new materialization range for public.device_readings larger than allowed in one run, truncating (time column observation_time) (1546196400000000)
 INFO:  new materialization range for public.device_readings (time column observation_time) (1543723200000000)
-INFO:  materializing continuous aggregate public.device_summary: new range up to 1543723200000000
+INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to 1543723200000000
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT min(min_time)::timestamp FROM device_summary;
            min            

--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -48,9 +48,9 @@ ANALYZE metrics_space;
 \set PREFIX_VERBOSE ''
 \set ECHO none
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
@@ -130,9 +130,9 @@ ANALYZE metrics_space;
 \set PREFIX_VERBOSE ''
 \set ECHO none
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -2319,7 +2319,7 @@ CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',t
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------
@@ -5619,7 +5619,7 @@ CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',t
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -48,9 +48,9 @@ ANALYZE metrics_space;
 \set PREFIX_VERBOSE ''
 \set ECHO none
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
@@ -130,9 +130,9 @@ ANALYZE metrics_space;
 \set PREFIX_VERBOSE ''
 \set ECHO none
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -2429,7 +2429,7 @@ CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',t
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------
@@ -5743,7 +5743,7 @@ CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',t
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 psql:include/transparent_decompression_query.sql:284: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:284: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------

--- a/tsl/test/isolation/expected/continuous_aggs_insert.out
+++ b/tsl/test/isolation/expected/continuous_aggs_insert.out
@@ -6,10 +6,10 @@ step Refresh2: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh2: <... completed>
 INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
-INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh: <... completed>
 
@@ -21,7 +21,7 @@ step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ic: COMMIT;
 step UnlockCompleted: ROLLBACK;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Ib LockCompleted Refresh I1 Ic UnlockCompleted
@@ -32,7 +32,7 @@ step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step Ic: COMMIT;
 step UnlockCompleted: ROLLBACK;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Sb LockCompleted Refresh S1 Sc UnlockCompleted
@@ -46,7 +46,7 @@ count
 step Sc: COMMIT;
 step UnlockCompleted: ROLLBACK;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Sb LockCompleted S1 Refresh Sc UnlockCompleted
@@ -60,14 +60,14 @@ step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Sc: COMMIT;
 step UnlockCompleted: ROLLBACK;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Ib LockInvalThr Refresh I1 Ic UnlockInvalThr
 step Ib: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
 step LockInvalThr: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold IN SHARE MODE;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step Ic: COMMIT; <waiting ...>
@@ -80,7 +80,7 @@ step Ib: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '1
 step LockInvalThr: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold IN SHARE MODE;
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ic: COMMIT; <waiting ...>
 step UnlockInvalThr: ROLLBACK;
@@ -92,32 +92,32 @@ step Ib: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '1
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step Ic: COMMIT;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step UnlockInval: ROLLBACK;
+INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Ipb LockInval Refresh Ip1 Ipc UnlockInval
 step Ipb: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ip1: INSERT INTO ts_continuous_test VALUES (29, 29);
 step Ipc: COMMIT;
 step UnlockInval: ROLLBACK;
+INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Ipb LockInval Ip1 Refresh Ipc UnlockInval
 step Ipb: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step Ip1: INSERT INTO ts_continuous_test VALUES (29, 29);
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ipc: COMMIT;
 step UnlockInval: ROLLBACK;
+INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Ipb LockInval Ip1 Ipc Refresh UnlockInval
@@ -125,15 +125,15 @@ step Ipb: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step Ip1: INSERT INTO ts_continuous_test VALUES (29, 29);
 step Ipc: COMMIT;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step UnlockInval: ROLLBACK;
+INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Refresh SV1 LockMatInval Refresh1 Ib I1 LockInvalThrEx Ic UnlockMatInval UnlockInvalThrEx SV1
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view;
 step SV1: SELECT * FROM continuous_view order by 1;
 time_bucket    count          
@@ -142,14 +142,14 @@ time_bucket    count
 5              5              
 10             5              
 step LockMatInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
-INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ib: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step LockInvalThrEx: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold ;
 step Ic: COMMIT; <waiting ...>
 step UnlockMatInval: ROLLBACK;
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh1: <... completed>
 step UnlockInvalThrEx: ROLLBACK;
@@ -164,11 +164,9 @@ time_bucket    count
 starting permutation: I1 Refresh LockInval Refresh Sb S1 Sc UnlockInval
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view;
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
-INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Sb: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
 step S1: SELECT count(*) FROM ts_continuous_test;
@@ -177,13 +175,15 @@ count
 31             
 step Sc: COMMIT;
 step UnlockInval: ROLLBACK;
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh: <... completed>
 
 starting permutation: I1 Refresh LockInval Sb S1 Refresh Sc UnlockInval
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view;
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 step Sb: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
@@ -191,10 +191,10 @@ step S1: SELECT count(*) FROM ts_continuous_test;
 count          
 
 31             
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
-INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Sc: COMMIT;
 step UnlockInval: ROLLBACK;
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
+INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh: <... completed>

--- a/tsl/test/isolation/expected/continuous_aggs_multi.out
+++ b/tsl/test/isolation/expected/continuous_aggs_multi.out
@@ -9,21 +9,21 @@ lock_mattable
                
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1; <waiting ...>
 INFO:  new materialization range for public.ts_continuous_test (time column time) (35)
-INFO:  materializing continuous aggregate public.continuous_view_2: new range up to 35
+INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 35
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 step Refresh2: <... completed>
 step UnlockMat1: ROLLBACK;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (30)
-INFO:  materializing continuous aggregate public.continuous_view_1: new range up to 30
+INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 30
 step Refresh1: <... completed>
 
 starting permutation: Refresh1 Refresh2 LockCompleted LockMat1 I1 Refresh1 Refresh2 UnlockCompleted UnlockMat1 Refresh1_sel Refresh2_sel
 INFO:  new materialization range for public.ts_continuous_test (time column time) (30)
-INFO:  materializing continuous aggregate public.continuous_view_1: new range up to 30
+INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 30
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (35)
-INFO:  materializing continuous aggregate public.continuous_view_2: new range up to 35
+INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 35
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2;
 step LockCompleted: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_completed_threshold IN SHARE MODE;
 step LockMat1: BEGIN; select lock_mattable(materialization_hypertable::text) from timescaledb_information.continuous_aggregates where view_name::text like 'continuous_view_1';
@@ -34,13 +34,13 @@ lock_mattable
 step I1: INSERT INTO ts_continuous_test SELECT 0, i*10 FROM (SELECT generate_series(0, 10) AS i) AS i;
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1; <waiting ...>
 INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (35)
-INFO:  materializing continuous aggregate public.continuous_view_2: no new range to materialize
+INFO:  materializing continuous aggregate public.continuous_view_2: processing invalidations, no new range
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 step Refresh2: <... completed>
 step UnlockMat1: ROLLBACK;
 INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (30)
-INFO:  materializing continuous aggregate public.continuous_view_1: no new range to materialize
+INFO:  materializing continuous aggregate public.continuous_view_1: processing invalidations, no new range
 step Refresh1: <... completed>
 step Refresh1_sel: select * from continuous_view_1 where bkt = 0 or bkt > 30
 bkt            cnt            
@@ -54,10 +54,10 @@ bkt            maxl
 starting permutation: AlterLag1 Refresh1 Refresh2 Refresh1_sel Refresh2_sel LockCompleted LockMat1 I2 Refresh1 Refresh2 UnlockCompleted UnlockMat1 Refresh1_sel Refresh2_sel
 step AlterLag1: alter view continuous_view_1 set (timescaledb.refresh_lag = 10);
 INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
-INFO:  materializing continuous aggregate public.continuous_view_1: new range up to 15
+INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 15
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (35)
-INFO:  materializing continuous aggregate public.continuous_view_2: new range up to 35
+INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 35
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2;
 step Refresh1_sel: select * from continuous_view_1 where bkt = 0 or bkt > 30
 bkt            cnt            
@@ -76,13 +76,13 @@ lock_mattable
 step I2: INSERT INTO ts_continuous_test SELECT 40, 1000 ;
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1; <waiting ...>
 INFO:  new materialization range for public.ts_continuous_test (time column time) (50)
-INFO:  materializing continuous aggregate public.continuous_view_2: new range up to 50
+INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 50
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 step Refresh2: <... completed>
 step UnlockMat1: ROLLBACK;
 INFO:  new materialization range for public.ts_continuous_test (time column time) (30)
-INFO:  materializing continuous aggregate public.continuous_view_1: new range up to 30
+INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 30
 step Refresh1: <... completed>
 step Refresh1_sel: select * from continuous_view_1 where bkt = 0 or bkt > 30
 bkt            cnt            

--- a/tsl/test/src/test_continuous_aggs.c
+++ b/tsl/test/src/test_continuous_aggs.c
@@ -12,6 +12,7 @@
 #include <continuous_aggs/materialize.h>
 #include <hypertable_cache.h>
 #include <utils.h>
+#include <time_bucket.h>
 
 TS_FUNCTION_INFO_V1(ts_run_continuous_agg_materialization);
 
@@ -24,22 +25,25 @@ ts_run_continuous_agg_materialization(PG_FUNCTION_ARGS)
 	Name partial_view_name = PG_GETARG_NAME(2);
 	Datum lowest_modified_value = PG_GETARG_DATUM(3);
 	Datum greatest_modified_value = PG_GETARG_DATUM(4);
-	Datum bucket_width = PG_GETARG_DATUM(5);
+	Datum bucket_width_datum = PG_GETARG_DATUM(5);
 	Name partial_view_schema = PG_GETARG_NAME(6);
 	Oid time_type = get_fn_expr_argtype(fcinfo->flinfo, 3);
-	int64 lmv = ts_time_value_to_internal(lowest_modified_value, time_type);
-	int64 gmv = ts_time_value_to_internal(greatest_modified_value, time_type);
-	int64 bw = ts_interval_value_to_internal(bucket_width, get_fn_expr_argtype(fcinfo->flinfo, 5));
-	Invalidation invalidation = {
-		.lowest_modified_value = lmv,
-		.greatest_modified_value = gmv,
-	};
-	List *invalidations = list_make1(&invalidation);
+	int64 bw =
+		ts_interval_value_to_internal(bucket_width_datum, get_fn_expr_argtype(fcinfo->flinfo, 5));
+	int64 lmv = ts_time_bucket_by_type(bw,
+									   ts_time_value_to_internal(lowest_modified_value, time_type),
+									   time_type);
+	int64 gmv = int64_saturating_add(
+		ts_time_bucket_by_type(bw,
+							   ts_time_value_to_internal(greatest_modified_value, time_type),
+							   time_type),
+		bw);
 	SchemaAndName partial_view = {
 		.schema = partial_view_schema,
 		.name = partial_view_name,
 	};
 	int64 invalidation_threshold;
+	int64 completed_threshold;
 	Cache *hcache = ts_hypertable_cache_pin();
 	int32 hypertable_id = ts_hypertable_cache_get_entry(hcache, hypertable)->fd.id;
 	int32 materialization_id = ts_hypertable_cache_get_entry(hcache, materialization_table)->fd.id;
@@ -48,12 +52,24 @@ ts_run_continuous_agg_materialization(PG_FUNCTION_ARGS)
 	if (partial_view.name == NULL)
 		elog(ERROR, "view cannot be NULL");
 	invalidation_threshold = invalidation_threshold_get(hypertable_id);
+	completed_threshold = continuous_agg_completed_threshold_get(materialization_id);
+
+	if (lmv > completed_threshold)
+	{
+		/* make empty inval range */
+		lmv = 0;
+		gmv = 0;
+	}
+	else if (gmv > completed_threshold)
+		gmv = completed_threshold;
+
 	/* since we have only 1 cagg, we can use the hypertable's inv. threshold */
 	continuous_agg_execute_materialization(bw,
 										   hypertable_id,
 										   materialization_id,
 										   partial_view,
-										   invalidations,
+										   lmv,
+										   gmv,
 										   invalidation_threshold);
 
 	PG_RETURN_VOID();


### PR DESCRIPTION
This change the continuous aggregate materialization logic so that
the max_interval_per_job applies to invalidation entries as well
as new ranges in the materialization. The new logic is that the
MIPJ setting limits the sum of work done by the invalidations
and new ranges. Invalidations take precedence so new ranges
are only processed if there is time left over in the MIPJ
budget after all invalidations are done.

This forces us to calculate the invalidation range during the first
transaction. We still delete and/or cut the invalidation entries
in the second transaction. This change also more neatly separates concerns:
all decisions on work to be done happens in the first txn while only
execution happens in the second. Further refactoring could make
this more clear by passing a list of InternalRanges to represent the
work. But this PR is big enough, so that's left to a future refactor.

Note: There is remaining work to be done in breaking up invalidation
entries as created during inserts to constrain the length of the entries.
But that's a separate issue to be addressed in the future.