### PR TITLE
Add MacOS PR check using GitHub Actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,27 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    name: ${{ matrix.build_type }} [${{ matrix.os }}] [PG${{ matrix.pg }}]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build_type: [ Debug, Release ]
+        os: [ macOS-latest ]
+        pg: [ 11 ]
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v1
+    - name: Install PostgreSQL
+      run: brew install postgresql@${{ matrix.pg }}
+    - name: Configure [${{ matrix.build_type }}]
+      run: cmake -B ${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DUSE_OPENSSL=True -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DREGRESS_CHECKS=OFF
+    - name: Build
+      run: cmake --build ${{ matrix.build_type }} -- -j4
+    - name: Install
+      run: cmake --install ${{ matrix.build_type }}
+    - name: Test
+      run: cmake --build ${{ matrix.build_type }} --target installcheck


### PR DESCRIPTION
Since Travis doesn't support MacOS X builds, this adds a check that
builds and tests both Debug and Release builds on MacOS X using GitHub
Actions.

Note that GitHub Actions supports build matrixes and can build for
Linux, Windows, and MacOS X. Thus, we could potentially run all our
checks on Actions in the future.

Currently, however, this only builds against a brew-installed
PostgreSQL version and only for PG11 and MacOS X (thus, possibly
without assertions, etc.). However, this is currently covered by other
platforms and we can consider changing this in the future (although
this will slow down builds).