### PR TITLE
Fix tests errors

### DIFF
--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -579,6 +579,7 @@ materialization_invalidation_log_get_range(int32 materialization_id, Oid type, i
 										   int64 max_interval_per_job, int64 completed_threshold)
 {
 	bool found = false;
+	InternalTimeRange invalidation_range;
 	ScanIterator iterator =
 		ts_scan_iterator_create(CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
 								AccessShareLock,
@@ -592,8 +593,6 @@ materialization_invalidation_log_get_range(int32 materialization_id, Oid type, i
 		BTEqualStrategyNumber,
 		F_INT4EQ,
 		Int32GetDatum(materialization_id));
-
-	InternalTimeRange invalidation_range;
 
 	/*  note: this scan is in ASC order of lowest_modified_value. This logic  depends on that. */
 	ts_scanner_foreach(&iterator)
@@ -682,7 +681,7 @@ materialization_invalidation_log_delete_or_cut(int32 cagg_id, InternalTimeRange 
 		HeapTuple tuple = heap_copytuple(ts_scan_iterator_tuple(&iterator));
 		Form_continuous_aggs_materialization_invalidation_log invalidation_form =
 			((Form_continuous_aggs_materialization_invalidation_log) GETSTRUCT(tuple));
-		bool delete_entry;
+		bool delete_entry = false;
 		bool modify_entry;
 
 		if (invalidation_form->lowest_modified_value >= completed_threshold)

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(TEST_FILES
-  continuous_aggs_dump.sql
   continuous_aggs_errors.sql
-  continuous_aggs_usage.sql
   continuous_aggs_watermark.sql
   edition.sql
   gapfill.sql
@@ -15,18 +13,26 @@ set(TEST_FILES_DEBUG
   bgw_reorder_drop_chunks.sql
   continuous_aggs.sql
   continuous_aggs_bgw.sql
+  continuous_aggs_dump.sql
   continuous_aggs_materialize.sql
   continuous_aggs_multi.sql
+  continuous_aggs_usage.sql
   ddl_hook.sql
   tsl_tables.sql
 )
 
 set(TEST_TEMPLATES
-  # parallel plans are different between postgres versions
-  continuous_aggs_ddl.sql.in
   continuous_aggs_permissions.sql.in
   plan_gapfill.sql.in
 )
+
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+  list(APPEND TEST_TEMPLATES
+    # parallel plans are different between postgres versions
+    continuous_aggs_ddl.sql.in
+    )
+endif(CMAKE_BUILD_TYPE MATCHES Debug)
+
 
 #compression only for PG > 9
 if (${PG_VERSION_MAJOR} GREATER "9")
@@ -45,8 +51,12 @@ if (${PG_VERSION_MAJOR} GREATER "9")
 
   list(APPEND TEST_TEMPLATES
     compression_permissions.sql.in
-    transparent_decompression.sql.in
   )
+  if (CMAKE_BUILD_TYPE MATCHES Debug)
+    list(APPEND TEST_TEMPLATES
+      transparent_decompression.sql.in
+      )
+  endif(CMAKE_BUILD_TYPE MATCHES Debug)
 endif ()
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
Fix some minor compiler warnings and errors. Move some tests that
require `timescaledb.current_timestamp_mock` from release to
debug-only.