### PR TITLE
Fix partial select query for continuous aggregate

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1145,10 +1145,15 @@ mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input, int original_q
 			colcollation = exprCollation((Node *) tle->expr);
 			col = makeColumnDef(colname, coltype, coltypmod, colcollation);
 			part_te = (TargetEntry *) copyObject(input);
+			/*need to project all the partial entries so that materialization table is filled */
+			part_te->resjunk = false;
 			if (timebkt_chk)
 			{
 				col->is_not_null = true;
-				part_te->resjunk = false; /* always project time_bucket column*/
+			}
+			if (part_te->resname == NULL)
+			{
+				part_te->resname = pstrdup(colname);
 			}
 		}
 		break;

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -1221,3 +1221,40 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
  POR      |  75
 (4 rows)
 
+-- test for bug when group by is not in project list
+create view conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+select time_bucket(100, timec),  sum(humidity) 
+from conditions 
+group by time_bucket(100, timec), location;
+NOTICE:  adding index _materialized_hypertable_30_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_30 USING BTREE(grp_3_3, time_bucket)
+REFRESH MATERIALIZED VIEW conditions_grpby_view;
+INFO:  new materialization range for public.conditions (time column timec) (400)
+INFO:  materializing continuous aggregate public.conditions_grpby_view: nothing to invalidate, new range up to 400
+select * from conditions_grpby_view order by 1, 2;
+ time_bucket | sum 
+-------------+-----
+           0 | 450
+           0 | 750
+         100 | 750
+         200 |  75
+(4 rows)
+
+create view conditions_grpby_view2 with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+select time_bucket(100, timec), sum(humidity)
+from conditions
+group by time_bucket(100, timec), location  
+having avg(temperature) > 0
+;
+NOTICE:  adding index _materialized_hypertable_31_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_31 USING BTREE(grp_3_3, time_bucket)
+REFRESH MATERIALIZED VIEW conditions_grpby_view2;
+INFO:  new materialization range for public.conditions (time column timec) (400)
+INFO:  materializing continuous aggregate public.conditions_grpby_view2: nothing to invalidate, new range up to 400
+select * from conditions_grpby_view2 order by 1, 2;
+ time_bucket | sum 
+-------------+-----
+           0 | 450
+           0 | 750
+         100 | 750
+         200 |  75
+(4 rows)
+

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -872,3 +872,20 @@ select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 SELECT * FROM mat_refresh_test order by 1,2 ;
+
+-- test for bug when group by is not in project list
+create view conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+select time_bucket(100, timec),  sum(humidity) 
+from conditions 
+group by time_bucket(100, timec), location;
+REFRESH MATERIALIZED VIEW conditions_grpby_view;
+select * from conditions_grpby_view order by 1, 2;
+
+create view conditions_grpby_view2 with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+select time_bucket(100, timec), sum(humidity)
+from conditions
+group by time_bucket(100, timec), location  
+having avg(temperature) > 0
+;
+REFRESH MATERIALIZED VIEW conditions_grpby_view2;
+select * from conditions_grpby_view2 order by 1, 2;


### PR DESCRIPTION
Continuous aggregate views like
select time_bucket(), sum(col)
from ...
group by time_bucket(), grpcol;

when grpcol is missing from the select targetlist, the
partialize query's select targetlist is incorrect and the view
cannot be materialized. This PR fixes this issue.