### PR TITLE
Add ignore_invalidation_older_than to continuous aggs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ value in the table. This change requires that an integer_now func be set on
 hypertables with integer-based time columns to use continuous aggregates on
 this table.
 
+We added a timescaledb.ignore_invalidation_older_than parameter for continuous 
+aggregatess. This parameter accept a time-interval (e.g. 1 month). if set, 
+it limits the amount of time for which to process invalidation. Thus, if
+timescaledb.ignore_invalidation_older_than = '1 month', then any modifications
+for data older than 1 month from the current timestamp at modification time may 
+not cause continuous aggregate to be updated. This limits the amount of work
+that a backfill can trigger. By default, all invalidations are processed.
+
 ## 1.5.1 (2019-11-12)
 
 This maintenance release contains bugfixes since the 1.5.0 release. We deem it low

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -213,6 +213,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 			[CONTINUOUS_AGG_PARTIAL_VIEW_SCHEMA_PARTIAL_VIEW_NAME_KEY] = "continuous_agg_partial_view_schema_partial_view_name_key",
 			[CONTINUOUS_AGG_PKEY] = "continuous_agg_pkey",
 			[CONTINUOUS_AGG_USER_VIEW_SCHEMA_USER_VIEW_NAME_KEY] = "continuous_agg_user_view_schema_user_view_name_key",
+			[CONTINUOUS_AGG_RAW_HYPERTABLE_ID_IDX] = "continuous_agg_raw_hypertable_id_idx"
 		},
 	},
 	[CONTINUOUS_AGGS_COMPLETED_THRESHOLD] = {
@@ -704,6 +705,7 @@ ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation)
 			break;
 		case HYPERTABLE:
 		case DIMENSION:
+		case CONTINUOUS_AGG:
 			relid = ts_catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE);
 			CacheInvalidateRelcacheByRelid(relid);
 			break;

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -839,6 +839,7 @@ typedef enum Anum_continuous_agg
 	Anum_continuous_agg_direct_view_schema,
 	Anum_continuous_agg_direct_view_name,
 	Anum_continuous_agg_max_interval_per_job,
+	Anum_continuous_agg_ignore_invalidation_older_than,
 	_Anum_continuous_agg_max,
 } Anum_continuous_agg;
 
@@ -858,6 +859,7 @@ typedef struct FormData_continuous_agg
 	NameData direct_view_schema;
 	NameData direct_view_name;
 	int64 max_interval_per_job;
+	int64 ignore_invalidation_older_than;
 } FormData_continuous_agg;
 
 typedef FormData_continuous_agg *Form_continuous_agg;
@@ -868,6 +870,7 @@ enum
 	CONTINUOUS_AGG_PARTIAL_VIEW_SCHEMA_PARTIAL_VIEW_NAME_KEY,
 	CONTINUOUS_AGG_PKEY,
 	CONTINUOUS_AGG_USER_VIEW_SCHEMA_USER_VIEW_NAME_KEY,
+	CONTINUOUS_AGG_RAW_HYPERTABLE_ID_IDX,
 	_MAX_CONTINUOUS_AGG_INDEX,
 };
 typedef enum Anum_continuous_agg_job_id_key
@@ -905,6 +908,15 @@ typedef enum Anum_continuous_agg_user_view_schema_user_view_name_key
 
 #define Natts_continuous_agg_user_view_schema_user_view_name_key                                   \
 	(_Anum_continuous_agg_user_view_schema_user_view_name_key_max - 1)
+
+typedef enum Anum_continuous_agg_raw_hypertable_id_idx
+{
+	Anum_continuous_agg_raw_hypertable_id_idx_raw_hypertable_id = 1,
+	_Anum_continuous_agg_raw_hypertable_id_idx_max,
+} Anum_continuous_agg_raw_hypertable_id_idx;
+
+#define Natts_continuous_agg_raw_hypertable_id_idx                                                 \
+	(_Anum_continuous_agg_raw_hypertable_id_idx_max - 1)
 
 /****** CONTINUOUS_AGGS_COMPLETED_THRESHOLD_TABLE definitions*/
 #define CONTINUOUS_AGGS_COMPLETED_THRESHOLD_TABLE_NAME "continuous_aggs_completed_threshold"
@@ -946,6 +958,7 @@ typedef enum Anum_continuous_aggs_completed_threshold_pkey
 typedef enum Anum_continuous_aggs_hypertable_invalidation_log
 {
 	Anum_continuous_aggs_hypertable_invalidation_log_hypertable_id = 1,
+	Anum_continuous_aggs_hypertable_invalidation_log_modification_time,
 	Anum_continuous_aggs_hypertable_invalidation_log_lowest_modified_value,
 	Anum_continuous_aggs_hypertable_invalidation_log_greatest_modified_value,
 	_Anum_continuous_aggs_hypertable_invalidation_log_max,
@@ -957,6 +970,7 @@ typedef enum Anum_continuous_aggs_hypertable_invalidation_log
 typedef struct FormData_continuous_aggs_hypertable_invalidation_log
 {
 	int32 hypertable_id;
+	int64 modification_time;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;
 } FormData_continuous_aggs_hypertable_invalidation_log;
@@ -1020,6 +1034,7 @@ typedef enum Anum_continuous_aggs_invalidation_threshold_pkey
 typedef enum Anum_continuous_aggs_materialization_invalidation_log
 {
 	Anum_continuous_aggs_materialization_invalidation_log_materialization_id = 1,
+	Anum_continuous_aggs_materialization_invalidation_log_modification_time,
 	Anum_continuous_aggs_materialization_invalidation_log_lowest_modified_value,
 	Anum_continuous_aggs_materialization_invalidation_log_greatest_modified_value,
 	_Anum_continuous_aggs_materialization_invalidation_log_max,
@@ -1031,6 +1046,7 @@ typedef enum Anum_continuous_aggs_materialization_invalidation_log
 typedef struct FormData_continuous_aggs_materialization_invalidation_log
 {
 	int32 materialization_id;
+	int64 modification_time;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;
 } FormData_continuous_aggs_materialization_invalidation_log;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -24,6 +24,7 @@ typedef enum ContinuousAggViewOption
 	ContinuousViewOptionRefreshInterval,
 	ContinuousViewOptionMaxIntervalPerRun,
 	ContinuousViewOptionCreateGroupIndex,
+	ContinuousViewOptionIgnoreInvalidationOlderThan,
 } ContinuousAggViewOption;
 
 typedef enum ContinuousAggViewType
@@ -54,6 +55,11 @@ ts_continuous_agg_hypertable_status(int32 hypertable_id);
 extern void ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks,
 													  Size num_chunks);
 extern TSDLLEXPORT List *ts_continuous_aggs_find_by_raw_table_id(int32 raw_hypertable_id);
+extern TSDLLEXPORT int64
+ts_continuous_aggs_max_ignore_invalidation_older_than(int32 raw_hypertable_id);
+extern TSDLLEXPORT int64 ts_continuous_aggs_get_minimum_invalidation_time(
+	int64 modification_time, int64 ignore_invalidation_older_than);
+
 extern TSDLLEXPORT ContinuousAgg *ts_continuous_agg_find_by_view_name(const char *schema,
 																	  const char *name);
 

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -40,6 +40,8 @@ typedef struct Hypertable
 	Oid chunk_sizing_func;
 	Hyperspace *space;
 	SubspaceStore *chunk_cache;
+	int64 max_ignore_invalidation_older_than; /* lazy-loaded, do not access directly, use
+											ts_hypertable_get_ignore_invalidation_older_than */
 } Hypertable;
 
 /* create_hypertable record attribute numbers */
@@ -92,6 +94,7 @@ extern int ts_hypertable_update(Hypertable *ht);
 extern int ts_hypertable_set_name(Hypertable *ht, const char *newname);
 extern int ts_hypertable_set_schema(Hypertable *ht, const char *newname);
 extern int ts_hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
+extern TSDLLEXPORT int64 ts_hypertable_get_max_ignore_invalidation_older_than(Hypertable *ht);
 extern int ts_hypertable_delete_by_name(const char *schema_name, const char *table_name);
 extern TSDLLEXPORT ObjectAddress ts_hypertable_create_trigger(Hypertable *ht, CreateTrigStmt *stmt,
 															  const char *query);

--- a/test/sql/updates/post.continuous_aggs.sql
+++ b/test/sql/updates/post.continuous_aggs.sql
@@ -7,6 +7,10 @@ SELECT * FROM mat_before;
 INSERT INTO conditions_before
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'POR', 165, 75, 40, 70, NULL, (1,2)::custom_type, 2, true;
 
+--cause invalidations way in the past
+INSERT INTO conditions_before
+SELECT generate_series('2017-12-01 00:00'::timestamp, '2017-12-31 00:00'::timestamp, '1 day'), 'POR', 1065, 75, 40, 70, NULL, (1,2)::custom_type, 2, true;
+
 SELECT * FROM mat_before;
 
 REFRESH MATERIALIZED VIEW mat_before;

--- a/test/sql/updates/setup.continuous_aggs.sql
+++ b/test/sql/updates/setup.continuous_aggs.sql
@@ -27,7 +27,7 @@ INSERT INTO conditions_before
 SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, NULL, 28, NULL, NULL, 8, true;
 
 CREATE VIEW mat_before
-WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
+WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
 AS
   SELECT time_bucket('1week', timec) as bucket,
     location,

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -18,6 +18,7 @@ typedef struct SchemaAndName
 
 typedef struct Invalidation
 {
+	int64 modification_time;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;
 } Invalidation;

--- a/tsl/src/continuous_aggs/options.h
+++ b/tsl/src/continuous_aggs/options.h
@@ -13,6 +13,9 @@
 
 extern int64 continuous_agg_parse_refresh_lag(Oid column_type,
 											  WithClauseResult *with_clause_options);
+extern int64
+continuous_agg_parse_ignore_invalidation_older_than(Oid column_type,
+													WithClauseResult *with_clause_options);
 
 extern int64 continuous_agg_parse_max_interval_per_job(Oid column_type,
 													   WithClauseResult *with_clause_options,

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -1258,3 +1258,68 @@ select * from conditions_grpby_view2 order by 1, 2;
          200 |  75
 (4 rows)
 
+--test ignore_invalidation_older_than on timestamps-based ht
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_69_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_30_70_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_71_chunk
+CREATE TABLE conditions (
+                            time       TIMESTAMPTZ       NOT NULL,
+                            temperature DOUBLE PRECISION  NULL
+);
+select table_name from create_hypertable( 'conditions', 'time');
+ table_name 
+------------
+ conditions
+(1 row)
+
+create or replace view mat_test5( timec, maxt)
+        WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='30 day', timescaledb.refresh_lag='-1day',
+               timescaledb.max_interval_per_job='260 day')
+as
+select time_bucket('1day', time), max(temperature)
+from conditions
+group by time_bucket('1day', time);
+SET timescaledb.current_timestamp_mock = '2001-03-11';
+insert into conditions values('2001-03-10', '1');
+insert into conditions values('2001-03-10', '2');
+REFRESH MATERIALIZED VIEW mat_test5;
+INFO:  new materialization range for public.conditions (time column time) (984355200000000)
+INFO:  materializing continuous aggregate public.mat_test5: nothing to invalidate, new range up to 984355200000000
+SELECT * FROM mat_test5;
+            timec             | maxt 
+------------------------------+------
+ Fri Mar 09 16:00:00 2001 PST |    2
+(1 row)
+
+insert into conditions values('2001-02-15', '1');
+insert into conditions values('2001-01-15', '1');
+REFRESH MATERIALIZED VIEW mat_test5;
+INFO:  new materialization range not found for public.conditions (time column time): not enough new data past completion threshold (984355200000000)
+INFO:  materializing continuous aggregate public.mat_test5: processing invalidations, no new range
+--will see the feb but not the january change
+SELECT * FROM mat_test5;
+            timec             | maxt 
+------------------------------+------
+ Fri Mar 09 16:00:00 2001 PST |    2
+ Wed Feb 14 16:00:00 2001 PST |    1
+(2 rows)
+
+--what matters is the time at insertion not materialization
+SET timescaledb.current_timestamp_mock = '2001-03-11';
+--will see this change
+insert into conditions values('2001-02-15', '3');
+SET timescaledb.current_timestamp_mock = '2001-05-11';
+--but not this one
+insert into conditions values('2001-02-20', '4');
+REFRESH MATERIALIZED VIEW mat_test5;
+INFO:  new materialization range for public.conditions (time column time) (989625600000000)
+INFO:  materializing continuous aggregate public.mat_test5: processing invalidations, new range up to 989625600000000
+SELECT * FROM mat_test5;
+            timec             | maxt 
+------------------------------+------
+ Fri Mar 09 16:00:00 2001 PST |    2
+ Wed Feb 14 16:00:00 2001 PST |    3
+(2 rows)
+

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -69,8 +69,8 @@ SELECT * FROM timescaledb_information.policy_stats;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_agg;
- mat_hypertable_id | raw_hypertable_id | user_view_schema | user_view_name | partial_view_schema | partial_view_name | bucket_width | job_id | refresh_lag | direct_view_schema | direct_view_name | max_interval_per_job 
--------------------+-------------------+------------------+----------------+---------------------+-------------------+--------------+--------+-------------+--------------------+------------------+----------------------
+ mat_hypertable_id | raw_hypertable_id | user_view_schema | user_view_name | partial_view_schema | partial_view_name | bucket_width | job_id | refresh_lag | direct_view_schema | direct_view_name | max_interval_per_job | ignore_invalidation_older_than 
+-------------------+-------------------+------------------+----------------+---------------------+-------------------+--------------+--------+-------------+--------------------+------------------+----------------------+--------------------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -104,10 +104,10 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_status, last_
 
 SELECT id as raw_table_id FROM _timescaledb_catalog.hypertable WHERE table_name='test_continuous_agg_table' \gset
 -- min distance from end should be 1
-SELECT  mat_hypertable_id, user_view_schema, user_view_name, bucket_width, job_id, refresh_lag FROM _timescaledb_catalog.continuous_agg;
- mat_hypertable_id | user_view_schema |      user_view_name      | bucket_width | job_id | refresh_lag 
--------------------+------------------+--------------------------+--------------+--------+-------------
-                 2 | public           | test_continuous_agg_view |            2 |   1000 |           4
+SELECT  mat_hypertable_id, user_view_schema, user_view_name, bucket_width, job_id, refresh_lag, ignore_invalidation_older_than FROM _timescaledb_catalog.continuous_agg;
+ mat_hypertable_id | user_view_schema |      user_view_name      | bucket_width | job_id | refresh_lag | ignore_invalidation_older_than 
+-------------------+------------------+--------------------------+--------------+--------+-------------+--------------------------------
+                 2 | public           | test_continuous_agg_view |            2 |   1000 |           4 |            9223372036854775807
 (1 row)
 
 SELECT job_id FROM _timescaledb_catalog.continuous_agg \gset

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -374,6 +374,13 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec);
+create or replace view mat_with_test_no_inval( timec, minl, sumt , sumh)
+        WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h',
+               timescaledb.ignore_invalidation_older_than='0')
+as
+select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket('1day', timec);
 SELECT  h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
        partial_view_name as "PART_VIEW_NAME",
@@ -397,7 +404,7 @@ ALTER VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME" SET(timescaledb.refresh_lag = '
 ERROR:  cannot alter the internal view of a continuous aggregate
 \set ON_ERROR_STOP 1
 DROP TABLE conditions CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 4 other objects
 --test WITH using a hypertable with an integer time dimension
 CREATE TABLE conditions (
       timec       SMALLINT       NOT NULL,
@@ -452,6 +459,21 @@ select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
 ERROR:  parameter timescaledb.max_interval_per_job must be at least the size of the time_bucket width
+--ignore_invalidation_older_than must be positive
+create or replace view mat_with_test( timec, minl, sumt , sumh)
+        WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='-10')
+as
+select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket(100, timec);
+ERROR:  parameter timescaledb.ignore_invalidation_older_than must not be negative
+create or replace view mat_with_test( timec, minl, sumt , sumh)
+        WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='1 hour')
+as
+select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket(100, timec);
+ERROR:  parameter timescaledb.ignore_invalidation_older_than must be an integer for hypertables with integer time values
 \set ON_ERROR_STOP 1
 create or replace view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647', timescaledb.refresh_interval = '2h')
@@ -484,7 +506,7 @@ CREATE TABLE text_time(time TEXT);
 NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
- (8,public,text_time,t)
+ (9,public,text_time,t)
 (1 row)
 
 \set ON_ERROR_STOP 0

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -786,9 +786,9 @@ INSERT INTO continuous_agg_test_t VALUES
     ('2019-02-02 4:00 UTC', 1),
     ('2019-02-02 5:00 UTC', 1);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             5 |      1549072800000000 |        1549083600000000
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             5 |  1549090800000000 |      1549072800000000 |        1549083600000000
 (1 row)
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -333,8 +333,8 @@ select * from _timescaledb_catalog.continuous_aggs_invalidation_threshold order 
 (1 row)
 
 select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
- materialization_id | lowest_modified_value | greatest_modified_value 
---------------------+-----------------------+-------------------------
+ materialization_id | modification_time | lowest_modified_value | greatest_modified_value 
+--------------------+-------------------+-----------------------+-------------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -369,10 +369,10 @@ select * from cagg_2 order by 1;
 insert into continuous_agg_test values( 18, -2, 100); 
 insert into continuous_agg_test values( 18, -2, 100); 
 select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             4 |                    18 |                      18
-             4 |                    18 |                      18
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             4 |                18 |                    18 |                      18
+             4 |                18 |                    18 |                      18
 (2 rows)
 
 refresh materialized view cagg_1;
@@ -386,10 +386,238 @@ select * from cagg_1 where timed = 18 ;
 
 --copied over for cagg_2 to process later?
 select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
- materialization_id | lowest_modified_value | greatest_modified_value 
---------------------+-----------------------+-------------------------
-                  6 |                    18 |                      18
-                  6 |                    18 |                      18
+ materialization_id | modification_time | lowest_modified_value | greatest_modified_value 
+--------------------+-------------------+-----------------------+-------------------------
+                  6 |                18 |                    18 |                      18
+                  6 |                18 |                    18 |                      18
 (2 rows)
 
+--test the ignore_invalidation_older_than setting
+CREATE TABLE continuous_agg_test_ignore_invalidation_older_than(timeval integer, col1 integer, col2 integer);
+select create_hypertable('continuous_agg_test_ignore_invalidation_older_than', 'timeval', chunk_time_interval=> 2);
+NOTICE:  adding not-null constraint to column "timeval"
+                        create_hypertable                        
+-----------------------------------------------------------------
+ (7,public,continuous_agg_test_ignore_invalidation_older_than,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timeval), 0) FROM continuous_agg_test_ignore_invalidation_older_than $$;
+SELECT set_integer_now_func('continuous_agg_test_ignore_invalidation_older_than', 'integer_now_test2');
+ set_integer_now_func 
+----------------------
  
+(1 row)
+
+INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES
+(10, - 4, 1), (11, - 3, 5), (12, -3, 7);
+CREATE VIEW cagg_iia1( timed, cnt )
+        WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 5 )
+AS
+SELECT time_bucket( 2, timeval), COUNT(col1)
+FROM continuous_agg_test_ignore_invalidation_older_than
+GROUP BY 1;
+CREATE VIEW cagg_iia2( timed, maxval)
+        WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 10)
+AS
+SELECT time_bucket(2, timeval), max(col2)
+FROM continuous_agg_test_ignore_invalidation_older_than
+GROUP BY 1;
+CREATE VIEW cagg_iia3( timed, maxval)
+        WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 0)
+AS
+SELECT time_bucket(2, timeval), max(col2)
+FROM continuous_agg_test_ignore_invalidation_older_than
+GROUP BY 1;
+refresh materialized view cagg_iia1;
+INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (14)
+INFO:  materializing continuous aggregate public.cagg_iia1: nothing to invalidate, new range up to 14
+select * from cagg_iia1 order by 1;
+ timed | cnt 
+-------+-----
+    10 |   2
+    12 |   1
+(2 rows)
+
+refresh materialized view cagg_iia2;
+INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (14)
+INFO:  materializing continuous aggregate public.cagg_iia2: nothing to invalidate, new range up to 14
+select * from cagg_iia2 order by 1;
+ timed | maxval 
+-------+--------
+    10 |      5
+    12 |      7
+(2 rows)
+
+refresh materialized view cagg_iia3;
+INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (14)
+INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, new range up to 14
+select * from cagg_iia3 order by 1;
+ timed | maxval 
+-------+--------
+    10 |      5
+    12 |      7
+(2 rows)
+
+INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES
+(1, -4, 1), (5, -3, 5), (10, -3, 9), (12,3,19);
+--modification happened at time 12
+SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             7 |                12 |                     5 |                      12
+(1 row)
+
+--move the time up (40), but invalidation logic should apply to old time (12)
+INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES (32,4,2),(36,5,5),(40,3,9);
+refresh materialized view cagg_iia1;
+INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (42)
+INFO:  materializing continuous aggregate public.cagg_iia1: processing invalidations, new range up to 42
+--should see change to the 12, 10 bucket but not the 4 or 1 bucket
+select * from cagg_iia1 order by 1;
+ timed | cnt 
+-------+-----
+    10 |   3
+    12 |   2
+    32 |   1
+    36 |   1
+    40 |   1
+(5 rows)
+
+--should see change to the 12, 10 and 4 bucket but not the 1 bucket
+refresh materialized view cagg_iia2;
+INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (42)
+INFO:  materializing continuous aggregate public.cagg_iia2: processing invalidations, new range up to 42
+select * from cagg_iia2 order by 1;
+ timed | maxval 
+-------+--------
+     4 |      5
+    10 |      9
+    12 |     19
+    32 |      2
+    36 |      5
+    40 |      9
+(6 rows)
+
+--sees no changes
+refresh materialized view cagg_iia3;
+INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (42)
+INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, new range up to 42
+select * from cagg_iia3 order by 1;
+ timed | maxval 
+-------+--------
+    10 |      5
+    12 |      7
+    32 |      2
+    36 |      5
+    40 |      9
+(5 rows)
+
+--tes UPDATES
+UPDATE continuous_agg_test_ignore_invalidation_older_than  set col1=NULL, col2=200 where timeval=32;
+UPDATE continuous_agg_test_ignore_invalidation_older_than  set col1=NULL, col2=120 where timeval=36;
+refresh materialized view cagg_iia1;
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  materializing continuous aggregate public.cagg_iia1: processing invalidations, no new range
+--should see change only for the 36 bucket not 32
+select * from cagg_iia1 order by 1;
+ timed | cnt 
+-------+-----
+    10 |   3
+    12 |   2
+    32 |   1
+    36 |   0
+    40 |   1
+(5 rows)
+
+--should see change to the 36 and 32
+refresh materialized view cagg_iia2;
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  materializing continuous aggregate public.cagg_iia2: processing invalidations, no new range
+select * from cagg_iia2 order by 1;
+ timed | maxval 
+-------+--------
+     4 |      5
+    10 |      9
+    12 |     19
+    32 |    200
+    36 |    120
+    40 |      9
+(6 rows)
+
+--sees no changes
+refresh materialized view cagg_iia3;
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, no new range
+INFO:  materializing continuous aggregate public.cagg_iia3: no new range to materialize or invalidations found, exiting early
+select * from cagg_iia3 order by 1;
+ timed | maxval 
+-------+--------
+    10 |      5
+    12 |      7
+    32 |      2
+    36 |      5
+    40 |      9
+(5 rows)
+
+--test DELETE
+DELETE FROM continuous_agg_test_ignore_invalidation_older_than WHERE timeval = 32;
+DELETE FROM continuous_agg_test_ignore_invalidation_older_than WHERE timeval = 36;
+refresh materialized view cagg_iia1;
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  materializing continuous aggregate public.cagg_iia1: processing invalidations, no new range
+--should see change only for the 36 bucket not 32
+select * from cagg_iia1 order by 1;
+ timed | cnt 
+-------+-----
+    10 |   3
+    12 |   2
+    32 |   1
+    40 |   1
+(4 rows)
+
+--should see change to the 36 and 32
+refresh materialized view cagg_iia2;
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  materializing continuous aggregate public.cagg_iia2: processing invalidations, no new range
+select * from cagg_iia2 order by 1;
+ timed | maxval 
+-------+--------
+     4 |      5
+    10 |      9
+    12 |     19
+    40 |      9
+(4 rows)
+
+--sees no changes
+refresh materialized view cagg_iia3;
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, no new range
+INFO:  materializing continuous aggregate public.cagg_iia3: no new range to materialize or invalidations found, exiting early
+select * from cagg_iia3 order by 1;
+ timed | maxval 
+-------+--------
+    10 |      5
+    12 |      7
+    32 |      2
+    36 |      5
+    40 |      9
+(5 rows)
+
+--change the parameter
+ALTER VIEW cagg_iia3 set (timescaledb.ignore_invalidation_older_than = 100);
+INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES
+ (10, -3, 20);
+--sees the change now
+refresh materialized view cagg_iia3;
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  materializing continuous aggregate public.cagg_iia3: processing invalidations, no new range
+select * from cagg_iia3 order by 1;
+ timed | maxval 
+-------+--------
+    10 |     20
+    12 |      7
+    32 |      2
+    36 |      5
+    40 |      9
+(5 rows)
+

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -32,8 +32,8 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
 (0 rows)
 
 -- inserting into a table that does not have continuous_agg_insert_trigger doesn't change the watermark
@@ -44,10 +44,22 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
 (0 rows)
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE continuous_agg_test_mat(time int);
+select create_hypertable('continuous_agg_test_mat', 'time', chunk_time_interval=> 10);
+NOTICE:  adding not-null constraint to column "time"
+          create_hypertable           
+--------------------------------------
+ (2,public,continuous_agg_test_mat,t)
+(1 row)
+
+INSERT INTO _timescaledb_config.bgw_job VALUES (2, '','continuous_aggregate',interval '1s', interval '1s',0, interval '1s');
+INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,2,0,'','',0, bigint '10000000');
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- create the trigger
 CREATE TRIGGER continuous_agg_insert_trigger
     AFTER INSERT ON continuous_agg_test
@@ -63,8 +75,8 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
 (0 rows)
 
 -- set the continuous_aggs_invalidation_threshold to 15, any insertions below that value need an invalidation
@@ -79,9 +91,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
 (1 row)
 
 -- INSERTs only above the continuous_aggs_invalidation_threshold won't change the continuous_aggs_hypertable_invalidation_log
@@ -93,9 +105,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
 (1 row)
 
 -- INSERTs only below the continuous_aggs_invalidation_threshold will change the continuous_aggs_hypertable_invalidation_log
@@ -107,10 +119,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
-             1 |                    10 |                      11
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
+             1 |                22 |                    10 |                      11
 (2 rows)
 
 -- test INSERTing other values
@@ -122,11 +134,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
-             1 |                    10 |                      11
-             1 |                     1 |                      51
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
+             1 |                22 |                    10 |                      11
+             1 |                22 |                     1 |                      51
 (3 rows)
 
 -- INSERT after dropping a COLUMN
@@ -139,12 +151,12 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
-             1 |                    10 |                      11
-             1 |                     1 |                      51
-             1 |                    -4 |                      -1
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
+             1 |                22 |                    10 |                      11
+             1 |                22 |                     1 |                      51
+             1 |                51 |                    -4 |                      -1
 (4 rows)
 
 INSERT INTO continuous_agg_test VALUES (100);
@@ -155,12 +167,12 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
-             1 |                    10 |                      11
-             1 |                     1 |                      51
-             1 |                    -4 |                      -1
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
+             1 |                22 |                    10 |                      11
+             1 |                22 |                     1 |                      51
+             1 |                51 |                    -4 |                      -1
 (4 rows)
 
 -- INSERT after adding a COLUMN
@@ -173,13 +185,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
-             1 |                    10 |                      11
-             1 |                     1 |                      51
-             1 |                    -4 |                      -1
-             1 |                    -7 |                      -3
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
+             1 |                22 |                    10 |                      11
+             1 |                22 |                     1 |                      51
+             1 |                51 |                    -4 |                      -1
+             1 |               100 |                    -7 |                      -3
 (5 rows)
 
 INSERT INTO continuous_agg_test VALUES (120, false), (200, true);
@@ -190,15 +202,19 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             1 |                    10 |                      22
-             1 |                    10 |                      11
-             1 |                     1 |                      51
-             1 |                    -4 |                      -1
-             1 |                    -7 |                      -3
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             1 |                22 |                    10 |                      22
+             1 |                22 |                    10 |                      11
+             1 |                22 |                     1 |                      51
+             1 |                51 |                    -4 |                      -1
+             1 |               100 |                    -7 |                      -3
 (5 rows)
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_agg where mat_hypertable_id =  2;
+DELETE FROM _timescaledb_config.bgw_job WHERE id = 2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 DROP TABLE continuous_agg_test CASCADE;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
@@ -210,7 +226,7 @@ SELECT create_hypertable('ca_inval_test', 'time', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
- (2,public,ca_inval_test,t)
+ (3,public,ca_inval_test,t)
 (1 row)
 
 CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ca_inval_test $$;
@@ -232,37 +248,37 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (2, 15);
+INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (3, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 INSERT INTO ca_inval_test SELECT generate_series(5, 15);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
 ---------------+-----------
-             2 |        15
+             3 |        15
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             2 |                     5 |                      15
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             3 |                 5 |                     5 |                      15
 (1 row)
 
 INSERT INTO ca_inval_test SELECT generate_series(16, 20);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
 ---------------+-----------
-             2 |        15
+             3 |        15
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             2 |                     5 |                      15
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             3 |                 5 |                     5 |                      15
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -279,16 +295,16 @@ UPDATE ca_inval_test SET time = 17 WHERE time = 19;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
 ---------------+-----------
-             2 |        15
+             3 |        15
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             2 |                     5 |                       6
-             2 |                     5 |                       7
-             2 |                    14 |                      17
-             2 |                    12 |                      16
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             3 |                20 |                     5 |                       6
+             3 |                20 |                     5 |                       7
+             3 |                20 |                    14 |                      17
+             3 |                20 |                    12 |                      16
 (4 rows)
 
 DROP TABLE ca_inval_test CASCADE;
@@ -304,7 +320,7 @@ CREATE TABLE ts_continuous_test(time INTEGER, location INTEGER);
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
- (4,public,ts_continuous_test,t)
+ (5,public,ts_continuous_test,t)
 (1 row)
 
 CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ts_continuous_test $$;
@@ -327,24 +343,24 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (4, 2);
+INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (5, 2);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 INSERT INTO ts_continuous_test VALUES (1, 1);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
 ---------------+-----------
-             4 |         2
+             5 |         2
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             4 |                     1 |                       1
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             5 |                29 |                     1 |                       1
 (1 row)
 
 -- aborts don't get written
@@ -354,13 +370,13 @@ ABORT;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
 ---------------+-----------
-             4 |         2
+             5 |         2
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | lowest_modified_value | greatest_modified_value 
----------------+-----------------------+-------------------------
-             4 |                     1 |                       1
+ hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
+---------------+-------------------+-----------------------+-------------------------
+             5 |                29 |                     1 |                       1
 (1 row)
 
 DROP TABLE ts_continuous_test CASCADE;

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -89,7 +89,7 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_status, last_
 SELECT id as raw_table_id FROM _timescaledb_catalog.hypertable WHERE table_name='test_continuous_agg_table' \gset
 
 -- min distance from end should be 1
-SELECT  mat_hypertable_id, user_view_schema, user_view_name, bucket_width, job_id, refresh_lag FROM _timescaledb_catalog.continuous_agg;
+SELECT  mat_hypertable_id, user_view_schema, user_view_name, bucket_width, job_id, refresh_lag, ignore_invalidation_older_than FROM _timescaledb_catalog.continuous_agg;
 SELECT job_id FROM _timescaledb_catalog.continuous_agg \gset
 
 -- job was created

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -366,6 +366,14 @@ select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec);
 
+create or replace view mat_with_test_no_inval( timec, minl, sumt , sumh)
+        WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h',
+               timescaledb.ignore_invalidation_older_than='0')
+as
+select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket('1day', timec);
+
 SELECT  h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
        partial_view_name as "PART_VIEW_NAME",
@@ -433,6 +441,22 @@ as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
+
+--ignore_invalidation_older_than must be positive
+create or replace view mat_with_test( timec, minl, sumt , sumh)
+        WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='-10')
+as
+select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket(100, timec);
+
+create or replace view mat_with_test( timec, minl, sumt , sumh)
+        WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='1 hour')
+as
+select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket(100, timec);
+
 \set ON_ERROR_STOP 1
 
 create or replace view mat_with_test( timec, minl, sumt , sumh)

--- a/tsl/test/sql/continuous_aggs_watermark.sql
+++ b/tsl/test/sql/continuous_aggs_watermark.sql
@@ -22,6 +22,13 @@ INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE continuous_agg_test_mat(time int);
+select create_hypertable('continuous_agg_test_mat', 'time', chunk_time_interval=> 10);
+INSERT INTO _timescaledb_config.bgw_job VALUES (2, '','continuous_aggregate',interval '1s', interval '1s',0, interval '1s');
+INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,2,0,'','',0, bigint '10000000');
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
 -- create the trigger
 CREATE TRIGGER continuous_agg_insert_trigger
     AFTER INSERT ON continuous_agg_test
@@ -90,6 +97,11 @@ INSERT INTO continuous_agg_test VALUES (120, false), (200, true);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_agg where mat_hypertable_id =  2;
+DELETE FROM _timescaledb_config.bgw_job WHERE id = 2;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
 DROP TABLE continuous_agg_test CASCADE;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
@@ -114,7 +126,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (2, 15);
+INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (3, 15);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 INSERT INTO ca_inval_test SELECT generate_series(5, 15);
@@ -168,7 +180,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (4, 2);
+INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (5, 2);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 INSERT INTO ts_continuous_test VALUES (1, 1);


### PR DESCRIPTION
We added a timescaledb.ignore_invalidation_older_than parameter for
continuous aggregatess. This parameter accept a time-interval (e.g. 1
month). if set, it limits the amount of time for which to process
invalidation. Thus, if
	timescaledb.ignore_invalidation_older_than = '1 month'
then any modifications for data older than 1 month from the current
timestamp at insert time will not cause updates to the continuous
aggregate. This limits the amount of work that a backfill can trigger.
This parameter must be >= 0. A value of 0 means that invalidations are
never processed.

When recording invalidations for the hypertable at insert time, we use
the maximum ignore_invalidation_older_than of any continuous agg attached
to the hypertable as a cutoff for whether to record the invalidation
at all. When materializing a particular continuous agg, we use that
aggs  ignore_invalidation_older_than cutoff. However we have to apply
that cutoff relative to the insert time not the materialization
time to make it easier for users to reason about. Therefore,
we record the insert time as part of the invalidation entry.