### PR TITLE
Reorder group-by clause for continuous aggregates

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -43,6 +43,7 @@ bool ts_guc_enable_chunk_append = true;
 bool ts_guc_enable_parallel_chunk_append = true;
 bool ts_guc_enable_runtime_exclusion = true;
 bool ts_guc_enable_constraint_exclusion = true;
+bool ts_guc_enable_cagg_reorder_groupby = true;
 TSDLLEXPORT bool ts_guc_enable_transparent_decompression = true;
 int ts_guc_max_open_chunks_per_insert = 10;
 int ts_guc_max_cached_chunks_per_hypertable = 10;
@@ -173,6 +174,17 @@ _guc_init(void)
 							 "Enable transparent decompression",
 							 "Enable transparent decompression when querying hypertable",
 							 &ts_guc_enable_transparent_decompression,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("timescaledb.enable_cagg_reorder_groupby",
+							 "Enable group by reordering",
+							 "Enable group by clause reordering for continuous aggregates",
+							 &ts_guc_enable_cagg_reorder_groupby,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -19,6 +19,7 @@ extern bool ts_guc_enable_chunk_append;
 extern bool ts_guc_enable_parallel_chunk_append;
 extern bool ts_guc_enable_runtime_exclusion;
 extern bool ts_guc_enable_constraint_exclusion;
+extern bool ts_guc_enable_cagg_reorder_groupby;
 extern TSDLLEXPORT bool ts_guc_enable_transparent_decompression;
 extern bool ts_guc_restoring;
 extern int ts_guc_max_open_chunks_per_insert;

--- a/tsl/test/expected/continuous_aggs_query-10.out
+++ b/tsl/test/expected/continuous_aggs_query-10.out
@@ -1,0 +1,408 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- stop the continous aggregate background workers from interfering
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set TEST_BASE_NAME continuous_aggs_query 
+SELECT 
+       format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",
+       format('%s/results/%s_results_view_hashagg.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW_HASHAGG",
+       format('%s/results/%s_results_table.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_TABLE"
+\gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "DIFF_CMD",
+      format('\! diff %s %s', :'TEST_RESULTS_VIEW_HASHAGG', :'TEST_RESULTS_TABLE') as "DIFF_CMD2"
+\gset
+\set ON_ERROR_STOP 0
+CREATE TABLE conditions (
+      timec        TIMESTAMPTZ       NOT NULL,
+      location    TEXT              NOT NULL,
+      temperature DOUBLE PRECISION  NULL,
+      humidity    DOUBLE PRECISION  NULL
+    );
+select table_name from create_hypertable( 'conditions', 'timec');
+ table_name 
+------------
+ conditions
+(1 row)
+
+insert into conditions values ( '2018-01-01 09:00:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'por', 100, 100);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 30);
+insert into conditions values ( '2018-11-01 10:00:00-08', 'NYC', 55, 35);
+insert into conditions values ( '2018-11-01 11:00:00-08', 'NYC', 65, 40);
+insert into conditions values ( '2018-11-01 12:00:00-08', 'NYC', 75, 45);
+insert into conditions values ( '2018-11-01 13:00:00-08', 'NYC', 85, 50);
+insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 10, 10);
+insert into conditions values ( '2018-11-02 10:00:00-08', 'NYC', 20, 15);
+insert into conditions values ( '2018-11-02 11:00:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', null, null);
+create table location_tab( locid integer, locname text );
+insert into location_tab values( 1, 'SFO');
+insert into location_tab values( 2, 'NYC');
+insert into location_tab values( 3, 'por');
+create or replace view mat_m1( location, timec, minl, sumt , sumh)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket('1day', timec), location;
+NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m1;
+INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
+INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to 1546041600000000
+--test first/last
+create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
+from conditions
+group by time_bucket('1day', timec), location;
+NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, timec)
+--time that refresh assumes as now() for repeatability
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m2;
+INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
+INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to 1546041600000000
+--normal view --
+create or replace view regview( location, timec, minl, sumt , sumh)
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by location, time_bucket('1day', timec);
+set enable_hashagg = false;
+-- NO pushdown cases ---
+--when we have addl. attrs in order by that are not in the
+-- group by, we will still need a sort
+explain verbose 
+select * from mat_m1 order by sumh, sumt, minl, timec ;
+                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=104.70..105.20 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
+   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), _hyper_2_3_chunk.timec
+   ->  GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+         ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+               ->  Append  (cost=0.00..29.60 rows=960 width=136)
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(14 rows)
+
+explain verbose 
+select * from regview order by timec desc;
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=210.84..211.34 rows=200 width=88)
+   Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+   ->  GroupAggregate  (cost=169.59..201.19 rows=200 width=88)
+         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
+         Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+         ->  Sort  (cost=169.59..174.44 rows=1940 width=56)
+               Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+               Sort Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+               ->  Result  (cost=0.00..63.65 rows=1940 width=56)
+                     Output: _hyper_1_1_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                     ->  Append  (cost=0.00..39.40 rows=1940 width=56)
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                 Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+(16 rows)
+
+-- PUSHDOWN cases --
+-- all group by elts in order by , reorder group by elts to match
+-- group by order
+-- This should prevent an additional sort after GroupAggregate
+explain verbose 
+select * from mat_m1 order by timec desc, location;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+   ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
+         ->  Append  (cost=0.00..29.60 rows=960 width=136)
+               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(11 rows)
+
+explain verbose 
+select * from mat_m1 order by location, timec desc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=0.30..61.41 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+   ->  Merge Append  (cost=0.30..45.91 rows=960 width=136)
+         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec DESC
+         ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_3_chunk  (cost=0.15..19.35 rows=480 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..19.35 rows=480 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(9 rows)
+
+explain verbose 
+select * from mat_m1 order by location, timec asc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+   ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+         ->  Append  (cost=0.00..29.60 rows=960 width=136)
+               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(11 rows)
+
+explain verbose 
+select * from mat_m1 where timec > '2018-10-01' order by timec desc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+   ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+         Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+         ->  Append  (cost=0.15..13.95 rows=160 width=136)
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                     Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(10 rows)
+
+-- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
+explain verbose 
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=116.97..119.51 rows=1016 width=92)
+   Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+   Sort Key: _hyper_2_4_chunk.timec DESC
+   ->  Hash Join  (cost=28.61..66.23 rows=1016 width=92)
+         Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+         Hash Cond: (l.locname = _hyper_2_4_chunk.location)
+         ->  Seq Scan on public.location_tab l  (cost=0.00..22.70 rows=1270 width=36)
+               Output: l.locid, l.locname
+         ->  Hash  (cost=26.61..26.61 rows=160 width=88)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+               ->  GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+                     Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+                     ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+                           ->  Append  (cost=0.15..13.95 rows=160 width=136)
+                                 ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                       Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(20 rows)
+
+explain verbose 
+select * from mat_m2 where timec > '2018-10-01' order by timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+   Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+   ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+         Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+         ->  Append  (cost=0.15..13.48 rows=133 width=168)
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                     Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(10 rows)
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=18.17..18.22 rows=1 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
+   ->  GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+         ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+               ->  Append  (cost=0.15..13.48 rows=133 width=168)
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(12 rows)
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=18.17..18.22 rows=1 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
+   ->  GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+         ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location NULLS FIRST
+               ->  Append  (cost=0.15..13.48 rows=133 width=168)
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(12 rows)
+
+--plans with CTE
+explain verbose
+with m1 as (
+Select * from mat_m2 where timec > '2018-10-01' order by timec desc ) 
+select * from m1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ CTE Scan on m1  (cost=24.48..27.14 rows=133 width=72)
+   Output: m1.location, m1.timec, m1.firsth, m1.lasth, m1.maxtemp, m1.mintemp
+   CTE m1
+     ->  GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+           Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+           ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                 Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+                 ->  Append  (cost=0.15..13.48 rows=133 width=168)
+                       ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                             Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                             Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(13 rows)
+
+-- should reorder mat_m1 group by only based on mat_m1 order-by
+explain verbose
+select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join  (cost=114.02..123.82 rows=160 width=160)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
+   Merge Cond: (_hyper_2_4_chunk.timec = _hyper_3_5_chunk.timec)
+   ->  GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+         ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+               ->  Append  (cost=0.15..13.95 rows=160 width=136)
+                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+   ->  Sort  (cost=94.22..94.72 rows=200 width=72)
+         Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
+         Sort Key: _hyper_3_5_chunk.timec DESC
+         ->  GroupAggregate  (cost=66.58..84.58 rows=200 width=72)
+               Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision)
+               Group Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
+               ->  Sort  (cost=66.58..68.58 rows=800 width=168)
+                     Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                     Sort Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
+                     ->  Append  (cost=0.00..28.00 rows=800 width=168)
+                           ->  Seq Scan on _timescaledb_internal._hyper_3_5_chunk  (cost=0.00..14.00 rows=400 width=168)
+                                 Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                           ->  Seq Scan on _timescaledb_internal._hyper_3_6_chunk  (cost=0.00..14.00 rows=400 width=168)
+                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+(27 rows)
+
+--should reorder only for mat_m1.
+explain verbose
+select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join  (cost=230.64..240.44 rows=160 width=176)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Merge Cond: (_hyper_2_4_chunk.timec = (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)))
+   ->  GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+         ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+               ->  Append  (cost=0.15..13.95 rows=160 width=136)
+                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+   ->  Sort  (cost=210.84..211.34 rows=200 width=88)
+         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+         ->  GroupAggregate  (cost=169.59..201.19 rows=200 width=88)
+               Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
+               Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+               ->  Sort  (cost=169.59..174.44 rows=1940 width=56)
+                     Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                     Sort Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+                     ->  Result  (cost=0.00..63.65 rows=1940 width=56)
+                           Output: _hyper_1_1_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                           ->  Append  (cost=0.00..39.40 rows=1940 width=56)
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                       Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                       Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+(29 rows)
+
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+ locid | location |            timec             | minl | sumt | sumh 
+-------+----------+------------------------------+------+------+------
+     2 | NYC      | Fri Nov 02 17:00:00 2018 PDT | NYC  |      |     
+     2 | NYC      | Thu Nov 01 17:00:00 2018 PDT | NYC  |   30 |   25
+     2 | NYC      | Wed Oct 31 17:00:00 2018 PDT | NYC  |  325 |  200
+(3 rows)
+
+\set ECHO none
+---- Run the same queries with hash agg enabled now 
+set enable_hashagg = true;
+\set ECHO none
+--- Run the queries directly on the table now
+set enable_hashagg = true;
+\set ECHO none
+-- diff results view select and table select
+:DIFF_CMD
+:DIFF_CMD2
+--check if the guc works , reordering will not work
+set timescaledb.enable_cagg_reorder_groupby = false;
+set enable_hashagg = false;
+explain verbose 
+select * from mat_m1 order by timec desc, location;
+                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=104.70..105.20 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
+   Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
+   ->  GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+         ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+               ->  Append  (cost=0.00..29.60 rows=960 width=136)
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(14 rows)
+

--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -1,0 +1,408 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- stop the continous aggregate background workers from interfering
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set TEST_BASE_NAME continuous_aggs_query 
+SELECT 
+       format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",
+       format('%s/results/%s_results_view_hashagg.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW_HASHAGG",
+       format('%s/results/%s_results_table.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_TABLE"
+\gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "DIFF_CMD",
+      format('\! diff %s %s', :'TEST_RESULTS_VIEW_HASHAGG', :'TEST_RESULTS_TABLE') as "DIFF_CMD2"
+\gset
+\set ON_ERROR_STOP 0
+CREATE TABLE conditions (
+      timec        TIMESTAMPTZ       NOT NULL,
+      location    TEXT              NOT NULL,
+      temperature DOUBLE PRECISION  NULL,
+      humidity    DOUBLE PRECISION  NULL
+    );
+select table_name from create_hypertable( 'conditions', 'timec');
+ table_name 
+------------
+ conditions
+(1 row)
+
+insert into conditions values ( '2018-01-01 09:00:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'por', 100, 100);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 30);
+insert into conditions values ( '2018-11-01 10:00:00-08', 'NYC', 55, 35);
+insert into conditions values ( '2018-11-01 11:00:00-08', 'NYC', 65, 40);
+insert into conditions values ( '2018-11-01 12:00:00-08', 'NYC', 75, 45);
+insert into conditions values ( '2018-11-01 13:00:00-08', 'NYC', 85, 50);
+insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 10, 10);
+insert into conditions values ( '2018-11-02 10:00:00-08', 'NYC', 20, 15);
+insert into conditions values ( '2018-11-02 11:00:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', null, null);
+create table location_tab( locid integer, locname text );
+insert into location_tab values( 1, 'SFO');
+insert into location_tab values( 2, 'NYC');
+insert into location_tab values( 3, 'por');
+create or replace view mat_m1( location, timec, minl, sumt , sumh)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket('1day', timec), location;
+NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m1;
+INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
+INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to 1546041600000000
+--test first/last
+create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
+from conditions
+group by time_bucket('1day', timec), location;
+NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, timec)
+--time that refresh assumes as now() for repeatability
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m2;
+INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
+INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to 1546041600000000
+--normal view --
+create or replace view regview( location, timec, minl, sumt , sumh)
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by location, time_bucket('1day', timec);
+set enable_hashagg = false;
+-- NO pushdown cases ---
+--when we have addl. attrs in order by that are not in the
+-- group by, we will still need a sort
+explain verbose 
+select * from mat_m1 order by sumh, sumt, minl, timec ;
+                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=109.50..110.00 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
+   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), _hyper_2_3_chunk.timec
+   ->  GroupAggregate  (cost=81.95..99.85 rows=200 width=88)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+         ->  Sort  (cost=81.95..84.35 rows=960 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+               ->  Append  (cost=0.00..34.40 rows=960 width=136)
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(14 rows)
+
+explain verbose 
+select * from regview order by timec desc;
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=220.54..221.04 rows=200 width=88)
+   Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+   ->  GroupAggregate  (cost=179.29..210.89 rows=200 width=88)
+         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
+         Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+         ->  Sort  (cost=179.29..184.14 rows=1940 width=56)
+               Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+               Sort Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+               ->  Result  (cost=0.00..73.35 rows=1940 width=56)
+                     Output: _hyper_1_1_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                     ->  Append  (cost=0.00..49.10 rows=1940 width=56)
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                 Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+(16 rows)
+
+-- PUSHDOWN cases --
+-- all group by elts in order by , reorder group by elts to match
+-- group by order
+-- This should prevent an additional sort after GroupAggregate
+explain verbose 
+select * from mat_m1 order by timec desc, location;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=81.95..99.85 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+   ->  Sort  (cost=81.95..84.35 rows=960 width=136)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
+         ->  Append  (cost=0.00..34.40 rows=960 width=136)
+               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(11 rows)
+
+explain verbose 
+select * from mat_m1 order by location, timec desc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=0.30..63.80 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+   ->  Merge Append  (cost=0.30..48.30 rows=960 width=136)
+         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec DESC
+         ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_3_chunk  (cost=0.15..19.35 rows=480 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..19.35 rows=480 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(9 rows)
+
+explain verbose 
+select * from mat_m1 order by location, timec asc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=81.95..99.85 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+   ->  Sort  (cost=81.95..84.35 rows=960 width=136)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+         ->  Append  (cost=0.00..34.40 rows=960 width=136)
+               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(11 rows)
+
+explain verbose 
+select * from mat_m1 where timec > '2018-10-01' order by timec desc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=20.61..25.81 rows=160 width=88)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+   ->  Sort  (cost=20.61..21.01 rows=160 width=136)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+         Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+         ->  Append  (cost=0.15..14.75 rows=160 width=136)
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                     Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(10 rows)
+
+-- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
+explain verbose 
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=117.77..120.31 rows=1016 width=92)
+   Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+   Sort Key: _hyper_2_4_chunk.timec DESC
+   ->  Hash Join  (cost=29.41..67.03 rows=1016 width=92)
+         Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+         Hash Cond: (l.locname = _hyper_2_4_chunk.location)
+         ->  Seq Scan on public.location_tab l  (cost=0.00..22.70 rows=1270 width=36)
+               Output: l.locid, l.locname
+         ->  Hash  (cost=27.41..27.41 rows=160 width=88)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+               ->  GroupAggregate  (cost=20.61..25.81 rows=160 width=88)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+                     Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+                     ->  Sort  (cost=20.61..21.01 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+                           ->  Append  (cost=0.15..14.75 rows=160 width=136)
+                                 ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                       Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(20 rows)
+
+explain verbose 
+select * from mat_m2 where timec > '2018-10-01' order by timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=18.83..23.82 rows=133 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+   Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+   ->  Sort  (cost=18.83..19.16 rows=133 width=168)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+         Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+         ->  Append  (cost=0.15..14.14 rows=133 width=168)
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                     Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(10 rows)
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=18.83..18.89 rows=1 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
+   ->  GroupAggregate  (cost=18.83..23.82 rows=133 width=72)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+         ->  Sort  (cost=18.83..19.16 rows=133 width=168)
+               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+               ->  Append  (cost=0.15..14.14 rows=133 width=168)
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(12 rows)
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=18.83..18.89 rows=1 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
+   ->  GroupAggregate  (cost=18.83..23.82 rows=133 width=72)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+         ->  Sort  (cost=18.83..19.16 rows=133 width=168)
+               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location NULLS FIRST
+               ->  Append  (cost=0.15..14.14 rows=133 width=168)
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(12 rows)
+
+--plans with CTE
+explain verbose
+with m1 as (
+Select * from mat_m2 where timec > '2018-10-01' order by timec desc ) 
+select * from m1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ CTE Scan on m1  (cost=25.15..27.81 rows=133 width=72)
+   Output: m1.location, m1.timec, m1.firsth, m1.lasth, m1.maxtemp, m1.mintemp
+   CTE m1
+     ->  GroupAggregate  (cost=18.83..23.82 rows=133 width=72)
+           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+           Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+           ->  Sort  (cost=18.83..19.16 rows=133 width=168)
+                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                 Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+                 ->  Append  (cost=0.15..14.14 rows=133 width=168)
+                       ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                             Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                             Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(13 rows)
+
+-- should reorder mat_m1 group by only based on mat_m1 order-by
+explain verbose
+select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join  (cost=118.82..128.62 rows=160 width=160)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
+   Merge Cond: (_hyper_2_4_chunk.timec = _hyper_3_5_chunk.timec)
+   ->  GroupAggregate  (cost=20.61..25.81 rows=160 width=88)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+         ->  Sort  (cost=20.61..21.01 rows=160 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+               ->  Append  (cost=0.15..14.75 rows=160 width=136)
+                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+   ->  Sort  (cost=98.22..98.72 rows=200 width=72)
+         Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
+         Sort Key: _hyper_3_5_chunk.timec DESC
+         ->  GroupAggregate  (cost=70.58..88.58 rows=200 width=72)
+               Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision)
+               Group Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
+               ->  Sort  (cost=70.58..72.58 rows=800 width=168)
+                     Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                     Sort Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
+                     ->  Append  (cost=0.00..32.00 rows=800 width=168)
+                           ->  Seq Scan on _timescaledb_internal._hyper_3_5_chunk  (cost=0.00..14.00 rows=400 width=168)
+                                 Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                           ->  Seq Scan on _timescaledb_internal._hyper_3_6_chunk  (cost=0.00..14.00 rows=400 width=168)
+                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+(27 rows)
+
+--should reorder only for mat_m1.
+explain verbose
+select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join  (cost=241.14..250.94 rows=160 width=176)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Merge Cond: (_hyper_2_4_chunk.timec = (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)))
+   ->  GroupAggregate  (cost=20.61..25.81 rows=160 width=88)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+         ->  Sort  (cost=20.61..21.01 rows=160 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+               ->  Append  (cost=0.15..14.75 rows=160 width=136)
+                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+   ->  Sort  (cost=220.54..221.04 rows=200 width=88)
+         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+         ->  GroupAggregate  (cost=179.29..210.89 rows=200 width=88)
+               Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
+               Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+               ->  Sort  (cost=179.29..184.14 rows=1940 width=56)
+                     Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                     Sort Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+                     ->  Result  (cost=0.00..73.35 rows=1940 width=56)
+                           Output: _hyper_1_1_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                           ->  Append  (cost=0.00..49.10 rows=1940 width=56)
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                       Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                       Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+(29 rows)
+
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+ locid | location |            timec             | minl | sumt | sumh 
+-------+----------+------------------------------+------+------+------
+     2 | NYC      | Fri Nov 02 17:00:00 2018 PDT | NYC  |      |     
+     2 | NYC      | Thu Nov 01 17:00:00 2018 PDT | NYC  |   30 |   25
+     2 | NYC      | Wed Oct 31 17:00:00 2018 PDT | NYC  |  325 |  200
+(3 rows)
+
+\set ECHO none
+---- Run the same queries with hash agg enabled now 
+set enable_hashagg = true;
+\set ECHO none
+--- Run the queries directly on the table now
+set enable_hashagg = true;
+\set ECHO none
+-- diff results view select and table select
+:DIFF_CMD
+:DIFF_CMD2
+--check if the guc works , reordering will not work
+set timescaledb.enable_cagg_reorder_groupby = false;
+set enable_hashagg = false;
+explain verbose 
+select * from mat_m1 order by timec desc, location;
+                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=109.50..110.00 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
+   Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
+   ->  GroupAggregate  (cost=81.95..99.85 rows=200 width=88)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+         ->  Sort  (cost=81.95..84.35 rows=960 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+               ->  Append  (cost=0.00..34.40 rows=960 width=136)
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(14 rows)
+

--- a/tsl/test/expected/continuous_aggs_query-9.6.out
+++ b/tsl/test/expected/continuous_aggs_query-9.6.out
@@ -1,0 +1,408 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- stop the continous aggregate background workers from interfering
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+\set TEST_BASE_NAME continuous_aggs_query 
+SELECT 
+       format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",
+       format('%s/results/%s_results_view_hashagg.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW_HASHAGG",
+       format('%s/results/%s_results_table.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_TABLE"
+\gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "DIFF_CMD",
+      format('\! diff %s %s', :'TEST_RESULTS_VIEW_HASHAGG', :'TEST_RESULTS_TABLE') as "DIFF_CMD2"
+\gset
+\set ON_ERROR_STOP 0
+CREATE TABLE conditions (
+      timec        TIMESTAMPTZ       NOT NULL,
+      location    TEXT              NOT NULL,
+      temperature DOUBLE PRECISION  NULL,
+      humidity    DOUBLE PRECISION  NULL
+    );
+select table_name from create_hypertable( 'conditions', 'timec');
+ table_name 
+------------
+ conditions
+(1 row)
+
+insert into conditions values ( '2018-01-01 09:00:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'por', 100, 100);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 30);
+insert into conditions values ( '2018-11-01 10:00:00-08', 'NYC', 55, 35);
+insert into conditions values ( '2018-11-01 11:00:00-08', 'NYC', 65, 40);
+insert into conditions values ( '2018-11-01 12:00:00-08', 'NYC', 75, 45);
+insert into conditions values ( '2018-11-01 13:00:00-08', 'NYC', 85, 50);
+insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 10, 10);
+insert into conditions values ( '2018-11-02 10:00:00-08', 'NYC', 20, 15);
+insert into conditions values ( '2018-11-02 11:00:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', null, null);
+create table location_tab( locid integer, locname text );
+insert into location_tab values( 1, 'SFO');
+insert into location_tab values( 2, 'NYC');
+insert into location_tab values( 3, 'por');
+create or replace view mat_m1( location, timec, minl, sumt , sumh)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket('1day', timec), location;
+NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m1;
+INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
+INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to 1546041600000000
+--test first/last
+create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
+from conditions
+group by time_bucket('1day', timec), location;
+NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, timec)
+--time that refresh assumes as now() for repeatability
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m2;
+INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
+INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to 1546041600000000
+--normal view --
+create or replace view regview( location, timec, minl, sumt , sumh)
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by location, time_bucket('1day', timec);
+set enable_hashagg = false;
+-- NO pushdown cases ---
+--when we have addl. attrs in order by that are not in the
+-- group by, we will still need a sort
+explain verbose 
+select * from mat_m1 order by sumh, sumt, minl, timec ;
+                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=104.70..105.20 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
+   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), _hyper_2_3_chunk.timec
+   ->  GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+         ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+               ->  Append  (cost=0.00..29.60 rows=960 width=136)
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(14 rows)
+
+explain verbose 
+select * from regview order by timec desc;
+                                                                                                QUERY PLAN                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=210.84..211.34 rows=200 width=88)
+   Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+   ->  GroupAggregate  (cost=169.59..201.19 rows=200 width=88)
+         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
+         Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+         ->  Sort  (cost=169.59..174.44 rows=1940 width=56)
+               Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+               Sort Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+               ->  Result  (cost=0.00..63.65 rows=1940 width=56)
+                     Output: _hyper_1_1_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                     ->  Append  (cost=0.00..39.40 rows=1940 width=56)
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                 Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                           ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+(16 rows)
+
+-- PUSHDOWN cases --
+-- all group by elts in order by , reorder group by elts to match
+-- group by order
+-- This should prevent an additional sort after GroupAggregate
+explain verbose 
+select * from mat_m1 order by timec desc, location;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+   ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
+         ->  Append  (cost=0.00..29.60 rows=960 width=136)
+               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(11 rows)
+
+explain verbose 
+select * from mat_m1 order by location, timec desc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=0.30..66.20 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+   ->  Merge Append  (cost=0.30..50.71 rows=960 width=136)
+         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec DESC
+         ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_3_chunk  (cost=0.15..19.35 rows=480 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..19.35 rows=480 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(9 rows)
+
+explain verbose 
+select * from mat_m1 order by location, timec asc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+   ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
+         ->  Append  (cost=0.00..29.60 rows=960 width=136)
+               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(11 rows)
+
+explain verbose 
+select * from mat_m1 where timec > '2018-10-01' order by timec desc;
+                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+   Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+   ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+         Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+         ->  Append  (cost=0.15..13.95 rows=160 width=136)
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                     Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(10 rows)
+
+-- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
+explain verbose 
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=116.97..119.51 rows=1016 width=92)
+   Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+   Sort Key: _hyper_2_4_chunk.timec DESC
+   ->  Hash Join  (cost=28.61..66.23 rows=1016 width=92)
+         Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+         Hash Cond: (l.locname = _hyper_2_4_chunk.location)
+         ->  Seq Scan on public.location_tab l  (cost=0.00..22.70 rows=1270 width=36)
+               Output: l.locid, l.locname
+         ->  Hash  (cost=26.61..26.61 rows=160 width=88)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
+               ->  GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+                     Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+                     ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+                           ->  Append  (cost=0.15..13.95 rows=160 width=136)
+                                 ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                       Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(20 rows)
+
+explain verbose 
+select * from mat_m2 where timec > '2018-10-01' order by timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+   Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+   ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+         Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+         ->  Append  (cost=0.15..13.48 rows=133 width=168)
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                     Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(10 rows)
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=18.17..18.22 rows=1 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
+   ->  GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+         ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+               ->  Append  (cost=0.15..13.48 rows=133 width=168)
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(12 rows)
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=18.17..18.22 rows=1 width=72)
+   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
+   ->  GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+         ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location NULLS FIRST
+               ->  Append  (cost=0.15..13.48 rows=133 width=168)
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(12 rows)
+
+--plans with CTE
+explain verbose
+with m1 as (
+Select * from mat_m2 where timec > '2018-10-01' order by timec desc ) 
+select * from m1;
+                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ CTE Scan on m1  (cost=24.48..27.14 rows=133 width=72)
+   Output: m1.location, m1.timec, m1.firsth, m1.lasth, m1.maxtemp, m1.mintemp
+   CTE m1
+     ->  GroupAggregate  (cost=18.17..23.15 rows=133 width=72)
+           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
+           Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
+           ->  Sort  (cost=18.17..18.50 rows=133 width=168)
+                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                 Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
+                 ->  Append  (cost=0.15..13.48 rows=133 width=168)
+                       ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk  (cost=0.15..13.48 rows=133 width=168)
+                             Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                             Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(13 rows)
+
+-- should reorder mat_m1 group by only based on mat_m1 order-by
+explain verbose
+select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join  (cost=114.02..123.82 rows=160 width=160)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
+   Merge Cond: (_hyper_2_4_chunk.timec = _hyper_3_5_chunk.timec)
+   ->  GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+         ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+               ->  Append  (cost=0.15..13.95 rows=160 width=136)
+                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+   ->  Sort  (cost=94.22..94.72 rows=200 width=72)
+         Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
+         Sort Key: _hyper_3_5_chunk.timec DESC
+         ->  GroupAggregate  (cost=66.58..84.58 rows=200 width=72)
+               Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision)
+               Group Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
+               ->  Sort  (cost=66.58..68.58 rows=800 width=168)
+                     Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                     Sort Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
+                     ->  Append  (cost=0.00..28.00 rows=800 width=168)
+                           ->  Seq Scan on _timescaledb_internal._hyper_3_5_chunk  (cost=0.00..14.00 rows=400 width=168)
+                                 Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                           ->  Seq Scan on _timescaledb_internal._hyper_3_6_chunk  (cost=0.00..14.00 rows=400 width=168)
+                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+(27 rows)
+
+--should reorder only for mat_m1.
+explain verbose
+select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
+                                                                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join  (cost=230.64..240.44 rows=160 width=176)
+   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Merge Cond: (_hyper_2_4_chunk.timec = (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)))
+   ->  GroupAggregate  (cost=19.81..25.01 rows=160 width=88)
+         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
+         ->  Sort  (cost=19.81..20.21 rows=160 width=136)
+               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+               ->  Append  (cost=0.15..13.95 rows=160 width=136)
+                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk  (cost=0.15..13.95 rows=160 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+   ->  Sort  (cost=210.84..211.34 rows=200 width=88)
+         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+         ->  GroupAggregate  (cost=169.59..201.19 rows=200 width=88)
+               Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
+               Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+               ->  Sort  (cost=169.59..174.44 rows=1940 width=56)
+                     Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                     Sort Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
+                     ->  Result  (cost=0.00..63.65 rows=1940 width=56)
+                           Output: _hyper_1_1_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec), _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                           ->  Append  (cost=0.00..39.40 rows=1940 width=56)
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_1_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                       Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
+                                 ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk  (cost=0.00..19.70 rows=970 width=56)
+                                       Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+(29 rows)
+
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+ locid | location |            timec             | minl | sumt | sumh 
+-------+----------+------------------------------+------+------+------
+     2 | NYC      | Fri Nov 02 17:00:00 2018 PDT | NYC  |      |     
+     2 | NYC      | Thu Nov 01 17:00:00 2018 PDT | NYC  |   30 |   25
+     2 | NYC      | Wed Oct 31 17:00:00 2018 PDT | NYC  |  325 |  200
+(3 rows)
+
+\set ECHO none
+---- Run the same queries with hash agg enabled now 
+set enable_hashagg = true;
+\set ECHO none
+--- Run the queries directly on the table now
+set enable_hashagg = true;
+\set ECHO none
+-- diff results view select and table select
+:DIFF_CMD
+:DIFF_CMD2
+--check if the guc works , reordering will not work
+set timescaledb.enable_cagg_reorder_groupby = false;
+set enable_hashagg = false;
+explain verbose 
+select * from mat_m1 order by timec desc, location;
+                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort  (cost=104.70..105.20 rows=200 width=88)
+   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
+   Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
+   ->  GroupAggregate  (cost=77.15..95.05 rows=200 width=88)
+         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
+         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+         ->  Sort  (cost=77.15..79.55 rows=960 width=136)
+               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
+               ->  Append  (cost=0.00..29.60 rows=960 width=136)
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk  (cost=0.00..14.80 rows=480 width=136)
+                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+(14 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_FILES_DEBUG
 set(TEST_TEMPLATES
   continuous_aggs_permissions.sql.in
   plan_gapfill.sql.in
+  continuous_aggs_query.sql.in
 )
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/tsl/test/sql/continuous_aggs_query.sql.in
+++ b/tsl/test/sql/continuous_aggs_query.sql.in
@@ -1,0 +1,189 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- stop the continous aggregate background workers from interfering
+SELECT _timescaledb_internal.stop_background_workers();
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+\set TEST_BASE_NAME continuous_aggs_query 
+SELECT 
+       format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",
+       format('%s/results/%s_results_view_hashagg.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW_HASHAGG",
+       format('%s/results/%s_results_table.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_TABLE"
+\gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "DIFF_CMD",
+      format('\! diff %s %s', :'TEST_RESULTS_VIEW_HASHAGG', :'TEST_RESULTS_TABLE') as "DIFF_CMD2"
+\gset
+
+\set ON_ERROR_STOP 0
+
+
+CREATE TABLE conditions (
+      timec        TIMESTAMPTZ       NOT NULL,
+      location    TEXT              NOT NULL,
+      temperature DOUBLE PRECISION  NULL,
+      humidity    DOUBLE PRECISION  NULL
+    );
+
+select table_name from create_hypertable( 'conditions', 'timec');
+
+insert into conditions values ( '2018-01-01 09:00:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'por', 100, 100);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-01-02 09:00:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 30);
+insert into conditions values ( '2018-11-01 10:00:00-08', 'NYC', 55, 35);
+insert into conditions values ( '2018-11-01 11:00:00-08', 'NYC', 65, 40);
+insert into conditions values ( '2018-11-01 12:00:00-08', 'NYC', 75, 45);
+insert into conditions values ( '2018-11-01 13:00:00-08', 'NYC', 85, 50);
+insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 10, 10);
+insert into conditions values ( '2018-11-02 10:00:00-08', 'NYC', 20, 15);
+insert into conditions values ( '2018-11-02 11:00:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', null, null);
+
+create table location_tab( locid integer, locname text );
+insert into location_tab values( 1, 'SFO');
+insert into location_tab values( 2, 'NYC');
+insert into location_tab values( 3, 'por');
+
+create or replace view mat_m1( location, timec, minl, sumt , sumh)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by time_bucket('1day', timec), location;
+
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m1;
+
+--test first/last
+create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
+WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
+as
+select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
+from conditions
+group by time_bucket('1day', timec), location;
+--time that refresh assumes as now() for repeatability
+SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
+REFRESH MATERIALIZED VIEW mat_m2;
+
+--normal view --
+create or replace view regview( location, timec, minl, sumt , sumh)
+as
+select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
+from conditions
+group by location, time_bucket('1day', timec);
+
+set enable_hashagg = false;
+
+-- NO pushdown cases ---
+--when we have addl. attrs in order by that are not in the
+-- group by, we will still need a sort
+explain verbose 
+select * from mat_m1 order by sumh, sumt, minl, timec ;
+explain verbose 
+select * from regview order by timec desc;
+
+-- PUSHDOWN cases --
+-- all group by elts in order by , reorder group by elts to match
+-- group by order
+-- This should prevent an additional sort after GroupAggregate
+explain verbose 
+select * from mat_m1 order by timec desc, location;
+
+explain verbose 
+select * from mat_m1 order by location, timec desc;
+
+explain verbose 
+select * from mat_m1 order by location, timec asc;
+explain verbose 
+select * from mat_m1 where timec > '2018-10-01' order by timec desc;
+-- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
+explain verbose 
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+
+explain verbose 
+select * from mat_m2 where timec > '2018-10-01' order by timec desc;
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
+
+explain verbose 
+select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
+
+--plans with CTE
+explain verbose
+with m1 as (
+Select * from mat_m2 where timec > '2018-10-01' order by timec desc ) 
+select * from m1;
+
+-- should reorder mat_m1 group by only based on mat_m1 order-by
+explain verbose
+select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
+--should reorder only for mat_m1.
+explain verbose
+select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
+
+select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
+
+\set ECHO none
+SET client_min_messages TO error;
+\o :TEST_RESULTS_VIEW
+select * from mat_m1 order by timec desc, location;
+select * from mat_m1 order by location, timec desc;
+select * from mat_m1 order by location, timec asc;
+select * from mat_m1 where timec > '2018-10-01' order by timec desc;
+select * from mat_m2 where timec > '2018-10-01' order by timec desc;
+\o
+RESET client_min_messages;
+\set ECHO all
+
+---- Run the same queries with hash agg enabled now 
+set enable_hashagg = true;
+\set ECHO none
+SET client_min_messages TO error;
+\o :TEST_RESULTS_VIEW_HASHAGG
+select * from mat_m1 order by timec desc, location;
+select * from mat_m1 order by location, timec desc;
+select * from mat_m1 order by location, timec asc;
+select * from mat_m1 where timec > '2018-10-01' order by timec desc;
+select * from mat_m2 where timec > '2018-10-01' order by timec desc;
+\o
+RESET client_min_messages;
+\set ECHO all
+
+--- Run the queries directly on the table now
+set enable_hashagg = true;
+\set ECHO none
+SET client_min_messages TO error;
+\o :TEST_RESULTS_TABLE
+SELECT location, time_bucket('1day', timec) as timec, min(location) as minl, sum(temperature) as sumt, sum(humidity) as sumh from conditions group by time_bucket('1day', timec) , location
+order by timec desc, location;
+SELECT location, time_bucket('1day', timec) as timec, min(location) as minl, sum(temperature) as sumt, sum(humidity) as sumh from conditions group by time_bucket('1day', timec) , location
+order by location, timec desc;
+SELECT location, time_bucket('1day', timec) as timec, min(location) as minl, sum(temperature) as sumt, sum(humidity) as sumh from conditions group by time_bucket('1day', timec) , location
+order by location, timec asc;
+select * from (SELECT location, time_bucket('1day', timec) as timec, min(location) as minl, sum(temperature) as sumt, sum(humidity) as sumh from conditions 
+group by time_bucket('1day', timec) , location ) as q
+where timec > '2018-10-01' order by timec desc;
+--comparison for mat_m2 queries
+select * from (
+select location, time_bucket('1day', timec) as timec, first(humidity, timec) firsth, last(humidity, timec) lasth, max(temperature) maxtemp, min(temperature) mintemp
+from conditions
+group by time_bucket('1day', timec), location) as q
+where timec > '2018-10-01' order by timec desc limit 10;
+\o
+RESET client_min_messages;
+\set ECHO all
+
+-- diff results view select and table select
+:DIFF_CMD
+:DIFF_CMD2
+
+--check if the guc works , reordering will not work
+set timescaledb.enable_cagg_reorder_groupby = false;
+set enable_hashagg = false;
+explain verbose 
+select * from mat_m1 order by timec desc, location;


### PR DESCRIPTION
    Modify group by clause on continuous aggr views
    
    Reorder the group by clause to match the ordering of the
    ORDER BY by clause. SELECTs on continuous aggregate queries
    often have an order by clause on the time_bucket column.
    If the order-by does not match the grouping clause,
    the planner inserts an additional Sort node after
    the view evaluation (Aggregate node).
    preprocess_groupclause does this reordering if the ORDER BY clause
    is part of the current subquery being processed. But when we have
    a continuous aggregate view, the order by needs to be derived
    from the outer query. This PR allows the order by from
    outer query to propagate to group clause of continuous aggr. view.
    The rewrite is :
    select * from (select a, b, max(c), min(d) from ...group by a, b)
          order by b;
    is transformed as
     SELECT * from (select a, b, max(c), min(d) from .. group by b, a
      ) order by b;
