### PR TITLE
Refactor chunk handling to separate out stub

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -46,6 +46,16 @@ typedef struct Chunk
 	ChunkConstraints *constraints;
 } Chunk;
 
+/* This structure is used during the join of the chunk constraints to find
+ * chunks that match all constraints. It is a stripped down version of the chunk
+ * since we don't want to fill in all the fields until we find a match. */
+typedef struct ChunkStub
+{
+	int32 id;
+	Hypercube *cube;
+	ChunkConstraints *constraints;
+} ChunkStub;
+
 /*
  * ChunkScanCtx is used to scan for chunks in a hypertable's N-dimensional
  * hyperspace.
@@ -64,11 +74,11 @@ typedef struct ChunkScanCtx
 	void *data;
 } ChunkScanCtx;
 
-/* Returns true if the chunk has a full set of constraints, otherwise
- * false. Used to find a chunk matching a point in an N-dimensional
+/* Returns true if the stub has a full set of constraints, otherwise
+ * false. Used to find a stub matching a point in an N-dimensional
  * hyperspace. */
 static inline bool
-chunk_is_complete(Chunk *chunk, Hyperspace *space)
+chunk_stub_is_complete(ChunkStub *chunk, Hyperspace *space)
 {
 	return space->num_dimensions == chunk->constraints->num_dimension_constraints;
 }
@@ -77,11 +87,12 @@ chunk_is_complete(Chunk *chunk, Hyperspace *space)
 typedef struct ChunkScanEntry
 {
 	int32 chunk_id;
-	Chunk *chunk;
+	ChunkStub *stub;
 } ChunkScanEntry;
 
 extern Chunk *ts_chunk_create(Hypertable *ht, Point *p, const char *schema, const char *prefix);
-extern TSDLLEXPORT Chunk *ts_chunk_create_stub(int32 id, int16 num_constraints);
+extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id, int16 num_constraints);
+extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id, int16 num_constraints);
 extern Chunk *ts_chunk_find(Hyperspace *hs, Point *p);
 extern Chunk **ts_chunk_find_all(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode,
 								 unsigned int *num_chunks);

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -437,7 +437,7 @@ ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx 
 	ts_scanner_foreach(&iterator)
 	{
 		Hyperspace *hs = ctx->space;
-		Chunk *chunk;
+		ChunkStub *stub;
 		ChunkScanEntry *entry;
 		bool found;
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
@@ -457,20 +457,20 @@ ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx 
 
 		if (!found)
 		{
-			chunk = ts_chunk_create_stub(chunk_id, hs->num_dimensions);
-			chunk->cube = ts_hypercube_alloc(hs->num_dimensions);
-			entry->chunk = chunk;
+			stub = ts_chunk_stub_create(chunk_id, hs->num_dimensions);
+			stub->cube = ts_hypercube_alloc(hs->num_dimensions);
+			entry->stub = stub;
 		}
 		else
-			chunk = entry->chunk;
+			stub = entry->stub;
 
-		chunk_constraints_add_from_tuple(chunk->constraints, ti);
+		chunk_constraints_add_from_tuple(stub->constraints, ti);
 
-		ts_hypercube_add_slice(chunk->cube, slice);
+		ts_hypercube_add_slice(stub->cube, slice);
 
-		/* A chunk is complete when we've added slices for all its dimensions,
+		/* A stub is complete when we've added slices for all its dimensions,
 		 * i.e., a complete hypercube */
-		if (chunk_is_complete(chunk, ctx->space))
+		if (chunk_stub_is_complete(stub, ctx->space))
 		{
 			ctx->num_complete_chunks++;
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -579,7 +579,7 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 	/* Create a new chunk based on the hypercube */
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	compress_chunk =
-		ts_chunk_create_stub(ts_catalog_table_next_seq_id(catalog, CHUNK), hs->num_dimensions);
+		ts_chunk_create_base(ts_catalog_table_next_seq_id(catalog, CHUNK), hs->num_dimensions);
 	ts_catalog_restore_user(&sec_ctx);
 
 	compress_chunk->fd.hypertable_id = hs->hypertable_id;


### PR DESCRIPTION
Previously, the Chunk struct was used to represent both a full
chunk and the stub used for joins. The stub used for joins
only contained valid values for some chunk fields and not others.
After the join determined that a Chunk was complete, it filled
in the rest of the chunk field. The fact that a chunk could have
only some fields filled out and not others at different times,
made the code hard to follow and error prone.

So we separate out the stub state of the chunk into a separate
struct that doesn't contain the not-filled-out fields inside
of it.  This leverages the type system to prevent errors that
try to access invalid fields during the join phase and makes
the code easier to follow.