### PR TITLE
Disable background workers in cagg ddl tests

### DIFF
--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -22,6 +22,12 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -22,6 +22,12 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -22,6 +22,12 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)

--- a/tsl/test/sql/continuous_aggs_ddl.sql.in
+++ b/tsl/test/sql/continuous_aggs_ddl.sql.in
@@ -23,6 +23,8 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)


### PR DESCRIPTION
The continuous agg ddl test is flaky and occasionally fails with a
deadlock which might be caused by background workers running.