### PR TITLE
Fix locf treat_null_as_missing option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
-## 1.6
+## 1.6.0 (unreleased)
 
 The semantics of the refresh_lag parameter for continuous aggregates has 
 been changed to be relative to the current timestamp instead of the maximum
@@ -19,6 +19,12 @@ timescaledb.ignore_invalidation_older_than = '1 month', then any modifications
 for data older than 1 month from the current timestamp at modification time may 
 not cause continuous aggregate to be updated. This limits the amount of work
 that a backfill can trigger. By default, all invalidations are processed.
+
+**Bugfixes**
+* #1591 Fix locf treat_null_as_missing option
+
+**Thanks**
+* @optijon for reporting an issue with locf treat_null_as_missing option
 
 ## 1.5.1 (2019-11-12)
 

--- a/tsl/src/nodes/gapfill/exec.c
+++ b/tsl/src/nodes/gapfill/exec.c
@@ -896,11 +896,14 @@ gapfill_state_return_subplan_slot(GapFillState *state)
 		{
 			case LOCF_COLUMN:
 				value = slot_getattr(state->subslot, AttrOffsetGetAttrNumber(i), &isnull);
-				if (isnull && column.locf->treat_null_as_missing && !column.locf->isnull)
+				if (isnull && column.locf->treat_null_as_missing)
 				{
-					state->subslot->tts_isnull[i] = false;
-					state->subslot->tts_values[i] = column.locf->value;
-					modified = true;
+					gapfill_locf_calculate(column.locf,
+										   state,
+										   state->subslot_time,
+										   &state->subslot->tts_values[i],
+										   &state->subslot->tts_isnull[i]);
+					modified = !state->subslot->tts_isnull[i];
 				}
 				else
 					gapfill_locf_tuple_returned(column.locf, value, isnull);

--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -833,6 +833,23 @@ GROUP BY 1 ORDER BY 1;
    50 |     6
 (6 rows)
 
+-- test locf with NULLs in first row of resultset and treat_null_as_missing with lookup query
+SELECT
+  time_bucket_gapfill(10,time,0,50) AS time,
+  locf(min(value),treat_null_as_missing:=false, prev := (SELECT 100)) AS v1,
+  locf(min(value),treat_null_as_missing:=true, prev := (SELECT 100)) AS v2
+FROM (values (0,NULL),(30,NULL),(50,6)) v(time,value)
+GROUP BY 1 ORDER BY 1;
+ time | v1 | v2  
+------+----+-----
+    0 |    | 100
+   10 |    | 100
+   20 |    | 100
+   30 |    | 100
+   40 |    | 100
+   50 |  6 |   6
+(6 rows)
+
 -- test locf with NULLs in resultset and treat_null_as_missing with resort
 SELECT
   time_bucket_gapfill(10,time,0,50) AS time,

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -525,6 +525,14 @@ SELECT
 FROM (values (10,9),(20,3),(30,NULL),(50,6)) v(time,value)
 GROUP BY 1 ORDER BY 1;
 
+-- test locf with NULLs in first row of resultset and treat_null_as_missing with lookup query
+SELECT
+  time_bucket_gapfill(10,time,0,50) AS time,
+  locf(min(value),treat_null_as_missing:=false, prev := (SELECT 100)) AS v1,
+  locf(min(value),treat_null_as_missing:=true, prev := (SELECT 100)) AS v2
+FROM (values (0,NULL),(30,NULL),(50,6)) v(time,value)
+GROUP BY 1 ORDER BY 1;
+
 -- test locf with NULLs in resultset and treat_null_as_missing with resort
 SELECT
   time_bucket_gapfill(10,time,0,50) AS time,


### PR DESCRIPTION
The locf treat_null_as_missing option would not trigger the lookup
query if there was a row for the first bucket and value in that row
was NULL. This patch fixes the behaviour and triggers the lookup
query for the first row too.

Fixes #1588 