### PR TITLE
Improve continuous agg user messages

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -311,6 +311,19 @@ ts_internal_to_time_value(int64 value, Oid type)
 	}
 }
 
+TSDLLEXPORT char *
+ts_internal_to_time_string(int64 value, Oid type)
+{
+	Datum time_datum = ts_internal_to_time_value(value, type);
+	Oid typoutputfunc;
+	bool typIsVarlena;
+	FmgrInfo typoutputinfo;
+
+	getTypeOutputInfo(type, &typoutputfunc, &typIsVarlena);
+	fmgr_info(typoutputfunc, &typoutputinfo);
+	return OutputFunctionCall(&typoutputinfo, time_datum);
+}
+
 TS_FUNCTION_INFO_V1(ts_pg_unix_microseconds_to_interval);
 
 Datum

--- a/src/utils.h
+++ b/src/utils.h
@@ -59,6 +59,7 @@ extern TSDLLEXPORT int64 ts_interval_value_to_internal(Datum time_val, Oid type_
  */
 extern TSDLLEXPORT Datum ts_internal_to_time_value(int64 value, Oid type);
 extern TSDLLEXPORT Datum ts_internal_to_interval_value(int64 value, Oid type);
+extern TSDLLEXPORT char *ts_internal_to_time_string(int64 value, Oid type);
 
 /*
  * Return the period in microseconds of the first argument to date_trunc.

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -446,8 +446,7 @@ AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1
    GROUP BY 1;
 REFRESH MATERIALIZED VIEW test1_cont_view;
-INFO:  new materialization range for public.test1 (time column Time) (1522216800000000)
-INFO:  materializing continuous aggregate public.test1_cont_view: nothing to invalidate, new range up to 1522216800000000
+INFO:  materializing continuous aggregate public.test1_cont_view: nothing to invalidate, new range up to Tue Mar 27 23:00:00 2018 PDT
 SELECT count(*) FROM test1_cont_view;
  count 
 -------

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -762,9 +762,8 @@ WHERE user_view_name = 'mat_drop_test'
 \gset
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_drop_test;
-INFO:  new materialization range for public.conditions larger than allowed in one run, truncating (time column timec) (1546041600000000)
-INFO:  new materialization range for public.conditions (time column timec) (1542758400000000)
-INFO:  materializing continuous aggregate public.mat_drop_test: nothing to invalidate, new range up to 1542758400000000
+INFO:  new materialization range for public.conditions (time column timec) larger than allowed in one run, truncating Fri Dec 28 16:00:00 2018 PST to Tue Nov 20 16:00:00 2018 PST
+INFO:  materializing continuous aggregate public.mat_drop_test: nothing to invalidate, new range up to Tue Nov 20 16:00:00 2018 PST
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 --force invalidation
 insert into conditions
@@ -1039,7 +1038,6 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 (0 rows)
 
 REFRESH MATERIALIZED VIEW space_view;
-INFO:  new materialization range for public.space_table (time column time) (12)
 INFO:  materializing continuous aggregate public.space_view: nothing to invalidate, new range up to 12
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
@@ -1060,7 +1058,7 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 
 INSERT INTO space_table VALUES (3, 2, 1);
 REFRESH MATERIALIZED VIEW space_view;
-INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold (12)
+INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold of 12 as of 11
 INFO:  materializing continuous aggregate public.space_view: processing invalidations, no new range
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
@@ -1081,7 +1079,7 @@ SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 
 INSERT INTO space_table VALUES (2, 3, 1);
 REFRESH MATERIALIZED VIEW space_view;
-INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold (12)
+INFO:  new materialization range not found for public.space_table (time column time): not enough new data past completion threshold of 12 as of 11
 INFO:  materializing continuous aggregate public.space_view: processing invalidations, no new range
 SELECT * FROM space_view ORDER BY 1;
  time_bucket | count 
@@ -1162,7 +1160,6 @@ select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test
 from conditions
 group by time_bucket(100, timec);
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
-INFO:  new materialization range for public.conditions (time column timec) (400)
 INFO:  materializing continuous aggregate public.mat_ffunc_test: nothing to invalidate, new range up to 400
 SELECT * FROM mat_ffunc_test;
 WARNING:  type integer text
@@ -1184,7 +1181,6 @@ select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigin
 from conditions
 group by time_bucket(100, timec);
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
-INFO:  new materialization range for public.conditions (time column timec) (400)
 INFO:  materializing continuous aggregate public.mat_ffunc_test: nothing to invalidate, new range up to 400
 SELECT * FROM mat_ffunc_test;
 WARNING:  type integer bigint
@@ -1210,7 +1206,6 @@ NOTICE:  adding index _materialized_hypertable_29_location_time_partition_col_id
 insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW mat_refresh_test;
-INFO:  new materialization range for public.conditions (time column timec) (400)
 INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 400
 SELECT * FROM mat_refresh_test order by 1,2 ;
  location | max 
@@ -1228,7 +1223,6 @@ from conditions
 group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_30_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_30 USING BTREE(grp_3_3, time_bucket)
 REFRESH MATERIALIZED VIEW conditions_grpby_view;
-INFO:  new materialization range for public.conditions (time column timec) (400)
 INFO:  materializing continuous aggregate public.conditions_grpby_view: nothing to invalidate, new range up to 400
 select * from conditions_grpby_view order by 1, 2;
  time_bucket | sum 
@@ -1247,7 +1241,6 @@ having avg(temperature) > 0
 ;
 NOTICE:  adding index _materialized_hypertable_31_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_31 USING BTREE(grp_3_3, time_bucket)
 REFRESH MATERIALIZED VIEW conditions_grpby_view2;
-INFO:  new materialization range for public.conditions (time column timec) (400)
 INFO:  materializing continuous aggregate public.conditions_grpby_view2: nothing to invalidate, new range up to 400
 select * from conditions_grpby_view2 order by 1, 2;
  time_bucket | sum 
@@ -1285,8 +1278,7 @@ SET timescaledb.current_timestamp_mock = '2001-03-11';
 insert into conditions values('2001-03-10', '1');
 insert into conditions values('2001-03-10', '2');
 REFRESH MATERIALIZED VIEW mat_test5;
-INFO:  new materialization range for public.conditions (time column time) (984355200000000)
-INFO:  materializing continuous aggregate public.mat_test5: nothing to invalidate, new range up to 984355200000000
+INFO:  materializing continuous aggregate public.mat_test5: nothing to invalidate, new range up to Sun Mar 11 16:00:00 2001 PST
 SELECT * FROM mat_test5;
             timec             | maxt 
 ------------------------------+------
@@ -1296,7 +1288,7 @@ SELECT * FROM mat_test5;
 insert into conditions values('2001-02-15', '1');
 insert into conditions values('2001-01-15', '1');
 REFRESH MATERIALIZED VIEW mat_test5;
-INFO:  new materialization range not found for public.conditions (time column time): not enough new data past completion threshold (984355200000000)
+INFO:  new materialization range not found for public.conditions (time column time): not enough new data past completion threshold of Sun Mar 11 16:00:00 2001 PST as of Sun Mar 11 00:00:00 2001 PST
 INFO:  materializing continuous aggregate public.mat_test5: processing invalidations, no new range
 --will see the feb but not the january change
 SELECT * FROM mat_test5;
@@ -1314,8 +1306,7 @@ SET timescaledb.current_timestamp_mock = '2001-05-11';
 --but not this one
 insert into conditions values('2001-02-20', '4');
 REFRESH MATERIALIZED VIEW mat_test5;
-INFO:  new materialization range for public.conditions (time column time) (989625600000000)
-INFO:  materializing continuous aggregate public.mat_test5: processing invalidations, new range up to 989625600000000
+INFO:  materializing continuous aggregate public.mat_test5: processing invalidations, new range up to Fri May 11 17:00:00 2001 PDT
 SELECT * FROM mat_test5;
             timec             | maxt 
 ------------------------------+------

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -237,7 +237,6 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
 -- create 3 chunks, with 3 time bucket
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 29) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (15)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
@@ -399,7 +398,6 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
 -- create 3 chunks, with 3 time bucket
 INSERT INTO drop_chunks_table_u SELECT i, i FROM generate_series(0, 21) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table_u (time column time) (15)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table_u') AS c;
  count 
@@ -557,8 +555,7 @@ NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_
 NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
-INFO:  new materialization range for public.metrics (time column time) (947289600000000)
-INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to 947289600000000
+INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to Fri Jan 07 16:00:00 2000 PST
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
 ------------------------------+-------+---------+----------------------------------------------+------+----------+------+------
@@ -611,8 +608,7 @@ SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table larger than allowed in one run, truncating (time column time) (25)
-INFO:  new materialization range for public.drop_chunks_table (time column time) (10)
+INFO:  new materialization range for public.drop_chunks_table (time column time) larger than allowed in one run, truncating 25 to 10
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 10
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 \set ON_ERROR_STOP 0
@@ -621,12 +617,10 @@ SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table larger than allowed in one run, truncating (time column time) (25)
-INFO:  new materialization range for public.drop_chunks_table (time column time) (20)
+INFO:  new materialization range for public.drop_chunks_table (time column time) larger than allowed in one run, truncating 25 to 20
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 20
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (25)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 25
 --now, this works
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
@@ -656,12 +650,10 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(20, 35) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table larger than allowed in one run, truncating (time column time) (40)
-INFO:  new materialization range for public.drop_chunks_table (time column time) (30)
+INFO:  new materialization range for public.drop_chunks_table (time column time) larger than allowed in one run, truncating 40 to 30
 INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, new range up to 30
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (40)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 40
 --this is invalidated but beyond ignore_invalidation_threshold so will never be seen (current time is 29)
 INSERT INTO drop_chunks_table SELECT i, 100 FROM generate_series(10, 19) AS i;
@@ -777,7 +769,7 @@ REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold (40)
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 40 as of 39
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.drop_chunks_view: no new range to materialize or invalidations found, exiting early
 --change to bucket 31 also seen
@@ -847,7 +839,6 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 ALTER VIEW drop_chunks_view SET (timescaledb.max_interval_per_job = 100);
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(50,55) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (60)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 60
 --one command and thus one range that spans 46 (which will be processed by drop_chunks) and (51 which won't, but will be later)
 INSERT INTO drop_chunks_table VALUES (46, 400), (51, 500);
@@ -897,7 +888,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (12 rows)
 
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold (60)
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 59
 INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
 --the change in bucket 50 is seen
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -237,7 +237,6 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
 -- create 3 chunks, with 3 time bucket
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 29) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (15)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
@@ -399,7 +398,6 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
 -- create 3 chunks, with 3 time bucket
 INSERT INTO drop_chunks_table_u SELECT i, i FROM generate_series(0, 21) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table_u (time column time) (15)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table_u') AS c;
  count 
@@ -557,8 +555,7 @@ NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_
 NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
-INFO:  new materialization range for public.metrics (time column time) (947289600000000)
-INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to 947289600000000
+INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to Fri Jan 07 16:00:00 2000 PST
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
 ------------------------------+-------+---------+----------------------------------------------+------+----------+------+------
@@ -611,8 +608,7 @@ SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table larger than allowed in one run, truncating (time column time) (25)
-INFO:  new materialization range for public.drop_chunks_table (time column time) (10)
+INFO:  new materialization range for public.drop_chunks_table (time column time) larger than allowed in one run, truncating 25 to 10
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 10
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 \set ON_ERROR_STOP 0
@@ -621,12 +617,10 @@ SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table larger than allowed in one run, truncating (time column time) (25)
-INFO:  new materialization range for public.drop_chunks_table (time column time) (20)
+INFO:  new materialization range for public.drop_chunks_table (time column time) larger than allowed in one run, truncating 25 to 20
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 20
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (25)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 25
 --now, this works
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
@@ -656,12 +650,10 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(20, 35) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table larger than allowed in one run, truncating (time column time) (40)
-INFO:  new materialization range for public.drop_chunks_table (time column time) (30)
+INFO:  new materialization range for public.drop_chunks_table (time column time) larger than allowed in one run, truncating 40 to 30
 INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, new range up to 30
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (40)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 40
 --this is invalidated but beyond ignore_invalidation_threshold so will never be seen (current time is 29)
 INSERT INTO drop_chunks_table SELECT i, 100 FROM generate_series(10, 19) AS i;
@@ -777,7 +769,7 @@ REFRESH MATERIALIZED VIEW drop_chunks_view;
 INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold (40)
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 40 as of 39
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.drop_chunks_view: no new range to materialize or invalidations found, exiting early
 --change to bucket 31 also seen
@@ -847,7 +839,6 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 ALTER VIEW drop_chunks_view SET (timescaledb.max_interval_per_job = 100);
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(50,55) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (60)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 60
 --one command and thus one range that spans 46 (which will be processed by drop_chunks) and (51 which won't, but will be later)
 INSERT INTO drop_chunks_table VALUES (46, 400), (51, 500);
@@ -897,7 +888,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (12 rows)
 
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold (60)
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 59
 INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
 --the change in bucket 50 is seen
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -237,7 +237,6 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
 -- create 3 chunks, with 3 time bucket
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 29) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table (time column time) (15)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
@@ -399,7 +398,6 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
 -- create 3 chunks, with 3 time bucket
 INSERT INTO drop_chunks_table_u SELECT i, i FROM generate_series(0, 21) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-INFO:  new materialization range for public.drop_chunks_table_u (time column time) (15)
 INFO:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 15
 SELECT count(c) FROM show_chunks('drop_chunks_table_u') AS c;
  count 
@@ -557,8 +555,7 @@ NOTICE:  adding index _materialized_hypertable_10_case_time_idx ON _timescaledb_
 NOTICE:  adding index _materialized_hypertable_10_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(coalesce, time)
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;
-INFO:  new materialization range for public.metrics (time column time) (947289600000000)
-INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to 947289600000000
+INFO:  materializing continuous aggregate public.cagg_expr: nothing to invalidate, new range up to Fri Jan 07 16:00:00 2000 PST
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
 ------------------------------+-------+---------+----------------------------------------------+------+----------+------+------

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -109,8 +109,7 @@ NOTICE:  adding index _materialized_hypertable_4_location_bucket_idx ON _timesca
 --materialize mat_before
 SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_before;
-INFO:  new materialization range for public.conditions_before (time column timec) (1551052800000000)
-INFO:  materializing continuous aggregate public.mat_before: nothing to invalidate, new range up to 1551052800000000
+INFO:  materializing continuous aggregate public.mat_before: nothing to invalidate, new range up to Sun Feb 24 16:00:00 2019 PST
 SELECT count(*) FROM conditions_before;
  count 
 -------
@@ -193,8 +192,7 @@ ERROR:  dropping a continous aggregate requires using CASCADE
 --materialize mat_after
 SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
 REFRESH MATERIALIZED VIEW mat_after;
-INFO:  new materialization range for public.conditions_after (time column timec) (1551052800000000)
-INFO:  materializing continuous aggregate public.mat_after: nothing to invalidate, new range up to 1551052800000000
+INFO:  materializing continuous aggregate public.mat_after: nothing to invalidate, new range up to Sun Feb 24 16:00:00 2019 PST
 SELECT count(*) FROM mat_after;
  count 
 -------

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -682,7 +682,7 @@ SELECT materialization_id, _timescaledb_internal.to_timestamp(watermark)
 
 SET timescaledb.current_timestamp_mock = '2019-02-02 5:00 UTC';
 REFRESH MATERIALIZED VIEW test_t_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549072800000000)
+INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold of 2019-02-02 02:00:00+00 as of 2019-02-02 05:00:00+00
 INFO:  materializing continuous aggregate public.test_t_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME" ORDER BY 1;
@@ -713,7 +713,7 @@ SELECT hypertable_id, _timescaledb_internal.to_timestamp(watermark) FROM _timesc
 (0 rows)
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549072800000000)
+INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold of 2019-02-02 02:00:00+00 as of 2019-02-02 05:00:00+00
 INFO:  materializing continuous aggregate public.test_t_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.test_t_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME" ORDER BY 1;
@@ -757,8 +757,7 @@ SELECT * FROM continuous_agg_test_t ORDER BY 1;
 (5 rows)
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;
-INFO:  new materialization range for public.continuous_agg_test_t (time column time) (1549080000000000)
-INFO:  materializing continuous aggregate public.test_t_mat_view: nothing to invalidate, new range up to 1549080000000000
+INFO:  materializing continuous aggregate public.test_t_mat_view: nothing to invalidate, new range up to 2019-02-02 04:00:00+00
 SELECT * FROM test_t_mat_view ORDER BY 1;
       time_bucket       | value 
 ------------------------+-------
@@ -792,7 +791,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 (1 row)
 
 REFRESH MATERIALIZED VIEW test_t_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold (1549080000000000)
+INFO:  new materialization range not found for public.continuous_agg_test_t (time column time): not enough new data past completion threshold of 2019-02-02 04:00:00+00 as of 2019-02-02 07:00:00+00
 INFO:  materializing continuous aggregate public.test_t_mat_view: processing invalidations, no new range
 SELECT * FROM test_t_mat_view ORDER BY 1;
       time_bucket       | value 
@@ -877,7 +876,7 @@ SELECT hypertable_id, watermark
 INSERT INTO continuous_agg_extreme VALUES
     (:big_int_min,   1);
 REFRESH MATERIALIZED VIEW extreme_view;
-INFO:  new materialization range not found for public.continuous_agg_extreme (time column time): not enough data in table (-9223372036854775808)
+INFO:  new materialization range not found for public.continuous_agg_extreme (time column time): not enough data that satisfies the refresh lag criterion as of -9223372036854775808
 INFO:  materializing continuous aggregate public.extreme_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.extreme_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM extreme_view;
@@ -903,7 +902,6 @@ SELECT hypertable_id, watermark
 INSERT INTO continuous_agg_extreme VALUES
     (:big_int_min+10, 11);
 REFRESH MATERIALIZED VIEW extreme_view;
-INFO:  new materialization range for public.continuous_agg_extreme (time column time) (-9223372036854775800)
 INFO:  materializing continuous aggregate public.extreme_view: nothing to invalidate, new range up to -9223372036854775800
 SELECT * FROM extreme_view;
      time_bucket      | value 
@@ -938,7 +936,6 @@ INSERT INTO continuous_agg_extreme VALUES
     (:big_int_max-1,          201),
     (:big_int_max,   :big_int_max);
 REFRESH MATERIALIZED VIEW extreme_view;
-INFO:  new materialization range for public.continuous_agg_extreme (time column time) (9223372036854775805)
 INFO:  materializing continuous aggregate public.extreme_view: nothing to invalidate, new range up to 9223372036854775805
 SELECT * FROM extreme_view ORDER BY 1;
      time_bucket      | value 
@@ -997,7 +994,6 @@ CREATE VIEW negative_view_5
 INSERT INTO continuous_agg_negative
     SELECT i, i FROM generate_series(0, 11) AS i;
 REFRESH MATERIALIZED VIEW negative_view_5;
-INFO:  new materialization range for public.continuous_agg_negative (time column time) (10)
 INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 10
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
@@ -1010,7 +1006,6 @@ SELECT * FROM negative_view_5 ORDER BY 1;
 -- even though the time_bucket would require us INSERT 14
 INSERT INTO continuous_agg_negative VALUES (12, 12), (13, 13);
 REFRESH MATERIALIZED VIEW negative_view_5;
-INFO:  new materialization range for public.continuous_agg_negative (time column time) (15)
 INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 15
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
@@ -1023,7 +1018,7 @@ SELECT * FROM negative_view_5 ORDER BY 1;
 -- bucket is finished as normal with the additional value
 INSERT INTO continuous_agg_negative VALUES (14, 14);
 REFRESH MATERIALIZED VIEW negative_view_5;
-INFO:  new materialization range not found for public.continuous_agg_negative (time column time): not enough new data past completion threshold (15)
+INFO:  new materialization range not found for public.continuous_agg_negative (time column time): not enough new data past completion threshold of 15 as of 14
 INFO:  materializing continuous aggregate public.negative_view_5: processing invalidations, no new range
 SELECT * FROM negative_view_5 ORDER BY 1;
  time_bucket | value 
@@ -1037,8 +1032,7 @@ SELECT * FROM negative_view_5 ORDER BY 1;
 INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
 SET client_min_messages TO error;
 REFRESH MATERIALIZED VIEW negative_view_5;
-INFO:  new materialization range for public.continuous_agg_negative larger than allowed in one run, truncating (time column time) (9223372036854775805)
-INFO:  new materialization range for public.continuous_agg_negative (time column time) (115)
+INFO:  new materialization range for public.continuous_agg_negative (time column time) larger than allowed in one run, truncating 9223372036854775805 to 115
 INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 115
 RESET client_min_messages;
 SELECT * FROM negative_view_5 ORDER BY 1;
@@ -1061,7 +1055,6 @@ AS SELECT time_bucket('5', time), COUNT(data) as value
 INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
 SET client_min_messages TO error;
 REFRESH MATERIALIZED VIEW negative_view_5;
-INFO:  new materialization range for public.continuous_agg_negative (time column time) (9223372036854775805)
 INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, new range up to 9223372036854775805
 RESET client_min_messages;
 SELECT * FROM negative_view_5 ORDER BY 1;
@@ -1074,7 +1067,7 @@ SELECT * FROM negative_view_5 ORDER BY 1;
 INSERT INTO continuous_agg_negative VALUES (:big_int_max-1, 201);
 SET client_min_messages TO error;
 REFRESH MATERIALIZED VIEW negative_view_5;
-INFO:  new materialization range not found for public.continuous_agg_negative (time column time): not enough new data past completion threshold (9223372036854775805)
+INFO:  new materialization range not found for public.continuous_agg_negative (time column time): not enough new data past completion threshold of 9223372036854775805 as of 9223372036854775805
 INFO:  materializing continuous aggregate public.negative_view_5: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.negative_view_5: no new range to materialize or invalidations found, exiting early
 RESET client_min_messages;
@@ -1112,8 +1105,7 @@ CREATE VIEW max_mat_view
 INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 10) AS i;
 -- first run create two materializations
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range for public.continuous_agg_max_mat larger than allowed in one run, truncating (time column time) (12)
-INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (4)
+INFO:  new materialization range for public.continuous_agg_max_mat (time column time) larger than allowed in one run, truncating 12 to 4
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, new range up to 4
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view ORDER BY 1;
@@ -1125,8 +1117,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 -- repeated runs will eventually materialize all the data
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range for public.continuous_agg_max_mat larger than allowed in one run, truncating (time column time) (12)
-INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (8)
+INFO:  new materialization range for public.continuous_agg_max_mat (time column time) larger than allowed in one run, truncating 12 to 8
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, new range up to 8
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view ORDER BY 1;
@@ -1139,7 +1130,6 @@ SELECT * FROM max_mat_view ORDER BY 1;
 (4 rows)
 
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (12)
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, new range up to 12
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
@@ -1153,7 +1143,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 (6 rows)
 
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold of 12 as of 10
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 SELECT * FROM max_mat_view ORDER BY 1;
@@ -1185,7 +1175,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 --nothing to do
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold of 12 as of 10
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 --one invalidation too big for max_interval will be split
@@ -1209,7 +1199,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 --nothing to do
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold of 12 as of 10
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 --many invalidation too big for max_interval will be split
@@ -1220,7 +1210,7 @@ REFRESH MATERIALIZED VIEW max_mat_view;
 INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold of 12 as of 10
 INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
@@ -1235,7 +1225,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 --nothing to do
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (12)
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold of 12 as of 10
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 --one invalidation + new entries  requires two refreshes if the refresh budget taken up by invalidation
@@ -1245,7 +1235,6 @@ REFRESH MATERIALIZED VIEW max_mat_view;
 INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, no new range
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (14)
 INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, new range up to 14
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
@@ -1261,14 +1250,13 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 --nothing to do
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (14)
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold of 14 as of 12
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 --one invalidation + new entries  done in one refresh if the refresh budget allows
 INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 1) AS i;
 INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(14, 15) AS i;
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range for public.continuous_agg_max_mat (time column time) (16)
 INFO:  materializing continuous aggregate public.max_mat_view: processing invalidations, new range up to 16
 SELECT * FROM max_mat_view ORDER BY 1;
  time_bucket | value 
@@ -1285,7 +1273,7 @@ SELECT * FROM max_mat_view ORDER BY 1;
 
 --nothing to do.
 REFRESH MATERIALIZED VIEW max_mat_view;
-INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold (16)
+INFO:  new materialization range not found for public.continuous_agg_max_mat (time column time): not enough new data past completion threshold of 16 as of 15
 INFO:  materializing continuous aggregate public.max_mat_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view: no new range to materialize or invalidations found, exiting early
 -- time type
@@ -1309,9 +1297,8 @@ INSERT INTO continuous_agg_max_mat_t
 SET timescaledb.current_timestamp_mock = '2019-09-09 10:00 UTC';
 -- first run create two materializations
 REFRESH MATERIALIZED VIEW max_mat_view_t;
-INFO:  new materialization range for public.continuous_agg_max_mat_t larger than allowed in one run, truncating (time column time) (1568030400000000)
-INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) (1568001600000000)
-INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 1568001600000000
+INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) larger than allowed in one run, truncating 2019-09-09 12:00:00+00 to 2019-09-09 04:00:00+00
+INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 2019-09-09 04:00:00+00
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view_t ORDER BY 1;
       time_bucket       | value 
@@ -1322,9 +1309,8 @@ SELECT * FROM max_mat_view_t ORDER BY 1;
 
 -- repeated runs will eventually materialize all the data
 REFRESH MATERIALIZED VIEW max_mat_view_t;
-INFO:  new materialization range for public.continuous_agg_max_mat_t larger than allowed in one run, truncating (time column time) (1568030400000000)
-INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) (1568016000000000)
-INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 1568016000000000
+INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) larger than allowed in one run, truncating 2019-09-09 12:00:00+00 to 2019-09-09 08:00:00+00
+INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 2019-09-09 08:00:00+00
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT * FROM max_mat_view_t ORDER BY 1;
       time_bucket       | value 
@@ -1336,8 +1322,7 @@ SELECT * FROM max_mat_view_t ORDER BY 1;
 (4 rows)
 
 REFRESH MATERIALIZED VIEW max_mat_view_t;
-INFO:  new materialization range for public.continuous_agg_max_mat_t (time column time) (1568030400000000)
-INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 1568030400000000
+INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, new range up to 2019-09-09 12:00:00+00
 SELECT * FROM max_mat_view_t ORDER BY 1;
       time_bucket       | value 
 ------------------------+-------
@@ -1350,7 +1335,7 @@ SELECT * FROM max_mat_view_t ORDER BY 1;
 (6 rows)
 
 REFRESH MATERIALIZED VIEW max_mat_view_t;
-INFO:  new materialization range not found for public.continuous_agg_max_mat_t (time column time): not enough new data past completion threshold (1568030400000000)
+INFO:  new materialization range not found for public.continuous_agg_max_mat_t (time column time): not enough new data past completion threshold of 2019-09-09 12:00:00+00 as of 2019-09-09 10:00:00+00
 INFO:  materializing continuous aggregate public.max_mat_view_t: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.max_mat_view_t: no new range to materialize or invalidations found, exiting early
 SELECT * FROM max_mat_view_t ORDER BY 1;
@@ -1382,8 +1367,7 @@ INSERT INTO continuous_agg_max_mat_timestamp
     SELECT generate_series('2019-09-09 1:00'::TIMESTAMPTZ, '2019-09-09 10:00', '1 hour');
 -- first materializes everything
 REFRESH MATERIALIZED VIEW max_mat_view_timestamp;
-INFO:  new materialization range for public.continuous_agg_max_mat_timestamp (time column time) (1568030400000000)
-INFO:  materializing continuous aggregate public.max_mat_view_timestamp: nothing to invalidate, new range up to 1568030400000000
+INFO:  materializing continuous aggregate public.max_mat_view_timestamp: nothing to invalidate, new range up to 2019-09-09 12:00:00
 SELECT * FROM max_mat_view_timestamp ORDER BY 1;
      time_bucket     
 ---------------------
@@ -1415,8 +1399,7 @@ SET timescaledb.current_timestamp_mock = '2019-09-09 01:00 UTC';
 --SET timescaledb.current_timestamp_mock = '2019-09-09 01:01:01 UTC';
 -- first materializes everything
 REFRESH MATERIALIZED VIEW max_mat_view_date;
-INFO:  new materialization range for public.continuous_agg_max_mat_date (time column time) (1568592000000000)
-INFO:  materializing continuous aggregate public.max_mat_view_date: nothing to invalidate, new range up to 1568592000000000
+INFO:  materializing continuous aggregate public.max_mat_view_date: nothing to invalidate, new range up to 2019-09-16
 SELECT * FROM max_mat_view_date ORDER BY 1;
  time_bucket 
 -------------

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -54,7 +54,6 @@ from timescaledb_information.continuous_aggregates;
 
 --TEST1: cagg_1 is materialized, not cagg_2.
 refresh materialized view cagg_1;
-INFO:  new materialization range for public.continuous_agg_test (time column timeval) (18)
 INFO:  materializing continuous aggregate public.cagg_1: nothing to invalidate, new range up to 18
 select * from cagg_1 order by 1;
  timed | cnt 
@@ -83,7 +82,6 @@ select * from cagg_2 order by 1,2;
 (0 rows)
 
 refresh materialized view cagg_2;
-INFO:  new materialization range for public.continuous_agg_test (time column timeval) (18)
 INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, new range up to 18
 select * from cagg_2 order by 1,2;
  timed | grp | maxval 
@@ -126,7 +124,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold of 18 as of 16
 INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select * from cagg_1 order by 1;
  timed | cnt 
@@ -173,7 +171,7 @@ order by 1,2 ;
 (5 rows)
 
 refresh materialized view cagg_2;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold of 18 as of 16
 INFO:  materializing continuous aggregate public.cagg_2: processing invalidations, no new range
 select * from cagg_2 order by 1, 2;
  timed | grp | maxval 
@@ -202,7 +200,7 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
 (1 row)
 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold of 18 as of 16
 INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select count(*) from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
  count 
@@ -279,7 +277,6 @@ AS
     FROM continuous_agg_test
     GROUP BY 1;
 refresh materialized view cagg_1;
-INFO:  new materialization range for public.continuous_agg_test (time column timeval) (18)
 INFO:  materializing continuous aggregate public.cagg_1: nothing to invalidate, new range up to 18
 select * from cagg_1 order by 1;
  timed | cnt 
@@ -291,7 +288,6 @@ select * from cagg_1 order by 1;
 (4 rows)
 
 refresh materialized view cagg_2;
-INFO:  new materialization range for public.continuous_agg_test (time column timeval) (14)
 INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, new range up to 14
 select * from cagg_2 order by 1;
  timed | maxval 
@@ -303,7 +299,7 @@ select * from cagg_2 order by 1;
 --this insert will be processed only by cagg_1 and copied over to cagg_2
 insert into continuous_agg_test values( 14, -2, 100); 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (18)
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold of 18 as of 16
 INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select * from cagg_1 order by 1;
  timed | cnt 
@@ -315,7 +311,7 @@ select * from cagg_1 order by 1;
 (4 rows)
 
 refresh materialized view cagg_2;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (14)
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold of 14 as of 16
 INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.cagg_2: no new range to materialize or invalidations found, exiting early
 select * from cagg_2 order by 1;
@@ -342,7 +338,6 @@ select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_
 --one
 insert into continuous_agg_test values( 18, -2, 200); 
 refresh materialized view cagg_1;
-INFO:  new materialization range for public.continuous_agg_test (time column timeval) (20)
 INFO:  materializing continuous aggregate public.cagg_1: nothing to invalidate, new range up to 20
 select * from cagg_1 order by 1;
  timed | cnt 
@@ -355,7 +350,6 @@ select * from cagg_1 order by 1;
 (5 rows)
 
 refresh materialized view cagg_2;
-INFO:  new materialization range for public.continuous_agg_test (time column timeval) (16)
 INFO:  materializing continuous aggregate public.cagg_2: nothing to invalidate, new range up to 16
 select * from cagg_2 order by 1;
  timed | maxval 
@@ -376,7 +370,7 @@ select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log o
 (2 rows)
 
 refresh materialized view cagg_1;
-INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold (20)
+INFO:  new materialization range not found for public.continuous_agg_test (time column timeval): not enough new data past completion threshold of 20 as of 18
 INFO:  materializing continuous aggregate public.cagg_1: processing invalidations, no new range
 select * from cagg_1 where timed = 18 ;
  timed | cnt 
@@ -429,7 +423,6 @@ SELECT time_bucket(2, timeval), max(col2)
 FROM continuous_agg_test_ignore_invalidation_older_than
 GROUP BY 1;
 refresh materialized view cagg_iia1;
-INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (14)
 INFO:  materializing continuous aggregate public.cagg_iia1: nothing to invalidate, new range up to 14
 select * from cagg_iia1 order by 1;
  timed | cnt 
@@ -439,7 +432,6 @@ select * from cagg_iia1 order by 1;
 (2 rows)
 
 refresh materialized view cagg_iia2;
-INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (14)
 INFO:  materializing continuous aggregate public.cagg_iia2: nothing to invalidate, new range up to 14
 select * from cagg_iia2 order by 1;
  timed | maxval 
@@ -449,7 +441,6 @@ select * from cagg_iia2 order by 1;
 (2 rows)
 
 refresh materialized view cagg_iia3;
-INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (14)
 INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, new range up to 14
 select * from cagg_iia3 order by 1;
  timed | maxval 
@@ -470,7 +461,6 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 --move the time up (40), but invalidation logic should apply to old time (12)
 INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES (32,4,2),(36,5,5),(40,3,9);
 refresh materialized view cagg_iia1;
-INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (42)
 INFO:  materializing continuous aggregate public.cagg_iia1: processing invalidations, new range up to 42
 --should see change to the 12, 10 bucket but not the 4 or 1 bucket
 select * from cagg_iia1 order by 1;
@@ -485,7 +475,6 @@ select * from cagg_iia1 order by 1;
 
 --should see change to the 12, 10 and 4 bucket but not the 1 bucket
 refresh materialized view cagg_iia2;
-INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (42)
 INFO:  materializing continuous aggregate public.cagg_iia2: processing invalidations, new range up to 42
 select * from cagg_iia2 order by 1;
  timed | maxval 
@@ -500,7 +489,6 @@ select * from cagg_iia2 order by 1;
 
 --sees no changes
 refresh materialized view cagg_iia3;
-INFO:  new materialization range for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval) (42)
 INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, new range up to 42
 select * from cagg_iia3 order by 1;
  timed | maxval 
@@ -516,7 +504,7 @@ select * from cagg_iia3 order by 1;
 UPDATE continuous_agg_test_ignore_invalidation_older_than  set col1=NULL, col2=200 where timeval=32;
 UPDATE continuous_agg_test_ignore_invalidation_older_than  set col1=NULL, col2=120 where timeval=36;
 refresh materialized view cagg_iia1;
-INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold of 42 as of 40
 INFO:  materializing continuous aggregate public.cagg_iia1: processing invalidations, no new range
 --should see change only for the 36 bucket not 32
 select * from cagg_iia1 order by 1;
@@ -531,7 +519,7 @@ select * from cagg_iia1 order by 1;
 
 --should see change to the 36 and 32
 refresh materialized view cagg_iia2;
-INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold of 42 as of 40
 INFO:  materializing continuous aggregate public.cagg_iia2: processing invalidations, no new range
 select * from cagg_iia2 order by 1;
  timed | maxval 
@@ -546,7 +534,7 @@ select * from cagg_iia2 order by 1;
 
 --sees no changes
 refresh materialized view cagg_iia3;
-INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold of 42 as of 40
 INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.cagg_iia3: no new range to materialize or invalidations found, exiting early
 select * from cagg_iia3 order by 1;
@@ -563,7 +551,7 @@ select * from cagg_iia3 order by 1;
 DELETE FROM continuous_agg_test_ignore_invalidation_older_than WHERE timeval = 32;
 DELETE FROM continuous_agg_test_ignore_invalidation_older_than WHERE timeval = 36;
 refresh materialized view cagg_iia1;
-INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold of 42 as of 40
 INFO:  materializing continuous aggregate public.cagg_iia1: processing invalidations, no new range
 --should see change only for the 36 bucket not 32
 select * from cagg_iia1 order by 1;
@@ -577,7 +565,7 @@ select * from cagg_iia1 order by 1;
 
 --should see change to the 36 and 32
 refresh materialized view cagg_iia2;
-INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold of 42 as of 40
 INFO:  materializing continuous aggregate public.cagg_iia2: processing invalidations, no new range
 select * from cagg_iia2 order by 1;
  timed | maxval 
@@ -590,7 +578,7 @@ select * from cagg_iia2 order by 1;
 
 --sees no changes
 refresh materialized view cagg_iia3;
-INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold of 42 as of 40
 INFO:  materializing continuous aggregate public.cagg_iia3: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.cagg_iia3: no new range to materialize or invalidations found, exiting early
 select * from cagg_iia3 order by 1;
@@ -609,7 +597,7 @@ INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES
  (10, -3, 20);
 --sees the change now
 refresh materialized view cagg_iia3;
-INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold (42)
+INFO:  new materialization range not found for public.continuous_agg_test_ignore_invalidation_older_than (time column timeval): not enough new data past completion threshold of 42 as of 40
 INFO:  materializing continuous aggregate public.cagg_iia3: processing invalidations, no new range
 select * from cagg_iia3 order by 1;
  timed | maxval 

--- a/tsl/test/expected/continuous_aggs_permissions-10.out
+++ b/tsl/test/expected/continuous_aggs_permissions-10.out
@@ -45,7 +45,6 @@ NOTICE:  adding index _materialized_hypertable_2_location_time_partition_col_idx
 insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW  mat_refresh_test;
-INFO:  new materialization range for public.conditions (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 200
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT materialization_hypertable FROM timescaledb_information.continuous_aggregates  WHERE view_name = 'mat_refresh_test'::regclass \gset 
@@ -159,7 +158,6 @@ NOTICE:  adding index _materialized_hypertable_7_location_time_partition_col_idx
 NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_7 USING BTREE(get_constant, time_partition_col)
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
@@ -172,7 +170,6 @@ from conditions_for_perm_check_w_grant
 group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 SELECT * FROM mat_perm_view_test;
  location | max 

--- a/tsl/test/expected/continuous_aggs_permissions-11.out
+++ b/tsl/test/expected/continuous_aggs_permissions-11.out
@@ -45,7 +45,6 @@ NOTICE:  adding index _materialized_hypertable_2_location_time_partition_col_idx
 insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW  mat_refresh_test;
-INFO:  new materialization range for public.conditions (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 200
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT materialization_hypertable FROM timescaledb_information.continuous_aggregates  WHERE view_name = 'mat_refresh_test'::regclass \gset 
@@ -159,7 +158,6 @@ NOTICE:  adding index _materialized_hypertable_7_location_time_partition_col_idx
 NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_7 USING BTREE(get_constant, time_partition_col)
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
@@ -172,7 +170,6 @@ from conditions_for_perm_check_w_grant
 group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 SELECT * FROM mat_perm_view_test;
  location | max 

--- a/tsl/test/expected/continuous_aggs_permissions-9.6.out
+++ b/tsl/test/expected/continuous_aggs_permissions-9.6.out
@@ -45,7 +45,6 @@ NOTICE:  adding index _materialized_hypertable_2_location_time_partition_col_idx
 insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 REFRESH MATERIALIZED VIEW  mat_refresh_test;
-INFO:  new materialization range for public.conditions (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_refresh_test: nothing to invalidate, new range up to 200
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT materialization_hypertable FROM timescaledb_information.continuous_aggregates  WHERE view_name = 'mat_refresh_test'::regclass \gset 
@@ -159,7 +158,6 @@ NOTICE:  adding index _materialized_hypertable_7_location_time_partition_col_idx
 NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_7 USING BTREE(get_constant, time_partition_col)
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
@@ -172,7 +170,6 @@ from conditions_for_perm_check_w_grant
 group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-INFO:  new materialization range for public.conditions_for_perm_check_w_grant (time column timec) (200)
 INFO:  materializing continuous aggregate public.mat_perm_view_test: nothing to invalidate, new range up to 200
 SELECT * FROM mat_perm_view_test;
  location | max 

--- a/tsl/test/expected/continuous_aggs_query-10.out
+++ b/tsl/test/expected/continuous_aggs_query-10.out
@@ -58,8 +58,7 @@ group by time_bucket('1day', timec), location;
 NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_m1;
-INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
-INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to 1546041600000000
+INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to Fri Dec 28 16:00:00 2018 PST
 --test first/last
 create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
@@ -71,8 +70,7 @@ NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescal
 --time that refresh assumes as now() for repeatability
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_m2;
-INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
-INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to 1546041600000000
+INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to Fri Dec 28 16:00:00 2018 PST
 --normal view --
 create or replace view regview( location, timec, minl, sumt , sumh)
 as

--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -58,8 +58,7 @@ group by time_bucket('1day', timec), location;
 NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_m1;
-INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
-INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to 1546041600000000
+INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to Fri Dec 28 16:00:00 2018 PST
 --test first/last
 create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
@@ -71,8 +70,7 @@ NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescal
 --time that refresh assumes as now() for repeatability
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_m2;
-INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
-INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to 1546041600000000
+INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to Fri Dec 28 16:00:00 2018 PST
 --normal view --
 create or replace view regview( location, timec, minl, sumt , sumh)
 as

--- a/tsl/test/expected/continuous_aggs_query-9.6.out
+++ b/tsl/test/expected/continuous_aggs_query-9.6.out
@@ -58,8 +58,7 @@ group by time_bucket('1day', timec), location;
 NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_m1;
-INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
-INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to 1546041600000000
+INFO:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to Fri Dec 28 16:00:00 2018 PST
 --test first/last
 create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
@@ -71,8 +70,7 @@ NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescal
 --time that refresh assumes as now() for repeatability
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW mat_m2;
-INFO:  new materialization range for public.conditions (time column timec) (1546041600000000)
-INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to 1546041600000000
+INFO:  materializing continuous aggregate public.mat_m2: nothing to invalidate, new range up to Fri Dec 28 16:00:00 2018 PST
 --normal view --
 create or replace view regview( location, timec, minl, sumt , sumh)
 as

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -56,8 +56,7 @@ SELECT * FROM device_summary;
 ALTER VIEW device_summary SET (timescaledb.max_interval_per_job = '60 day');
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW device_summary;
-INFO:  new materialization range for public.device_readings (time column observation_time) (1546236000000000)
-INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to 1546236000000000
+INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to Sun Dec 30 22:00:00 2018 PST
 --Now you can run selects over your view as normal
 SELECT * FROM device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, device_id LIMIT 10;
             bucket            | device_id | metric_avg | metric_spread 
@@ -161,8 +160,7 @@ SELECT max(bucket) FROM device_summary;
 --will slow down your inserts because of invalidation.
 ALTER VIEW device_summary SET (timescaledb.refresh_lag = '-1 hour');
 REFRESH MATERIALIZED VIEW device_summary;
-INFO:  new materialization range for public.device_readings (time column observation_time) (1546246800000000)
-INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to 1546246800000000
+INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to Mon Dec 31 01:00:00 2018 PST
 SELECT max(observation_time) FROM device_readings;
              max              
 ------------------------------
@@ -196,7 +194,7 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 
 SET timescaledb.current_timestamp_mock = 'Sun Dec 30 13:01:00 2018 PST';
 REFRESH MATERIALIZED VIEW device_summary;
-INFO:  new materialization range not found for public.device_readings (time column observation_time): not enough new data past completion threshold (1546207200000000)
+INFO:  new materialization range not found for public.device_readings (time column observation_time): not enough new data past completion threshold of Mon Dec 31 01:00:00 2018 PST as of Sun Dec 30 13:01:00 2018 PST
 INFO:  materializing continuous aggregate public.device_summary: processing invalidations, no new range
 --But is reflected after.
 SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 30 13:00:00 2018 PST';
@@ -264,9 +262,8 @@ FROM
 GROUP BY bucket, device_id;
 NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 REFRESH MATERIALIZED VIEW device_summary;
-INFO:  new materialization range for public.device_readings larger than allowed in one run, truncating (time column observation_time) (1546196400000000)
-INFO:  new materialization range for public.device_readings (time column observation_time) (1543723200000000)
-INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to 1543723200000000
+INFO:  new materialization range for public.device_readings (time column observation_time) larger than allowed in one run, truncating Sun Dec 30 11:00:00 2018 PST to Sat Dec 01 20:00:00 2018 PST
+INFO:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to Sat Dec 01 20:00:00 2018 PST
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 SELECT min(min_time)::timestamp FROM device_summary;
            min            

--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -47,10 +47,8 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
@@ -129,10 +127,8 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -2318,8 +2314,7 @@ SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------
@@ -5666,8 +5661,7 @@ SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -47,10 +47,8 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
@@ -129,10 +127,8 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 -- look at postgres version to decide whether we run with analyze or without
 SELECT
   CASE WHEN current_setting('server_version_num')::int >= 100000
@@ -2428,8 +2424,7 @@ SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------
@@ -5790,8 +5785,7 @@ SET client_min_messages TO error;
 CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-psql:include/transparent_decompression_query.sql:286: INFO:  new materialization range for public.metrics_space (time column time) (948067200000000)
-psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to 948067200000000
+psql:include/transparent_decompression_query.sql:286: INFO:  materializing continuous aggregate public.cagg_test: nothing to invalidate, new range up to Sun Jan 16 16:00:00 2000 PST
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
              time             
 ------------------------------

--- a/tsl/test/isolation/expected/continuous_aggs_insert.out
+++ b/tsl/test/isolation/expected/continuous_aggs_insert.out
@@ -5,10 +5,9 @@ step LockCompleted: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_compl
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step UnlockCompleted: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh2: <... completed>
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold of 15 as of 29
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh: <... completed>
@@ -20,7 +19,6 @@ step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ic: COMMIT;
 step UnlockCompleted: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
@@ -31,7 +29,6 @@ step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step Ic: COMMIT;
 step UnlockCompleted: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
@@ -45,7 +42,6 @@ count
 30             
 step Sc: COMMIT;
 step UnlockCompleted: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
@@ -59,14 +55,12 @@ count
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Sc: COMMIT;
 step UnlockCompleted: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Ib LockInvalThr Refresh I1 Ic UnlockInvalThr
 step Ib: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
 step LockInvalThr: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold IN SHARE MODE;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
@@ -79,7 +73,6 @@ starting permutation: Ib LockInvalThr I1 Refresh Ic UnlockInvalThr
 step Ib: BEGIN; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms';
 step LockInvalThr: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold IN SHARE MODE;
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ic: COMMIT; <waiting ...>
@@ -94,7 +87,6 @@ step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step Ic: COMMIT;
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step UnlockInval: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
@@ -105,7 +97,6 @@ step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ip1: INSERT INTO ts_continuous_test VALUES (29, 29);
 step Ipc: COMMIT;
 step UnlockInval: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
@@ -116,7 +107,6 @@ step Ip1: INSERT INTO ts_continuous_test VALUES (29, 29);
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Ipc: COMMIT;
 step UnlockInval: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
@@ -127,12 +117,10 @@ step Ip1: INSERT INTO ts_continuous_test VALUES (29, 29);
 step Ipc: COMMIT;
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step UnlockInval: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: <... completed>
 
 starting permutation: Refresh SV1 LockMatInval Refresh1 Ib I1 LockInvalThrEx Ic UnlockMatInval UnlockInvalThrEx SV1
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view;
 step SV1: SELECT * FROM continuous_view order by 1;
@@ -148,7 +136,7 @@ step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
 step LockInvalThrEx: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold ;
 step Ic: COMMIT; <waiting ...>
 step UnlockMatInval: ROLLBACK;
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold of 15 as of 29
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh1: <... completed>
@@ -163,7 +151,6 @@ time_bucket    count
 
 starting permutation: I1 Refresh LockInval Refresh Sb S1 Sc UnlockInval
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view;
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
@@ -175,14 +162,13 @@ count
 31             
 step Sc: COMMIT;
 step UnlockInval: ROLLBACK;
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold of 15 as of 29
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh: <... completed>
 
 starting permutation: I1 Refresh LockInval Sb S1 Refresh Sc UnlockInval
 step I1: INSERT INTO ts_continuous_test VALUES (1, 1);
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, new range up to 15
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view;
 step LockInval: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
@@ -194,7 +180,7 @@ count
 step Refresh: REFRESH MATERIALIZED VIEW continuous_view; <waiting ...>
 step Sc: COMMIT;
 step UnlockInval: ROLLBACK;
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (15)
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold of 15 as of 29
 INFO:  materializing continuous aggregate public.continuous_view: nothing to invalidate, no new range
 INFO:  materializing continuous aggregate public.continuous_view: no new range to materialize or invalidations found, exiting early
 step Refresh: <... completed>

--- a/tsl/test/isolation/expected/continuous_aggs_multi.out
+++ b/tsl/test/isolation/expected/continuous_aggs_multi.out
@@ -23,13 +23,11 @@ lock_mattable
 
                
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1; <waiting ...>
-INFO:  new materialization range for public.ts_continuous_test (time column time) (35)
 INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 35
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 step Refresh2: <... completed>
 step UnlockMat1: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (30)
 INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 30
 step Refresh1: <... completed>
 
@@ -49,10 +47,8 @@ step Setup2:
     BEGIN EXECUTE format( 'lock table %s', name);
     END; $$ LANGUAGE plpgsql;
 
-INFO:  new materialization range for public.ts_continuous_test (time column time) (30)
 INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 30
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (35)
 INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 35
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2;
 step LockCompleted: BEGIN; LOCK TABLE _timescaledb_catalog.continuous_aggs_completed_threshold IN SHARE MODE;
@@ -63,13 +59,13 @@ lock_mattable
                
 step I1: INSERT INTO ts_continuous_test SELECT 0, i*10 FROM (SELECT generate_series(0, 10) AS i) AS i;
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1; <waiting ...>
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (35)
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold of 35 as of 29
 INFO:  materializing continuous aggregate public.continuous_view_2: processing invalidations, no new range
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 step Refresh2: <... completed>
 step UnlockMat1: ROLLBACK;
-INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold (30)
+INFO:  new materialization range not found for public.ts_continuous_test (time column time): not enough new data past completion threshold of 30 as of 29
 INFO:  materializing continuous aggregate public.continuous_view_1: processing invalidations, no new range
 step Refresh1: <... completed>
 step Refresh1_sel: select * from continuous_view_1 where bkt = 0 or bkt > 30
@@ -98,10 +94,8 @@ step Setup2:
     END; $$ LANGUAGE plpgsql;
 
 step AlterLag1: alter view continuous_view_1 set (timescaledb.refresh_lag = 10);
-INFO:  new materialization range for public.ts_continuous_test (time column time) (15)
 INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 15
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (35)
 INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 35
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2;
 step Refresh1_sel: select * from continuous_view_1 where bkt = 0 or bkt > 30
@@ -120,13 +114,11 @@ lock_mattable
                
 step I2: INSERT INTO ts_continuous_test SELECT 40, 1000 ;
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1; <waiting ...>
-INFO:  new materialization range for public.ts_continuous_test (time column time) (50)
 INFO:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 50
 step Refresh2: REFRESH MATERIALIZED VIEW continuous_view_2; <waiting ...>
 step UnlockCompleted: ROLLBACK;
 step Refresh2: <... completed>
 step UnlockMat1: ROLLBACK;
-INFO:  new materialization range for public.ts_continuous_test (time column time) (30)
 INFO:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 30
 step Refresh1: <... completed>
 step Refresh1_sel: select * from continuous_view_1 where bkt = 0 or bkt > 30


### PR DESCRIPTION
Switch from using internal timestamps to more user-friendly
timestamps in our log messages and clean up some messages.