### PR TITLE
Fix error in compression constraint check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ that a backfill can trigger. By default, all invalidations are processed.
 
 **Bugfixes**
 * #1591 Fix locf treat_null_as_missing option
+* #1594 Fix error in compression constraint check
 
 **Thanks**
 * @optijon for reporting an issue with locf treat_null_as_missing option
+* @ChristopherZellermann for reporting an issue with the compression constraint check
 
 ## 1.5.1 (2019-11-12)
 

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -298,6 +298,24 @@ NOTICE:  adding index _compressed_hypertable_17_d__ts_meta_sequence_num_idx ON _
 --can't add fks after compression enabled
 alter table table_constr add constraint table_constr_fk_add_after FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
 ERROR:  operation not supported on hypertables that have compression enabled
+--FK check should not error even with dropped columns (previously had a bug related to this)
+CREATE TABLE table_fk (
+	time timestamptz NOT NULL,
+	id1 int8 NOT NULL,
+	id2 int8 NOT NULL,
+	value float8 NULL,
+	CONSTRAINT fk1 FOREIGN KEY (id1) REFERENCES fortable(col),
+	CONSTRAINT fk2 FOREIGN KEY (id2) REFERENCES fortable(col)
+);
+SELECT create_hypertable('table_fk', 'time');
+   create_hypertable    
+------------------------
+ (18,public,table_fk,t)
+(1 row)
+
+ALTER TABLE table_fk DROP COLUMN id1;
+ALTER TABLE table_fk SET (timescaledb.compress,timescaledb.compress_segmentby = 'id2');
+NOTICE:  adding index _compressed_hypertable_19_id2__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_19 USING BTREE(id2, _ts_meta_sequence_num)
 -- TEST fk cascade delete behavior on compressed chunk --
 insert into fortable values(1);
 insert into fortable values(10);

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -173,6 +173,20 @@ ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby
 --can't add fks after compression enabled
 alter table table_constr add constraint table_constr_fk_add_after FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
 
+--FK check should not error even with dropped columns (previously had a bug related to this)
+CREATE TABLE table_fk (
+	time timestamptz NOT NULL,
+	id1 int8 NOT NULL,
+	id2 int8 NOT NULL,
+	value float8 NULL,
+	CONSTRAINT fk1 FOREIGN KEY (id1) REFERENCES fortable(col),
+	CONSTRAINT fk2 FOREIGN KEY (id2) REFERENCES fortable(col)
+);
+
+SELECT create_hypertable('table_fk', 'time');
+ALTER TABLE table_fk DROP COLUMN id1;
+ALTER TABLE table_fk SET (timescaledb.compress,timescaledb.compress_segmentby = 'id2');
+
 -- TEST fk cascade delete behavior on compressed chunk --
 insert into fortable values(1);
 insert into fortable values(10);


### PR DESCRIPTION
The constraint check previously assumed that the col_meta
offset for a column was equal to that columns attribute
offset. This is incorrect in the presence of dropped columns.

Fixed to match on column names.

Fixes #1590