### PR TITLE
Delete compression policy when drop hypertable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ that a backfill can trigger. By default, all invalidations are processed.
 **Bugfixes**
 * #1591 Fix locf treat_null_as_missing option
 * #1594 Fix error in compression constraint check
+* #1607 Delete compression policy when drop hypertable
 
 **Thanks**
 * @optijon for reporting an issue with locf treat_null_as_missing option

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -382,6 +382,7 @@ bgw_job_tuple_delete(TupleInfo *ti, void *data)
 	/* Delete any policy args associated with this job */
 	ts_bgw_policy_reorder_delete_row_only_by_job_id(job_id);
 	ts_bgw_policy_drop_chunks_delete_row_only_by_job_id(job_id);
+	ts_bgw_policy_compress_chunks_delete_row_only_by_job_id(job_id);
 
 	/* Delete any stats in bgw_policy_chunk_stats related to this job */
 	ts_bgw_policy_chunk_stats_delete_row_only_by_job_id(job_id);

--- a/src/bgw_policy/compress_chunks.c
+++ b/src/bgw_policy/compress_chunks.c
@@ -55,9 +55,9 @@ compress_policy_delete_row_tuple_found(TupleInfo *ti, void *const data)
 	return SCAN_CONTINUE;
 }
 
-/*deletes only from the compress_chunks policy table. need to remove the job separately */
+/* deletes only from the compress_chunks policy table. need to remove the job separately */
 bool
-ts_bgw_policy_compress_chunks_delete(int32 job_id)
+ts_bgw_policy_compress_chunks_delete_row_only_by_job_id(int32 job_id)
 {
 	ScanKeyData scankey[1];
 

--- a/src/bgw_policy/compress_chunks.h
+++ b/src/bgw_policy/compress_chunks.h
@@ -19,5 +19,5 @@ extern TSDLLEXPORT BgwPolicyCompressChunks *ts_bgw_policy_compress_chunks_find_b
 extern TSDLLEXPORT BgwPolicyCompressChunks *
 ts_bgw_policy_compress_chunks_find_by_hypertable(int32 hypertable_id);
 extern TSDLLEXPORT void ts_bgw_policy_compress_chunks_insert(BgwPolicyCompressChunks *policy);
-extern TSDLLEXPORT bool ts_bgw_policy_compress_chunks_delete(int32 job_id);
+extern TSDLLEXPORT bool ts_bgw_policy_compress_chunks_delete_row_only_by_job_id(int32 job_id);
 #endif /* TIMESCALEDB_BGW_POLICY_COMPRESS_CHUNKS_H */

--- a/src/bgw_policy/policy.c
+++ b/src/bgw_policy/policy.c
@@ -4,11 +4,13 @@
  * LICENSE-APACHE for a copy of the license.
  */
 
+#include "bgw_policy/compress_chunks.h"
 #include <postgres.h>
 
 #include "policy.h"
 #include "bgw_policy/reorder.h"
 #include "bgw_policy/drop_chunks.h"
+#include "bgw_policy/compress_chunks.h"
 #include "bgw/job.h"
 
 void
@@ -28,6 +30,11 @@ ts_bgw_policy_delete_by_hypertable_id(int32 hypertable_id)
 
 	if (policy)
 		ts_bgw_job_delete_by_id(((BgwPolicyDropChunks *) policy)->job_id);
+
+	policy = ts_bgw_policy_compress_chunks_find_by_hypertable(hypertable_id);
+
+	if (policy)
+		ts_bgw_job_delete_by_id(((BgwPolicyCompressChunks *) policy)->fd.job_id);
 }
 
 /* This function does NOT cascade deletes to the bgw_job table. */

--- a/tsl/src/bgw_policy/compress_chunks_api.c
+++ b/tsl/src/bgw_policy/compress_chunks_api.c
@@ -182,8 +182,6 @@ compress_chunks_remove_policy(PG_FUNCTION_ARGS)
 	}
 
 	ts_bgw_job_delete_by_id(policy->fd.job_id);
-	/* Now, delete from policy table */
-	ts_bgw_policy_compress_chunks_delete(policy->fd.job_id);
 
 	PG_RETURN_BOOL(true);
 }

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -407,6 +407,19 @@ SELECT count(*) FROM _timescaledb_catalog.hypertable hypertable;
      2
 (1 row)
 
+--add policy to make sure it's dropped later
+select add_compress_chunks_policy(:'UNCOMPRESSED_HYPER_NAME', interval '1 day');
+ add_compress_chunks_policy 
+----------------------------
+                       1000
+(1 row)
+
+SELECT count(*) FROM _timescaledb_config.bgw_policy_compress_chunks;
+ count 
+-------
+     1
+(1 row)
+
 DROP TABLE :UNCOMPRESSED_HYPER_NAME;
 --verify that there are no more hypertable remaining
 SELECT count(*) FROM _timescaledb_catalog.hypertable hypertable;
@@ -416,6 +429,13 @@ SELECT count(*) FROM _timescaledb_catalog.hypertable hypertable;
 (1 row)
 
 SELECT count(*) FROM _timescaledb_catalog.hypertable_compression;
+ count 
+-------
+     0
+(1 row)
+
+--verify that the policy is gone
+SELECT count(*) FROM _timescaledb_config.bgw_policy_compress_chunks;
  count 
 -------
      0
@@ -495,6 +515,22 @@ AS sub;
  count_compressed 
 ------------------
                 1
+(1 row)
+
+select add_compress_chunks_policy('test1', interval '1 day');
+ add_compress_chunks_policy 
+----------------------------
+                       1002
+(1 row)
+
+\set ON_ERROR_STOP 0
+ALTER table test1 set (timescaledb.compress='f');
+ERROR:  cannot change compression options as a compression policy exists on the table
+\set ON_ERROR_STOP 1
+select remove_compress_chunks_policy('test1');
+ remove_compress_chunks_policy 
+-------------------------------
+ t
 (1 row)
 
 ALTER table test1 set (timescaledb.compress='f');


### PR DESCRIPTION
Previously we could have a dangling policy and job referring
to a now-dropped hypertable.

We also block changing the compression options if a policy exists.

Fixes #1570