### PR TITLE
Add jobs to timescaledb_information.policy_stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ that a backfill can trigger. By default, all invalidations are processed.
 * #1591 Fix locf treat_null_as_missing option
 * #1594 Fix error in compression constraint check
 * #1607 Delete compression policy when drop hypertable
+* #1608 Add jobs to timescaledb_information.policy_stats
 
 **Thanks**
 * @optijon for reporting an issue with locf treat_null_as_missing option

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -69,7 +69,9 @@ CREATE OR REPLACE VIEW timescaledb_information.policy_stats as
   SELECT format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as hypertable, p.job_id, j.job_type, js.last_run_success, js.last_finish, js.last_successful_finish, js.last_start, js.next_start,
     js.total_runs, js.total_failures
   FROM (SELECT job_id, hypertable_id FROM _timescaledb_config.bgw_policy_reorder
-        UNION SELECT job_id, hypertable_id FROM _timescaledb_config.bgw_policy_drop_chunks) p
+        UNION SELECT job_id, hypertable_id FROM _timescaledb_config.bgw_policy_drop_chunks
+        UNION SELECT job_id, hypertable_id FROM _timescaledb_config.bgw_policy_compress_chunks
+        UNION SELECT job_id, raw_hypertable_id FROM _timescaledb_catalog.continuous_agg) p
     INNER JOIN _timescaledb_catalog.hypertable ht ON p.hypertable_id = ht.id
     INNER JOIN _timescaledb_config.bgw_job j ON p.job_id = j.id
     INNER JOIN _timescaledb_internal.bgw_job_stat js on p.job_id = js.job_id


### PR DESCRIPTION
Add the compression and continuous aggs job types to the
timescaledb_information.policy_stats view. It is a bug
that it wasn't there before.