### PR TITLE
Fix bug with parent table in decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ that a backfill can trigger. By default, all invalidations are processed.
 * #1606 Fix constify params during runtime exclusion
 * #1607 Delete compression policy when drop hypertable
 * #1608 Add jobs to timescaledb_information.policy_stats
+* #1609 Fix bug with parent table in decompression 
 
 **Thanks**
 * @optijon for reporting an issue with locf treat_null_as_missing option

--- a/src/planner.c
+++ b/src/planner.c
@@ -563,7 +563,7 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 		Cache *hcache = ts_hypertable_cache_pin();
 		Hypertable *ht = ts_hypertable_cache_get_entry(hcache, ht_oid);
 
-		if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION(ht))
+		if (ht != NULL && ht_oid != rte->relid && TS_HYPERTABLE_HAS_COMPRESSION(ht))
 		{
 			Chunk *chunk = ts_chunk_get_by_relid(rte->relid, 0, true);
 

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -41,6 +41,11 @@ insert into foo values( 30 , 12 , 20, NULL);
 alter table foo set (timescaledb.compress, timescaledb.compress_segmentby = 'a,b', timescaledb.compress_orderby = 'c desc, d asc nulls last');
 NOTICE:  adding index _compressed_hypertable_2_a__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(a, _ts_meta_sequence_num)
 NOTICE:  adding index _compressed_hypertable_2_b__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(b, _ts_meta_sequence_num)
+--test self-refencing updates
+SET timescaledb.enable_transparent_decompression to ON;
+update foo set c = 40
+where  a = (SELECT max(a) FROM foo);
+SET timescaledb.enable_transparent_decompression to OFF;
 select id, schema_name, table_name, compressed, compressed_hypertable_id from
 _timescaledb_catalog.hypertable order by id;
  id |      schema_name      |        table_name        | compressed | compressed_hypertable_id 

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -19,6 +19,13 @@ insert into foo values( 20 , 11 , 20, NULL);
 insert into foo values( 30 , 12 , 20, NULL);
 
 alter table foo set (timescaledb.compress, timescaledb.compress_segmentby = 'a,b', timescaledb.compress_orderby = 'c desc, d asc nulls last');
+
+--test self-refencing updates
+SET timescaledb.enable_transparent_decompression to ON;
+update foo set c = 40
+where  a = (SELECT max(a) FROM foo);
+SET timescaledb.enable_transparent_decompression to OFF;
+
 select id, schema_name, table_name, compressed, compressed_hypertable_id from
 _timescaledb_catalog.hypertable order by id;
 select * from _timescaledb_catalog.hypertable_compression order by hypertable_id, attname;


### PR DESCRIPTION
Fix bug with transparent decompression getting the
hypertable parent table. This can happen with self-referencing
updates.

Fixes #1555