### PR TITLE
Print notice for COPY TO on hypertable

### DIFF
--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -95,3 +95,17 @@ SELECT create_hypertable('hyper2', 'time', chunk_time_interval => 10);
 (1 row)
 
 \copy hyper2 from data/copy_data.csv with csv header ;
+----------------------------------------------------------------
+-- Testing COPY TO.
+----------------------------------------------------------------
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages TO NOTICE;
+-- COPY TO using a hypertable will not copy any tuples, but should
+-- show a notice.
+COPY hyper TO STDOUT DELIMITER ',';
+NOTICE:  hypertable data are in the chunks, no data will be copied
+-- COPY TO using a query should display all the tuples and not show a
+-- notice.
+COPY (SELECT * FROM hyper) TO STDOUT DELIMITER ',';
+1,1,1
+1,2,1

--- a/test/expected/metadata.out
+++ b/test/expected/metadata.out
@@ -79,6 +79,7 @@ SELECT _timescaledb_internal.test_install_timestamp() = :'timestamp_1' as timest
 
 -- Now make sure that only the exported_uuid is exported on pg_dump
 \c postgres :ROLE_SUPERUSER
+\setenv PGOPTIONS '--client-min-messages=warning'
 \! ${PG_BINDIR}/pg_dump -h ${TEST_PGHOST} -U super_user -Fc "${TEST_DBNAME}" > dump/instmeta.sql
 pg_dump: NOTICE: there are circular foreign-key constraints on this table:
 pg_dump:   hypertable

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -63,3 +63,17 @@ CREATE TABLE "hyper2" (
 SELECT create_hypertable('hyper2', 'time', chunk_time_interval => 10); 
 \copy hyper2 from data/copy_data.csv with csv header ;
 
+----------------------------------------------------------------
+-- Testing COPY TO.
+----------------------------------------------------------------
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages TO NOTICE;
+
+-- COPY TO using a hypertable will not copy any tuples, but should
+-- show a notice.
+COPY hyper TO STDOUT DELIMITER ',';
+
+-- COPY TO using a query should display all the tuples and not show a
+-- notice.
+COPY (SELECT * FROM hyper) TO STDOUT DELIMITER ',';

--- a/test/sql/metadata.sql
+++ b/test/sql/metadata.sql
@@ -36,6 +36,7 @@ SELECT _timescaledb_internal.test_install_timestamp() = :'timestamp_1' as timest
 -- Now make sure that only the exported_uuid is exported on pg_dump
 \c postgres :ROLE_SUPERUSER
 
+\setenv PGOPTIONS '--client-min-messages=warning'
 \! ${PG_BINDIR}/pg_dump -h ${TEST_PGHOST} -U super_user -Fc "${TEST_DBNAME}" > dump/instmeta.sql
 \! ${PG_BINDIR}/dropdb -h ${TEST_PGHOST} -U super_user "${TEST_DBNAME}"
 \! ${PG_BINDIR}/createdb -h ${TEST_PGHOST} -U super_user "${TEST_DBNAME}"

--- a/test/sql/utils/pg_dump_aux_dump.sh
+++ b/test/sql/utils/pg_dump_aux_dump.sh
@@ -1,4 +1,7 @@
+export PGOPTIONS
+
 DUMPFILE=$1
+PGOPTIONS='--client-min-messages=warning'
 
 ${PG_BINDIR}/pg_dump -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -Fc ${TEST_DBNAME} > ${DUMPFILE}
 ${PG_BINDIR}/dropdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} ${TEST_DBNAME}

--- a/test/sql/utils/pg_dump_unprivileged.sh
+++ b/test/sql/utils/pg_dump_unprivileged.sh
@@ -1,3 +1,6 @@
+export PGOPTIONS
+PGOPTIONS='--client-min-messages=warning'
+
 ${PG_BINDIR}/pg_dump -h ${PGHOST} -U dump_unprivileged dump_unprivileged > /dev/null
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
When using `COPY TO` on a hypertable (which copies from the hypertable
to some other destination), nothing will be printed and nothing will be
copied. Since this can be potentially confusing for users, this commit
print a notice when an attempt is made to copy from a hypertable
directly (not using a query) to some other destination.

First part of fix for timescaledb/timescaledb-private#461. Need to be implemented for distributed hypertables as well.