### PR TITLE
Remove -Wdeclaration-after-statement from PG_CFLAGS

### DIFF
--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -3,6 +3,12 @@ if(NOT USE_DEFAULT_VISIBILITY)
   set(CMAKE_C_VISIBILITY_PRESET "hidden")
 endif()
 
+# postgres CFLAGS includes -Wdeclaration-after-statement which leads
+# to problems when compiling with -Werror since we aim for C99 and allow
+# that so we strip this flag from PG_CFLAGS before adding postgres flags
+# to our own
+string(REPLACE "-Wdeclaration-after-statement" "" PG_CFLAGS "${PG_CFLAGS}")
+
 if(UNIX)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${PG_LIBDIR}")

--- a/tsl/src/build-defs.cmake
+++ b/tsl/src/build-defs.cmake
@@ -1,6 +1,12 @@
 # Hide symbols by default in shared libraries
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
 
+# postgres CFLAGS includes -Wdeclaration-after-statement which leads
+# to problems when compiling with -Werror since we aim for C99 and allow
+# that so we strip this flag from PG_CFLAGS before adding postgres flags
+# to our own
+string(REPLACE "-Wdeclaration-after-statement" "" PG_CFLAGS "${PG_CFLAGS}")
+
 if (UNIX)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${PG_LIBDIR}")


### PR DESCRIPTION
Postgres CFLAGS includes -Wdeclaration-after-statement which leads
to problems when compiling with -Werror since we aim for C99 and allow
that so we strip this flag from PG_CFLAGS before adding postgres flags
to our own