### PR TITLE
Add CODEOWNERS file to auto-assign reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @timescale/database-eng


### PR DESCRIPTION
A `CODEOWNERS` file allows assigning default reviewers for a branch,
obviating the need to add reviewers manually.