### PR TITLE
Drop chunks for materialized hypertable

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -140,6 +140,11 @@ ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum, Datum newer_tha
 						Oid older_than_type, Oid newer_than_type, bool cascade,
 						CascadeToMaterializationOption cascades_to_materializations,
 						int32 log_level);
+extern TSDLLEXPORT Chunk *
+ts_chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum newer_than_datum,
+								  Oid older_than_type, Oid newer_than_type, char *caller_name,
+								  MemoryContext mctx, uint64 *num_chunks_returned,
+								  bool include_chunks_marked_as_dropped);
 
 extern bool TSDLLEXPORT ts_chunk_contains_compressed_data(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_has_associated_compressed_chunk(int32 chunk_id);

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -61,8 +61,6 @@ typedef struct ContinuousAggMatOptions
 
 extern TSDLLEXPORT ContinuousAggHypertableStatus
 ts_continuous_agg_hypertable_status(int32 hypertable_id);
-extern void ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks,
-													  Size num_chunks);
 extern TSDLLEXPORT List *ts_continuous_aggs_find_by_raw_table_id(int32 raw_hypertable_id);
 extern TSDLLEXPORT int64 ts_continuous_aggs_max_ignore_invalidation_older_than(
 	int32 raw_hypertable_id, FormData_continuous_agg *entry);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -345,7 +345,9 @@ continuous_agg_update_options_default(ContinuousAgg *cagg, WithClauseResult *wit
 
 static void
 continuous_agg_drop_chunks_by_chunk_id_default(int32 raw_hypertable_id, Chunk **chunks,
-											   Size num_chunks)
+											   Size num_chunks, Datum older_than_datum,
+											   Datum newer_than_datum, Oid older_than_type,
+											   Oid newer_than_type, bool cascade, int32 log_level)
 {
 	error_no_default_fn_community();
 }

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -67,7 +67,11 @@ typedef struct CrossModuleFunctions
 	bool (*process_cagg_viewstmt)(ViewStmt *stmt, const char *query_string, void *pstmt,
 								  WithClauseResult *with_clause_options);
 	void (*continuous_agg_drop_chunks_by_chunk_id)(int32 raw_hypertable_id, Chunk **chunks,
-												   Size num_chunks);
+												   Size num_chunks,
+
+												   Datum older_than_datum, Datum newer_than_datum,
+												   Oid older_than_type, Oid newer_than_type,
+												   bool cascade, int32 log_level);
 	PGFunction continuous_agg_trigfn;
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);

--- a/tsl/src/continuous_aggs/drop.h
+++ b/tsl/src/continuous_aggs/drop.h
@@ -10,7 +10,12 @@
 
 #include <chunk.h>
 
-extern void ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks,
-													  Size num_chunks);
+extern void ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks_ptr,
+													  Size num_chunks,
+
+													  Datum older_than_datum,
+													  Datum newer_than_datum, Oid older_than_type,
+													  Oid newer_than_type, bool cascade,
+													  int32 log_level);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_DROP_H */

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -272,6 +272,7 @@ SELECT drop_chunks(
 INFO:  dropping chunk _timescaledb_internal._hyper_5_1_chunk
 INFO:  dropping chunk _timescaledb_internal._hyper_5_2_chunk
 INFO:  dropping chunk _timescaledb_internal._hyper_5_3_chunk
+INFO:  dropping chunk _timescaledb_internal._hyper_6_4_chunk
 ERROR:  cannot drop_chunks on a continuous aggregate materialization table
 \set ON_ERROR_STOP 1
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
@@ -576,14 +577,9 @@ DROP TABLE IF EXISTS drop_chunks_table_u CASCADE;
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_9_chunk
 CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
-SELECT hypertable_id AS drop_chunks_table_u_id
-    FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10);
+SELECT hypertable_id AS drop_chunks_table_nid
+    FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10) \gset
 NOTICE:  adding not-null constraint to column "time"
- drop_chunks_table_u_id 
-------------------------
-                     12
-(1 row)
-
 CREATE OR REPLACE FUNCTION integer_now_test2() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table $$;
 SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
  set_integer_now_func 
@@ -598,11 +594,11 @@ AS SELECT time_bucket('5', time), max(data)
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 13, cascade_to_materializations => false);
-ERROR:  older_than must be greater than the ignore_invalidation_older_than parameter of public.drop_chunks_view
+ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 ALTER VIEW drop_chunks_view SET (timescaledb.ignore_invalidation_older_than = 9);
 -- 9 is too small (less than timescaledb.ignore_invalidation_older_than)
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-8), cascade_to_materializations => false);
-ERROR:  older_than must be greater than the ignore_invalidation_older_than parameter of public.drop_chunks_view
+ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 -- 10 works but we don't have the completion threshold far enough along
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
@@ -942,4 +938,113 @@ SELECT chunk_table, ranges FROM chunk_relation_size('drop_chunks_table');
  _timescaledb_internal._hyper_12_15_chunk | {"[20,30)"}
  _timescaledb_internal._hyper_12_19_chunk | {"[50,60)"}
 (2 rows)
+
+--test drop_chunks with cascade_to_materialization set to true (github 1644)
+-- This checks if chunks from mat. hypertable are actually dropped 
+-- and deletes data from chunks that cannot be dropped from that mat. hypertable.
+SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_tablen
+    FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
+    WHERE _timescaledb_catalog.continuous_agg.raw_hypertable_id = :drop_chunks_table_nid
+        AND _timescaledb_catalog.hypertable.id = _timescaledb_catalog.continuous_agg.mat_hypertable_id \gset
+SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() + 200, cascade_to_materializations => true);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_12_19_chunk
+ _timescaledb_internal._hyper_12_15_chunk
+(2 rows)
+
+SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
+ count 
+-------
+     0
+(1 row)
+
+SELECT set_chunk_time_interval('drop_chunks_table', 10);
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
+SELECT set_chunk_time_interval(:'drop_chunks_mat_tablen', 20);
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
+INSERT INTO drop_chunks_table SELECT generate_series(1,35), 100;
+update drop_chunks_table set data = 250 where time = 25;
+update drop_chunks_table set data = 290 where time = 29;
+REFRESH materialized view drop_chunks_view;
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 35
+INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
+REFRESH materialized view drop_chunks_view;
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 35
+INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
+--now we have chunks in both mat and raw hypertables
+select * from drop_chunks_view order by 1;
+ time_bucket | max 
+-------------+-----
+           0 | 100
+           5 | 100
+          10 | 100
+          15 | 100
+          20 | 100
+          25 | 290
+          30 | 100
+          35 | 100
+(8 rows)
+
+SELECT chunk_table, ranges FROM chunk_relation_size('drop_chunks_table')
+ORDER BY ranges;
+               chunk_table                |   ranges    
+------------------------------------------+-------------
+ _timescaledb_internal._hyper_12_13_chunk | {"[0,10)"}
+ _timescaledb_internal._hyper_12_14_chunk | {"[10,20)"}
+ _timescaledb_internal._hyper_12_20_chunk | {"[20,30)"}
+ _timescaledb_internal._hyper_12_17_chunk | {"[30,40)"}
+(4 rows)
+
+SELECT chunk_table, ranges FROM chunk_relation_size(:'drop_chunks_mat_tablen')
+ORDER BY ranges;
+               chunk_table                |   ranges    
+------------------------------------------+-------------
+ _timescaledb_internal._hyper_13_21_chunk | {"[0,20)"}
+ _timescaledb_internal._hyper_13_22_chunk | {"[20,40)"}
+(2 rows)
+
+--1 chunk from the mat. hypertable will be dropped and the other will
+--need deletes when the chunks from the raw hypertable are dropped.
+SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() - 4 , cascade_to_materializations => true);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_12_13_chunk
+ _timescaledb_internal._hyper_12_14_chunk
+ _timescaledb_internal._hyper_12_20_chunk
+(3 rows)
+
+SELECT * from drop_chunks_view ORDER BY 1;
+ time_bucket | max 
+-------------+-----
+          30 | 100
+          35 | 100
+(2 rows)
+
+SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
+ count 
+-------
+     1
+(1 row)
+
+SELECT chunk_table, ranges FROM chunk_relation_size(:'drop_chunks_mat_tablen')
+ORDER BY ranges;
+               chunk_table                |   ranges    
+------------------------------------------+-------------
+ _timescaledb_internal._hyper_13_22_chunk | {"[20,40)"}
+(1 row)
 

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -272,6 +272,7 @@ SELECT drop_chunks(
 INFO:  dropping chunk _timescaledb_internal._hyper_5_1_chunk
 INFO:  dropping chunk _timescaledb_internal._hyper_5_2_chunk
 INFO:  dropping chunk _timescaledb_internal._hyper_5_3_chunk
+INFO:  dropping chunk _timescaledb_internal._hyper_6_4_chunk
 ERROR:  cannot drop_chunks on a continuous aggregate materialization table
 \set ON_ERROR_STOP 1
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
@@ -576,14 +577,9 @@ DROP TABLE IF EXISTS drop_chunks_table_u CASCADE;
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_9_chunk
 CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
-SELECT hypertable_id AS drop_chunks_table_u_id
-    FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10);
+SELECT hypertable_id AS drop_chunks_table_nid
+    FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10) \gset
 NOTICE:  adding not-null constraint to column "time"
- drop_chunks_table_u_id 
-------------------------
-                     12
-(1 row)
-
 CREATE OR REPLACE FUNCTION integer_now_test2() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table $$;
 SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
  set_integer_now_func 
@@ -598,11 +594,11 @@ AS SELECT time_bucket('5', time), max(data)
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 13, cascade_to_materializations => false);
-ERROR:  older_than must be greater than the ignore_invalidation_older_than parameter of public.drop_chunks_view
+ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 ALTER VIEW drop_chunks_view SET (timescaledb.ignore_invalidation_older_than = 9);
 -- 9 is too small (less than timescaledb.ignore_invalidation_older_than)
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-8), cascade_to_materializations => false);
-ERROR:  older_than must be greater than the ignore_invalidation_older_than parameter of public.drop_chunks_view
+ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 -- 10 works but we don't have the completion threshold far enough along
 SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
@@ -942,4 +938,113 @@ SELECT chunk_table, ranges FROM chunk_relation_size('drop_chunks_table');
  _timescaledb_internal._hyper_12_15_chunk | {"[20,30)"}
  _timescaledb_internal._hyper_12_19_chunk | {"[50,60)"}
 (2 rows)
+
+--test drop_chunks with cascade_to_materialization set to true (github 1644)
+-- This checks if chunks from mat. hypertable are actually dropped 
+-- and deletes data from chunks that cannot be dropped from that mat. hypertable.
+SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_tablen
+    FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
+    WHERE _timescaledb_catalog.continuous_agg.raw_hypertable_id = :drop_chunks_table_nid
+        AND _timescaledb_catalog.hypertable.id = _timescaledb_catalog.continuous_agg.mat_hypertable_id \gset
+SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() + 200, cascade_to_materializations => true);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_12_19_chunk
+ _timescaledb_internal._hyper_12_15_chunk
+(2 rows)
+
+SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
+ count 
+-------
+     0
+(1 row)
+
+SELECT set_chunk_time_interval('drop_chunks_table', 10);
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
+SELECT set_chunk_time_interval(:'drop_chunks_mat_tablen', 20);
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
+INSERT INTO drop_chunks_table SELECT generate_series(1,35), 100;
+update drop_chunks_table set data = 250 where time = 25;
+update drop_chunks_table set data = 290 where time = 29;
+REFRESH materialized view drop_chunks_view;
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 35
+INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
+REFRESH materialized view drop_chunks_view;
+INFO:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 35
+INFO:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
+--now we have chunks in both mat and raw hypertables
+select * from drop_chunks_view order by 1;
+ time_bucket | max 
+-------------+-----
+           0 | 100
+           5 | 100
+          10 | 100
+          15 | 100
+          20 | 100
+          25 | 290
+          30 | 100
+          35 | 100
+(8 rows)
+
+SELECT chunk_table, ranges FROM chunk_relation_size('drop_chunks_table')
+ORDER BY ranges;
+               chunk_table                |   ranges    
+------------------------------------------+-------------
+ _timescaledb_internal._hyper_12_13_chunk | {"[0,10)"}
+ _timescaledb_internal._hyper_12_14_chunk | {"[10,20)"}
+ _timescaledb_internal._hyper_12_20_chunk | {"[20,30)"}
+ _timescaledb_internal._hyper_12_17_chunk | {"[30,40)"}
+(4 rows)
+
+SELECT chunk_table, ranges FROM chunk_relation_size(:'drop_chunks_mat_tablen')
+ORDER BY ranges;
+               chunk_table                |   ranges    
+------------------------------------------+-------------
+ _timescaledb_internal._hyper_13_21_chunk | {"[0,20)"}
+ _timescaledb_internal._hyper_13_22_chunk | {"[20,40)"}
+(2 rows)
+
+--1 chunk from the mat. hypertable will be dropped and the other will
+--need deletes when the chunks from the raw hypertable are dropped.
+SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() - 4 , cascade_to_materializations => true);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_12_13_chunk
+ _timescaledb_internal._hyper_12_14_chunk
+ _timescaledb_internal._hyper_12_20_chunk
+(3 rows)
+
+SELECT * from drop_chunks_view ORDER BY 1;
+ time_bucket | max 
+-------------+-----
+          30 | 100
+          35 | 100
+(2 rows)
+
+SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
+ count 
+-------
+     1
+(1 row)
+
+SELECT chunk_table, ranges FROM chunk_relation_size(:'drop_chunks_mat_tablen')
+ORDER BY ranges;
+               chunk_table                |   ranges    
+------------------------------------------+-------------
+ _timescaledb_internal._hyper_13_22_chunk | {"[20,40)"}
+(1 row)
 

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -272,6 +272,7 @@ SELECT drop_chunks(
 INFO:  dropping chunk _timescaledb_internal._hyper_5_1_chunk
 INFO:  dropping chunk _timescaledb_internal._hyper_5_2_chunk
 INFO:  dropping chunk _timescaledb_internal._hyper_5_3_chunk
+INFO:  dropping chunk _timescaledb_internal._hyper_6_4_chunk
 ERROR:  cannot drop_chunks on a continuous aggregate materialization table
 \set ON_ERROR_STOP 1
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;

--- a/tsl/test/sql/continuous_aggs_ddl.sql.in
+++ b/tsl/test/sql/continuous_aggs_ddl.sql.in
@@ -364,8 +364,8 @@ ALTER TABLE metrics set(timescaledb.compress);
 DROP TABLE IF EXISTS drop_chunks_table CASCADE;
 DROP TABLE IF EXISTS drop_chunks_table_u CASCADE;
 CREATE TABLE drop_chunks_table(time BIGINT, data INTEGER);
-SELECT hypertable_id AS drop_chunks_table_u_id
-    FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10);
+SELECT hypertable_id AS drop_chunks_table_nid
+    FROM create_hypertable('drop_chunks_table', 'time', chunk_time_interval => 10) \gset
 
 CREATE OR REPLACE FUNCTION integer_now_test2() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), bigint '0') FROM drop_chunks_table $$;
 SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
@@ -480,3 +480,37 @@ INSERT INTO drop_chunks_table VALUES (20, 20);
 SELECT * FROM drop_chunks_table WHERE time < (integer_now_test2()-9) ORDER BY time DESC;
 --should show chunk with old name and old ranges
 SELECT chunk_table, ranges FROM chunk_relation_size('drop_chunks_table');
+
+--test drop_chunks with cascade_to_materialization set to true (github 1644)
+-- This checks if chunks from mat. hypertable are actually dropped 
+-- and deletes data from chunks that cannot be dropped from that mat. hypertable.
+SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_tablen
+    FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
+    WHERE _timescaledb_catalog.continuous_agg.raw_hypertable_id = :drop_chunks_table_nid
+        AND _timescaledb_catalog.hypertable.id = _timescaledb_catalog.continuous_agg.mat_hypertable_id \gset
+
+SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() + 200, cascade_to_materializations => true);
+SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
+SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
+
+SELECT set_chunk_time_interval('drop_chunks_table', 10);
+SELECT set_chunk_time_interval(:'drop_chunks_mat_tablen', 20);
+INSERT INTO drop_chunks_table SELECT generate_series(1,35), 100;
+update drop_chunks_table set data = 250 where time = 25;
+update drop_chunks_table set data = 290 where time = 29;
+REFRESH materialized view drop_chunks_view;
+REFRESH materialized view drop_chunks_view;
+--now we have chunks in both mat and raw hypertables
+select * from drop_chunks_view order by 1;
+SELECT chunk_table, ranges FROM chunk_relation_size('drop_chunks_table')
+ORDER BY ranges;
+SELECT chunk_table, ranges FROM chunk_relation_size(:'drop_chunks_mat_tablen')
+ORDER BY ranges;
+--1 chunk from the mat. hypertable will be dropped and the other will
+--need deletes when the chunks from the raw hypertable are dropped.
+SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() - 4 , cascade_to_materializations => true);
+SELECT * from drop_chunks_view ORDER BY 1;
+SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
+SELECT chunk_table, ranges FROM chunk_relation_size(:'drop_chunks_mat_tablen')
+ORDER BY ranges;
+


### PR DESCRIPTION
When drop_chunks is called with cascade_to_materialization = true,
 the materialized data is deleted from the materialization
hypertable, but the chunks are not dropped. This fix drops chunks
if possible and deletes the data only if the materialized chunk
cannot be dropped (which is the case if the materialzied chunk
contains data from multiple raw chunks and some of the raw chunks
are not dropped).

Fixes #1644