### PR TITLE
Use timescaledb prefix for compression errors

### DIFF
--- a/src/compression_with_clause.c
+++ b/src/compression_with_clause.c
@@ -50,8 +50,9 @@ throw_segment_by_error(char *segment_by)
 {
 	ereport(ERROR,
 			(errcode(ERRCODE_SYNTAX_ERROR),
-			 errmsg("unable to parse the compress_segmentby option '%s'", segment_by),
-			 errhint("The compress_segmentby option should be a comma separated list of column "
+			 errmsg("unable to parse timescaledb.compress_segmentby option '%s'", segment_by),
+			 errhint("timescaledb.compress_segmentby option should be a comma separated list "
+					 "of column "
 					 "names.")));
 }
 
@@ -155,8 +156,9 @@ throw_order_by_error(char *order_by)
 {
 	ereport(ERROR,
 			(errcode(ERRCODE_SYNTAX_ERROR),
-			 errmsg("unable to parse the compress_orderby option '%s'", order_by),
-			 errhint("The compress_orderby option should be a comma separated list of column "
+			 errmsg("unable to parse timescaledb.compress_orderby option '%s'", order_by),
+			 errhint("timescaledb.compress_orderby option should be a comma separated list of "
+					 "column "
 					 "names with sort options. It is the same format as an ORDER BY clause.")));
 }
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2896,8 +2896,8 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 		if (parse_results[CompressEnabled].is_default)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("must set the 'compress' boolean option when setting compression "
-							"options")));
+					 errmsg("the option timescaledb.compress must be set to true to enable "
+							"compression")));
 	}
 	else
 		return false;

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -245,7 +245,8 @@ compresscolinfo_init(CompressColInfo *cc, Oid srctbl_relid, List *segmentby_cols
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("column %s in compress_segmentby list does not exist",
+					 errmsg("column \"%s\" specified in option timescaledb.compress_segmentby does "
+							"not exist",
 							NameStr(col->colname))));
 		}
 		segorder_colindex[col_attno - 1] = i++;
@@ -261,7 +262,7 @@ compresscolinfo_init(CompressColInfo *cc, Oid srctbl_relid, List *segmentby_cols
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("column %s in compress_orderby list does not exist",
+					 errmsg("column \"%s\" in option timescaledb.compress_orderby does not exist",
 							NameStr(col->colname))));
 		}
 		/* check if orderby_cols and segmentby_cols are distinct */
@@ -269,8 +270,8 @@ compresscolinfo_init(CompressColInfo *cc, Oid srctbl_relid, List *segmentby_cols
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-					 errmsg("cannot use the same column %s in compress_orderby and "
-							"compress_segmentby",
+					 errmsg("cannot use column \"%s\" in both timescaledb.compress_orderby and "
+							"timescaledb.compress_segmentby",
 							NameStr(col->colname))));
 		}
 		segorder_colindex[col_attno - 1] = i++;
@@ -766,7 +767,8 @@ validate_existing_constraints(Hypertable *ht, CompressColInfo *colinfo)
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("constraint %s requires column %s to be a segment_by "
+								 errmsg("constraint \"%s\" requires column \"%s\" to be a "
+										"timescaledb.compress_segmentby "
 										"column for compression",
 										NameStr(form->conname),
 										NameStr(col_def->attname)),
@@ -786,11 +788,13 @@ validate_existing_constraints(Hypertable *ht, CompressColInfo *colinfo)
 					if (col_def->segmentby_column_index < 1 && col_def->orderby_column_index < 1)
 						ereport(ERROR,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-								 errmsg("constraint %s requires column %s to be a segment_by or "
-										"order_by column for compression",
+								 errmsg("constraint \"%s\" requires column \"%s\" to be a "
+										"timescaledb.compress_segmentby or "
+										"timescaledb.compress_orderby column for compression",
 										NameStr(form->conname),
 										NameStr(col_def->attname)),
-								 errhint("Only segment by and order by columns can be used in "
+								 errhint("Only columns specified in timescaledb.compress_segmentby "
+										 "and timescaledb.compress_orderby can be used in "
 										 "constraints on hypertables that are compressed.")));
 				}
 			}
@@ -904,12 +908,14 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 		if (with_clause_options[CompressOrderBy].is_default && order_by_set)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("need to specify compress_orderby if it was previously set")));
+					 errmsg(
+						 "need to specify timescaledb.compress_orderby if it was previously set")));
 
 		if (with_clause_options[CompressSegmentBy].is_default && segment_by_set)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("need to specify compress_segmentby if it was previously set")));
+					 errmsg("need to specify timescaledb.compress_segmentby if it was previously "
+							"set")));
 	}
 
 	compresscolinfo_init(&compress_cols, ht->main_table_relid, segmentby_cols, orderby_cols);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -542,7 +542,7 @@ select create_hypertable( 'test_collation', 'time', chunk_time_interval=> '1 day
 \set ON_ERROR_STOP 0
 --forbid setting collation in compression ORDER BY clause. (parse error is fine)
 alter table test_collation set (timescaledb.compress, timescaledb.compress_segmentby='device_id, device_id_2', timescaledb.compress_orderby = 'val_1 COLLATE "POSIX", val2, time');
-ERROR:  unable to parse the compress_orderby option 'val_1 COLLATE "POSIX", val2, time'
+ERROR:  unable to parse timescaledb.compress_orderby option 'val_1 COLLATE "POSIX", val2, time'
 \set ON_ERROR_STOP 1
 alter table test_collation set (timescaledb.compress, timescaledb.compress_segmentby='device_id, device_id_2', timescaledb.compress_orderby = 'val_1, val_2, time');
 NOTICE:  adding index _compressed_hypertable_10_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_10 USING BTREE(device_id, _ts_meta_sequence_num)

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -29,9 +29,9 @@ NOTICE:  adding not-null constraint to column "a"
 
 insert into non_compressed values( 3 , 16 , 20, 4);
 ALTER TABLE foo2 set (timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
-ERROR:  must set the 'compress' boolean option when setting compression options
+ERROR:  the option timescaledb.compress must be set to true to enable compression
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
-ERROR:  cannot use the same column c in compress_orderby and compress_segmentby
+ERROR:  cannot use column "c" in both timescaledb.compress_orderby and timescaledb.compress_segmentby
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'd DESC');
 NOTICE:  adding index _compressed_hypertable_4_bacB toD__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(bacB toD, _ts_meta_sequence_num)
 NOTICE:  adding index _compressed_hypertable_4_c__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(c, _ts_meta_sequence_num)
@@ -78,7 +78,7 @@ NOTICE:  adding index _compressed_hypertable_10_bacB toD__ts_meta_sequence_num_i
 NOTICE:  adding index _compressed_hypertable_10_c__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_10 USING BTREE(c, _ts_meta_sequence_num)
 -- Negative test cases ---
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c');
-ERROR:  need to specify compress_orderby if it was previously set
+ERROR:  need to specify timescaledb.compress_orderby if it was previously set
 create table reserved_column_prefix (a integer, _ts_meta_foo integer, "bacB toD" integer, c integer, d integer);
 select table_name from create_hypertable('reserved_column_prefix', 'a', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "a"
@@ -114,49 +114,49 @@ select attname, attnotnull from pg_attribute where attrelid = (select oid from p
 (1 row)
 
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'd');
-ERROR:  column d in compress_segmentby list does not exist
+ERROR:  column "d" specified in option timescaledb.compress_segmentby does not exist
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'd');
-ERROR:  column d in compress_orderby list does not exist
+ERROR:  column "d" in option timescaledb.compress_orderby does not exist
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c desc nulls');
-ERROR:  unable to parse the compress_orderby option 'c desc nulls'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c desc nulls'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c desc nulls thirsty');
-ERROR:  unable to parse the compress_orderby option 'c desc nulls thirsty'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c desc nulls thirsty'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c climb nulls first');
-ERROR:  unable to parse the compress_orderby option 'c climb nulls first'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c climb nulls first'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c nulls first asC');
-ERROR:  unable to parse the compress_orderby option 'c nulls first asC'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c nulls first asC'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c desc nulls first asc');
-ERROR:  unable to parse the compress_orderby option 'c desc nulls first asc'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c desc nulls first asc'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c desc hurry');
-ERROR:  unable to parse the compress_orderby option 'c desc hurry'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c desc hurry'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c descend');
-ERROR:  unable to parse the compress_orderby option 'c descend'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c descend'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c; SELECT 1');
-ERROR:  unable to parse the compress_orderby option 'c; SELECT 1'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c; SELECT 1'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = '1,2');
-ERROR:  unable to parse the compress_orderby option '1,2'
+ERROR:  unable to parse timescaledb.compress_orderby option '1,2'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c + 1');
-ERROR:  unable to parse the compress_orderby option 'c + 1'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c + 1'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'random()');
-ERROR:  unable to parse the compress_orderby option 'random()'
+ERROR:  unable to parse timescaledb.compress_orderby option 'random()'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c LIMIT 1');
-ERROR:  unable to parse the compress_orderby option 'c LIMIT 1'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c LIMIT 1'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'c USING <');
-ERROR:  unable to parse the compress_orderby option 'c USING <'
+ERROR:  unable to parse timescaledb.compress_orderby option 'c USING <'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 't COLLATE "en_US"');
-ERROR:  unable to parse the compress_orderby option 't COLLATE "en_US"'
+ERROR:  unable to parse timescaledb.compress_orderby option 't COLLATE "en_US"'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'c asc' , timescaledb.compress_orderby = 'c');
-ERROR:  unable to parse the compress_segmentby option 'c asc'
+ERROR:  unable to parse timescaledb.compress_segmentby option 'c asc'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'c nulls last');
-ERROR:  unable to parse the compress_segmentby option 'c nulls last'
+ERROR:  unable to parse timescaledb.compress_segmentby option 'c nulls last'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'c + 1');
-ERROR:  unable to parse the compress_segmentby option 'c + 1'
+ERROR:  unable to parse timescaledb.compress_segmentby option 'c + 1'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'random()');
-ERROR:  unable to parse the compress_segmentby option 'random()'
+ERROR:  unable to parse timescaledb.compress_segmentby option 'random()'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'c LIMIT 1');
-ERROR:  unable to parse the compress_segmentby option 'c LIMIT 1'
+ERROR:  unable to parse timescaledb.compress_segmentby option 'c LIMIT 1'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_segmentby = 'c + b');
-ERROR:  unable to parse the compress_segmentby option 'c + b'
+ERROR:  unable to parse timescaledb.compress_segmentby option 'c + b'
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, p');
 ERROR:  invalid order by column type: could not identify an less-than operator for type point
 --should succeed
@@ -278,13 +278,13 @@ select table_name from create_hypertable('table_constr', 'timec', chunk_time_int
 (1 row)
 
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_segmentby = 'd');
-ERROR:  constraint table_constr_pkey requires column device_id to be a segment_by or order_by column for compression
+ERROR:  constraint "table_constr_pkey" requires column "device_id" to be a timescaledb.compress_segmentby or timescaledb.compress_orderby column for compression
 alter table table_constr add constraint table_constr_uk unique (location, timec, device_id);
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id');
-ERROR:  constraint table_constr_uk requires column location to be a segment_by or order_by column for compression
+ERROR:  constraint "table_constr_uk" requires column "location" to be a timescaledb.compress_segmentby or timescaledb.compress_orderby column for compression
 alter table table_constr add constraint table_constr_fk FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location');
-ERROR:  constraint table_constr_fk requires column d to be a segment_by column for compression
+ERROR:  constraint "table_constr_fk" requires column "d" to be a timescaledb.compress_segmentby column for compression
 --exclusion constraints not allowed
 alter table table_constr add constraint table_constr_exclu exclude using btree (timec with = );
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');


### PR DESCRIPTION
Modify compression parameter related error messages
to make them consistent.
Fixes #1642