### PR TITLE
Unify error message if hypertable not found

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1462,12 +1462,7 @@ ts_chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum
 	}
 	else
 	{
-		ht = ts_hypertable_cache_get_entry(hypertable_cache, table_relid);
-		if (!ht)
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("table \"%s\" does not exist or is not a hypertable",
-							get_rel_name(table_relid))));
+		ht = ts_hypertable_cache_get_entry(hypertable_cache, table_relid, false);
 		hypertables = list_make1(ht);
 	}
 
@@ -2321,11 +2316,7 @@ ts_chunk_drop_process_materialization(Oid hypertable_relid,
 				 errmsg("must use older_than parameter to drop_chunks with "
 						"cascade_to_materializations")));
 
-	hcache = ts_hypertable_cache_pin();
-	ht = ts_hypertable_cache_get_entry(hcache, hypertable_relid);
-	if (!ht)
-		elog(ERROR, "can only call drop_chunks on hypertables");
-
+	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_relid, false, &hcache);
 	time_dimension = hyperspace_get_open_dimension(ht->space, 0);
 	older_than_time = get_internal_time_from_endpoint_specifiers(ht->main_table_relid,
 																 time_dimension,

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -758,13 +758,7 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 
 	ts_hypertable_permissions_check(info.table_relid, GetUserId());
 
-	hcache = ts_hypertable_cache_pin();
-	ht = ts_hypertable_cache_get_entry(hcache, info.table_relid);
-
-	if (NULL == ht)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("table \"%s\" is not a hypertable", get_rel_name(info.table_relid))));
+	ht = ts_hypertable_cache_get_cache_and_entry(info.table_relid, false, &hcache);
 
 	/* Get the first open dimension that we will adapt on */
 	dim = ts_hyperspace_get_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);

--- a/src/chunk_dispatch_state.c
+++ b/src/chunk_dispatch_state.c
@@ -28,15 +28,7 @@ chunk_dispatch_begin(CustomScanState *node, EState *estate, int eflags)
 	Cache *hypertable_cache;
 	PlanState *ps;
 
-	hypertable_cache = ts_hypertable_cache_pin();
-
-	ht = ts_hypertable_cache_get_entry(hypertable_cache, state->hypertable_relid);
-
-	if (NULL == ht)
-	{
-		ts_cache_release(hypertable_cache);
-		elog(ERROR, "no hypertable for relid %d", state->hypertable_relid);
-	}
+	ht = ts_hypertable_cache_get_cache_and_entry(state->hypertable_relid, false, &hypertable_cache);
 	ps = ExecInitNode(state->subplan, estate, eflags);
 	state->hypertable_cache = hypertable_cache;
 	state->dispatch = ts_chunk_dispatch_create(ht, estate);

--- a/src/hypertable_cache.h
+++ b/src/hypertable_cache.h
@@ -12,7 +12,10 @@
 #include "cache.h"
 #include "hypertable.h"
 
-extern TSDLLEXPORT Hypertable *ts_hypertable_cache_get_entry(Cache *cache, Oid relid);
+extern TSDLLEXPORT Hypertable *ts_hypertable_cache_get_entry(Cache *cache, Oid relid,
+															 bool missing_ok);
+extern TSDLLEXPORT Hypertable *ts_hypertable_cache_get_cache_and_entry(Oid relid, bool missing_ok,
+																	   Cache **cache);
 extern Hypertable *ts_hypertable_cache_get_entry_rv(Cache *cache, RangeVar *rv);
 extern Hypertable *ts_hypertable_cache_get_entry_with_table(Cache *cache, Oid relid,
 															const char *schema, const char *table);

--- a/src/hypertable_insert.c
+++ b/src/hypertable_insert.c
@@ -212,7 +212,7 @@ ts_hypertable_insert_path_create(PlannerInfo *root, ModifyTablePath *mtpath)
 		Index rti = lfirst_int(lc_rel);
 		RangeTblEntry *rte = planner_rt_fetch(rti, root);
 
-		ht = ts_hypertable_cache_get_entry(hcache, rte->relid);
+		ht = ts_hypertable_cache_get_entry(hcache, rte->relid, true);
 
 		if (ht != NULL)
 		{

--- a/src/interval.c
+++ b/src/interval.c
@@ -101,17 +101,10 @@ ts_interval_from_sql_input(Oid relid, Datum interval, Oid interval_type, const c
 
 	ts_hypertable_permissions_check(relid, GetUserId());
 
-	hcache = ts_hypertable_cache_pin();
-	hypertable = ts_hypertable_cache_get_entry(hcache, relid);
-	/* First verify that the hypertable corresponds to a valid table */
-	if (hypertable == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("could not add drop_chunks policy because \"%s\" is not a hypertable",
-						get_rel_name(relid))));
+	hypertable = ts_hypertable_cache_get_cache_and_entry(relid, false, &hcache);
+
 	/* validate that the open dimension uses a time type */
 	open_dim = hyperspace_get_open_dimension(hypertable->space, 0);
-
 	if (NULL == open_dim)
 		elog(ERROR, "internal error: no open dimension found while parsing interval");
 

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -498,13 +498,7 @@ ts_tablespace_attach_internal(Name tspcname, Oid hypertable_oid, bool if_not_att
 							NameStr(*tspcname),
 							GetUserNameFromId(ownerid, true))));
 	}
-	hcache = ts_hypertable_cache_pin();
-	ht = ts_hypertable_cache_get_entry(hcache, hypertable_oid);
-
-	if (NULL == ht)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("table \"%s\" is not a hypertable", get_rel_name(hypertable_oid))));
+	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_oid, false, &hcache);
 
 	if (ts_hypertable_has_tablespace(ht, tspc_oid))
 	{
@@ -540,13 +534,7 @@ tablespace_detach_one(Oid hypertable_oid, const char *tspcname, Oid tspcoid, boo
 
 	ts_hypertable_permissions_check(hypertable_oid, GetUserId());
 
-	hcache = ts_hypertable_cache_pin();
-	ht = ts_hypertable_cache_get_entry(hcache, hypertable_oid);
-
-	if (NULL == ht)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("table \"%s\" is not a hypertable", get_rel_name(hypertable_oid))));
+	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_oid, false, &hcache);
 
 	if (ts_hypertable_has_tablespace(ht, tspcoid))
 		ret = ts_tablespace_delete(ht->fd.id, tspcname);
@@ -577,13 +565,7 @@ tablespace_detach_all(Oid hypertable_oid)
 
 	ts_hypertable_permissions_check(hypertable_oid, GetUserId());
 
-	hcache = ts_hypertable_cache_pin();
-	ht = ts_hypertable_cache_get_entry(hcache, hypertable_oid);
-
-	if (NULL == ht)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("table \"%s\" is not a hypertable", get_rel_name(hypertable_oid))));
+	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_oid, false, &hcache);
 
 	ret = ts_tablespace_delete(ht->fd.id, NULL);
 
@@ -668,12 +650,7 @@ ts_tablespace_show(PG_FUNCTION_ARGS)
 
 	funcctx = SRF_PERCALL_SETUP();
 	hcache = funcctx->user_fctx;
-	ht = ts_hypertable_cache_get_entry(hcache, hypertable_oid);
-
-	if (NULL == ht)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("table \"%s\" is not a hypertable", get_rel_name(hypertable_oid))));
+	ht = ts_hypertable_cache_get_entry(hcache, hypertable_oid, false);
 
 	tspcs = ts_tablespace_scan(ht->fd.id);
 

--- a/tsl/src/bgw_policy/compress_chunks_api.c
+++ b/tsl/src/bgw_policy/compress_chunks_api.c
@@ -80,10 +80,10 @@ compress_chunks_add_policy(PG_FUNCTION_ARGS)
 											older_than_type,
 											"older_than",
 											"compress_chunks_add_policy");
+
 	/* check if this is a table with compression enabled */
-	hcache = ts_hypertable_cache_pin();
-	hypertable = ts_hypertable_cache_get_entry(hcache, ht_oid);
-	if (!hypertable || !TS_HYPERTABLE_HAS_COMPRESSION(hypertable))
+	hypertable = ts_hypertable_cache_get_cache_and_entry(ht_oid, false, &hcache);
+	if (!TS_HYPERTABLE_HAS_COMPRESSION(hypertable))
 	{
 		ts_cache_release(hcache);
 		ereport(ERROR,

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -62,14 +62,7 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	ts_hypertable_permissions_check(ht_oid, GetUserId());
 
 	/* Make sure that an existing policy doesn't exist on this hypertable */
-	hcache = ts_hypertable_cache_pin();
-	hypertable = ts_hypertable_cache_get_entry(hcache, ht_oid);
-
-	if (NULL == hypertable)
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("\"%s\" is not a hypertable", get_rel_name(ht_oid)),
-				 errhint("add_drop_chunk_policy can only be used with hypertables.")));
+	hypertable = ts_hypertable_cache_get_cache_and_entry(ht_oid, false, &hcache);
 
 	if (hypertable->fd.compressed)
 		ereport(ERROR,

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -196,15 +196,7 @@ execute_drop_chunks_policy(int32 job_id)
 						job_id)));
 
 	table_relid = ts_hypertable_id_to_relid(args->hypertable_id);
-	hcache = ts_hypertable_cache_pin();
-	hypertable = ts_hypertable_cache_get_entry(hcache, table_relid);
-	/* First verify that the hypertable corresponds to a valid table */
-	if (hypertable == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("could not run drop_chunks policy #%d because \"%s\" is not a hypertable",
-						job_id,
-						get_rel_name(table_relid))));
+	hypertable = ts_hypertable_cache_get_cache_and_entry(table_relid, false, &hcache);
 
 	open_dim = hyperspace_get_open_dimension(hypertable->space, 0);
 	ts_chunk_do_drop_chunks(table_relid,
@@ -296,16 +288,7 @@ execute_compress_chunks_policy(BgwJob *job)
 						job_id)));
 
 	table_relid = ts_hypertable_id_to_relid(args->fd.hypertable_id);
-	hcache = ts_hypertable_cache_pin();
-	ht = ts_hypertable_cache_get_entry(hcache, table_relid);
-	/* First verify that the hypertable corresponds to a valid table */
-	if (ht == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("could not run compress_chunks policy #%d because \"%s\" is not a "
-						"hypertable",
-						job_id,
-						get_rel_name(table_relid))));
+	ht = ts_hypertable_cache_get_cache_and_entry(table_relid, false, &hcache);
 
 	chunkid = get_chunk_to_compress(ht, &args->fd.older_than);
 	if (chunkid == INVALID_CHUNK_ID)

--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -161,13 +161,10 @@ chunk_dml_trigger_drop(Oid relid)
 static void
 compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid, Oid chunk_relid)
 {
-	Hypertable *srcht = ts_hypertable_cache_get_entry(hcache, hypertable_relid);
+	Hypertable *srcht = ts_hypertable_cache_get_entry(hcache, hypertable_relid, false);
 	Hypertable *compress_ht;
 	Chunk *srcchunk;
-	if (srcht == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("table \"%s\" is not a hypertable", get_rel_name(hypertable_relid))));
+
 	ts_hypertable_permissions_check(srcht->main_table_relid, GetUserId());
 	if (!TS_HYPERTABLE_HAS_COMPRESSION(srcht))
 	{
@@ -250,18 +247,12 @@ static bool
 decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_relid,
 					  bool if_compressed)
 {
-	Cache *hcache = ts_hypertable_cache_pin();
+	Cache *hcache;
 	Hypertable *uncompressed_hypertable =
-		ts_hypertable_cache_get_entry(hcache, uncompressed_hypertable_relid);
+		ts_hypertable_cache_get_cache_and_entry(uncompressed_hypertable_relid, false, &hcache);
 	Hypertable *compressed_hypertable;
 	Chunk *uncompressed_chunk;
 	Chunk *compressed_chunk;
-
-	if (uncompressed_hypertable == NULL)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-				 errmsg("table \"%s\" is not a hypertable",
-						get_rel_name(uncompressed_hypertable_relid))));
 
 	ts_hypertable_permissions_check(uncompressed_hypertable->main_table_relid, GetUserId());
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -398,8 +398,8 @@ compresscolinfo_add_catalog_entries(CompressColInfo *compress_cols, int32 htid)
 static void
 create_compressed_table_indexes(Oid compresstable_relid, CompressColInfo *compress_cols)
 {
-	Cache *hcache = ts_hypertable_cache_pin();
-	Hypertable *ht = ts_hypertable_cache_get_entry(hcache, compresstable_relid);
+	Cache *hcache;
+	Hypertable *ht = ts_hypertable_cache_get_cache_and_entry(compresstable_relid, false, &hcache);
 	IndexStmt stmt = {
 		.type = T_IndexStmt,
 		.accessMethod = DEFAULT_INDEX_TYPE,

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -179,15 +179,7 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("\"%s\" is a compressed chunk", get_rel_name(chunk_id))));
 
-	hcache = ts_hypertable_cache_pin();
-	ht = ts_hypertable_cache_get_entry(hcache, chunk->hypertable_relid);
-	if (NULL == ht)
-	{
-		ts_cache_release(hcache);
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("cannot find hypertable for chunk \"%s\"", get_rel_name(chunk_id))));
-	}
+	ht = ts_hypertable_cache_get_cache_and_entry(chunk->hypertable_relid, false, &hcache);
 
 	/* Our check gives better error messages, but keep the original one too. */
 	ts_hypertable_permissions_check(ht->main_table_relid, GetUserId());

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -55,7 +55,7 @@ create  view mat_m1 WITH ( timescaledb.continuous)
 as
 select a, count(*) from mat_t1
 group by a;
-ERROR:  can create continuous aggregate only on hypertables
+ERROR:  table "mat_t1" is not a hypertable
 -- no group by
 create  view mat_m1 WITH ( timescaledb.continuous)
 as

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -531,7 +531,7 @@ CREATE TABLE non_hypertable(junk int, more_junk int);
 CREATE INDEX non_ht_index on non_hypertable(junk);
 \set ON_ERROR_STOP 0
 select add_drop_chunks_policy('non_hypertable', INTERVAL '2 month');
-ERROR:  "non_hypertable" is not a hypertable
+ERROR:  table "non_hypertable" is not a hypertable
 select add_reorder_policy('non_hypertable', 'non_ht_index');
 ERROR:  could not add reorder policy because "non_hypertable" is not a hypertable
 \set ON_ERROR_STOP 1

--- a/tsl/test/src/test_continuous_aggs.c
+++ b/tsl/test/src/test_continuous_aggs.c
@@ -45,9 +45,11 @@ ts_run_continuous_agg_materialization(PG_FUNCTION_ARGS)
 	};
 	int64 invalidation_threshold;
 	int64 completed_threshold;
-	Cache *hcache = ts_hypertable_cache_pin();
-	int32 hypertable_id = ts_hypertable_cache_get_entry(hcache, hypertable)->fd.id;
-	int32 materialization_id = ts_hypertable_cache_get_entry(hcache, materialization_table)->fd.id;
+	Cache *hcache;
+	int32 hypertable_id =
+		ts_hypertable_cache_get_cache_and_entry(hypertable, false, &hcache)->fd.id;
+	int32 materialization_id =
+		ts_hypertable_cache_get_entry(hcache, materialization_table, false)->fd.id;
 	ts_cache_release(hcache);
 
 	if (partial_view.name == NULL)

--- a/tsl/test/src/test_ddl_hook.c
+++ b/tsl/test/src/test_ddl_hook.c
@@ -57,8 +57,7 @@ test_ddl_command_start(ProcessUtilityArgs *args)
 	{
 		Oid relid = lfirst_oid(cell);
 
-		ht = ts_hypertable_cache_get_entry(hcache, relid);
-		Assert(ht != NULL);
+		ht = ts_hypertable_cache_get_entry(hcache, relid, false);
 
 		elog(NOTICE,
 			 "test_ddl_command_start: %s.%s",
@@ -91,8 +90,7 @@ test_ddl_command_end(EventTriggerData *command)
 	{
 		Oid relid = lfirst_oid(cell);
 
-		ht = ts_hypertable_cache_get_entry(hcache, relid);
-		Assert(ht != NULL);
+		ht = ts_hypertable_cache_get_entry(hcache, relid, false);
 
 		elog(NOTICE,
 			 "test_ddl_command_end: %s.%s",


### PR DESCRIPTION
Refactors multiple implementations of finding hypertables in cache
and failing with different error messages if not found. The
implementations are replaced with calling functions, which encapsulate
a single error message. This provides the unified error message and
removes need for copy-paste.

PR notes:
Closes https://github.com/timescale/timescaledb-private/issues/539
I am not sure if I gave good names to functions. Let me know if you have better suggestions.