### PR TITLE
Prevent deadlock in create_hypertable

### DIFF
--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -79,6 +79,7 @@ extern TSDLLEXPORT bool ts_hypertable_create_from_info(Oid table_relid, int32 hy
 extern TSDLLEXPORT bool ts_hypertable_create_compressed(Oid table_relid, int32 hypertable_id);
 extern TSDLLEXPORT Hypertable *ts_hypertable_get_by_id(int32 hypertable_id);
 extern Hypertable *ts_hypertable_get_by_name(char *schema, char *name);
+extern List *ts_hypertable_get_and_lock_referenced_tables(Oid table_relid, LOCKMODE lockmode);
 extern bool ts_hypertable_has_privs_of(Oid hypertable_oid, Oid userid);
 extern TSDLLEXPORT Oid ts_hypertable_permissions_check(Oid hypertable_oid, Oid userid);
 


### PR DESCRIPTION
The table, which is transformed into hypertable by create_hypertable,
can have foreign key constraints to other tables. If an application
tries to insert data into both a referenced table and the future
hypertable in the same transaction, it results into a deadlock, since
create_hypertable locks the future hypertable, while transforming it
and migrating existing data into chunks. This commit adds locks on the
referenced tables to prevent from the deadlock.
Fixes #1652.

PR note:
A test will be added as a separate PR.