### PR TITLE
Improve time_bucket_gapfill optimizations

### DIFF
--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -1605,17 +1605,18 @@ SELECT
   interpolate(avg(v1)) AS interpolate_v1,
   interpolate(avg(v2)) AS interpolate_v2
 FROM metrics_tstz
-GROUP BY 1,2;
+GROUP BY 1,2
+ORDER BY 1,2;
      time_bucket_gapfill      | device_id | locf_v1 | locf_v2 | interpolate_v1 | interpolate_v2 
 ------------------------------+-----------+---------+---------+----------------+----------------
  Mon Jan 01 05:00:00 2018 PST |         1 |     0.5 |      10 |            0.5 |             10
- Mon Jan 01 06:00:00 2018 PST |         1 |     0.5 |      10 |           0.25 |              5
- Mon Jan 01 07:00:00 2018 PST |         1 |       0 |       0 |              0 |              0
  Mon Jan 01 05:00:00 2018 PST |         2 |     0.7 |      20 |            0.7 |             20
- Mon Jan 01 06:00:00 2018 PST |         2 |     0.7 |      20 |           1.05 |             30
- Mon Jan 01 07:00:00 2018 PST |         2 |     1.4 |      40 |            1.4 |             40
  Mon Jan 01 05:00:00 2018 PST |         3 |     0.9 |      30 |            0.9 |             30
+ Mon Jan 01 06:00:00 2018 PST |         1 |     0.5 |      10 |           0.25 |              5
+ Mon Jan 01 06:00:00 2018 PST |         2 |     0.7 |      20 |           1.05 |             30
  Mon Jan 01 06:00:00 2018 PST |         3 |     0.9 |      30 |            0.9 |             30
+ Mon Jan 01 07:00:00 2018 PST |         1 |       0 |       0 |              0 |              0
+ Mon Jan 01 07:00:00 2018 PST |         2 |     1.4 |      40 |            1.4 |             40
  Mon Jan 01 07:00:00 2018 PST |         3 |     0.9 |      30 |            0.9 |             30
 (9 rows)
 
@@ -1634,6 +1635,21 @@ FROM metrics_tstz WHERE time < '2017-01-01' GROUP BY 1;
  Sun Jan 01 16:00:00 2017 PST |  1.66666666666667
 (3 rows)
 
+SELECT
+  time_bucket_gapfill('12h'::interval,time,'2017-01-01'::timestamptz, '2017-01-02'::timestamptz),
+  interpolate(
+    avg(v1),
+    (SELECT ('2017-01-01'::timestamptz,1::float)),
+    (SELECT ('2017-01-02'::timestamptz,2::float))
+  )
+FROM metrics_tstz WHERE time_bucket_gapfill('12h'::interval,time,'2017-01-01'::timestamptz, '2017-01-02'::timestamptz) < '2017-01-01' GROUP BY 1;
+     time_bucket_gapfill      |    interpolate    
+------------------------------+-------------------
+ Sat Dec 31 16:00:00 2016 PST | 0.666666666666667
+ Sun Jan 01 04:00:00 2017 PST |  1.16666666666667
+ Sun Jan 01 16:00:00 2017 PST |  1.66666666666667
+(3 rows)
+
 -- interpolation with correlated subquery lookup before interval
 SELECT
   time_bucket_gapfill('1h'::interval,time,'2018-01-01 3:00 PST'::timestamptz, '2018-01-01 8:00 PST'::timestamptz),
@@ -1644,7 +1660,7 @@ SELECT
   ),
   avg(v1)
 FROM metrics_tstz m1
-WHERE device_id=1 GROUP BY 1,2;
+WHERE device_id=1 GROUP BY 1,2 ORDER BY 1,2;
      time_bucket_gapfill      | device_id | interpolate | avg 
 ------------------------------+-----------+-------------+-----
  Mon Jan 01 03:00:00 2018 PST |         1 |         0.5 |    
@@ -1662,7 +1678,7 @@ SELECT
     avg(v1),
     next=>(SELECT (time,v2::float) FROM metrics_tstz m2 WHERE m1.device_id=m2.device_id ORDER BY time LIMIT 1)
   ),avg(v1)
-FROM metrics_tstz m1 WHERE device_id=1 GROUP BY 1,2;
+FROM metrics_tstz m1 WHERE device_id=1 GROUP BY 1,2 ORDER BY 1,2;
      time_bucket_gapfill      | device_id | interpolate | avg 
 ------------------------------+-----------+-------------+-----
  Mon Jan 01 05:00:00 2018 PST |         1 |         0.5 | 0.5

--- a/tsl/test/expected/plan_gapfill-10.out
+++ b/tsl/test/expected/plan_gapfill-10.out
@@ -231,3 +231,91 @@ LIMIT 1;
  Mon Jan 01 00:00:00 2018 PST |           1
 (1 row)
 
+-- test sort optimizations
+-- test sort optimization with single member order by,
+-- should use index scan (no GapFill node for this one since we're not gapfilling)
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on gapfill_plan_test
+   Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+   ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+   ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+   ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(6 rows)
+
+SET max_parallel_workers_per_gather TO 0;
+-- test sort optimizations with locf
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), locf(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time"))
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+-- test sort optimizations with interpolate
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time"))
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+RESET max_parallel_workers_per_gather;
+CREATE INDEX ON gapfill_plan_test(value, time);
+-- test sort optimization with ordering by multiple columns and time_bucket_gapfill not last,
+-- must not use index scan
+:EXPLAIN  SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1,2;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone)), _hyper_1_1_chunk.value
+   ->  Result
+         ->  Append
+               ->  Seq Scan on _hyper_1_1_chunk
+               ->  Seq Scan on _hyper_1_2_chunk
+               ->  Seq Scan on _hyper_1_3_chunk
+               ->  Seq Scan on _hyper_1_4_chunk
+(8 rows)
+
+-- test sort optimization with ordering by multiple columns and time_bucket as last member,
+-- should use index scan
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 2,1;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   ->  Merge Append
+         Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+(7 rows)
+

--- a/tsl/test/expected/plan_gapfill-11.out
+++ b/tsl/test/expected/plan_gapfill-11.out
@@ -231,3 +231,91 @@ LIMIT 1;
  Mon Jan 01 00:00:00 2018 PST |           1
 (1 row)
 
+-- test sort optimizations
+-- test sort optimization with single member order by,
+-- should use index scan (no GapFill node for this one since we're not gapfilling)
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on gapfill_plan_test
+   Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+   ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+   ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+   ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(6 rows)
+
+SET max_parallel_workers_per_gather TO 0;
+-- test sort optimizations with locf
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), locf(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+-- test sort optimizations with interpolate
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+RESET max_parallel_workers_per_gather;
+CREATE INDEX ON gapfill_plan_test(value, time);
+-- test sort optimization with ordering by multiple columns and time_bucket_gapfill not last,
+-- must not use index scan
+:EXPLAIN  SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1,2;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone)), _hyper_1_1_chunk.value
+   ->  Result
+         ->  Append
+               ->  Seq Scan on _hyper_1_1_chunk
+               ->  Seq Scan on _hyper_1_2_chunk
+               ->  Seq Scan on _hyper_1_3_chunk
+               ->  Seq Scan on _hyper_1_4_chunk
+(8 rows)
+
+-- test sort optimization with ordering by multiple columns and time_bucket as last member,
+-- should use index scan
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 2,1;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   ->  Merge Append
+         Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+(7 rows)
+

--- a/tsl/test/expected/plan_gapfill-12.out
+++ b/tsl/test/expected/plan_gapfill-12.out
@@ -231,3 +231,91 @@ LIMIT 1;
  Mon Jan 01 00:00:00 2018 PST |           1
 (1 row)
 
+-- test sort optimizations
+-- test sort optimization with single member order by,
+-- should use index scan (no GapFill node for this one since we're not gapfilling)
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on gapfill_plan_test
+   Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+   ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+   ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+   ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(6 rows)
+
+SET max_parallel_workers_per_gather TO 0;
+-- test sort optimizations with locf
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), locf(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+-- test sort optimizations with interpolate
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                                                                  QUERY PLAN                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+RESET max_parallel_workers_per_gather;
+CREATE INDEX ON gapfill_plan_test(value, time);
+-- test sort optimization with ordering by multiple columns and time_bucket_gapfill not last,
+-- must not use index scan
+:EXPLAIN  SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1,2;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone)), _hyper_1_1_chunk.value
+   ->  Result
+         ->  Append
+               ->  Seq Scan on _hyper_1_1_chunk
+               ->  Seq Scan on _hyper_1_2_chunk
+               ->  Seq Scan on _hyper_1_3_chunk
+               ->  Seq Scan on _hyper_1_4_chunk
+(8 rows)
+
+-- test sort optimization with ordering by multiple columns and time_bucket as last member,
+-- should use index scan
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 2,1;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   ->  Merge Append
+         Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+(7 rows)
+

--- a/tsl/test/expected/plan_gapfill-9.6.out
+++ b/tsl/test/expected/plan_gapfill-9.6.out
@@ -113,20 +113,18 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
-   ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
-         ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
-               ->  Result
-                     ->  Append
-                           ->  Seq Scan on _hyper_1_1_chunk
-                           ->  Seq Scan on _hyper_1_2_chunk
-                           ->  Seq Scan on _hyper_1_3_chunk
-                           ->  Seq Scan on _hyper_1_4_chunk
-(11 rows)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time"))
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
 
 -- test parallel query with locf
 :EXPLAIN
@@ -136,20 +134,18 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
-   ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
-         ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
-               ->  Result
-                     ->  Append
-                           ->  Seq Scan on _hyper_1_1_chunk
-                           ->  Seq Scan on _hyper_1_2_chunk
-                           ->  Seq Scan on _hyper_1_3_chunk
-                           ->  Seq Scan on _hyper_1_4_chunk
-(11 rows)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time"))
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
 
 -- test parallel query with interpolate
 :EXPLAIN
@@ -159,20 +155,18 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
-   ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
-         ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
-               ->  Result
-                     ->  Append
-                           ->  Seq Scan on _hyper_1_1_chunk
-                           ->  Seq Scan on _hyper_1_2_chunk
-                           ->  Seq Scan on _hyper_1_3_chunk
-                           ->  Seq Scan on _hyper_1_4_chunk
-(11 rows)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time"))
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
 
 -- make sure we can run gapfill in parallel workers
 -- ensure this plan runs in parallel
@@ -214,4 +208,92 @@ LIMIT 1;
 ------------------------------+-------------
  Mon Jan 01 00:00:00 2018 PST |           1
 (1 row)
+
+-- test sort optimizations
+-- test sort optimization with single member order by,
+-- should use index scan (no GapFill node for this one since we're not gapfilling)
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on gapfill_plan_test
+   Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time", NULL::timestamp with time zone, NULL::timestamp with time zone)
+   ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+   ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+   ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+   ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(6 rows)
+
+SET max_parallel_workers_per_gather TO 0;
+-- test sort optimizations with locf
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), locf(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time"))
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+-- test sort optimizations with interpolate
+:EXPLAIN SELECT time_bucket_gapfill('5m',time,to_timestamp(0),to_timestamp(0)), interpolate(avg(value))
+FROM gapfill_plan_test
+GROUP BY 1
+ORDER BY 1;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  GroupAggregate
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time"))
+         ->  Custom Scan (ChunkAppend) on gapfill_plan_test
+               Order: time_bucket_gapfill('@ 5 mins'::interval, gapfill_plan_test."time")
+               ->  Index Scan Backward using _hyper_1_1_chunk_gapfill_plan_test_time_idx on _hyper_1_1_chunk
+               ->  Index Scan Backward using _hyper_1_2_chunk_gapfill_plan_test_time_idx on _hyper_1_2_chunk
+               ->  Index Scan Backward using _hyper_1_3_chunk_gapfill_plan_test_time_idx on _hyper_1_3_chunk
+               ->  Index Scan Backward using _hyper_1_4_chunk_gapfill_plan_test_time_idx on _hyper_1_4_chunk
+(9 rows)
+
+RESET max_parallel_workers_per_gather;
+CREATE INDEX ON gapfill_plan_test(value, time);
+-- test sort optimization with ordering by multiple columns and time_bucket_gapfill not last,
+-- must not use index scan
+:EXPLAIN  SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 1,2;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone)), _hyper_1_1_chunk.value
+   ->  Result
+         ->  Append
+               ->  Seq Scan on _hyper_1_1_chunk
+               ->  Seq Scan on _hyper_1_2_chunk
+               ->  Seq Scan on _hyper_1_3_chunk
+               ->  Seq Scan on _hyper_1_4_chunk
+(8 rows)
+
+-- test sort optimization with ordering by multiple columns and time_bucket as last member,
+-- should use index scan
+:EXPLAIN SELECT time_bucket_gapfill('5m',time),value
+FROM gapfill_plan_test
+ORDER BY 2,1;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   ->  Merge Append
+         Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
+         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+(7 rows)
 


### PR DESCRIPTION
This commit adds the optimization pushing down sort orders to the underlying time column to `time_bucket_gapfill`. This is made slightly more invasive by the fact that `time_bucket_gapfill` is marked as `VOLATILE` (to prevent postgres from moving it in inappropriate ways) so we much manually fix up orderings ourselves.

This PR requires @svenklemm's review, as he wrote the gapfill code, and @cevian is marked as he requested the feature