### PR TITLE
Real-time support for continuous aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
-## latest
+## 1.7.0 (unreleased)
 
 **Major Features**
+* #1685 Add real-time support to continuous aggregates
 
 **Minor Features**
 

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -25,6 +25,7 @@ typedef enum ContinuousAggViewOption
 	ContinuousViewOptionMaxIntervalPerRun,
 	ContinuousViewOptionCreateGroupIndex,
 	ContinuousViewOptionIgnoreInvalidationOlderThan,
+	ContinuousViewOptionMaterializedOnly,
 } ContinuousAggViewOption;
 
 typedef enum ContinuousAggViewType

--- a/tsl/src/continuous_aggs/create.h
+++ b/tsl/src/continuous_aggs/create.h
@@ -9,10 +9,14 @@
 #include <nodes/parsenodes.h>
 
 #include "with_clause_parser.h"
+#include "continuous_agg.h"
 
 #define CONTINUOUS_AGG_CHUNK_ID_COL_NAME "chunk_id"
 
 bool tsl_process_continuous_agg_viewstmt(ViewStmt *stmt, const char *query_string, void *pstmt,
 										 WithClauseResult *with_clause_options);
+
+void cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht,
+								 WithClauseResult *with_clause_options);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_CREATE_H */

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -461,7 +461,7 @@ ROLLBACK;
 DROP VIEW dependent_1;
 --create a cont agg view on the ht as well then the drop should nuke everything
 SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
-CREATE VIEW test1_cont_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
+CREATE VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1
    GROUP BY 1;

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -43,7 +43,7 @@ SELECT set_integer_now_func('foo', 'integer_now_foo');
 (1 row)
 
 create or replace view mat_m1( a, countb )
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select a, count(b)
 from foo
@@ -117,7 +117,7 @@ insert into conditions values ( '2010-01-02 09:00:00-08', 'NYC', 65, 45);
 insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 35);
 insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 35, 15);
 create or replace view mat_m1( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -190,7 +190,7 @@ insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 35);
 insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 35, 15);
 insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', 35, 25);
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -244,7 +244,7 @@ order by time_bucket('1week', timec);
 drop view mat_m1 cascade;
 NOTICE:  drop cascades to 2 other objects
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -298,7 +298,7 @@ order by time_bucket('1week', timec);
 drop view mat_m1 cascade;
 NOTICE:  drop cascades to 2 other objects
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -373,7 +373,7 @@ select generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timest
 --drop view mat_m1 cascade;
 --naming with AS clauses
 create or replace view mat_naming
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
@@ -408,7 +408,7 @@ order by attnum, attname;
 DROP VIEW mat_naming CASCADE;
 --naming with default names
 create or replace view mat_naming
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
@@ -443,7 +443,7 @@ order by attnum, attname;
 DROP VIEW mat_naming CASCADE;
 --naming with view col names
 create or replace view mat_naming (bucket, loc, sum_t_h, stdd)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
@@ -477,7 +477,7 @@ order by attnum, attname;
 
 DROP VIEW mat_naming CASCADE;
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -728,7 +728,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 
 --no data in hyper table on purpose so that CASCADE is not required because of chunks
 create or replace view mat_drop_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -857,7 +857,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 (1 row)
 
 create or replace view mat_with_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -907,7 +907,7 @@ order by indexname;
 drop view mat_with_test cascade;
 --no additional indexes
 create or replace view mat_with_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h', timescaledb.create_group_indexes=false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h', timescaledb.create_group_indexes=false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -948,7 +948,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_conditions');
 (1 row)
 
 create or replace view mat_with_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '500', timescaledb.refresh_interval = '2h')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '500', timescaledb.refresh_interval = '2h')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -1008,7 +1008,7 @@ SELECT set_integer_now_func('space_table', 'integer_now_space_table');
 (1 row)
 
 CREATE VIEW space_view
-WITH (timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.refresh_interval = '72h')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-2', timescaledb.refresh_interval = '72h')
 AS SELECT time_bucket('4', time), COUNT(data)
    FROM space_table
    GROUP BY 1;
@@ -1148,7 +1148,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_conditions');
 insert into conditions
 select generate_series(0, 200, 10), 'POR', 55, 75, 40, 70, NULL;
 create or replace view mat_ffunc_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test'::text)
 from conditions
@@ -1169,7 +1169,7 @@ WARNING:  type integer text
 DROP view mat_ffunc_test cascade;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_67_chunk
 create or replace view mat_ffunc_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigint '123')
 from conditions
@@ -1191,7 +1191,7 @@ WARNING:  type integer bigint
 drop view mat_ffunc_test cascade;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_68_chunk
 create or replace view mat_refresh_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions
@@ -1247,7 +1247,7 @@ select * from conditions_grpby_view2 order by 1, 2;
 
 --test ignore_invalidation_older_than on timestamps-based ht
 DROP TABLE conditions CASCADE;
-NOTICE:  drop cascades to 6 other objects
+NOTICE:  drop cascades to 8 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_69_chunk
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_30_70_chunk
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_71_chunk

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -84,7 +84,7 @@ SELECT set_integer_now_func('test_continuous_agg_table', 'integer_now_test');
 (1 row)
 
 CREATE VIEW test_continuous_agg_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
         GROUP BY 1;
@@ -346,6 +346,7 @@ DROP VIEW test_continuous_agg_view CASCADE;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
 CREATE VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
+        timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
@@ -490,6 +491,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute
 CREATE VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
+        timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value, get_constant_no_perms()
@@ -538,7 +540,8 @@ INSERT INTO test_continuous_agg_table_w_grant
 -- make sure view can be created
 CREATE VIEW test_continuous_agg_view_user_2
     WITH ( timescaledb.continuous,
-         timescaledb.max_interval_per_job='2',
+        timescaledb.materialized_only=true,
+        timescaledb.max_interval_per_job='2',
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table_w_grant

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -33,7 +33,8 @@ NOTICE:  adding not-null constraint to column "time"
  (2,public,foo,t)
 (1 row)
 
-CREATE VIEW rename_test WITH ( timescaledb.continuous)
+CREATE VIEW rename_test
+  WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1week', time), COUNT(data)
     FROM foo
     GROUP BY 1;
@@ -186,7 +187,12 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test');
  
 (1 row)
 
-CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
+CREATE VIEW drop_chunks_view
+  WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only=true,
+    timescaledb.refresh_interval='72 hours'
+  )
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
     GROUP BY 1;
@@ -343,7 +349,12 @@ SELECT set_integer_now_func('drop_chunks_table_u', 'integer_now_test1');
  
 (1 row)
 
-CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
+CREATE VIEW drop_chunks_view
+  WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only=true,
+    timescaledb.refresh_interval='72 hours'
+  )
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
     GROUP BY 1;
@@ -472,13 +483,23 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
 
 \set ON_ERROR_STOP 0
 -- no continuous aggregates on a continuous aggregate materialization table
-CREATE VIEW new_name_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
+CREATE VIEW new_name_view
+  WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only=true,
+    timescaledb.refresh_interval='72 hours'
+  )
 AS SELECT time_bucket('6', time_bucket), COUNT(agg_2_2)
     FROM new_name
     GROUP BY 1;
 ERROR:  hypertable is a continuous aggregate materialization table
 -- cannot create a continuous aggregate on a continuous aggregate view
-CREATE VIEW drop_chunks_view_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
+CREATE VIEW drop_chunks_view_view
+  WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only=true,
+    timescaledb.refresh_interval='72 hours'
+  )
 AS SELECT time_bucket('6', time_bucket), SUM(count)
     FROM drop_chunks_view
     GROUP BY 1;
@@ -495,7 +516,8 @@ NOTICE:  adding not-null constraint to column "time"
 
 INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
 -- check expressions in view definition
-CREATE VIEW cagg_expr WITH (timescaledb.continuous)
+CREATE VIEW cagg_expr
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
   time_bucket('1d', time) AS time,
@@ -544,7 +566,14 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
  
 (1 row)
 
-CREATE VIEW drop_chunks_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours', timescaledb.refresh_lag = '-5', timescaledb.max_interval_per_job=10)
+CREATE VIEW drop_chunks_view
+  WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only=true,
+    timescaledb.refresh_interval='72 hours',
+    timescaledb.refresh_lag = '-5',
+    timescaledb.max_interval_per_job=10
+  )
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
     GROUP BY 1;

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -404,7 +404,7 @@ ALTER VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME" SET(timescaledb.refresh_lag = '
 ERROR:  cannot alter the internal view of a continuous aggregate
 \set ON_ERROR_STOP 1
 DROP TABLE conditions CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 6 other objects
 --test WITH using a hypertable with an integer time dimension
 CREATE TABLE conditions (
       timec       SMALLINT       NOT NULL,

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -614,7 +614,7 @@ SELECT * FROM continuous_agg_test_t;
 (4 rows)
 
 CREATE VIEW test_t_mat_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_test_t
         GROUP BY 1;
@@ -832,7 +832,7 @@ SELECT set_integer_now_func('continuous_agg_extreme', 'integer_now_continuous_ag
 -- TODO we should be able to use time_bucket(5, ...) (note lack of '), but that is currently not
 --      recognized as a constant
 CREATE VIEW extreme_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('1', time), SUM(data) as value
         FROM continuous_agg_extreme
         GROUP BY 1;
@@ -980,7 +980,7 @@ SELECT set_integer_now_func('continuous_agg_negative', 'integer_now_continuous_a
 (1 row)
 
 CREATE VIEW negative_view_5
-    WITH (timescaledb.continuous, timescaledb.refresh_lag='-2')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('5', time), COUNT(data) as value
         FROM continuous_agg_negative
         GROUP BY 1;
@@ -1040,7 +1040,7 @@ DROP VIEW negative_view_5 CASCADE;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_10_27_chunk
 TRUNCATE continuous_agg_negative;
 CREATE VIEW negative_view_5
-            WITH (timescaledb.continuous, timescaledb.refresh_lag='-2')
+            WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
 AS SELECT time_bucket('5', time), COUNT(data) as value
    FROM continuous_agg_negative
    GROUP BY 1;
@@ -1087,7 +1087,7 @@ SELECT set_integer_now_func('continuous_agg_max_mat', 'integer_now_continuous_ag
 
 -- only allow two time_buckets per run
 CREATE VIEW max_mat_view
-    WITH (timescaledb.continuous, timescaledb.max_interval_per_job='4', timescaledb.refresh_lag='-2')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4', timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), COUNT(data) as value
         FROM continuous_agg_max_mat
         GROUP BY 1;
@@ -1277,7 +1277,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- only allow two time_buckets per run
 CREATE VIEW max_mat_view_t
-    WITH (timescaledb.continuous, timescaledb.max_interval_per_job='4 hours', timescaledb.refresh_lag='-2 hours')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4 hours', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_max_mat_t
         GROUP BY 1;
@@ -1349,7 +1349,7 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 CREATE VIEW max_mat_view_timestamp
-    WITH (timescaledb.continuous, timescaledb.refresh_lag='-2 hours')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time)
         FROM continuous_agg_max_mat_timestamp
         GROUP BY 1;
@@ -1379,7 +1379,7 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 CREATE VIEW max_mat_view_date
-    WITH (timescaledb.continuous, timescaledb.refresh_lag='-7 days')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-7 days')
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
         GROUP BY 1;
@@ -1452,7 +1452,7 @@ SELECT table_name FROM create_hypertable('timezone_test','time');
 
 INSERT INTO timezone_test VALUES (now() - '30m'::interval), (now()), (now() + '30m'::interval);
 CREATE VIEW timezone_test_summary
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
         GROUP BY 1;
@@ -1478,7 +1478,7 @@ SELECT table_name FROM create_hypertable('timezone_test','time');
 
 INSERT INTO timezone_test VALUES (now() - '30m'::interval), (now()), (now() + '30m'::interval);
 CREATE VIEW timezone_test_summary
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
         GROUP BY 1;

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -224,7 +224,7 @@ select view_name from timescaledb_information.continuous_aggregates;
 (1 row)
 
 drop table continuous_agg_test cascade;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_6_chunk
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
  count 

--- a/tsl/test/expected/continuous_aggs_permissions-10.out
+++ b/tsl/test/expected/continuous_aggs_permissions-10.out
@@ -109,6 +109,8 @@ ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
 ERROR:  must be owner of relation mat_refresh_test
+ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
+ERROR:  must be owner of relation mat_refresh_test
 DROP VIEW mat_refresh_test CASCADE; 
 ERROR:  must be owner of relation mat_refresh_test
 REFRESH MATERIALIZED VIEW mat_refresh_test;
@@ -121,7 +123,7 @@ SELECT * FROM :"mat_chunk_schema".:"mat_chunk_table";
 ERROR:  permission denied for relation _hyper_2_2_chunk
 --cannot create a mat view without select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check
@@ -130,7 +132,7 @@ NOTICE:  adding index _materialized_hypertable_5_location_time_partition_col_idx
 ERROR:  permission denied for relation conditions_for_perm_check
 --cannot create mat view in a schema without create privileges
 create or replace view custom_schema.mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
@@ -140,7 +142,7 @@ ERROR:  permission denied for schema custom_schema
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity), get_constant()
 from conditions_for_perm_check_w_grant
@@ -153,7 +155,7 @@ ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
 --can create a mat view on something with select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant

--- a/tsl/test/expected/continuous_aggs_permissions-11.out
+++ b/tsl/test/expected/continuous_aggs_permissions-11.out
@@ -109,6 +109,8 @@ ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
 ERROR:  must be owner of view mat_refresh_test
+ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
+ERROR:  must be owner of view mat_refresh_test
 DROP VIEW mat_refresh_test CASCADE; 
 ERROR:  must be owner of view mat_refresh_test
 REFRESH MATERIALIZED VIEW mat_refresh_test;
@@ -121,7 +123,7 @@ SELECT * FROM :"mat_chunk_schema".:"mat_chunk_table";
 ERROR:  permission denied for table _hyper_2_2_chunk
 --cannot create a mat view without select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check
@@ -130,7 +132,7 @@ NOTICE:  adding index _materialized_hypertable_5_location_time_partition_col_idx
 ERROR:  permission denied for table conditions_for_perm_check
 --cannot create mat view in a schema without create privileges
 create or replace view custom_schema.mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
@@ -140,7 +142,7 @@ ERROR:  permission denied for schema custom_schema
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity), get_constant()
 from conditions_for_perm_check_w_grant
@@ -153,7 +155,7 @@ ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
 --can create a mat view on something with select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant

--- a/tsl/test/expected/continuous_aggs_permissions-9.6.out
+++ b/tsl/test/expected/continuous_aggs_permissions-9.6.out
@@ -109,6 +109,8 @@ ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
 ERROR:  must be owner of relation mat_refresh_test
+ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
+ERROR:  must be owner of relation mat_refresh_test
 DROP VIEW mat_refresh_test CASCADE; 
 ERROR:  must be owner of relation mat_refresh_test
 REFRESH MATERIALIZED VIEW mat_refresh_test;
@@ -121,7 +123,7 @@ SELECT * FROM :"mat_chunk_schema".:"mat_chunk_table";
 ERROR:  permission denied for relation _hyper_2_2_chunk
 --cannot create a mat view without select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check
@@ -130,7 +132,7 @@ NOTICE:  adding index _materialized_hypertable_5_location_time_partition_col_idx
 ERROR:  permission denied for relation conditions_for_perm_check
 --cannot create mat view in a schema without create privileges
 create or replace view custom_schema.mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
@@ -140,7 +142,7 @@ ERROR:  permission denied for schema custom_schema
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity), get_constant()
 from conditions_for_perm_check_w_grant
@@ -153,7 +155,7 @@ ERROR:  permission denied for function get_constant
 DROP VIEW mat_perm_view_test CASCADE;
 --can create a mat view on something with select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant

--- a/tsl/test/expected/continuous_aggs_query-10.out
+++ b/tsl/test/expected/continuous_aggs_query-10.out
@@ -90,23 +90,44 @@ set enable_hashagg = false;
 -- group by, we will still need a sort
 :EXPLAIN
 select * from mat_m1 order by sumh, sumt, minl, timec ;
-                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
-   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), _hyper_2_3_chunk.timec
-   ->  GroupAggregate
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-         ->  Sort
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-               ->  Append
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(14 rows)
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), _materialized_hypertable_2.timec
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from regview order by timec desc;
@@ -136,225 +157,467 @@ select * from regview order by timec desc;
 -- This should prevent an additional sort after GroupAggregate
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-   ->  Sort
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
-         ->  Append
-               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(11 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec desc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-   ->  Merge Append
-         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec DESC
-         ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(9 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec asc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-   ->  Sort
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-         ->  Append
-               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(11 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-   ->  Sort
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-         Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-         ->  Append
-               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                     Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(10 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                 Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(33 rows)
 
 -- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
 :EXPLAIN
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
-                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-   Sort Key: _hyper_2_4_chunk.timec DESC
+   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-         Hash Cond: (l.locname = _hyper_2_4_chunk.location)
+         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+         Hash Cond: (l.locname = _materialized_hypertable_2.location)
          ->  Seq Scan on public.location_tab l
                Output: l.locid, l.locname
          ->  Hash
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-               ->  GroupAggregate
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-                     Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-                     ->  Sort
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-                           ->  Append
-                                 ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(20 rows)
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               ->  Append
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Sort
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions
+                                       Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                             Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                             Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(40 rows)
 
 :EXPLAIN
 select * from mat_m2 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-   Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-   ->  Sort
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-         Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-         ->  Append
-               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                     Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(10 rows)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Sort Key: _materialized_hypertable_3.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+               ->  Sort
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                 Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                 Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(33 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
-   ->  GroupAggregate
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-         ->  Sort
-               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-               ->  Append
-                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(12 rows)
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   ->  Sort
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Sort Key: _materialized_hypertable_3.timec DESC
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                       Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(35 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
-   ->  GroupAggregate
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-         ->  Sort
-               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location NULLS FIRST
-               ->  Append
-                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(12 rows)
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   ->  Sort
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Sort Key: _materialized_hypertable_3.timec DESC, _materialized_hypertable_3.location NULLS FIRST
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                       Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(35 rows)
 
 --plans with CTE
 :EXPLAIN
 with m1 as (
 Select * from mat_m2 where timec > '2018-10-01' order by timec desc ) 
 select * from m1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CTE Scan on m1
    Output: m1.location, m1.timec, m1.firsth, m1.lasth, m1.maxtemp, m1.mintemp
    CTE m1
-     ->  GroupAggregate
-           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-           Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-           ->  Sort
-                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                 Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-                 ->  Append
-                       ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                             Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                             Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(13 rows)
+     ->  Sort
+           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+           Sort Key: _materialized_hypertable_3.timec DESC
+           ->  Append
+                 ->  GroupAggregate
+                       Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                       Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                       ->  Sort
+                             Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                             Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                             ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                   Startup Exclusion: true
+                                   Runtime Exclusion: false
+                                   Chunks excluded during startup: 0
+                                   ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                         Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                 ->  GroupAggregate
+                       Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                       Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                       ->  Sort
+                             Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                             Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                             ->  Custom Scan (ChunkAppend) on public.conditions
+                                   Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                   Startup Exclusion: true
+                                   Runtime Exclusion: false
+                                   Chunks excluded during startup: 0
+                                   ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                         Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                         Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                         Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(36 rows)
 
 -- should reorder mat_m1 group by only based on mat_m1 order-by
 :EXPLAIN
 select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
-   Merge Cond: (_hyper_2_4_chunk.timec = _hyper_3_5_chunk.timec)
-   ->  GroupAggregate
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-         ->  Sort
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Hash Join
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Hash Cond: (_materialized_hypertable_3.timec = _materialized_hypertable_2.timec)
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
+                                       Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                                       Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 1
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                       Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  Hash
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
                ->  Append
-                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-   ->  Sort
-         Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
-         Sort Key: _hyper_3_5_chunk.timec DESC
-         ->  GroupAggregate
-               Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision)
-               Group Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
-               ->  Sort
-                     Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                     Sort Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
-                     ->  Append
-                           ->  Seq Scan on _timescaledb_internal._hyper_3_5_chunk
-                                 Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                           ->  Seq Scan on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-(27 rows)
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
+                           ->  Sort
+                                 Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.temperature, conditions_1.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions conditions_1
+                                       Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.temperature, conditions_1.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk _hyper_1_2_chunk_1
+                                             Output: _hyper_1_2_chunk_1.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec), _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
+                                             Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(70 rows)
 
 --should reorder only for mat_m1.
 :EXPLAIN
 select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
-   Merge Cond: (_hyper_2_4_chunk.timec = (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)))
-   ->  GroupAggregate
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-         ->  Sort
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-               ->  Append
-                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-   ->  Sort
-         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
-         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Hash Join
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Hash Cond: ((time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) = _materialized_hypertable_2.timec)
          ->  GroupAggregate
                Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
                Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
@@ -368,7 +631,39 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                        Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
-(29 rows)
+         ->  Hash
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               ->  Append
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Sort
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions
+                                       Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk _hyper_1_2_chunk_1
+                                             Output: _hyper_1_2_chunk_1.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec), _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
+                                             Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(51 rows)
 
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
  locid | location |            timec             | minl | sumt | sumh 
@@ -393,21 +688,42 @@ set timescaledb.enable_cagg_reorder_groupby = false;
 set enable_hashagg = false;
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
-   Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
-   ->  GroupAggregate
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-         ->  Sort
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-               ->  Append
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(14 rows)
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 

--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -90,23 +90,44 @@ set enable_hashagg = false;
 -- group by, we will still need a sort
 :EXPLAIN
 select * from mat_m1 order by sumh, sumt, minl, timec ;
-                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
-   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), _hyper_2_3_chunk.timec
-   ->  GroupAggregate
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-         ->  Sort
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-               ->  Append
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(14 rows)
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), _materialized_hypertable_2.timec
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from regview order by timec desc;
@@ -136,225 +157,467 @@ select * from regview order by timec desc;
 -- This should prevent an additional sort after GroupAggregate
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-   ->  Sort
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
-         ->  Append
-               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(11 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec desc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-   ->  Merge Append
-         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec DESC
-         ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(9 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec asc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-   ->  Sort
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-         ->  Append
-               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(11 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-   ->  Sort
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-         Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-         ->  Append
-               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                     Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(10 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                 Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(33 rows)
 
 -- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
 :EXPLAIN
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
-                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-   Sort Key: _hyper_2_4_chunk.timec DESC
+   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-         Hash Cond: (l.locname = _hyper_2_4_chunk.location)
+         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+         Hash Cond: (l.locname = _materialized_hypertable_2.location)
          ->  Seq Scan on public.location_tab l
                Output: l.locid, l.locname
          ->  Hash
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-               ->  GroupAggregate
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-                     Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-                     ->  Sort
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-                           ->  Append
-                                 ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(20 rows)
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               ->  Append
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Sort
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions
+                                       Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                             Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                             Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(40 rows)
 
 :EXPLAIN
 select * from mat_m2 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-   Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-   ->  Sort
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-         Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-         ->  Append
-               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                     Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(10 rows)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Sort Key: _materialized_hypertable_3.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+               ->  Sort
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.humidity, conditions.timec, conditions.temperature
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
+                                 Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                 Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(33 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
-   ->  GroupAggregate
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-         ->  Sort
-               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-               ->  Append
-                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(12 rows)
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   ->  Sort
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Sort Key: _materialized_hypertable_3.timec DESC
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
+                                       Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(35 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
-   ->  GroupAggregate
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-         ->  Sort
-               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location NULLS FIRST
-               ->  Append
-                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(12 rows)
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   ->  Sort
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Sort Key: _materialized_hypertable_3.timec DESC, _materialized_hypertable_3.location NULLS FIRST
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
+                                       Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(35 rows)
 
 --plans with CTE
 :EXPLAIN
 with m1 as (
 Select * from mat_m2 where timec > '2018-10-01' order by timec desc ) 
 select * from m1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CTE Scan on m1
    Output: m1.location, m1.timec, m1.firsth, m1.lasth, m1.maxtemp, m1.mintemp
    CTE m1
-     ->  GroupAggregate
-           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-           Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-           ->  Sort
-                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                 Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-                 ->  Append
-                       ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                             Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                             Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(13 rows)
+     ->  Sort
+           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+           Sort Key: _materialized_hypertable_3.timec DESC
+           ->  Append
+                 ->  GroupAggregate
+                       Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                       Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                       ->  Sort
+                             Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                             Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                             ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                   Startup Exclusion: true
+                                   Runtime Exclusion: false
+                                   Chunks excluded during startup: 0
+                                   ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                         Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                 ->  GroupAggregate
+                       Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                       Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                       ->  Sort
+                             Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                             Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                             ->  Custom Scan (ChunkAppend) on public.conditions
+                                   Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.humidity, conditions.timec, conditions.temperature
+                                   Startup Exclusion: true
+                                   Runtime Exclusion: false
+                                   Chunks excluded during startup: 0
+                                   ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                         Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
+                                         Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                         Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(36 rows)
 
 -- should reorder mat_m1 group by only based on mat_m1 order-by
 :EXPLAIN
 select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
-   Merge Cond: (_hyper_2_4_chunk.timec = _hyper_3_5_chunk.timec)
-   ->  GroupAggregate
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-         ->  Sort
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Hash Join
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Hash Cond: (_materialized_hypertable_3.timec = _materialized_hypertable_2.timec)
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
+                                       Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                                       Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 1
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
+                                       Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  Hash
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
                ->  Append
-                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-   ->  Sort
-         Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
-         Sort Key: _hyper_3_5_chunk.timec DESC
-         ->  GroupAggregate
-               Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision)
-               Group Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
-               ->  Sort
-                     Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                     Sort Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
-                     ->  Append
-                           ->  Seq Scan on _timescaledb_internal._hyper_3_5_chunk
-                                 Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                           ->  Seq Scan on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-(27 rows)
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
+                           ->  Sort
+                                 Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.temperature, conditions_1.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions conditions_1
+                                       Output: conditions_1.location, time_bucket('@ 1 day'::interval, conditions_1.timec), conditions_1.temperature, conditions_1.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk _hyper_1_2_chunk_1
+                                             Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
+                                             Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(70 rows)
 
 --should reorder only for mat_m1.
 :EXPLAIN
 select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
-   Merge Cond: (_hyper_2_4_chunk.timec = (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)))
-   ->  GroupAggregate
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-         ->  Sort
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-               ->  Append
-                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-   ->  Sort
-         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
-         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Hash Join
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Hash Cond: ((time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) = _materialized_hypertable_2.timec)
          ->  GroupAggregate
                Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
                Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
@@ -368,7 +631,39 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                        Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
-(29 rows)
+         ->  Hash
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               ->  Append
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Sort
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions
+                                       Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk _hyper_1_2_chunk_1
+                                             Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
+                                             Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(51 rows)
 
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
  locid | location |            timec             | minl | sumt | sumh 
@@ -393,21 +688,42 @@ set timescaledb.enable_cagg_reorder_groupby = false;
 set enable_hashagg = false;
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
-   Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
-   ->  GroupAggregate
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-         ->  Sort
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-               ->  Append
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(14 rows)
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, time_bucket('@ 1 day'::interval, conditions.timec), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 

--- a/tsl/test/expected/continuous_aggs_query-9.6.out
+++ b/tsl/test/expected/continuous_aggs_query-9.6.out
@@ -90,23 +90,44 @@ set enable_hashagg = false;
 -- group by, we will still need a sort
 :EXPLAIN
 select * from mat_m1 order by sumh, sumt, minl, timec ;
-                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
-   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), _hyper_2_3_chunk.timec
-   ->  GroupAggregate
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-         ->  Sort
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-               ->  Append
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(14 rows)
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), _materialized_hypertable_2.timec
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from regview order by timec desc;
@@ -136,225 +157,467 @@ select * from regview order by timec desc;
 -- This should prevent an additional sort after GroupAggregate
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-   ->  Sort
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
-         ->  Append
-               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(11 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec desc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-   ->  Merge Append
-         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec DESC
-         ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_location_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(9 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec asc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-   ->  Sort
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-         Sort Key: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec
-         ->  Append
-               ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(11 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 
 :EXPLAIN
 select * from mat_m1 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-   Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-   ->  Sort
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-         Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-         ->  Append
-               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                     Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(10 rows)
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                 Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(33 rows)
 
 -- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
 :EXPLAIN
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
-                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-   Sort Key: _hyper_2_4_chunk.timec DESC
+   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: l.locid, _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-         Hash Cond: (l.locname = _hyper_2_4_chunk.location)
+         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+         Hash Cond: (l.locname = _materialized_hypertable_2.location)
          ->  Seq Scan on public.location_tab l
                Output: l.locid, l.locname
          ->  Hash
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision))
-               ->  GroupAggregate
-                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-                     Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-                     ->  Sort
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-                           ->  Append
-                                 ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(20 rows)
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               ->  Append
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Sort
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions
+                                       Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                             Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                             Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(40 rows)
 
 :EXPLAIN
 select * from mat_m2 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-   Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-   ->  Sort
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-         Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-         ->  Append
-               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                     Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(10 rows)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Sort Key: _materialized_hypertable_3.timec DESC
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+               ->  Sort
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                 Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                 Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(33 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
-   ->  GroupAggregate
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-         ->  Sort
-               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-               ->  Append
-                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(12 rows)
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   ->  Sort
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Sort Key: _materialized_hypertable_3.timec DESC
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                       Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(35 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision))
-   ->  GroupAggregate
-         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-         Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-         ->  Sort
-               Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-               Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location NULLS FIRST
-               ->  Append
-                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                           Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(12 rows)
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   ->  Sort
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Sort Key: _materialized_hypertable_3.timec DESC, _materialized_hypertable_3.location NULLS FIRST
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                       Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                       Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(35 rows)
 
 --plans with CTE
 :EXPLAIN
 with m1 as (
 Select * from mat_m2 where timec > '2018-10-01' order by timec desc ) 
 select * from m1;
-                                                                                                                                                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CTE Scan on m1
    Output: m1.location, m1.timec, m1.firsth, m1.lasth, m1.maxtemp, m1.mintemp
    CTE m1
-     ->  GroupAggregate
-           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_6_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_6_chunk.agg_6_6, NULL::double precision)
-           Group Key: _hyper_3_6_chunk.timec, _hyper_3_6_chunk.location
-           ->  Sort
-                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                 Sort Key: _hyper_3_6_chunk.timec DESC, _hyper_3_6_chunk.location
-                 ->  Append
-                       ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                             Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                             Index Cond: (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(13 rows)
+     ->  Sort
+           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+           Sort Key: _materialized_hypertable_3.timec DESC
+           ->  Append
+                 ->  GroupAggregate
+                       Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                       Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                       ->  Sort
+                             Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                             Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                             ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                   Startup Exclusion: true
+                                   Runtime Exclusion: false
+                                   Chunks excluded during startup: 0
+                                   ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                         Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                         Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                 ->  GroupAggregate
+                       Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                       Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                       ->  Sort
+                             Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                             Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                             ->  Custom Scan (ChunkAppend) on public.conditions
+                                   Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                   Startup Exclusion: true
+                                   Runtime Exclusion: false
+                                   Chunks excluded during startup: 0
+                                   ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                         Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                         Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                         Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(36 rows)
 
 -- should reorder mat_m1 group by only based on mat_m1 order-by
 :EXPLAIN
 select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
-   Merge Cond: (_hyper_2_4_chunk.timec = _hyper_3_5_chunk.timec)
-   ->  GroupAggregate
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-         ->  Sort
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Hash Join
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Hash Cond: (_materialized_hypertable_3.timec = _materialized_hypertable_2.timec)
+         ->  Append
+               ->  GroupAggregate
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
+                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                     ->  Sort
+                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
+                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 0
+                                 ->  Index Scan using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
+                                       Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
+                                       Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
+                                       Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+               ->  GroupAggregate
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
+                     Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Sort
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                           Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Custom Scan (ChunkAppend) on public.conditions
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.humidity, conditions.timec, conditions.temperature
+                                 Startup Exclusion: true
+                                 Runtime Exclusion: false
+                                 Chunks excluded during startup: 1
+                                 ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                       Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature
+                                       Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  Hash
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
                ->  Append
-                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-   ->  Sort
-         Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, (_timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision))
-         Sort Key: _hyper_3_5_chunk.timec DESC
-         ->  GroupAggregate
-               Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _timescaledb_internal.finalize_agg('first(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('last(anyelement,"any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _hyper_3_5_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_3_5_chunk.agg_6_6, NULL::double precision)
-               Group Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
-               ->  Sort
-                     Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                     Sort Key: _hyper_3_5_chunk.timec, _hyper_3_5_chunk.location
-                     ->  Append
-                           ->  Seq Scan on _timescaledb_internal._hyper_3_5_chunk
-                                 Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                           ->  Seq Scan on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-(27 rows)
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
+                           ->  Sort
+                                 Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.temperature, conditions_1.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions conditions_1
+                                       Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.temperature, conditions_1.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk _hyper_1_2_chunk_1
+                                             Output: _hyper_1_2_chunk_1.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec), _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
+                                             Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(70 rows)
 
 --should reorder only for mat_m1.
 :EXPLAIN
 select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join
-   Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
-   Merge Cond: (_hyper_2_4_chunk.timec = (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)))
-   ->  GroupAggregate
-         Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_4_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_4_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_4_chunk.timec, _hyper_2_4_chunk.location
-         ->  Sort
-               Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-               Sort Key: _hyper_2_4_chunk.timec DESC, _hyper_2_4_chunk.location
-               ->  Append
-                     ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                           Index Cond: (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-   ->  Sort
-         Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
-         Sort Key: (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) DESC
+                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Sort Key: _materialized_hypertable_2.timec DESC
+   ->  Hash Join
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Hash Cond: ((time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) = _materialized_hypertable_2.timec)
          ->  GroupAggregate
                Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
                Group Key: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec))
@@ -368,7 +631,39 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                        Output: _hyper_1_1_chunk.location, _hyper_1_1_chunk.timec, _hyper_1_1_chunk.temperature, _hyper_1_1_chunk.humidity
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
-(29 rows)
+         ->  Hash
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               ->  Append
+                     ->  GroupAggregate
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                           ->  Sort
+                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  GroupAggregate
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+                           Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                           ->  Sort
+                                 Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                 Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                                 ->  Custom Scan (ChunkAppend) on public.conditions
+                                       Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                                       Startup Exclusion: true
+                                       Runtime Exclusion: false
+                                       Chunks excluded during startup: 0
+                                       ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk _hyper_1_2_chunk_1
+                                             Output: _hyper_1_2_chunk_1.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec), _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
+                                             Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                                             Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
+(51 rows)
 
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
  locid | location |            timec             | minl | sumt | sumh 
@@ -393,21 +688,42 @@ set timescaledb.enable_cagg_reorder_groupby = false;
 set enable_hashagg = false;
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision))
-   Sort Key: _hyper_2_3_chunk.timec DESC, _hyper_2_3_chunk.location
-   ->  GroupAggregate
-         Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _hyper_2_3_chunk.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _hyper_2_3_chunk.agg_5_5, NULL::double precision)
-         Group Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-         ->  Sort
-               Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-               Sort Key: _hyper_2_3_chunk.timec, _hyper_2_3_chunk.location
-               ->  Append
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_3_chunk
-                           Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                     ->  Seq Scan on _timescaledb_internal._hyper_2_4_chunk
-                           Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-(14 rows)
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
+   ->  Append
+         ->  GroupAggregate
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('min(text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
+               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+               ->  Sort
+                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
+                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+         ->  GroupAggregate
+               Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
+               Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+               ->  Sort
+                     Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                     Sort Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
+                     ->  Custom Scan (ChunkAppend) on public.conditions
+                           Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.temperature, conditions.humidity
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 1
+                           ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
+                                 Output: _hyper_1_2_chunk.location, time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec), _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
+                                 Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone))
+(35 rows)
 

--- a/tsl/test/expected/continuous_aggs_union_view-10.out
+++ b/tsl/test/expected/continuous_aggs_union_view-10.out
@@ -1,0 +1,383 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- disable background workers to make results reproducible
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
+SELECT create_hypertable('metrics','time');
+  create_hypertable   
+----------------------
+ (1,public,metrics,t)
+(1 row)
+
+ALTER TABLE metrics DROP COLUMN f1;
+INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, device_id, 0.5 FROM generate_series(1,3) g(device_id);
+--
+-- test switching continuous agg view between different modes
+--
+-- check default view for new continuous aggregate
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+ALTER TABLE metrics DROP COLUMN f2;
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   GROUP BY _materialized_hypertable_2.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+-- upgrade view to union view again
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- try upgrade view to union view that is already union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- refresh
+REFRESH MATERIALIZED VIEW metrics_summary;
+-- result should not change after refresh for union view
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   GROUP BY _materialized_hypertable_2.time_bucket;
+(1 row)
+
+-- view should have results now after refresh
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+DROP VIEW metrics_summary CASCADE;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+-- check default view for new continuous aggregate with materialized_only to true
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   GROUP BY _materialized_hypertable_3.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+-- upgrade view to union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_3.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   GROUP BY _materialized_hypertable_3.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+DROP VIEW metrics_summary CASCADE;
+--
+-- test queries on union view
+--
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- query should not have results since cagg is materialized only and no refresh has happened yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- after switch to union view all results should be returned
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+REFRESH MATERIALIZED VIEW metrics_summary;
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- materialized only view should return data now too because refresh has happened
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- add some more data
+INSERT INTO metrics(time, device_id, value) SELECT '2000-02-01'::timestamptz, device_id, device_id/10.0 FROM generate_series(1,3) g(device_id);
+-- materialized only view should not have new data yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- but union view should
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+ Mon Jan 31 16:00:00 2000 PST | 0.2
+(2 rows)
+
+-- and after refresh non union view should have new data too
+REFRESH MATERIALIZED VIEW metrics_summary;
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- hardcoding now to 50 will lead to 30 watermark
+CREATE OR REPLACE FUNCTION boundary_test_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 50;
+$BODY$;
+-- test watermark interaction with just in time aggregates
+CREATE TABLE boundary_test(time int, value float);
+SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (5,public,boundary_test,t)
+(1 row)
+
+SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE VIEW boundary_view
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
+INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
+-- watermark should be NULL
+SELECT _timescaledb_internal.cagg_watermark(5);
+ cagg_watermark 
+----------------
+               
+(1 row)
+
+-- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
+:PREFIX SELECT * FROM boundary_view;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=4 loops=1)
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: time_bucket
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: (time_bucket(10, boundary_test."time"))
+         ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
+               Chunks excluded during startup: 0
+               ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+(17 rows)
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+
+REFRESH MATERIALIZED VIEW boundary_view;
+-- watermark should be 30
+SELECT _timescaledb_internal.cagg_watermark(5);
+ cagg_watermark 
+----------------
+             30
+(1 row)
+
+-- both sides of the UNION should return 2 rows
+:PREFIX SELECT * FROM boundary_view;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=4 loops=1)
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _materialized_hypertable_6.time_bucket
+         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
+               Chunks excluded during startup: 0
+               ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
+                     Index Cond: (time_bucket < COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: (time_bucket(10, boundary_test."time"))
+         ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=2 loops=1)
+               Chunks excluded during startup: 2
+               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+(15 rows)
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -1,0 +1,383 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- disable background workers to make results reproducible
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
+SELECT create_hypertable('metrics','time');
+  create_hypertable   
+----------------------
+ (1,public,metrics,t)
+(1 row)
+
+ALTER TABLE metrics DROP COLUMN f1;
+INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, device_id, 0.5 FROM generate_series(1,3) g(device_id);
+--
+-- test switching continuous agg view between different modes
+--
+-- check default view for new continuous aggregate
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+ALTER TABLE metrics DROP COLUMN f2;
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   GROUP BY _materialized_hypertable_2.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+-- upgrade view to union view again
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- try upgrade view to union view that is already union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- refresh
+REFRESH MATERIALIZED VIEW metrics_summary;
+-- result should not change after refresh for union view
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   GROUP BY _materialized_hypertable_2.time_bucket;
+(1 row)
+
+-- view should have results now after refresh
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+DROP VIEW metrics_summary CASCADE;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+-- check default view for new continuous aggregate with materialized_only to true
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   GROUP BY _materialized_hypertable_3.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+-- upgrade view to union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_3.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   GROUP BY _materialized_hypertable_3.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+DROP VIEW metrics_summary CASCADE;
+--
+-- test queries on union view
+--
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- query should not have results since cagg is materialized only and no refresh has happened yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- after switch to union view all results should be returned
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+REFRESH MATERIALIZED VIEW metrics_summary;
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- materialized only view should return data now too because refresh has happened
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- add some more data
+INSERT INTO metrics(time, device_id, value) SELECT '2000-02-01'::timestamptz, device_id, device_id/10.0 FROM generate_series(1,3) g(device_id);
+-- materialized only view should not have new data yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- but union view should
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+ Mon Jan 31 16:00:00 2000 PST | 0.2
+(2 rows)
+
+-- and after refresh non union view should have new data too
+REFRESH MATERIALIZED VIEW metrics_summary;
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- hardcoding now to 50 will lead to 30 watermark
+CREATE OR REPLACE FUNCTION boundary_test_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 50;
+$BODY$;
+-- test watermark interaction with just in time aggregates
+CREATE TABLE boundary_test(time int, value float);
+SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (5,public,boundary_test,t)
+(1 row)
+
+SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE VIEW boundary_view
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
+INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
+-- watermark should be NULL
+SELECT _timescaledb_internal.cagg_watermark(5);
+ cagg_watermark 
+----------------
+               
+(1 row)
+
+-- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
+:PREFIX SELECT * FROM boundary_view;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=4 loops=1)
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: time_bucket
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: time_bucket(10, boundary_test."time")
+         ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
+               Chunks excluded during startup: 0
+               ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+(17 rows)
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+
+REFRESH MATERIALIZED VIEW boundary_view;
+-- watermark should be 30
+SELECT _timescaledb_internal.cagg_watermark(5);
+ cagg_watermark 
+----------------
+             30
+(1 row)
+
+-- both sides of the UNION should return 2 rows
+:PREFIX SELECT * FROM boundary_view;
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=4 loops=1)
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _materialized_hypertable_6.time_bucket
+         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
+               Chunks excluded during startup: 0
+               ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
+                     Index Cond: (time_bucket < COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: time_bucket(10, boundary_test."time")
+         ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=2 loops=1)
+               Chunks excluded during startup: 2
+               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+(15 rows)
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+

--- a/tsl/test/expected/continuous_aggs_union_view-9.6.out
+++ b/tsl/test/expected/continuous_aggs_union_view-9.6.out
@@ -1,0 +1,383 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- disable background workers to make results reproducible
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
+SELECT create_hypertable('metrics','time');
+  create_hypertable   
+----------------------
+ (1,public,metrics,t)
+(1 row)
+
+ALTER TABLE metrics DROP COLUMN f1;
+INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, device_id, 0.5 FROM generate_series(1,3) g(device_id);
+--
+-- test switching continuous agg view between different modes
+--
+-- check default view for new continuous aggregate
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+ALTER TABLE metrics DROP COLUMN f2;
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   GROUP BY _materialized_hypertable_2.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+-- upgrade view to union view again
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- try upgrade view to union view that is already union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- refresh
+REFRESH MATERIALIZED VIEW metrics_summary;
+-- result should not change after refresh for union view
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                         +
+   GROUP BY _materialized_hypertable_2.time_bucket;
+(1 row)
+
+-- view should have results now after refresh
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+DROP VIEW metrics_summary CASCADE;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+-- check default view for new continuous aggregate with materialized_only to true
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   GROUP BY _materialized_hypertable_3.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+-- upgrade view to union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                    +
+   GROUP BY _materialized_hypertable_3.time_bucket                                                                                                                                                +
+ UNION ALL                                                                                                                                                                                        +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                         +
+     avg(metrics.value) AS avg                                                                                                                                                                    +
+    FROM metrics                                                                                                                                                                                  +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(1)), '-infinity'::timestamp with time zone)                                           +
+   GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+                                                                                          pg_get_viewdef                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                  +
+     _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                         +
+   GROUP BY _materialized_hypertable_3.time_bucket;
+(1 row)
+
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+DROP VIEW metrics_summary CASCADE;
+--
+-- test queries on union view
+--
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- query should not have results since cagg is materialized only and no refresh has happened yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- after switch to union view all results should be returned
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+REFRESH MATERIALIZED VIEW metrics_summary;
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- materialized only view should return data now too because refresh has happened
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- add some more data
+INSERT INTO metrics(time, device_id, value) SELECT '2000-02-01'::timestamptz, device_id, device_id/10.0 FROM generate_series(1,3) g(device_id);
+-- materialized only view should not have new data yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- but union view should
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+ Mon Jan 31 16:00:00 2000 PST | 0.2
+(2 rows)
+
+-- and after refresh non union view should have new data too
+REFRESH MATERIALIZED VIEW metrics_summary;
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+         time_bucket          | avg 
+------------------------------+-----
+ Fri Dec 31 16:00:00 1999 PST | 0.5
+(1 row)
+
+-- hardcoding now to 50 will lead to 30 watermark
+CREATE OR REPLACE FUNCTION boundary_test_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 50;
+$BODY$;
+-- test watermark interaction with just in time aggregates
+CREATE TABLE boundary_test(time int, value float);
+SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (5,public,boundary_test,t)
+(1 row)
+
+SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE VIEW boundary_view
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
+INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
+-- watermark should be NULL
+SELECT _timescaledb_internal.cagg_watermark(5);
+ cagg_watermark 
+----------------
+               
+(1 row)
+
+-- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
+:PREFIX SELECT * FROM boundary_view;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  HashAggregate
+         Group Key: time_bucket
+         ->  Result
+               One-Time Filter: false
+   ->  HashAggregate
+         Group Key: (time_bucket(10, boundary_test."time"))
+         ->  Custom Scan (ChunkAppend) on boundary_test
+               Chunks excluded during startup: 0
+               ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+(17 rows)
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+
+REFRESH MATERIALIZED VIEW boundary_view;
+-- watermark should be 30
+SELECT _timescaledb_internal.cagg_watermark(5);
+ cagg_watermark 
+----------------
+             30
+(1 row)
+
+-- both sides of the UNION should return 2 rows
+:PREFIX SELECT * FROM boundary_view;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  HashAggregate
+         Group Key: _materialized_hypertable_6.time_bucket
+         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6
+               Chunks excluded during startup: 0
+               ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk
+                     Index Cond: (time_bucket < COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+   ->  HashAggregate
+         Group Key: (time_bucket(10, boundary_test."time"))
+         ->  Custom Scan (ChunkAppend) on boundary_test
+               Chunks excluded during startup: 2
+               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk
+                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+(15 rows)
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -20,7 +20,7 @@ SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
 
 --Next, create your continuous aggregate view
 CREATE VIEW device_summary
-WITH (timescaledb.continuous) --This flag is what makes the view continuous
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) --This flag is what makes the view continuous
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket, --time_bucket is required
@@ -205,7 +205,7 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 DROP VIEW device_summary CASCADE;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
 CREATE VIEW device_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,
@@ -223,7 +223,7 @@ ERROR:  only immutable functions are supported for continuous aggregate query
 DROP VIEW device_summary CASCADE;
 ERROR:  view "device_summary" does not exist
 CREATE VIEW device_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,
@@ -241,7 +241,7 @@ DROP VIEW device_summary CASCADE;
 DROP VIEW device_summary CASCADE;
 ERROR:  view "device_summary" does not exist
 CREATE VIEW device_summary
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,
@@ -262,4 +262,131 @@ SELECT min(min_time)::timestamp FROM device_summary;
 --------------------------
  Sat Dec 01 00:00:00 2018
 (1 row)
+
+--
+-- test just in time aggregate / materialization only view
+--
+-- hardcoding now to 50 will lead to 30 watermark
+CREATE OR REPLACE FUNCTION device_readings_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 50;
+$BODY$;
+CREATE TABLE device_readings_int(time int, value float);
+SELECT create_hypertable('device_readings_int','time',chunk_time_interval:=10);
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable         
+----------------------------------
+ (5,public,device_readings_int,t)
+(1 row)
+
+SELECT set_integer_now_func('device_readings_int','device_readings_int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE VIEW device_readings_mat_only
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1;
+CREATE VIEW device_readings_jit
+  WITH (timescaledb.continuous, timescaledb.materialized_only=false)
+AS
+  SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1;
+INSERT INTO device_readings_int SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
+-- materialization only should have 0 rows
+SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+(0 rows)
+
+-- jit aggregate should have 4 rows
+SELECT * FROM device_readings_jit ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+
+REFRESH MATERIALIZED VIEW device_readings_mat_only;
+LOG:  materializing continuous aggregate public.device_readings_mat_only: nothing to invalidate, new range up to 30
+REFRESH MATERIALIZED VIEW device_readings_jit;
+LOG:  materializing continuous aggregate public.device_readings_jit: nothing to invalidate, new range up to 30
+-- materialization only should have 2 rows
+SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+(2 rows)
+
+-- jit aggregate should have 4 rows
+SELECT * FROM device_readings_jit ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+(4 rows)
+
+-- add 2 more rows
+INSERT INTO device_readings_int SELECT i, i*10 FROM generate_series(50,60,10) AS g(i);
+-- materialization only should have 2 rows
+SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+(2 rows)
+
+-- jit aggregate should have 6 rows
+SELECT * FROM device_readings_jit ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+          50 | 500
+          60 | 600
+(6 rows)
+
+-- hardcoding now to 100 will lead to 80 watermark
+CREATE OR REPLACE FUNCTION device_readings_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 100;
+$BODY$;
+-- refresh should materialize all now
+REFRESH MATERIALIZED VIEW device_readings_mat_only;
+LOG:  materializing continuous aggregate public.device_readings_mat_only: nothing to invalidate, new range up to 70
+REFRESH MATERIALIZED VIEW device_readings_jit;
+LOG:  materializing continuous aggregate public.device_readings_jit: nothing to invalidate, new range up to 70
+-- materialization only should have 6 rows
+SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+          50 | 500
+          60 | 600
+(6 rows)
+
+-- jit aggregate should have 6 rows
+SELECT * FROM device_readings_jit ORDER BY time_bucket;
+ time_bucket | avg 
+-------------+-----
+          10 | 100
+          20 | 200
+          30 | 300
+          40 | 400
+          50 | 500
+          60 | 600
+(6 rows)
 

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -299,7 +299,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 (4 rows)
 
 DROP TABLE ca_inval_test CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;
@@ -371,7 +371,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 (1 row)
 
 DROP TABLE ts_continuous_test CASCADE;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to 3 other objects
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 TRUNCATE _timescaledb_catalog.continuous_aggs_invalidation_threshold;

--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -2325,7 +2325,7 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
@@ -5717,7 +5717,7 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -2435,7 +2435,7 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;
@@ -5834,7 +5834,7 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;

--- a/tsl/test/isolation/specs/continuous_aggs_insert.spec.in
+++ b/tsl/test/isolation/specs/continuous_aggs_insert.spec.in
@@ -9,7 +9,7 @@ setup
     INSERT INTO ts_continuous_test SELECT i, i FROM
         (SELECT generate_series(0, 29) AS i) AS i;
     CREATE VIEW continuous_view
-        WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
+        WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_interval='72 hours')
         AS SELECT time_bucket('5', time), COUNT(location)
             FROM ts_continuous_test
             GROUP BY 1;

--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -1,6 +1,7 @@
 /continuous_aggs_ddl-*.sql
 /continuous_aggs_permissions-*.sql
 /continuous_aggs_query-*.sql
+/continuous_aggs_union_view-*.sql
 /plan_gapfill-*.sql
 /transparent_decompression-*.sql
 /compression_permissions-*.sql

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_FILES_DEBUG
 
 set(TEST_TEMPLATES
   continuous_aggs_permissions.sql.in
+  continuous_aggs_union_view.sql.in
   plan_gapfill.sql.in
 )
 

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -311,7 +311,7 @@ DROP VIEW dependent_1;
 
 --create a cont agg view on the ht as well then the drop should nuke everything
 SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
-CREATE VIEW test1_cont_view WITH ( timescaledb.continuous, timescaledb.refresh_interval='72 hours')
+CREATE VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_interval='72 hours')
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1
    GROUP BY 1;

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -39,7 +39,7 @@ SELECT set_integer_now_func('foo', 'integer_now_foo');
 
 
 create or replace view mat_m1( a, countb )
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select a, count(b)
 from foo
@@ -97,7 +97,7 @@ insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 35, 15);
 
 
 create or replace view mat_m1( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -158,7 +158,7 @@ insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', 35, 25);
 
 
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -203,7 +203,7 @@ order by time_bucket('1week', timec);
 -- apply where clause on result of mat_m1 --
 drop view mat_m1 cascade;
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -249,7 +249,7 @@ order by time_bucket('1week', timec);
 ---------test with having clause ----------------------
 drop view mat_m1 cascade;
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -315,7 +315,7 @@ select generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timest
 --drop view mat_m1 cascade;
 --naming with AS clauses
 create or replace view mat_naming
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
@@ -341,7 +341,7 @@ DROP VIEW mat_naming CASCADE;
 
 --naming with default names
 create or replace view mat_naming
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
@@ -367,7 +367,7 @@ DROP VIEW mat_naming CASCADE;
 
 --naming with view col names
 create or replace view mat_naming (bucket, loc, sum_t_h, stdd)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
@@ -392,7 +392,7 @@ order by attnum, attname;
 DROP VIEW mat_naming CASCADE;
 
 create or replace view mat_m1( timec, minl, sumth, stddevh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
@@ -562,7 +562,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 --no data in hyper table on purpose so that CASCADE is not required because of chunks
 
 create or replace view mat_drop_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -637,7 +637,7 @@ CREATE TABLE conditions (
 select table_name from create_hypertable( 'conditions', 'timec');
 
 create or replace view mat_with_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -660,7 +660,7 @@ order by indexname;
 drop view mat_with_test cascade;
 --no additional indexes
 create or replace view mat_with_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h', timescaledb.create_group_indexes=false)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h', timescaledb.create_group_indexes=false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -691,7 +691,7 @@ CREATE OR REPLACE FUNCTION integer_now_conditions() returns int LANGUAGE SQL STA
 SELECT set_integer_now_func('conditions', 'integer_now_conditions');
 
 create or replace view mat_with_test( timec, minl, sumt , sumh)
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '500', timescaledb.refresh_interval = '2h')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '500', timescaledb.refresh_interval = '2h')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
@@ -728,7 +728,7 @@ CREATE OR REPLACE FUNCTION integer_now_space_table() returns BIGINT LANGUAGE SQL
 SELECT set_integer_now_func('space_table', 'integer_now_space_table');
 
 CREATE VIEW space_view
-WITH (timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.refresh_interval = '72h')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-2', timescaledb.refresh_interval = '72h')
 AS SELECT time_bucket('4', time), COUNT(data)
    FROM space_table
    GROUP BY 1;
@@ -834,7 +834,7 @@ select generate_series(0, 200, 10), 'POR', 55, 75, 40, 70, NULL;
 
 
 create or replace view mat_ffunc_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test'::text)
 from conditions
@@ -847,7 +847,7 @@ SELECT * FROM mat_ffunc_test;
 DROP view mat_ffunc_test cascade;
 
 create or replace view mat_ffunc_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigint '123')
 from conditions
@@ -860,7 +860,7 @@ SELECT * FROM mat_ffunc_test;
 --refresh mat view test when time_bucket is not projected --
 drop view mat_ffunc_test cascade;
 create or replace view mat_refresh_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -76,7 +76,7 @@ SELECT create_hypertable('test_continuous_agg_table', 'time', chunk_time_interva
 CREATE OR REPLACE FUNCTION integer_now_test() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM test_continuous_agg_table $$;
 SELECT set_integer_now_func('test_continuous_agg_table', 'integer_now_test');
 CREATE VIEW test_continuous_agg_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
         GROUP BY 1;
@@ -223,6 +223,7 @@ DROP VIEW test_continuous_agg_view CASCADE;
 
 CREATE VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
+        timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
@@ -287,6 +288,7 @@ DROP VIEW test_continuous_agg_view CASCADE;
 --create a view with a function that it has no permission to execute
 CREATE VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
+        timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value, get_constant_no_perms()
@@ -320,7 +322,8 @@ INSERT INTO test_continuous_agg_table_w_grant
 -- make sure view can be created
 CREATE VIEW test_continuous_agg_view_user_2
     WITH ( timescaledb.continuous,
-         timescaledb.max_interval_per_job='2',
+        timescaledb.materialized_only=true,
+        timescaledb.max_interval_per_job='2',
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table_w_grant

--- a/tsl/test/sql/continuous_aggs_materialize.sql
+++ b/tsl/test/sql/continuous_aggs_materialize.sql
@@ -271,7 +271,7 @@ SET client_min_messages TO LOG;
 SELECT * FROM continuous_agg_test_t;
 
 CREATE VIEW test_t_mat_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_test_t
         GROUP BY 1;
@@ -370,7 +370,7 @@ SELECT set_integer_now_func('continuous_agg_extreme', 'integer_now_continuous_ag
 -- TODO we should be able to use time_bucket(5, ...) (note lack of '), but that is currently not
 --      recognized as a constant
 CREATE VIEW extreme_view
-    WITH ( timescaledb.continuous)
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('1', time), SUM(data) as value
         FROM continuous_agg_extreme
         GROUP BY 1;
@@ -449,7 +449,7 @@ CREATE OR REPLACE FUNCTION integer_now_continuous_agg_negative() returns BIGINT 
 SELECT set_integer_now_func('continuous_agg_negative', 'integer_now_continuous_agg_negative');
 
 CREATE VIEW negative_view_5
-    WITH (timescaledb.continuous, timescaledb.refresh_lag='-2')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('5', time), COUNT(data) as value
         FROM continuous_agg_negative
         GROUP BY 1;
@@ -480,7 +480,7 @@ DROP VIEW negative_view_5 CASCADE;
 TRUNCATE continuous_agg_negative;
 
 CREATE VIEW negative_view_5
-            WITH (timescaledb.continuous, timescaledb.refresh_lag='-2')
+            WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
 AS SELECT time_bucket('5', time), COUNT(data) as value
    FROM continuous_agg_negative
    GROUP BY 1;
@@ -511,7 +511,7 @@ SELECT set_integer_now_func('continuous_agg_max_mat', 'integer_now_continuous_ag
 
 -- only allow two time_buckets per run
 CREATE VIEW max_mat_view
-    WITH (timescaledb.continuous, timescaledb.max_interval_per_job='4', timescaledb.refresh_lag='-2')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4', timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), COUNT(data) as value
         FROM continuous_agg_max_mat
         GROUP BY 1;
@@ -582,7 +582,7 @@ SELECT create_hypertable('continuous_agg_max_mat_t', 'time');
 
 -- only allow two time_buckets per run
 CREATE VIEW max_mat_view_t
-    WITH (timescaledb.continuous, timescaledb.max_interval_per_job='4 hours', timescaledb.refresh_lag='-2 hours')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4 hours', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_max_mat_t
         GROUP BY 1;
@@ -611,7 +611,7 @@ CREATE TABLE continuous_agg_max_mat_timestamp(time TIMESTAMP);
 SELECT create_hypertable('continuous_agg_max_mat_timestamp', 'time');
 
 CREATE VIEW max_mat_view_timestamp
-    WITH (timescaledb.continuous, timescaledb.refresh_lag='-2 hours')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time)
         FROM continuous_agg_max_mat_timestamp
         GROUP BY 1;
@@ -628,7 +628,7 @@ CREATE TABLE continuous_agg_max_mat_date(time DATE);
 SELECT create_hypertable('continuous_agg_max_mat_date', 'time');
 
 CREATE VIEW max_mat_view_date
-    WITH (timescaledb.continuous, timescaledb.refresh_lag='-7 days')
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-7 days')
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
         GROUP BY 1;
@@ -666,7 +666,7 @@ SELECT table_name FROM create_hypertable('timezone_test','time');
 INSERT INTO timezone_test VALUES (now() - '30m'::interval), (now()), (now() + '30m'::interval);
 
 CREATE VIEW timezone_test_summary
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
         GROUP BY 1;
@@ -685,7 +685,7 @@ SELECT table_name FROM create_hypertable('timezone_test','time');
 INSERT INTO timezone_test VALUES (now() - '30m'::interval), (now()), (now() + '30m'::interval);
 
 CREATE VIEW timezone_test_summary
-    WITH (timescaledb.continuous)
+    WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
         GROUP BY 1;

--- a/tsl/test/sql/continuous_aggs_permissions.sql.in
+++ b/tsl/test/sql/continuous_aggs_permissions.sql.in
@@ -102,6 +102,7 @@ select from alter_job_schedule(:cagg_job_id, max_runtime => NULL);
 --make sure that commands fail
 
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
+ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
 DROP VIEW mat_refresh_test CASCADE; 
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 SELECT * FROM mat_refresh_test;
@@ -110,7 +111,7 @@ SELECT * FROM :"mat_chunk_schema".:"mat_chunk_table";
 
 --cannot create a mat view without select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check
@@ -118,7 +119,7 @@ group by time_bucket(100, timec), location;
 
 --cannot create mat view in a schema without create privileges
 create or replace view custom_schema.mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
@@ -127,7 +128,7 @@ group by time_bucket(100, timec), location;
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity), get_constant()
 from conditions_for_perm_check_w_grant
@@ -139,7 +140,7 @@ DROP VIEW mat_perm_view_test CASCADE;
 
 --can create a mat view on something with select and trigger grants
 create or replace view mat_perm_view_test
-WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
+WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -1,0 +1,174 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- disable background workers to make results reproducible
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-- look at postgres version to decide whether we run with analyze or without
+SELECT
+  CASE WHEN current_setting('server_version_num')::int >= 100000
+    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
+    ELSE 'EXPLAIN (costs off)'
+  END AS "PREFIX"
+\gset
+
+
+CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
+SELECT create_hypertable('metrics','time');
+ALTER TABLE metrics DROP COLUMN f1;
+
+INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, device_id, 0.5 FROM generate_series(1,3) g(device_id);
+
+--
+-- test switching continuous agg view between different modes
+--
+
+-- check default view for new continuous aggregate
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+
+ALTER TABLE metrics DROP COLUMN f2;
+
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- upgrade view to union view again
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- try upgrade view to union view that is already union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- refresh
+REFRESH MATERIALIZED VIEW metrics_summary;
+-- result should not change after refresh for union view
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+-- view should have results now after refresh
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+DROP VIEW metrics_summary CASCADE;
+
+-- check default view for new continuous aggregate with materialized_only to true
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- upgrade view to union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+-- this should be union view
+SELECT pg_get_viewdef('metrics_summary',true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- downgrade view to non-union view
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+-- this should be view without union
+SELECT pg_get_viewdef('metrics_summary',true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+DROP VIEW metrics_summary CASCADE;
+
+--
+-- test queries on union view
+--
+
+CREATE VIEW metrics_summary
+  WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+
+-- query should not have results since cagg is materialized only and no refresh has happened yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+
+-- after switch to union view all results should be returned
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+REFRESH MATERIALIZED VIEW metrics_summary;
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+
+-- materialized only view should return data now too because refresh has happened
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- add some more data
+INSERT INTO metrics(time, device_id, value) SELECT '2000-02-01'::timestamptz, device_id, device_id/10.0 FROM generate_series(1,3) g(device_id);
+
+-- materialized only view should not have new data yet
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- but union view should
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- and after refresh non union view should have new data too
+REFRESH MATERIALIZED VIEW metrics_summary;
+ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
+
+-- hardcoding now to 50 will lead to 30 watermark
+CREATE OR REPLACE FUNCTION boundary_test_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 50;
+$BODY$;
+
+-- test watermark interaction with just in time aggregates
+CREATE TABLE boundary_test(time int, value float);
+SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
+
+SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
+
+CREATE VIEW boundary_view
+  WITH (timescaledb.continuous)
+AS
+  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
+
+INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
+
+-- watermark should be NULL
+SELECT _timescaledb_internal.cagg_watermark(5);
+
+-- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
+:PREFIX SELECT * FROM boundary_view;
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+
+REFRESH MATERIALIZED VIEW boundary_view;
+
+-- watermark should be 30
+SELECT _timescaledb_internal.cagg_watermark(5);
+
+-- both sides of the UNION should return 2 rows
+:PREFIX SELECT * FROM boundary_view;
+
+-- result should have 4 rows
+SELECT * FROM boundary_view ORDER BY time_bucket;
+

--- a/tsl/test/sql/include/transparent_decompression_query.sql
+++ b/tsl/test/sql/include/transparent_decompression_query.sql
@@ -281,7 +281,7 @@ DEALLOCATE param_prep;
 
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time FROM cagg_test ORDER BY time LIMIT 1;


### PR DESCRIPTION
This PR adds a new mode for continuous aggregates that we name
real-time aggregates. Unlike the original this new mode will
combine materialized data with new data received after the last
refresh has happened. This new mode will be the default behaviour
for newly created continuous aggregates.

To upgrade existing continuous aggregates to the new behaviour
the following command needs to be run for all continuous aggregates

ALTER VIEW continuous_view_name SET (timescaledb.materialized_only=false);

To disable this behaviour for newly created continuous aggregates
and get the old behaviour the following command can be run

ALTER VIEW continuous_view_name SET (timescaledb.materialized_only=true);
