### PR TITLE
Fix segment_by var for decompress chunk node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ accidentally triggering the load of a previous DB version.**
 * #1665 Add ignore_invalidation_older_than to timescaledb_information.continuous_aggregates view
 * #1668 Cannot add dimension if hypertable has empty chunks
 * #1674 Fix time_bucket_gapfill's interaction with GROUP BY
+* #1686 Fix order by queries on compressed hypertables that have char segment by column
 * #1687 Fix issue with disabling compression when foreign keys are present
 
 **Thanks**
 * @RJPhillips01 for reporting an issue with drop chunks.
 * @b4eEx for reporting an issue with disabling compression.
+* @dark048 for reporting an issue with order by on compressed hypertables
 
 ## 1.6.0 (2020-01-14)
 

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -465,14 +465,13 @@ compressed_reltarget_add_var_for_column(RelOptInfo *compressed_rel, Oid compress
 										const char *column_name)
 {
 	AttrNumber attnum = get_attnum(compressed_relid, column_name);
+	Oid typid, collid;
+	int32 typmod;
 	Assert(attnum > 0);
-	compressed_rel->reltarget->exprs = lappend(compressed_rel->reltarget->exprs,
-											   makeVar(compressed_rel->relid,
-													   attnum,
-													   get_atttype(compressed_rel->relid, attnum),
-													   -1,
-													   0,
-													   0));
+	get_atttypetypmodcoll(compressed_relid, attnum, &typid, &typmod, &collid);
+	compressed_rel->reltarget->exprs =
+		lappend(compressed_rel->reltarget->exprs,
+				makeVar(compressed_rel->relid, attnum, typid, typmod, collid, 0));
 }
 
 /* copy over the vars from the chunk_rel->reltarget to the compressed_rel->reltarget

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -90,13 +90,14 @@ make_compressed_scan_targetentry(DecompressChunkPath *path, AttrNumber ht_attno,
 	Assert(!get_rte_attribute_is_dropped(path->info->chunk_rte, chunk_attno));
 	Assert(!get_rte_attribute_is_dropped(path->info->compressed_rte, scan_varattno));
 
-	if (ht_info->algo_id == 0)
-		scan_var = makeVar(path->info->compressed_rel->relid,
-						   scan_varattno,
-						   get_atttype(path->info->ht_rte->relid, ht_attno),
-						   -1,
-						   0,
-						   0);
+	if (ht_info->algo_id == _INVALID_COMPRESSION_ALGORITHM)
+	{
+		Oid typid, collid;
+		int32 typmod;
+		get_atttypetypmodcoll(path->info->ht_rte->relid, ht_attno, &typid, &typmod, &collid);
+		scan_var =
+			makeVar(path->info->compressed_rel->relid, scan_varattno, typid, typmod, collid, 0);
+	}
 	else
 		scan_var = makeVar(path->info->compressed_rel->relid,
 						   scan_varattno,

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -1,0 +1,55 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--TEST github issue 1650 character segment by column 
+CREATE TABLE test_chartab ( job_run_id INTEGER NOT NULL, mac_id CHAR(16) NOT NULL, rtt INTEGER NOT NULL, ts TIMESTAMP(3) NOT NULL );
+SELECT create_hypertable('test_chartab', 'ts', chunk_time_interval => interval '1 day', migrate_data => true);
+     create_hypertable     
+---------------------------
+ (1,public,test_chartab,t)
+(1 row)
+
+insert into test_chartab
+values(8864, '0014070000006190' , 392 , '2019-12-14 02:52:05.863');
+insert into test_chartab
+values( 8864 , '0014070000011039' , 150 , '2019-12-14 02:52:05.863');
+insert into test_chartab
+values( 8864 , '001407000001DD2E' , 228 , '2019-12-14 02:52:05.863');
+insert into test_chartab
+values( 8890 , '001407000001DD2E' , 228 , '2019-12-20 02:52:05.863');
+ALTER TABLE test_chartab SET (timescaledb.compress, timescaledb.compress_segmentby = 'mac_id', timescaledb.compress_orderby = 'ts DESC');
+NOTICE:  adding index _compressed_hypertable_2_mac_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(mac_id, _ts_meta_sequence_num)
+select * from test_chartab order by mac_id , ts limit 2;
+ job_run_id |      mac_id      | rtt |              ts              
+------------+------------------+-----+------------------------------
+       8864 | 0014070000006190 | 392 | Sat Dec 14 02:52:05.863 2019
+       8864 | 0014070000011039 | 150 | Sat Dec 14 02:52:05.863 2019
+(2 rows)
+
+--compress the data and check --
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+select * from test_chartab order by mac_id , ts limit 2;
+ job_run_id |      mac_id      | rtt |              ts              
+------------+------------------+-----+------------------------------
+       8864 | 0014070000006190 | 392 | Sat Dec 14 02:52:05.863 2019
+       8864 | 0014070000011039 | 150 | Sat Dec 14 02:52:05.863 2019
+(2 rows)
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+(1 row)
+
+select * from test_chartab order by mac_id , ts limit 2;
+ job_run_id |      mac_id      | rtt |              ts              
+------------+------------------+-----+------------------------------
+       8864 | 0014070000006190 | 392 | Sat Dec 14 02:52:05.863 2019
+       8864 | 0014070000011039 | 150 | Sat Dec 14 02:52:05.863 2019
+(2 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -49,6 +49,7 @@ if (${PG_VERSION_MAJOR} GREATER "9")
     compression_segment_meta.sql
     compression_bgw.sql
     compress_bgw_drop_chunks.sql
+    transparent_decompression_queries.sql
   )
 
   list(APPEND TEST_TEMPLATES

--- a/tsl/test/sql/transparent_decompression_queries.sql
+++ b/tsl/test/sql/transparent_decompression_queries.sql
@@ -1,0 +1,29 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+--TEST github issue 1650 character segment by column 
+CREATE TABLE test_chartab ( job_run_id INTEGER NOT NULL, mac_id CHAR(16) NOT NULL, rtt INTEGER NOT NULL, ts TIMESTAMP(3) NOT NULL );
+
+SELECT create_hypertable('test_chartab', 'ts', chunk_time_interval => interval '1 day', migrate_data => true);
+insert into test_chartab
+values(8864, '0014070000006190' , 392 , '2019-12-14 02:52:05.863');
+insert into test_chartab
+values( 8864 , '0014070000011039' , 150 , '2019-12-14 02:52:05.863');
+insert into test_chartab
+values( 8864 , '001407000001DD2E' , 228 , '2019-12-14 02:52:05.863');
+insert into test_chartab
+values( 8890 , '001407000001DD2E' , 228 , '2019-12-20 02:52:05.863');
+
+ALTER TABLE test_chartab SET (timescaledb.compress, timescaledb.compress_segmentby = 'mac_id', timescaledb.compress_orderby = 'ts DESC');
+
+select * from test_chartab order by mac_id , ts limit 2;
+
+--compress the data and check --
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+select * from test_chartab order by mac_id , ts limit 2;
+
+SELECT compress_chunk('_timescaledb_internal._hyper_1_2_chunk');
+select * from test_chartab order by mac_id , ts limit 2;
+
+


### PR DESCRIPTION
Fix order by queries on compressed hypertables that
    have char segment by column.
    The segment by var column for decompressed chunks should be
    created after settng the typmod and collation ids. Otherwise, we
    get failures with char datatypes while decompressing.
    
    Fixes #1650