### PR TITLE
Support disabling compression when foreign keys are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ accidentally triggering the load of a previous DB version.**
 * #1665 Add ignore_invalidation_older_than to timescaledb_information.continuous_aggregates view
 * #1668 Cannot add dimension if hypertable has empty chunks
 * #1674 Fix time_bucket_gapfill's interaction with GROUP BY
+* #1687 Fix issue with disabling compression when foreign keys are present
 
 **Thanks**
 * @RJPhillips01 for reporting an issue with drop chunks.
+* @b4eEx for reporting an issue with disabling compression.
 
 ## 1.6.0 (2020-01-14)
 

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -354,3 +354,44 @@ select device_id, d from table_constr order by device_id, d;
 -----------+---
 (0 rows)
 
+--github issue 1661
+--disable compression after enabling it on a table that has fk constraints
+CREATE TABLE  table_constr2( device_id integer,
+                    timec integer ,
+                    location integer ,
+                   d integer references fortable(col),
+                    primary key ( device_id, timec)
+);
+SELECT table_name from create_hypertable('table_constr2', 'timec', chunk_time_interval=> 10);
+  table_name   
+---------------
+ table_constr2
+(1 row)
+
+INSERT INTO fortable VALUES( 99 );
+INSERT INTO table_constr2 VALUES( 1000, 10, 5, 99);
+ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
+ERROR:  constraint "table_constr2_d_fkey" requires column "d" to be a timescaledb.compress_segmentby column for compression
+ ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id, d');
+NOTICE:  adding index _compressed_hypertable_21_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_21 USING BTREE(device_id, _ts_meta_sequence_num)
+NOTICE:  adding index _compressed_hypertable_21_d__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_21 USING BTREE(d, _ts_meta_sequence_num)
+--compress a chunk and try to disable compression, it should fail --
+SELECT ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht
+WHERE ch1.hypertable_id = ht.id and ht.table_name like 'table_constr2' \gset
+SELECT compress_chunk(:'CHUNK_NAME');
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_20_10_chunk
+(1 row)
+
+ALTER TABLE table_constr2 set (timescaledb.compress=false);
+ERROR:  cannot change compression options as compressed chunks already exist for this table
+--decompress all chunks and disable compression.
+SELECT decompress_chunk(:'CHUNK_NAME');
+             decompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_20_10_chunk
+(1 row)
+
+ALTER TABLE table_constr2 SET (timescaledb.compress=false);


### PR DESCRIPTION
Fix failure with disabling compression when no
compressed chunks are present and the table has foreign
key constraints

Fixes #1661 