### PR TITLE
Handle many BGW jobs better

### DIFF
--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -303,9 +303,12 @@ bgw_job_stat_tuple_mark_end(TupleInfo *ti, void *const data)
 
 		/*
 		 * Mark the next start at the end if the job itself hasn't (this may
-		 * have happened before failure)
+		 * have happened before failure) and the failure was not in starting.
+		 * If the failure was in starting, then next_start should have been
+		 * restored in `on_failure_to_start_job` and thus we don't change it here.
+		 * Even if it wasn't restored, then keep it as DT_NOBEGIN to mark it as highest priority.
 		 */
-		if (!bgw_job_stat_next_start_was_set(fd))
+		if (!bgw_job_stat_next_start_was_set(fd) && result_ctx->result != JOB_FAILURE_TO_START)
 			fd->next_start = calculate_next_start_on_failure(fd->last_finish,
 															 fd->consecutive_failures,
 															 result_ctx->job);

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -14,8 +14,10 @@ typedef struct BgwJobStat
 	FormData_bgw_job_stat fd;
 } BgwJobStat;
 
+/* Positive result numbers reserved for success */
 typedef enum JobResult
 {
+	JOB_FAILURE_TO_START = -1,
 	JOB_FAILURE = 0,
 	JOB_SUCCESS = 1,
 } JobResult;

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -754,6 +754,42 @@ SELECT * FROM sorted_bgw_log;
       1 | 300500000 | test_job_3_long  | After sleep job 3
 (14 rows)
 
+CREATE FUNCTION wait_for_timer_to_run(started_at INTEGER, spins INTEGER=:TEST_SPINWAIT_ITERS) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+	num_runs INTEGER;
+	message TEXT;
+BEGIN
+	select format('[TESTING] Wait until %%, started at %s', started_at) into message;
+	FOR i in 1..spins
+	LOOP
+	SELECT COUNT(*) from bgw_log where msg LIKE message INTO num_runs;
+	if (num_runs > 0) THEN
+		RETURN true;
+	ELSE
+		PERFORM pg_sleep(0.1);
+	END IF;
+	END LOOP;
+	RETURN false;
+END
+$BODY$;
+CREATE FUNCTION wait_for_job_3_to_finish(runs INTEGER, spins INTEGER=:TEST_SPINWAIT_ITERS) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+	num_runs INTEGER;
+BEGIN
+	FOR i in 1..spins
+	LOOP
+	SELECT COUNT(*) from bgw_log where msg='After sleep job 3' INTO num_runs;
+	if (num_runs = runs) THEN
+		RETURN true;
+	ELSE
+		PERFORM pg_sleep(0.1);
+	END IF;
+	END LOOP;
+	RETURN false;
+END
+$BODY$;
 --
 -- Test starting more jobs than availlable workers
 --
@@ -767,6 +803,12 @@ SELECT ts_bgw_params_reset_time();
 (1 row)
 
 DELETE FROM _timescaledb_config.bgw_job;
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_FOR_OTHER_TO_ADVANCE);
+ ts_bgw_params_mock_wait_returns_immediately 
+---------------------------------------------
+ 
+(1 row)
+
 --Our normal limit is 8 jobs (1 already taken up by the launcher, we don't register the test scheduler)
 --so start 8 workers. Make the schedule_INTERVAL long and the retry period short so that the
 --retries happen within the scheduler run time but everything only runs once.
@@ -780,10 +822,23 @@ INSERT INTO _timescaledb_config.bgw_job (application_name, job_type, schedule_IN
 ('test_job_3_long_7', 'bgw_test_job_3_long', INTERVAL '5000ms', INTERVAL '100s', 3, INTERVAL '10ms'),
 ('test_job_3_long_8', 'bgw_test_job_3_long', INTERVAL '5000ms', INTERVAL '100s', 3, INTERVAL '10ms');
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(500);
- ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
-------------------------------------------------------------
+SELECT ts_bgw_db_scheduler_test_run(25000); --quit at second 25
+ ts_bgw_db_scheduler_test_run 
+------------------------------
  
+(1 row)
+
+--the first 7 jobs will run right away, but not the last one
+SELECT wait_for_timer_to_run(0);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+SELECT wait_for_job_3_to_finish(7);
+ wait_for_job_3_to_finish 
+--------------------------
+ t
 (1 row)
 
 SELECT job_id, last_run_success, total_runs, total_successes, total_failures, total_crashes, consecutive_crashes
@@ -798,7 +853,53 @@ ORDER BY job_id;
    1010 | t                |          1 |               1 |              0 |             0 |                   0
    1011 | t                |          1 |               1 |              0 |             0 |                   0
    1012 | t                |          1 |               1 |              0 |             0 |                   0
-   1013 | t                |          2 |               1 |              1 |             0 |                   0
+(7 rows)
+
+--but after the first batch finishes and 1 second (START_RETRY_MS) passes, the last job will run.
+SELECT ts_bgw_params_reset_time(1000000, true); --set to second 1
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT wait_for_timer_to_run(1000000);
+ wait_for_timer_to_run 
+-----------------------
+ t
+(1 row)
+
+SELECT wait_for_job_3_to_finish(8);
+ wait_for_job_3_to_finish 
+--------------------------
+ t
+(1 row)
+
+SELECT ts_bgw_params_reset_time(30000000, true); --set to second 30, which causes a quit.
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_wait_for_scheduler_finish();
+ ts_bgw_db_scheduler_test_wait_for_scheduler_finish 
+----------------------------------------------------
+ 
+(1 row)
+
+--should have all 8 runs, all with success runs
+SELECT job_id, last_run_success, total_runs, total_successes, total_failures, total_crashes, consecutive_crashes
+FROM _timescaledb_internal.bgw_job_stat
+ORDER BY job_id;
+ job_id | last_run_success | total_runs | total_successes | total_failures | total_crashes | consecutive_crashes 
+--------+------------------+------------+-----------------+----------------+---------------+---------------------
+   1006 | t                |          1 |               1 |              0 |             0 |                   0
+   1007 | t                |          1 |               1 |              0 |             0 |                   0
+   1008 | t                |          1 |               1 |              0 |             0 |                   0
+   1009 | t                |          1 |               1 |              0 |             0 |                   0
+   1010 | t                |          1 |               1 |              0 |             0 |                   0
+   1011 | t                |          1 |               1 |              0 |             0 |                   0
+   1012 | t                |          1 |               1 |              0 |             0 |                   0
+   1013 | t                |          1 |               1 |              0 |             0 |                   0
 (8 rows)
 
 SELECT * FROM bgw_log WHERE application_name = 'DB Scheduler' ORDER BY mock_time, application_name, msg_no;
@@ -812,9 +913,9 @@ SELECT * FROM bgw_log WHERE application_name = 'DB Scheduler' ORDER BY mock_time
       5 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       6 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       7 |         0 | DB Scheduler     | failed to launch job 1013 "test_job_3_long_8": out of background workers
-      8 |         0 | DB Scheduler     | [TESTING] Wait until 9844, started at 0
-      9 |      9844 | DB Scheduler     | [TESTING] Registered new background worker
-     10 |      9844 | DB Scheduler     | [TESTING] Wait until 500000, started at 9844
+      8 |         0 | DB Scheduler     | [TESTING] Wait until 1000000, started at 0
+      9 |   1000000 | DB Scheduler     | [TESTING] Registered new background worker
+     10 |   1000000 | DB Scheduler     | [TESTING] Wait until 5000000, started at 1000000
 (11 rows)
 
 SELECT ts_bgw_params_destroy();
@@ -832,6 +933,12 @@ TRUNCATE _timescaledb_internal.bgw_job_stat;
 SELECT ts_bgw_params_reset_time();
  ts_bgw_params_reset_time 
 --------------------------
+ 
+(1 row)
+
+SELECT ts_bgw_params_mock_wait_returns_immediately(:WAIT_ON_JOB);
+ ts_bgw_params_mock_wait_returns_immediately 
+---------------------------------------------
  
 (1 row)
 
@@ -949,25 +1056,6 @@ BEGIN
 	LOOP
 	SELECT COUNT(*) from bgw_log where msg='Execute job 1' INTO num_runs;
 	if (num_runs = runs) THEN
-		RETURN true;
-	ELSE
-		PERFORM pg_sleep(0.1);
-	END IF;
-	END LOOP;
-	RETURN false;
-END
-$BODY$;
-CREATE FUNCTION wait_for_timer_to_run(started_at INTEGER, spins INTEGER=:TEST_SPINWAIT_ITERS) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
-$BODY$
-DECLARE
-	num_runs INTEGER;
-	message TEXT;
-BEGIN
-	select format('[TESTING] Wait until %%, started at %s', started_at) into message;
-	FOR i in 1..spins
-	LOOP
-	SELECT COUNT(*) from bgw_log where msg LIKE message INTO num_runs;
-	if (num_runs > 0) THEN
 		RETURN true;
 	ELSE
 		PERFORM pg_sleep(0.1);


### PR DESCRIPTION
This PR improves the scheduling of jobs when the number of
jobs exceeds the amount of background workers. Previously,
this was not a case the scheduler handled well.

The basic strategy we employ to handle this case better is to
use a job's next_start field to create a priority for jobs.
More concretely, jobs are scheduled in increasing order of
next_start. If the scheduler runs out of bgw's it waits to
until bgws become available and then retries again, also
in increasing next_start order.

The first change this PR implements is start jobs in order
of increasing next_start. We also make sure that if we run
out of BGWs, the scheduler will try again in START_RETRY_MS
(1 second by default).

This PR also needed to change the logic of what happens when
a job fails to start because BGWs have run out. Previously,
such jobs were marked as failed and their next_start was reset
using the regular post-failure backoff logic. But, this means
that a job looses its priority every time we run out of BGWs.
Thus, we changed this logic so that next_start does not change
when we encounter this situation.

There are actually 2 ways to run out of BGWs:
1) We run out of the timescale limit on BGWs - in this case
the job is simply put back into the scheduled state, and it
will be retried in START_RETRY_MS. The job is not marked
started or failed. This is the common error.

2) We run out of PostgreSQL workers. We won't know if this
failed until we try to start the worker, by which time the
job must be in the started state. Thus if we run into this
error we must mark the job as failed. But we don't change
next_start. To do this we create a new job result type
called JOB_FAILURE_TO_START.