### PR TITLE
Add logic to ignore dropped chunks in hypertable_relation_size

### DIFF
--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -55,6 +55,7 @@ BEGIN
                       pg_class pgc,
                       pg_namespace pns
                       WHERE h.schema_name = %L
+                      AND c.dropped = false
                       AND h.table_name = %L
                       AND c.hypertable_id = h.id
                       AND pgc.relname = h.table_name


### PR DESCRIPTION
Relation size should not include dropped chunks

Function hypertable_relation_size includes chunks that were dropped which causes a failure when looking up the size of dropped chunks. Adding this check to the WHERE statement in the SQL will ignore dropped chunks from the size calculation.

Fixes: #1692