### PR TITLE
Prevent starting background workers with NOLOGIN

### DIFF
--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -58,6 +58,8 @@ extern TSDLLEXPORT void ts_bgw_job_update_by_id(int32 job_id, BgwJob *updated_jo
 
 extern TSDLLEXPORT void ts_bgw_job_permission_check(BgwJob *job);
 
+extern TSDLLEXPORT void ts_bgw_job_validate_job_owner(Oid owner, JobType type);
+
 extern bool ts_bgw_job_execute(BgwJob *job);
 
 extern Oid ts_bgw_job_owner(BgwJob *job);

--- a/tsl/src/bgw_policy/compress_chunks_api.c
+++ b/tsl/src/bgw_policy/compress_chunks_api.c
@@ -74,6 +74,7 @@ compress_chunks_add_policy(PG_FUNCTION_ARGS)
 	Dimension *dim;
 	FormData_ts_interval *older_than;
 	ts_hypertable_permissions_check(ht_oid, GetUserId());
+	Oid owner_id = ts_hypertable_permissions_check(ht_oid, GetUserId());
 
 	older_than = ts_interval_from_sql_input(ht_oid,
 											older_than_datum,
@@ -91,6 +92,8 @@ compress_chunks_add_policy(PG_FUNCTION_ARGS)
 				 errmsg("can add compress_chunks policy only on hypertables with compression "
 						"enabled")));
 	}
+
+	ts_bgw_job_validate_job_owner(owner_id, JOB_TYPE_COMPRESS_CHUNKS);
 
 	/* Make sure that an existing policy doesn't exist on this hypertable */
 	existing = ts_bgw_policy_compress_chunks_find_by_hypertable(hypertable->fd.id);

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -139,7 +139,10 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	FormData_ts_interval *older_than;
 	DropChunksMeta meta;
 	Oid mapped_oid;
-	ts_hypertable_permissions_check(ht_oid, GetUserId());
+	Oid owner_id = ts_hypertable_permissions_check(ht_oid, GetUserId());
+
+	/* Verify that the hypertable owner can create a background worker */
+	ts_bgw_job_validate_job_owner(owner_id, JOB_TYPE_DROP_CHUNKS);
 
 	/* Make sure that an existing policy doesn't exist on this hypertable */
 	hcache = ts_hypertable_cache_pin();

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -82,13 +82,14 @@ reorder_add_policy(PG_FUNCTION_ARGS)
 	int32 hypertable_id = ts_hypertable_relid_to_id(ht_oid);
 	Hypertable *ht = ts_hypertable_get_by_id(hypertable_id);
 	Oid partitioning_type;
+	Oid owner_id;
 
 	BgwPolicyReorder policy = { .fd = {
 									.hypertable_id = hypertable_id,
 									.hypertable_index_name = *index_name,
 								} };
 
-	ts_hypertable_permissions_check(ht_oid, GetUserId());
+	owner_id = ts_hypertable_permissions_check(ht_oid, GetUserId());
 
 	/* First verify that the hypertable corresponds to a valid table */
 	if (!ts_is_hypertable(ht_oid))
@@ -99,6 +100,9 @@ reorder_add_policy(PG_FUNCTION_ARGS)
 
 	/* Now verify that the index is an actual index on that hypertable */
 	check_valid_index(ht, index_name);
+
+	/* Verify that the hypertable owner can create a background worker */
+	ts_bgw_job_validate_job_owner(owner_id, JOB_TYPE_REORDER);
 
 	/* Make sure that an existing policy doesn't exist on this hypertable */
 	existing = ts_bgw_policy_reorder_find_by_hypertable(ts_hypertable_relid_to_id(ht_oid));

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -12,6 +12,8 @@ CREATE OR REPLACE FUNCTION test_compress_chunks_policy(job_id INTEGER)
 RETURNS VOID
 AS :TSL_MODULE_PATHNAME, 'ts_test_auto_compress_chunks'
 LANGUAGE C VOLATILE STRICT;
+CREATE ROLE NOLOGIN_ROLE WITH nologin noinherit;
+GRANT NOLOGIN_ROLE TO :ROLE_DEFAULT_PERM_USER WITH ADMIN OPTION;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE conditions (
       time        TIMESTAMPTZ       NOT NULL,
@@ -179,3 +181,27 @@ order by chunk_name;
  test_table_int  | _timescaledb_internal._hyper_3_6_chunk | 24 kB                    | 16 kB
 (2 rows)
 
+--TEST 8
+--hypertable owner lacks permission to start background worker
+SET ROLE NOLOGIN_ROLE;
+CREATE TABLE test_table_nologin(time bigint, val int);
+SELECT create_hypertable('test_table_nologin', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (5,public,test_table_nologin,t)
+(1 row)
+
+SELECT set_integer_now_func('test_table_nologin', 'dummy_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+ALTER TABLE test_table_nologin set (timescaledb.compress);
+\set ON_ERROR_STOP 0
+SELECT add_compress_chunks_policy('test_table_nologin', 2::int);
+ERROR:  permission denied to start compress_chunks background process as role "nologin_role"
+\set ON_ERROR_STOP 1
+RESET ROLE;
+REVOKE NOLOGIN_ROLE FROM :ROLE_DEFAULT_PERM_USER;

--- a/tsl/test/expected/continuous_aggs_permissions-10.out
+++ b/tsl/test/expected/continuous_aggs_permissions-10.out
@@ -105,7 +105,7 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
 select from alter_job_schedule(:cagg_job_id, max_runtime => NULL);
-ERROR:  insufficient permssions to alter job 1000
+ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
 ERROR:  must be owner of relation mat_refresh_test

--- a/tsl/test/expected/continuous_aggs_permissions-11.out
+++ b/tsl/test/expected/continuous_aggs_permissions-11.out
@@ -105,7 +105,7 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
 select from alter_job_schedule(:cagg_job_id, max_runtime => NULL);
-ERROR:  insufficient permssions to alter job 1000
+ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
 ERROR:  must be owner of view mat_refresh_test

--- a/tsl/test/expected/continuous_aggs_permissions-9.6.out
+++ b/tsl/test/expected/continuous_aggs_permissions-9.6.out
@@ -105,7 +105,7 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
 select from alter_job_schedule(:cagg_job_id, max_runtime => NULL);
-ERROR:  insufficient permssions to alter job 1000
+ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
 ERROR:  must be owner of relation mat_refresh_test

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -936,7 +936,7 @@ select add_drop_chunks_policy('test_table', INTERVAL '4 months', true) as drop_c
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
 select from alter_job_schedule(:reorder_job_id, max_runtime => NULL);
-ERROR:  insufficient permssions to alter job 1015
+ERROR:  insufficient permissions to alter job 1015
 select from alter_job_schedule(:drop_chunks_job_id, max_runtime => NULL);
-ERROR:  insufficient permssions to alter job 1016
+ERROR:  insufficient permissions to alter job 1016
 \set ON_ERROR_STOP 1


### PR DESCRIPTION
This change will check sql commands which start a background worker
on a hypertable to verify that the table owner has permission to
log into the database.  This is necessary, as background workers for
these commands will run with the permissions of the table owner, and
thus immediately fail if unable to log in.