### PR TITLE
Fix restoring/scheduler entrypoint to avoid BGW death

### DIFF
--- a/sql/restoring.sql
+++ b/sql/restoring.sql
@@ -27,7 +27,7 @@ BEGIN
     SELECT current_database() INTO db;
     EXECUTE format($$ALTER DATABASE %I SET timescaledb.restoring ='off'$$, db);
     SET SESSION timescaledb.restoring='off';
-    PERFORM _timescaledb_internal.start_background_workers();
+    PERFORM _timescaledb_internal.restart_background_workers();
 
     --try to restore the backed up uuid, if the restore did not set one
     INSERT INTO _timescaledb_catalog.metadata

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -350,13 +350,44 @@ SELECT wait_worker_counts(1,0,0,0);
  t
 (1 row)
 
---And post_restore starts them
+-- Make sure a restart with restoring on first starts the background worker 
+BEGIN;
+SELECT _timescaledb_internal.restart_background_workers();
+ restart_background_workers 
+----------------------------
+ t
+(1 row)
+
+SELECT wait_worker_counts(1,0,1,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+COMMIT;
+-- Then the worker dies when it sees that restoring is on after the txn commits
+SELECT wait_worker_counts(1,0,0,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+--And post_restore starts them 
+BEGIN;
 SELECT timescaledb_post_restore();
  timescaledb_post_restore 
 --------------------------
  t
 (1 row)
 
+SELECT wait_worker_counts(1,0,1,0);
+ wait_worker_counts 
+--------------------
+ t
+(1 row)
+
+COMMIT;
+-- And they stay started
 SELECT wait_worker_counts(1,0,1,0);
  wait_worker_counts 
 --------------------


### PR DESCRIPTION
There was a race condition between the post_restore function
restarting the background worker and the setting of the
restoring flag to "off". If the worker started before the
change to the restoring flag had been committed, it would not
see the change and then die because the worker should exit
when the db is in a restoring state. This modifies the
post_restore function to use a restart instead of a start
so that it waits on the commit to start up. It also adds
logic to the entrypoint to reload config changes caused
by an `ALTER DATABASE SET` command. These changes are
normally only seen at connection startup but we have to
wait until after our lock on the modifying transaction is
released to know whether we should adopt them.

Fixes #1712 

Changes the loader so would require a restart on upgrade.