### PR TITLE
Scheduler cache invalidations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,14 @@ accidentally triggering the load of a previous DB version.**
 * #1674 Fix time_bucket_gapfill's interaction with GROUP BY
 * #1686 Fix order by queries on compressed hypertables that have char segment by column
 * #1687 Fix issue with disabling compression when foreign keys are present
+* #1704 Fix bad plan for continuous aggregate materialization
+* #1713 Fix miscellaneous background worker issues
 * #1715 Fix issue with overly aggressive chunk exclusion in outer joins
+* #1720 Add scheduler cache invalidations
 * #1727 Fix compressing INTERVAL columns
 * #1728 Handle Sort nodes in ConstraintAwareAppend
 * #1730 Fix partial index handling on chunks
+* #1740 Fix copy of continuous aggregate invalidation entries
 
 **Licensing changes**
 * Reorder and policies around reorder and drop chunks are now

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -258,8 +258,9 @@ SELECT * FROM sorted_bgw_log;
 --------+-----------+------------------+--------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
-      1 |         0 | test_job_2       | Error job 2
-(3 rows)
+      1 |         0 | test_job_2       | job 1001 threw an error
+      2 |         0 | test_job_2       | Error job 2
+(4 rows)
 
 SELECT last_finish, last_successful_finish, last_run_success FROM _timescaledb_internal.bgw_job_stat;
          last_finish          | last_successful_finish | last_run_success 
@@ -286,12 +287,14 @@ SELECT * FROM sorted_bgw_log;
 --------+-----------+------------------+-----------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
-      1 |         0 | test_job_2       | Error job 2
+      1 |         0 | test_job_2       | job 1001 threw an error
+      2 |         0 | test_job_2       | Error job 2
       0 |     25000 | DB Scheduler     | [TESTING] Wait until 98438, started at 25000
       1 |     98438 | DB Scheduler     | [TESTING] Registered new background worker
       2 |     98438 | DB Scheduler     | [TESTING] Wait until 150000, started at 98438
-      1 |     98438 | test_job_2       | Error job 2
-(7 rows)
+      1 |     98438 | test_job_2       | job 1001 threw an error
+      2 |     98438 | test_job_2       | Error job 2
+(9 rows)
 
 --The job runs and fails again a few more times increasing the wait time each time.
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(225);
@@ -302,9 +305,9 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(225);
 
 SELECT job_id, next_start-last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
 FROM _timescaledb_internal.bgw_job_stat;
- job_id |   until_next   | last_run_success | total_runs | total_successes | total_failures | total_crashes 
---------+----------------+------------------+------------+-----------------+----------------+---------------
-   1001 | @ 0.39375 secs | f                |          3 |               0 |              3 |             0
+ job_id |   until_next    | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+-----------------+------------------+------------+-----------------+----------------+---------------
+   1001 | @ 0.295312 secs | f                |          3 |               0 |              3 |             0
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
@@ -312,16 +315,19 @@ SELECT * FROM sorted_bgw_log;
 --------+-----------+------------------+------------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
-      1 |         0 | test_job_2       | Error job 2
+      1 |         0 | test_job_2       | job 1001 threw an error
+      2 |         0 | test_job_2       | Error job 2
       0 |     25000 | DB Scheduler     | [TESTING] Wait until 98438, started at 25000
       1 |     98438 | DB Scheduler     | [TESTING] Registered new background worker
       2 |     98438 | DB Scheduler     | [TESTING] Wait until 150000, started at 98438
-      1 |     98438 | test_job_2       | Error job 2
+      1 |     98438 | test_job_2       | job 1001 threw an error
+      2 |     98438 | test_job_2       | Error job 2
       0 |    150000 | DB Scheduler     | [TESTING] Wait until 295313, started at 150000
       1 |    295313 | DB Scheduler     | [TESTING] Registered new background worker
       2 |    295313 | DB Scheduler     | [TESTING] Wait until 375000, started at 295313
-      1 |    295313 | test_job_2       | Error job 2
-(11 rows)
+      1 |    295313 | test_job_2       | job 1001 threw an error
+      2 |    295313 | test_job_2       | Error job 2
+(14 rows)
 
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(425);
  ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
@@ -331,9 +337,9 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(425);
 
 SELECT job_id, next_start-last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
 FROM _timescaledb_internal.bgw_job_stat;
- job_id |   until_next    | last_run_success | total_runs | total_successes | total_failures | total_crashes 
---------+-----------------+------------------+------------+-----------------+----------------+---------------
-   1001 | @ 0.492188 secs | f                |          4 |               0 |              4 |             0
+ job_id |   until_next   | last_run_success | total_runs | total_successes | total_failures | total_crashes 
+--------+----------------+------------------+------------+-----------------+----------------+---------------
+   1001 | @ 0.39375 secs | f                |          4 |               0 |              4 |             0
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
@@ -341,20 +347,24 @@ SELECT * FROM sorted_bgw_log;
 --------+-----------+------------------+------------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
-      1 |         0 | test_job_2       | Error job 2
+      1 |         0 | test_job_2       | job 1001 threw an error
+      2 |         0 | test_job_2       | Error job 2
       0 |     25000 | DB Scheduler     | [TESTING] Wait until 98438, started at 25000
       1 |     98438 | DB Scheduler     | [TESTING] Registered new background worker
       2 |     98438 | DB Scheduler     | [TESTING] Wait until 150000, started at 98438
-      1 |     98438 | test_job_2       | Error job 2
+      1 |     98438 | test_job_2       | job 1001 threw an error
+      2 |     98438 | test_job_2       | Error job 2
       0 |    150000 | DB Scheduler     | [TESTING] Wait until 295313, started at 150000
       1 |    295313 | DB Scheduler     | [TESTING] Registered new background worker
       2 |    295313 | DB Scheduler     | [TESTING] Wait until 375000, started at 295313
-      1 |    295313 | test_job_2       | Error job 2
-      0 |    375000 | DB Scheduler     | [TESTING] Wait until 689063, started at 375000
-      1 |    689063 | DB Scheduler     | [TESTING] Registered new background worker
-      2 |    689063 | DB Scheduler     | [TESTING] Wait until 800000, started at 689063
-      1 |    689063 | test_job_2       | Error job 2
-(15 rows)
+      1 |    295313 | test_job_2       | job 1001 threw an error
+      2 |    295313 | test_job_2       | Error job 2
+      0 |    375000 | DB Scheduler     | [TESTING] Wait until 590625, started at 375000
+      1 |    590625 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |    590625 | DB Scheduler     | [TESTING] Wait until 800000, started at 590625
+      1 |    590625 | test_job_2       | job 1001 threw an error
+      2 |    590625 | test_job_2       | Error job 2
+(19 rows)
 
 --Once the wait time reaches 500ms it stops increasion
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(525);
@@ -371,28 +381,33 @@ FROM _timescaledb_internal.bgw_job_stat;
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time | application_name |                       msg                        
---------+-----------+------------------+--------------------------------------------------
+ msg_no | mock_time | application_name |                       msg                       
+--------+-----------+------------------+-------------------------------------------------
       0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler     | [TESTING] Wait until 25000, started at 0
-      1 |         0 | test_job_2       | Error job 2
+      1 |         0 | test_job_2       | job 1001 threw an error
+      2 |         0 | test_job_2       | Error job 2
       0 |     25000 | DB Scheduler     | [TESTING] Wait until 98438, started at 25000
       1 |     98438 | DB Scheduler     | [TESTING] Registered new background worker
       2 |     98438 | DB Scheduler     | [TESTING] Wait until 150000, started at 98438
-      1 |     98438 | test_job_2       | Error job 2
+      1 |     98438 | test_job_2       | job 1001 threw an error
+      2 |     98438 | test_job_2       | Error job 2
       0 |    150000 | DB Scheduler     | [TESTING] Wait until 295313, started at 150000
       1 |    295313 | DB Scheduler     | [TESTING] Registered new background worker
       2 |    295313 | DB Scheduler     | [TESTING] Wait until 375000, started at 295313
-      1 |    295313 | test_job_2       | Error job 2
-      0 |    375000 | DB Scheduler     | [TESTING] Wait until 689063, started at 375000
-      1 |    689063 | DB Scheduler     | [TESTING] Registered new background worker
-      2 |    689063 | DB Scheduler     | [TESTING] Wait until 800000, started at 689063
-      1 |    689063 | test_job_2       | Error job 2
-      0 |    800000 | DB Scheduler     | [TESTING] Wait until 1181251, started at 800000
-      1 |   1181251 | DB Scheduler     | [TESTING] Registered new background worker
-      2 |   1181251 | DB Scheduler     | [TESTING] Wait until 1325000, started at 1181251
-      1 |   1181251 | test_job_2       | Error job 2
-(19 rows)
+      1 |    295313 | test_job_2       | job 1001 threw an error
+      2 |    295313 | test_job_2       | Error job 2
+      0 |    375000 | DB Scheduler     | [TESTING] Wait until 590625, started at 375000
+      1 |    590625 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |    590625 | DB Scheduler     | [TESTING] Wait until 800000, started at 590625
+      1 |    590625 | test_job_2       | job 1001 threw an error
+      2 |    590625 | test_job_2       | Error job 2
+      0 |    800000 | DB Scheduler     | [TESTING] Wait until 984375, started at 800000
+      1 |    984375 | DB Scheduler     | [TESTING] Registered new background worker
+      2 |    984375 | DB Scheduler     | [TESTING] Wait until 1325000, started at 984375
+      1 |    984375 | test_job_2       | job 1001 threw an error
+      2 |    984375 | test_job_2       | Error job 2
+(24 rows)
 
 --
 -- Test timeout logic
@@ -438,7 +453,8 @@ SELECT * FROM sorted_bgw_log;
       1 |         0 | DB Scheduler     | [TESTING] Wait until 20000, started at 0
       2 |     20000 | DB Scheduler     | terminating background worker "test_job_3_long" due to timeout
       3 |     20000 | DB Scheduler     | [TESTING] Wait until 200000, started at 20000
-(4 rows)
+      4 |    200000 | DB Scheduler     | job 1002 failed
+(5 rows)
 
 --Check that the scheduler does not kill a job with infinite timeout
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -529,7 +545,8 @@ SELECT * FROM sorted_bgw_log;
       1 |         0 | test_job_3_long  | Job got term signal
       2 |         0 | test_job_3_long  | terminating TimescaleDB background job "test_job_3_long" due to administrator command
       3 |         0 | test_job_3_long  | terminating connection due to administrator command
-(6 rows)
+      2 |    300000 | DB Scheduler     | job 1004 failed
+(7 rows)
 
 SELECT job_id, next_start - last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
 FROM _timescaledb_internal.bgw_job_stat;
@@ -562,11 +579,12 @@ SELECT * FROM sorted_bgw_log;
       2 |         0 | test_job_3_long  | terminating TimescaleDB background job "test_job_3_long" due to administrator command
       3 |         0 | test_job_3_long  | terminating connection due to administrator command
       0 |    300000 | DB Scheduler     | [TESTING] Wait until 792188, started at 300000
+      2 |    300000 | DB Scheduler     | job 1004 failed
       1 |    792188 | DB Scheduler     | [TESTING] Registered new background worker
       2 |    792188 | DB Scheduler     | [TESTING] Wait until 1200000, started at 792188
       0 |    792188 | test_job_3_long  | Before sleep job 3
       1 |    792188 | test_job_3_long  | After sleep job 3
-(11 rows)
+(12 rows)
 
 --Test sending a SIGHUP to a job
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/test/isolation/expected/bgw_job_delete.out
+++ b/test/isolation/expected/bgw_job_delete.out
@@ -30,7 +30,8 @@ msg_no         mock_time      application_namemsg
 0              0              DB Scheduler   [TESTING] Registered new background worker
 1              0              DB Scheduler   [TESTING] Wait until 25000, started at 0
 0              0              test_job_1     Before lock job 5
-1              0              test_job_1     canceling statement due to user request
+1              0              test_job_1     job 1000 threw an error
+2              0              test_job_1     canceling statement due to user request
 pg_advisory_unlock_all
 
                

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -165,7 +165,7 @@ execute_reorder_policy(BgwJob *job, reorder_func reorder, bool fast_continue)
 commit:
 	if (started)
 		CommitTransactionCommand();
-
+	elog(LOG, "job %d completed reordering", job_id);
 	return true;
 }
 
@@ -234,7 +234,7 @@ execute_drop_chunks_policy(int32 job_id)
 	);
 
 	ts_cache_release(hcache);
-	elog(LOG, "completed dropping chunks");
+	elog(LOG, "job %d completed dropping chunks", job_id);
 
 	if (started)
 	{
@@ -343,6 +343,7 @@ execute_compress_chunks_policy(BgwJob *job)
 		PopActiveSnapshot();
 		CommitTransactionCommand();
 	}
+	elog(LOG, "job %d completed compressing chunk", job_id);
 	return true;
 }
 


### PR DESCRIPTION
   Make scheduler more resilient to failures
    
    Invalidate cache state when jobs are detected as
    potentially missing. This will update the jobs list
    used by the scheduler.
    Restrict job start times to a finite interval when
    there are consecutive job failures.
    Additional logging.
