### PR TITLE
Fix typo of "continuous"

### DIFF
--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -847,7 +847,7 @@ find_raw_hypertable_for_materialization(int32 mat_hypertable_id)
  * we find a hypertable that has integer_now_func set.
  */
 TSDLLEXPORT Dimension *
-ts_continous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid)
+ts_continuous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid)
 {
 	int32 raw_htid = mat_htid;
 	Dimension *par_dim = NULL;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -91,7 +91,7 @@ extern TSDLLEXPORT int32 ts_number_of_continuous_aggs(void);
 
 extern Oid ts_continuous_agg_get_user_view_oid(ContinuousAgg *agg);
 extern TSDLLEXPORT Dimension *
-ts_continous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid);
+ts_continuous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid);
 extern ContinuousAgg *ts_continuous_agg_find_userview_name(const char *schema, const char *name);
 
 #endif /* TIMESCALEDB_CONTINUOUS_AGG_H */

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1053,7 +1053,7 @@ block_dropping_continuous_aggregates_without_cascade(ProcessUtilityArgs *args, D
 		if (ts_continuous_agg_view_type(&cagg->data, schema, name) == ContinuousAggUserView)
 			ereport(ERROR,
 					(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
-					 errmsg("dropping a continous aggregate requires using CASCADE")));
+					 errmsg("dropping a continuous aggregate requires using CASCADE")));
 	}
 }
 

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -104,7 +104,7 @@ validate_drop_chunks_hypertable(Cache *hcache, Oid user_htoid, Oid older_than_ty
 		partitioning_type = ts_dimension_get_partition_type(open_dim);
 		if (IS_INTEGER_TYPE(partitioning_type))
 		{
-			open_dim = ts_continous_agg_find_integer_now_func_by_materialization_id(mat_id);
+			open_dim = ts_continuous_agg_find_integer_now_func_by_materialization_id(mat_id);
 		}
 		older_than = ts_interval_from_sql_input_internal(open_dim,
 														 older_than_datum,

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -182,7 +182,7 @@ get_open_dimension_for_hypertable(Hypertable *ht)
 		 * integer_now function
 		 */
 
-		open_dim = ts_continous_agg_find_integer_now_func_by_materialization_id(mat_id);
+		open_dim = ts_continuous_agg_find_integer_now_func_by_materialization_id(mat_id);
 		if (open_dim == NULL)
 		{
 			elog(ERROR,

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -637,7 +637,7 @@ ERROR:  cannot drop the partial/direct view because it is required by a continuo
 DROP VIEW :"DIR_VIEW_SCHEMA".:"DIR_VIEW_NAME";
 ERROR:  cannot drop the partial/direct view because it is required by a continuous aggregate
 DROP VIEW mat_test;
-ERROR:  dropping a continous aggregate requires using CASCADE
+ERROR:  dropping a continuous aggregate requires using CASCADE
 \set ON_ERROR_STOP 1
 --catalog entry still there;
 SELECT count(*)

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -177,9 +177,9 @@ ERROR:  cannot drop table _timescaledb_internal._materialized_hypertable_3 becau
 DROP VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 ERROR:  cannot drop the partial/direct view because it is required by a continuous aggregate
 DROP VIEW mat_before;
-ERROR:  dropping a continous aggregate requires using CASCADE
+ERROR:  dropping a continuous aggregate requires using CASCADE
 DROP VIEW mat_after;
-ERROR:  dropping a continous aggregate requires using CASCADE
+ERROR:  dropping a continuous aggregate requires using CASCADE
 \set ON_ERROR_STOP 1
 --materialize mat_after
 SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';


### PR DESCRIPTION
A nit, but it doesn't look professional to have typos in the error messages. Fixed the names of functions at the same time.