### PR TITLE
Stop background worker in tests

### DIFF
--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -57,12 +57,6 @@ BEGIN
 END
 $BODY$;
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -3,6 +3,13 @@
 -- LICENSE-APACHE for a copy of the license.
 \set TEST_DBNAME_2 :TEST_DBNAME _2
 \c :TEST_DBNAME :ROLE_SUPERUSER
+-- start bgw since they are stopped for tests by default
+SELECT _timescaledb_internal.start_background_workers();
+ start_background_workers 
+--------------------------
+ t
+(1 row)
+
 CREATE DATABASE :TEST_DBNAME_2;
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER
 \ir include/bgw_launcher_utils.sql

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -53,7 +53,7 @@ cd ${EXE_DIR}/sql
 
 # create database and install timescaledb
 ${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d postgres -v ECHO=none -c "CREATE DATABASE \"${TEST_DBNAME}\";"
-${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -c "set client_min_messages=error; CREATE EXTENSION timescaledb;"
+${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -c "SET client_min_messages=error; CREATE EXTENSION timescaledb;"
 ${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" < ${CURRENT_DIR}/sql/utils/testsupport.sql >/dev/null 2>&1
 
 export TEST_DBNAME

--- a/test/sql/bgw_db_scheduler.sql
+++ b/test/sql/bgw_db_scheduler.sql
@@ -71,7 +71,6 @@ END
 $BODY$;
 
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -4,6 +4,10 @@
 
 \set TEST_DBNAME_2 :TEST_DBNAME _2
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- start bgw since they are stopped for tests by default
+SELECT _timescaledb_internal.start_background_workers();
+
 CREATE DATABASE :TEST_DBNAME_2;
 
 \c :TEST_DBNAME_2 :ROLE_SUPERUSER

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -2,6 +2,9 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+
+SELECT _timescaledb_internal.stop_background_workers();
+
 CREATE SCHEMA IF NOT EXISTS test;
 GRANT USAGE ON SCHEMA test TO PUBLIC;
 

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -2,12 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 SET timescaledb.license_key='CommunityLicense';
 CREATE OR REPLACE FUNCTION test_reorder(job_id INTEGER)
 RETURNS TABLE(

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -21,12 +21,6 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set IMMEDIATELY_SET_UNTIL 1
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/compress_bgw_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_drop_chunks.out
@@ -13,12 +13,6 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set IMMEDIATELY_SET_UNTIL 1
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -2,12 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 SELECT _timescaledb_internal.enterprise_enabled();
  enterprise_enabled 
 --------------------

--- a/tsl/test/expected/compression_permissions-10.out
+++ b/tsl/test/expected/compression_permissions-10.out
@@ -2,16 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ON_ERROR_STOP 0
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the background workers 
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,

--- a/tsl/test/expected/compression_permissions-11.out
+++ b/tsl/test/expected/compression_permissions-11.out
@@ -2,16 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ON_ERROR_STOP 0
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the background workers 
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -8,14 +8,7 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set WAIT_ON_JOB 0
 \set IMMEDIATELY_SET_UNTIL 1
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
--- stop the background workers from locking up the tables,
--- and remove any default jobs, e.g., telemetry so bgw_job isn't polluted
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
+-- remove any default jobs, e.g., telemetry so bgw_job isn't polluted
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_config.bgw_job;

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -31,12 +31,6 @@ REVOKE EXECUTE ON FUNCTION get_constant_no_perms() FROM PUBLIC;
 CREATE OR REPLACE FUNCTION ts_bgw_params_mock_wait_returns_immediately(new_val INTEGER) RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
@@ -13,12 +13,6 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set IMMEDIATELY_SET_UNTIL 1
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/continuous_aggs_ddl-10.out
+++ b/tsl/test/expected/continuous_aggs_ddl-10.out
@@ -22,12 +22,6 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)

--- a/tsl/test/expected/continuous_aggs_ddl-11.out
+++ b/tsl/test/expected/continuous_aggs_ddl-11.out
@@ -22,12 +22,6 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)

--- a/tsl/test/expected/continuous_aggs_ddl-9.6.out
+++ b/tsl/test/expected/continuous_aggs_ddl-9.6.out
@@ -22,12 +22,6 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -1,15 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TYPE custom_type AS (high int, low int);
 CREATE TABLE conditions_before (
       timec       TIMESTAMPTZ       NOT NULL,

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -11,13 +11,6 @@ CREATE OR REPLACE FUNCTION run_continuous_agg_materialization(
     bucket_width "any",
     input_view_schema NAME = 'public'
 ) RETURNS VOID AS :TSL_MODULE_PATHNAME, 'ts_run_continuous_agg_materialization' LANGUAGE C VOLATILE;
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE continuous_agg_test(time BIGINT, data BIGINT, dummy BOOLEAN);
 select create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -2,13 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO LOG;
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);

--- a/tsl/test/expected/continuous_aggs_permissions-10.out
+++ b/tsl/test/expected/continuous_aggs_permissions-10.out
@@ -3,14 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- initialize the bgw mock state to prevent the materialization workers from running
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the background workers from locking up the tables,
--- and remove any default jobs, e.g., telemetry so bgw_job isn't polluted
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
+-- remove any default jobs, e.g., telemetry so bgw_job isn't polluted
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE conditions (

--- a/tsl/test/expected/continuous_aggs_permissions-11.out
+++ b/tsl/test/expected/continuous_aggs_permissions-11.out
@@ -3,14 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- initialize the bgw mock state to prevent the materialization workers from running
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the background workers from locking up the tables,
--- and remove any default jobs, e.g., telemetry so bgw_job isn't polluted
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
+-- remove any default jobs, e.g., telemetry so bgw_job isn't polluted
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE conditions (

--- a/tsl/test/expected/continuous_aggs_permissions-9.6.out
+++ b/tsl/test/expected/continuous_aggs_permissions-9.6.out
@@ -3,14 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- initialize the bgw mock state to prevent the materialization workers from running
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the background workers from locking up the tables,
--- and remove any default jobs, e.g., telemetry so bgw_job isn't polluted
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
+-- remove any default jobs, e.g., telemetry so bgw_job isn't polluted
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE conditions (

--- a/tsl/test/expected/continuous_aggs_query-10.out
+++ b/tsl/test/expected/continuous_aggs_query-10.out
@@ -1,15 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set TEST_BASE_NAME continuous_aggs_query
 SELECT
        format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",

--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -1,15 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set TEST_BASE_NAME continuous_aggs_query
 SELECT
        format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",

--- a/tsl/test/expected/continuous_aggs_query-9.6.out
+++ b/tsl/test/expected/continuous_aggs_query-9.6.out
@@ -1,15 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set TEST_BASE_NAME continuous_aggs_query
 SELECT
        format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -2,16 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- TEST SETUP --
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering, nothing will be scheduled.
--- In normal execution you wouldn't do this, but for tests we need to be reproducible regardless of what the scheduler does.
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 SET client_min_messages TO LOG;
 -- START OF USAGE TEST --

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -1,15 +1,6 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE continuous_agg_test(time int, data int);
 select create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);
 NOTICE:  adding not-null constraint to column "time"

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -2,12 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
- stop_background_workers 
--------------------------
- t
-(1 row)
-
 SET timescaledb.license_key='CommunityLicense';
 CREATE OR REPLACE FUNCTION ts_test_chunk_stats_insert(job_id INTEGER, chunk_id INTEGER, num_times_run INTEGER, last_time_run TIMESTAMPTZ = NULL) RETURNS VOID
 AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;

--- a/tsl/test/sql/bgw_policy.sql
+++ b/tsl/test/sql/bgw_policy.sql
@@ -3,7 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
 SET timescaledb.license_key='CommunityLicense';
 
 CREATE OR REPLACE FUNCTION test_reorder(job_id INTEGER)

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -29,7 +29,6 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
 
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 

--- a/tsl/test/sql/compress_bgw_drop_chunks.sql
+++ b/tsl/test/sql/compress_bgw_drop_chunks.sql
@@ -17,7 +17,6 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
 
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -3,7 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
 SELECT _timescaledb_internal.enterprise_enabled();
 
 CREATE OR REPLACE FUNCTION test_compress_chunks_policy(job_id INTEGER)

--- a/tsl/test/sql/compression_permissions.sql.in
+++ b/tsl/test/sql/compression_permissions.sql.in
@@ -4,13 +4,6 @@
 
 \set ON_ERROR_STOP 0
 
-\c :TEST_DBNAME :ROLE_SUPERUSER
-
--- stop the background workers 
-SELECT _timescaledb_internal.stop_background_workers();
-DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
-
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -12,9 +12,7 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set IMMEDIATELY_SET_UNTIL 1
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
 
--- stop the background workers from locking up the tables,
--- and remove any default jobs, e.g., telemetry so bgw_job isn't polluted
-SELECT _timescaledb_internal.stop_background_workers();
+-- remove any default jobs, e.g., telemetry so bgw_job isn't polluted
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -43,7 +43,6 @@ CREATE OR REPLACE FUNCTION ts_bgw_params_mock_wait_returns_immediately(new_val I
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 

--- a/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
@@ -17,7 +17,6 @@ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 \set WAIT_FOR_OTHER_TO_ADVANCE 2
 
 -- Remove any default jobs, e.g., telemetry
-SELECT _timescaledb_internal.stop_background_workers();
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 TRUNCATE _timescaledb_internal.bgw_job_stat;
 

--- a/tsl/test/sql/continuous_aggs_ddl.sql.in
+++ b/tsl/test/sql/continuous_aggs_ddl.sql.in
@@ -23,7 +23,6 @@ select table_name from create_hypertable('conditions', 'timec');
 
 -- check that GRANTS work correctly
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
 
 create  view mat_m1 WITH ( timescaledb.continuous)
 AS

--- a/tsl/test/sql/continuous_aggs_dump.sql
+++ b/tsl/test/sql/continuous_aggs_dump.sql
@@ -2,11 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-
 CREATE TYPE custom_type AS (high int, low int);
 
 CREATE TABLE conditions_before (

--- a/tsl/test/sql/continuous_aggs_materialize.sql
+++ b/tsl/test/sql/continuous_aggs_materialize.sql
@@ -13,8 +13,6 @@ CREATE OR REPLACE FUNCTION run_continuous_agg_materialization(
     input_view_schema NAME = 'public'
 ) RETURNS VOID AS :TSL_MODULE_PATHNAME, 'ts_run_continuous_agg_materialization' LANGUAGE C VOLATILE;
 
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 CREATE TABLE continuous_agg_test(time BIGINT, data BIGINT, dummy BOOLEAN);

--- a/tsl/test/sql/continuous_aggs_multi.sql
+++ b/tsl/test/sql/continuous_aggs_multi.sql
@@ -3,12 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
-
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-
 SET client_min_messages TO LOG;
 
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);

--- a/tsl/test/sql/continuous_aggs_permissions.sql.in
+++ b/tsl/test/sql/continuous_aggs_permissions.sql.in
@@ -5,9 +5,7 @@
 -- initialize the bgw mock state to prevent the materialization workers from running
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
--- stop the background workers from locking up the tables,
--- and remove any default jobs, e.g., telemetry so bgw_job isn't polluted
-SELECT _timescaledb_internal.stop_background_workers();
+-- remove any default jobs, e.g., telemetry so bgw_job isn't polluted
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/sql/continuous_aggs_query.sql.in
+++ b/tsl/test/sql/continuous_aggs_query.sql.in
@@ -2,12 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-\c :TEST_DBNAME :ROLE_SUPERUSER
-
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
-SET ROLE :ROLE_DEFAULT_PERM_USER;
-
 \set TEST_BASE_NAME continuous_aggs_query
 SELECT
        format('%s/results/%s_results_view.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_VIEW",

--- a/tsl/test/sql/continuous_aggs_usage.sql
+++ b/tsl/test/sql/continuous_aggs_usage.sql
@@ -3,11 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 -- TEST SETUP --
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering, nothing will be scheduled.
--- In normal execution you wouldn't do this, but for tests we need to be reproducible regardless of what the scheduler does.
-SELECT _timescaledb_internal.stop_background_workers();
-SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 SET client_min_messages TO LOG;
 

--- a/tsl/test/sql/continuous_aggs_watermark.sql
+++ b/tsl/test/sql/continuous_aggs_watermark.sql
@@ -2,11 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-\c :TEST_DBNAME :ROLE_SUPERUSER
--- stop the continous aggregate background workers from interfering
-SELECT _timescaledb_internal.stop_background_workers();
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-
 CREATE TABLE continuous_agg_test(time int, data int);
 select create_hypertable('continuous_agg_test', 'time', chunk_time_interval=> 10);
 CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM continuous_agg_test $$;

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -3,7 +3,6 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
-SELECT _timescaledb_internal.stop_background_workers();
 SET timescaledb.license_key='CommunityLicense';
 
 CREATE OR REPLACE FUNCTION ts_test_chunk_stats_insert(job_id INTEGER, chunk_id INTEGER, num_times_run INTEGER, last_time_run TIMESTAMPTZ = NULL) RETURNS VOID


### PR DESCRIPTION
To make tests more stable and to remove some repeated code in the
tests this PR changes the test runner to stop background workers.
Individual tests that need background workers can still start them
and this PR will only stop background workers for the initial database
for the test, behaviour for additional databases created during the
tests will not change.