### PR TITLE
Fix compressing interval columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Minor Features**
 * #1666 Support drop_chunks API for continuous aggregates
+* #1711 Change log level for continuous aggregate materialization messages
 
 **Bugfixes**
 * #1648 Drop chunks from materialized hypertable
@@ -18,7 +19,8 @@ accidentally triggering the load of a previous DB version.**
 * #1674 Fix time_bucket_gapfill's interaction with GROUP BY
 * #1686 Fix order by queries on compressed hypertables that have char segment by column
 * #1687 Fix issue with disabling compression when foreign keys are present
-* Fix issue with overly aggressive chunk exclusion in outer joins
+* #1715 Fix issue with overly aggressive chunk exclusion in outer joins
+* #1727 Fix compressing INTERVAL columns
 
 **Licensing changes**
 * Reorder and policies around reorder and drop chunks are now

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -81,27 +81,18 @@ get_default_algorithm_id(Oid typeoid)
 		case INT4OID:
 		case INT2OID:
 		case INT8OID:
-		case INTERVALOID:
 		case DATEOID:
 		case TIMESTAMPOID:
 		case TIMESTAMPTZOID:
-		{
 			return COMPRESSION_ALGORITHM_DELTADELTA;
-		}
+
 		case FLOAT4OID:
 		case FLOAT8OID:
-		{
 			return COMPRESSION_ALGORITHM_GORILLA;
-		}
+
 		case NUMERICOID:
-		{
 			return COMPRESSION_ALGORITHM_ARRAY;
-		}
-		case TEXTOID:
-		case CHAROID:
-		{
-			return COMPRESSION_ALGORITHM_DICTIONARY;
-		}
+
 		default:
 		{
 			/* use dictitionary if possible, otherwise use array */

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -805,3 +805,61 @@ EXPLAIN (costs off) SELECT * FROM test_collation WHERE val_2 < 'a' COLLATE "C";
          Filter: (val_2 < 'a'::text COLLATE "C")
 (23 rows)
 
+--test datatypes
+CREATE TABLE datatype_test(
+  time timestamptz NOT NULL,
+  int2_column int2,
+  int4_column int4,
+  int8_column int8,
+  float4_column float4,
+  float8_column float8,
+  date_column date,
+  timestamp_column timestamp,
+  timestamptz_column timestamptz,
+  interval_column interval,
+  numeric_column numeric,
+  decimal_column decimal,
+  text_column text,
+  char_column char
+);
+SELECT create_hypertable('datatype_test','time');
+      create_hypertable      
+-----------------------------
+ (11,public,datatype_test,t)
+(1 row)
+
+ALTER TABLE datatype_test SET (timescaledb.compress);
+INSERT INTO datatype_test VALUES ('2000-01-01',2,4,8,4.0,8.0,'2000-01-01','2001-01-01 12:00','2001-01-01 6:00','1 week', 3.41, 4.2, 'text', 'x');
+SELECT compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id
+and ht.table_name like 'datatype_test' ORDER BY ch1.id;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_31_chunk
+(1 row)
+
+SELECT
+  attname, alg.name
+FROM _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable_compression htc ON ht.id=htc.hypertable_id
+  INNER JOIN _timescaledb_catalog.compression_algorithm alg ON alg.id=htc.compression_algorithm_id
+WHERE ht.table_name='datatype_test'
+ORDER BY attname;
+      attname       |               name               
+--------------------+----------------------------------
+ char_column        | COMPRESSION_ALGORITHM_DICTIONARY
+ date_column        | COMPRESSION_ALGORITHM_DELTADELTA
+ decimal_column     | COMPRESSION_ALGORITHM_ARRAY
+ float4_column      | COMPRESSION_ALGORITHM_GORILLA
+ float8_column      | COMPRESSION_ALGORITHM_GORILLA
+ int2_column        | COMPRESSION_ALGORITHM_DELTADELTA
+ int4_column        | COMPRESSION_ALGORITHM_DELTADELTA
+ int8_column        | COMPRESSION_ALGORITHM_DELTADELTA
+ interval_column    | COMPRESSION_ALGORITHM_DICTIONARY
+ numeric_column     | COMPRESSION_ALGORITHM_ARRAY
+ text_column        | COMPRESSION_ALGORITHM_DICTIONARY
+ time               | COMPRESSION_ALGORITHM_DELTADELTA
+ timestamp_column   | COMPRESSION_ALGORITHM_DELTADELTA
+ timestamptz_column | COMPRESSION_ALGORITHM_DELTADELTA
+(14 rows)
+


### PR DESCRIPTION
When trying to compress a chunk that had a column of datatype
interval delta-delta compression would be selected for the column
but our delta-delta compression does not support interval and
would throw an errow when trying to compress a chunk.

This PR changes the compression selected for interval to dictionary
compression.

Fixes #1726 