### PR TITLE
Adjust index predicate attnos when creating chunk index

### DIFF
--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -494,3 +494,17 @@ ALTER TABLE idx_expr_test DROP COLUMN filler;
 CREATE INDEX tag_idx ON idx_expr_test((t1||t2||t3));
 INSERT INTO idx_expr_test(time, t1, t2, t3) VALUES ('2000-01-01', 'foo', 'bar', 'baz');
 DROP TABLE idx_expr_test CASCADE;
+-- test index with predicate and dropped columns
+CREATE TABLE idx_predicate_test(filler int, time timestamptz);
+SELECT table_name FROM create_hypertable('idx_predicate_test', 'time');
+NOTICE:  adding not-null constraint to column "time"
+     table_name     
+--------------------
+ idx_predicate_test
+(1 row)
+
+ALTER TABLE idx_predicate_test DROP COLUMN filler;
+ALTER TABLE idx_predicate_test ADD COLUMN b1 bool;
+CREATE INDEX idx_predicate_test_b1 ON idx_predicate_test(b1) WHERE b1=true;
+INSERT INTO idx_predicate_test VALUES ('2000-01-01',true);
+DROP TABLE idx_predicate_test;

--- a/test/sql/index.sql
+++ b/test/sql/index.sql
@@ -220,3 +220,12 @@ CREATE INDEX tag_idx ON idx_expr_test((t1||t2||t3));
 INSERT INTO idx_expr_test(time, t1, t2, t3) VALUES ('2000-01-01', 'foo', 'bar', 'baz');
 DROP TABLE idx_expr_test CASCADE;
 
+-- test index with predicate and dropped columns
+CREATE TABLE idx_predicate_test(filler int, time timestamptz);
+SELECT table_name FROM create_hypertable('idx_predicate_test', 'time');
+ALTER TABLE idx_predicate_test DROP COLUMN filler;
+ALTER TABLE idx_predicate_test ADD COLUMN b1 bool;
+CREATE INDEX idx_predicate_test_b1 ON idx_predicate_test(b1) WHERE b1=true;
+INSERT INTO idx_predicate_test VALUES ('2000-01-01',true);
+DROP TABLE idx_predicate_test;
+


### PR DESCRIPTION
When the index for a chunk was created the attnos for the index
predicate were not adjusted leading to insert errors on hypertables
with dropped columns that had indexes with predicates.
This PR adjust index predicate attnos when creating the chunk index
to match the chunk attno.

Fixes #1675