### PR TITLE
Remove usage of uninitilized value

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -111,7 +111,7 @@ timescaledb_CopyFrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht)
 	TupleTableSlot *myslot;
 	MemoryContext oldcontext = CurrentMemoryContext;
 
-	ErrorContextCallback errcallback;
+	ErrorContextCallback errcallback = { 0 };
 	CommandId mycid = GetCurrentCommandId(true);
 	int hi_options = 0; /* start with default heap_insert options */
 	BulkInsertState bistate;
@@ -366,8 +366,10 @@ timescaledb_CopyFrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht)
 			}
 		}
 	}
+
 	/* Done, clean up */
-	error_context_stack = errcallback.previous;
+	if (errcallback.previous)
+		error_context_stack = errcallback.previous;
 
 	FreeBulkInsertState(bistate);
 


### PR DESCRIPTION
Function `timescaledb_CopyFrom` created a variable `errcallback` to
save away the previous error callback and restoring it afterwards.
However, if `ccstate->cstate` was false, the variable would not be set
and the later restore of the error callback would use a random value.

This commit fixes the issue by initializing `errcallback` to all zeroes
and checking if a callback has been saved away before restoring it.