### PR TITLE
Fix flaky gapfill test

### DIFF
--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -2026,10 +2026,10 @@ GROUP BY 1;
 
 -- time_bucket_gapfill with now() as start
 SELECT
- time_bucket_gapfill('1d'::interval,t)
+ time_bucket_gapfill('1h'::interval,t)
 FROM (VALUES (now()),(now())) v(t)
 WHERE
- t >= now() AND t < now() - '1d'::interval
+ t >= now() AND t < now() - '1h'::interval
 GROUP BY 1;
  time_bucket_gapfill 
 ---------------------

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -1239,10 +1239,10 @@ GROUP BY 1;
 
 -- time_bucket_gapfill with now() as start
 SELECT
- time_bucket_gapfill('1d'::interval,t)
+ time_bucket_gapfill('1h'::interval,t)
 FROM (VALUES (now()),(now())) v(t)
 WHERE
- t >= now() AND t < now() - '1d'::interval
+ t >= now() AND t < now() - '1h'::interval
 GROUP BY 1;
 
 -- time_bucket_gapfill with multiple constraints


### PR DESCRIPTION
The gapfill test assumed 1 day is always <= 24 hours which is not
true during DST switch leading to a failing test when run in that
time. This PR fixes the test to have reproducable output even
when run during DST switch.