### PR TITLE
Cleanup compression-related errors

### DIFF
--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -61,7 +61,7 @@ validate_drop_chunks_hypertable(Cache *hcache, Oid user_htoid, Oid older_than_ty
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("cannot add drop chunks policy to compresed hypertable \"%s\"",
+					 errmsg("cannot add drop chunks policy to compressed hypertable \"%s\"",
 							get_rel_name(user_htoid)),
 					 errhint("Please add the policy to the corresponding uncompressed hypertable "
 							 "instead.")));

--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -139,7 +139,7 @@ chunk_dml_blocker_trigger_add(Oid relid)
 	objaddr = CreateTriggerCompat(&stmt, NULL, relid, InvalidOid, InvalidOid, InvalidOid, false);
 
 	if (!OidIsValid(objaddr.objectId))
-		elog(ERROR, "could not create dml blocker trigger");
+		elog(ERROR, "could not create DML blocker trigger");
 
 	return;
 }
@@ -180,7 +180,7 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 	/* user has to be the owner of the compression table too */
 	ts_hypertable_permissions_check(compress_ht->main_table_relid, GetUserId());
 
-	if (!srcht->space) // something is wrong
+	if (!srcht->space) /* something is wrong */
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing hyperspace for hypertable")));
 	/* refetch the srcchunk with all attributes filled in */
@@ -216,10 +216,10 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 					AccessShareLock);
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), CHUNK), RowExclusiveLock);
 
-	// get compression properties for hypertable
+	/* get compression properties for hypertable */
 	htcols_list = ts_hypertable_compression_get(cxt.srcht->fd.id);
 	htcols_listlen = list_length(htcols_list);
-	// create compressed chunk DDL and compress the data
+	/* create compressed chunk DDL and compress the data */
 	compress_ht_chunk = create_compress_chunk_table(cxt.compress_ht, cxt.srcht_chunk);
 	/* convert list to array of pointers for compress_chunk */
 	colinfo_array = palloc(sizeof(ColumnCompressionInfo *) * htcols_listlen);
@@ -334,7 +334,7 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 	bool if_compressed = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
 	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, 0, true);
 	if (NULL == uncompressed_chunk)
-		elog(ERROR, "unkown chunk id %d", uncompressed_chunk_id);
+		elog(ERROR, "unknown chunk id %d", uncompressed_chunk_id);
 
 	if (!decompress_chunk_impl(uncompressed_chunk->hypertable_relid,
 							   uncompressed_chunk_id,

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -497,9 +497,9 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 				AttrNumber segment_max_attr_number =
 					get_attnum(compressed_table->rd_id, segment_max_col_name);
 				if (segment_min_attr_number == InvalidAttrNumber)
-					elog(ERROR, "couldn't find metadata column %s", segment_min_col_name);
+					elog(ERROR, "couldn't find metadata column \"%s\"", segment_min_col_name);
 				if (segment_max_attr_number == InvalidAttrNumber)
-					elog(ERROR, "couldn't find metadata column %s", segment_max_col_name);
+					elog(ERROR, "couldn't find metadata column \"%s\"", segment_max_col_name);
 				segment_min_attr_offset = AttrNumberGetAttrOffset(segment_min_attr_number);
 				segment_max_attr_offset = AttrNumberGetAttrOffset(segment_max_attr_number);
 				segment_min_max_builder =
@@ -518,7 +518,7 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 		{
 			if (column_attr->atttypid != compressed_column_attr->atttypid)
 				elog(ERROR,
-					 "expected segment by column '%s' to be same type as uncompressed column",
+					 "expected segment by column \"%s\" to be same type as uncompressed column",
 					 compression_info->attname.data);
 			*column = (PerColumn){
 				.segment_info = segment_info_new(column_attr),

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -609,7 +609,7 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 							  get_tablespace_name(get_rel_tablespace(src_chunk->table_id)));
 
 	if (!OidIsValid(compress_chunk->table_id))
-		elog(ERROR, "could not create compress chunk table");
+		elog(ERROR, "could not create compressed chunk table");
 
 	/* Create the chunk's constraints*/
 	ts_chunk_constraints_create(compress_chunk->constraints,
@@ -729,13 +729,13 @@ validate_existing_constraints(Hypertable *ht, CompressColInfo *colinfo)
 		{
 			int j, numkeys;
 			int16 *attnums;
-			bool isNull;
+			bool is_null;
 			/* Extract the conkey array, ie, attnums of PK's columns */
 			Datum adatum = heap_getattr(tuple,
 										Anum_pg_constraint_conkey,
 										RelationGetDescr(pg_constr),
-										&isNull);
-			if (isNull)
+										&is_null);
+			if (is_null)
 				elog(ERROR, "null conkey for constraint %u", HeapTupleGetOid(tuple));
 			arr = DatumGetArrayTypeP(adatum); /* ensure not toasted */
 			numkeys = ARR_DIMS(arr)[0];
@@ -763,7 +763,7 @@ validate_existing_constraints(Hypertable *ht, CompressColInfo *colinfo)
 										"column for compression",
 										NameStr(form->conname),
 										NameStr(col_def->attname)),
-								 errhint("Only segment by columns can be used in foreign key"
+								 errhint("Only segment by columns can be used in foreign key "
 										 "constraints on hypertables that are compressed.")));
 					}
 					else

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -260,7 +260,7 @@ FROM _timescaledb_catalog.hypertable comp_hyper
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'foo' ORDER BY comp_hyper.id LIMIT 1 \gset
 select add_drop_chunks_policy(:'COMPRESSED_HYPER_NAME', INTERVAL '4 months', true);
-ERROR:  cannot add drop chunks policy to compresed hypertable "_compressed_hypertable_15"
+ERROR:  cannot add drop chunks policy to compressed hypertable "_compressed_hypertable_15"
 --Constraint checking for compression
 create table fortable(col integer primary key);
 create table  table_constr( device_id integer,


### PR DESCRIPTION
This change fixes a number of typos and issues with inconsistent
formatting for compression-related code. A couple of other fixes for
variable names, etc. have also been applied.