### PR TITLE
Fix remove_drop_chunks_policy for continuous aggregates

### DIFF
--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -213,14 +213,42 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 Datum
 drop_chunks_remove_policy(PG_FUNCTION_ARGS)
 {
-	Oid hypertable_oid = PG_GETARG_OID(0);
+	Oid table_oid = PG_GETARG_OID(0);
 	bool if_exists = PG_GETARG_BOOL(1);
+	Cache *hcache;
+
+	Hypertable *hypertable = ts_hypertable_cache_get_cache_and_entry(table_oid, true, &hcache);
+	if (!hypertable)
+	{
+		char *view_name = get_rel_name(table_oid);
+		if (!view_name)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_OBJECT),
+					 errmsg("OID %d does not refer to a hypertable or continuous aggregate",
+							table_oid)));
+		}
+		else
+		{
+			char *schema_name = get_namespace_name(get_rel_namespace(table_oid));
+			ContinuousAgg *ca = ts_continuous_agg_find_by_view_name(schema_name, view_name);
+			if (!ca)
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_OBJECT),
+						 errmsg("no hypertable or continuous aggregate by the name \"%s\" exists",
+								view_name)));
+			hypertable = ts_hypertable_get_by_id(ca->data.mat_hypertable_id);
+		}
+	}
+
+	Assert(hypertable != NULL);
 
 	/* Remove the job, then remove the policy */
-	int ht_id = ts_hypertable_relid_to_id(hypertable_oid);
-	BgwPolicyDropChunks *policy = ts_bgw_policy_drop_chunks_find_by_hypertable(ht_id);
+	BgwPolicyDropChunks *policy = ts_bgw_policy_drop_chunks_find_by_hypertable(hypertable->fd.id);
 
-	ts_hypertable_permissions_check(hypertable_oid, GetUserId());
+	ts_cache_release(hcache);
+
+	ts_hypertable_permissions_check(table_oid, GetUserId());
 
 	if (policy == NULL)
 	{
@@ -232,7 +260,7 @@ drop_chunks_remove_policy(PG_FUNCTION_ARGS)
 		{
 			ereport(NOTICE,
 					(errmsg("drop chunks policy does not exist on hypertable \"%s\", skipping",
-							get_rel_name(hypertable_oid))));
+							get_rel_name(table_oid))));
 			PG_RETURN_NULL();
 		}
 	}

--- a/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
@@ -113,3 +113,15 @@ SELECT count(c) from show_chunks('_timescaledb_internal._materialized_hypertable
      1
 (1 row)
 
+SELECT remove_drop_chunks_policy('drop_chunks_view1');
+ remove_drop_chunks_policy 
+---------------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT remove_drop_chunks_policy('unknown');
+ERROR:  relation "unknown" does not exist at character 34
+SELECT remove_drop_chunks_policy('1');
+ERROR:  OID 1 does not refer to a hypertable or continuous aggregate
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
@@ -83,3 +83,9 @@ SELECT add_drop_chunks_policy( 'drop_chunks_view1', older_than=> 10, cascade_to_
 SELECT alter_job_schedule(:drop_chunks_job_id1, schedule_interval => INTERVAL '1 second');
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(2000000);
 SELECT count(c) from show_chunks('_timescaledb_internal._materialized_hypertable_2') as c ;
+SELECT remove_drop_chunks_policy('drop_chunks_view1');
+
+\set ON_ERROR_STOP 0
+SELECT remove_drop_chunks_policy('unknown');
+SELECT remove_drop_chunks_policy('1');
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Function `remove_drop_chunks_policy` did not work if a continuous
aggregate was provided as input.

This commit fixes that by looking for a continuous aggregate if a
hypertable is not found.

Fixes timescale/timescaledb-private#670