### PR TITLE
Release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,9 @@ accidentally triggering the load of a previous DB version.**
 **Major Features**
 
 **Minor Features**
-* #1666 Support drop_chunks API for continuous aggregates
-* #1711 Change log level for continuous aggregate materialization messages
 
 **Bugfixes**
-* #1648 Drop chunks from materialized hypertable
 * #1665 Add ignore_invalidation_older_than to timescaledb_information.continuous_aggregates view
-* #1668 Cannot add dimension if hypertable has empty chunks
-* #1674 Fix time_bucket_gapfill's interaction with GROUP BY
-* #1686 Fix order by queries on compressed hypertables that have char segment by column
-* #1687 Fix issue with disabling compression when foreign keys are present
-* #1704 Fix bad plan for continuous aggregate materialization
-* #1713 Fix miscellaneous background worker issues
-* #1715 Fix issue with overly aggressive chunk exclusion in outer joins
-* #1720 Add scheduler cache invalidations
-* #1727 Fix compressing INTERVAL columns
-* #1728 Handle Sort nodes in ConstraintAwareAppend
-* #1730 Fix partial index handling on chunks
-* #1740 Fix copy of continuous aggregate invalidation entries
 
 **Licensing changes**
 * Reorder and policies around reorder and drop chunks are now
@@ -34,12 +19,57 @@ accidentally triggering the load of a previous DB version.**
 * Gapfill functionality no longer warns about expired license
 
 **Thanks**
+
+## 1.6.1 (2020-03-16)
+
+This maintenance release contains bugfixes since the 1.6.0 release. We deem it medium
+priority for upgrading.
+
+In particular the fixes contained in this maintenance release address bugs in continuous
+aggregates, time_bucket_gapfill, partial index handling and drop_chunks.
+
+**For this release only**, you will need to restart the database after upgrade before
+restoring a backup.
+
+**Minor Features**
+* #1666 Support drop_chunks API for continuous aggregates
+* #1711 Change log level for continuous aggregate materialization messages
+
+**Bugfixes**
+* #1630 Print notice for COPY TO on hypertable
+* #1648 Drop chunks from materialized hypertable
+* #1668 Cannot add dimension if hypertable has empty chunks
+* #1673 Fix crash when interrupting create_hypertable
+* #1674 Fix time_bucket_gapfill's interaction with GROUP BY
+* #1686 Fix order by queries on compressed hypertables that have char segment by column
+* #1687 Fix issue with disabling compression when foreign keys are present
+* #1688 Handle many BGW jobs better
+* #1698 Add logic to ignore dropped chunks in hypertable_relation_size
+* #1704 Fix bad plan for continuous aggregate materialization
+* #1709 Prevent starting background workers with NOLOGIN
+* #1713 Fix miscellaneous background worker issues
+* #1715 Fix issue with overly aggressive chunk exclusion in outer joins
+* #1719 Fix restoring/scheduler entrypoint to avoid BGW death
+* #1720 Add scheduler cache invalidations
+* #1727 Fix compressing INTERVAL columns
+* #1728 Handle Sort nodes in ConstraintAwareAppend
+* #1730 Fix partial index handling on hypertables
+* #1739 Use release OpenSSL DLLs for debug builds on Windows
+* #1740 Fix invalidation entries from multiple caggs on same hypertable
+* #1743 Fix continuous aggregate materialization timezone handling
+* #1748 Fix remove_drop_chunks_policy for continuous aggregates
+
+**Thanks**
 * @RJPhillips01 for reporting an issue with drop chunks.
 * @b4eEx for reporting an issue with disabling compression.
-* @dark048 for reporting an issue with order by on compressed hypertables
+* @darko408 for reporting an issue with order by on compressed hypertables
 * @mrechte for reporting an issue with compressing INTERVAL columns
 * @tstaehli for reporting an issue with ConstraintAwareAppend
 * @chadshowalter for reporting an issue with partial index on hypertables
+* @geoffreybennett for reporting an issue with create_hypertable when interrupting operations
+* @alxndrdude for reporting an issue with background workers during restore
+* @zcavaliero for reporting and fixing an issue with dropped columns in hypertable_relation_size
+* @ismailakpolat for reporting an issue with cagg materialization on hypertables with TIMESTAMP column
 
 ## 1.6.0 (2020-01-14)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -101,6 +101,7 @@ set(MOD_FILES
   updates/1.4.2--1.5.0.sql
   updates/1.5.0--1.5.1.sql
   updates/1.5.1--1.6.0.sql
+  updates/1.6.0--1.6.1.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/sql/updates/1.6.0--1.6.1.sql
+++ b/sql/updates/1.6.0--1.6.1.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,1 +1,0 @@
-DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;

--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
 version = 1.7.0-dev
-update_from_version = 1.6.0
+update_from_version = 1.6.1


### PR DESCRIPTION
This maintenance release contains bugfixes since the 1.6.0 release. We deem it medium
priority for upgrading.

In particular the fixes contained in this maintenance release address bugs in continuous
aggregates, time_bucket_gapfill, partial index handling and drop_chunks.

**Minor Features**
* #1666 Support drop_chunks API for continuous aggregates
* #1711 Change log level for continuous aggregate materialization messages

**Bugfixes**
* #1630 Print notice for COPY TO on hypertable
* #1648 Drop chunks from materialized hypertable
* #1668 Cannot add dimension if hypertable has empty chunks
* #1673 Fix crash when interrupting create_hypertable
* #1674 Fix time_bucket_gapfill's interaction with GROUP BY
* #1686 Fix order by queries on compressed hypertables that have char segment by column
* #1687 Fix issue with disabling compression when foreign keys are present
* #1688 Handle many BGW jobs better
* #1698 Add logic to ignore dropped chunks in hypertable_relation_size
* #1704 Fix bad plan for continuous aggregate materialization
* #1709 Prevent starting background workers with NOLOGIN
* #1713 Fix miscellaneous background worker issues
* #1715 Fix issue with overly aggressive chunk exclusion in outer joins
* #1719 Fix restoring/scheduler entrypoint to avoid BGW death
* #1720 Add scheduler cache invalidations
* #1727 Fix compressing INTERVAL columns
* #1728 Handle Sort nodes in ConstraintAwareAppend
* #1730 Fix partial index handling hypertables
* #1739 Use release OpenSSL DLLs for debug builds on Windows
* #1740 Fix invalidation entries from multiple caggs on same hypertable
* #1743 Fix continuous aggregate materialization timezone handling
* #1748 Fix remove_drop_chunks_policy for continuous aggregates

**Thanks**
* @RJPhillips01 for reporting an issue with drop chunks.
* @b4eEX for reporting an issue with disabling compression.
* @darko408 for reporting an issue with order by on compressed hypertables
* @mrechte for reporting an issue with compressing INTERVAL columns
* @tstaehli for reporting an issue with ConstraintAwareAppend
* @chadshowalter for reporting an issue with partial index on hypertables
* @geoffreybennett for reporting an issue with create_hypertable when interrupting operations
* @alxndrdude for reporting an issue with background workers during restore
* @zcavaliero for reporting and fixing an issue with dropped columns in hypertable_relation_size
* @ismailakpolat for reporting an issue with cagg materialization on hypertables with TIMESTAMP column