### PR TITLE
Handle undefined ignore_invalidation_older_than

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -100,14 +100,19 @@ CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregates as
         THEN _timescaledb_internal.to_interval(cagg.max_interval_per_job)::TEXT
       ELSE cagg.max_interval_per_job::TEXT
     END AS max_interval_per_job,
-    CASE _timescaledb_internal.get_time_type(cagg.raw_hypertable_id)
-      WHEN 'TIMESTAMP'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
-      WHEN 'TIMESTAMPTZ'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
-      WHEN 'DATE'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
-      ELSE cagg.ignore_invalidation_older_than::TEXT
+    CASE
+      WHEN cagg.ignore_invalidation_older_than = BIGINT '9223372036854775807'
+        THEN NULL
+      ELSE
+	CASE _timescaledb_internal.get_time_type(cagg.raw_hypertable_id)
+          WHEN 'TIMESTAMP'::regtype
+            THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
+          WHEN 'TIMESTAMPTZ'::regtype
+            THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
+          WHEN 'DATE'::regtype
+            THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
+          ELSE cagg.ignore_invalidation_older_than::TEXT
+        END
     END AS ignore_invalidation_older_than,
     format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as materialization_hypertable,
     directview.viewdefinition as view_definition

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -73,7 +73,7 @@ view_owner                     | default_perm_user
 refresh_lag                    | @ 2 hours
 refresh_interval               | @ 2 hours
 max_interval_per_job           | @ 60 days
-ignore_invalidation_older_than | @ 106751991 days 4 hours 54.775807 secs
+ignore_invalidation_older_than | 
 materialization_hypertable     | _timescaledb_internal._materialized_hypertable_2
 view_definition                |  SELECT time_bucket('@ 1 hour'::interval, device_readings.observation_time) AS bucket,                      +
                                |     device_readings.device_id,                                                                              +


### PR DESCRIPTION
If `ignore_invalidation_older_than` is undefined, it is set to maximum
for `BIGINT` type. This is not handled in `continuous_aggregates`
information schema so the column shows up as a very strange value.

This commit fixes this by checking if `ignore_invalidation_older_than`
is set to maximum, and uses `NULL` in the view in that case, which will
show up as empty.

Duplicate commit of timescale/timescaledb-private#624