### PR TITLE
Docker version of clang-format use wrong user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ if (NOT CLANG_FORMAT)
   else ()
     message(STATUS "Using docker based clang-format")
     add_custom_target(format
-      COMMAND docker run --rm -it -v ${PROJECT_SOURCE_DIR}:/timescaledb timescaledev/postgres-dev-clang:clang7-pg11.1 /timescaledb/scripts/clang_format_all.sh
+      COMMAND docker run --rm -it --user=`id -u`:`id -g` --volume=${PROJECT_SOURCE_DIR}:/timescaledb timescaledev/postgres-dev-clang:clang7-pg11.1 /timescaledb/scripts/clang_format_all.sh
     )
   endif()
 else()


### PR DESCRIPTION
If `clang-format` with the correct usage does not exist on the machine,
the `clang_format_all.sh` script is executed in a docker image. Since a
`--user` is not provided, the script is executed with the wrong user,
which gives wrong user for formatted files.