### PR TITLE
Fix size utility functions for compressed hypertables

### DIFF
--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -412,20 +412,20 @@ table_name     | conditions
 table_owner    | default_perm_user
 num_dimensions | 1
 num_chunks     | 2
-table_size     | 16 kB
-index_size     | 48 kB
-toast_size     | 32 kB
-total_size     | 96 kB
+table_size     | 32 kB
+index_size     | 80 kB
+toast_size     | 48 kB
+total_size     | 160 kB
 -[ RECORD 2 ]--+------------------
 table_schema   | public
 table_name     | foo
 table_owner    | default_perm_user
 num_dimensions | 1
 num_chunks     | 4
-table_size     | 32 kB
-index_size     | 144 kB
+table_size     | 48 kB
+index_size     | 176 kB
 toast_size     | 8192 bytes
-total_size     | 184 kB
+total_size     | 232 kB
 
 \x
 select decompress_chunk(ch1.schema_name|| '.' || ch1.table_name)

--- a/tsl/test/expected/size_utils.out
+++ b/tsl/test/expected/size_utils.out
@@ -1,0 +1,71 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+CREATE TABLE compressed(time timestamptz NOT NULL);
+SELECT create_hypertable('compressed','time');
+    create_hypertable    
+-------------------------
+ (1,public,compressed,t)
+(1 row)
+
+-- test that empty hypertable is still included in result
+SELECT * FROM hypertable_approximate_row_count('compressed');
+ schema_name | table_name | row_estimate 
+-------------+------------+--------------
+ public      | compressed |            0
+(1 row)
+
+-- create 5 chunks
+INSERT INTO compressed SELECT generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval);
+VACUUM compressed;
+-- row count should be 32
+SELECT * FROM hypertable_approximate_row_count('compressed');
+ schema_name | table_name | row_estimate 
+-------------+------------+--------------
+ public      | compressed |           32
+(1 row)
+
+SELECT * FROM hypertable_relation_size('compressed');
+ table_bytes | index_bytes | toast_bytes | total_bytes 
+-------------+-------------+-------------+-------------
+      204800 |       81920 |             |      286720
+(1 row)
+
+SELECT * FROM hypertable_relation_size_pretty('compressed');
+ table_size | index_size | toast_size | total_size 
+------------+------------+------------+------------
+ 200 kB     | 80 kB      |            | 280 kB
+(1 row)
+
+-- compress first 2 chunks
+ALTER TABLE compressed SET (timescaledb.compress);
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
+WHERE ht.table_name like 'compressed' ORDER BY c.id limit 2;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+(2 rows)
+
+VACUUM compressed;
+-- row count should be 32
+SELECT * FROM hypertable_approximate_row_count('compressed');
+ schema_name | table_name | row_estimate 
+-------------+------------+--------------
+ public      | compressed |           32
+(1 row)
+
+SELECT * FROM hypertable_relation_size('compressed');
+ table_bytes | index_bytes | toast_bytes | total_bytes 
+-------------+-------------+-------------+-------------
+      155648 |       65536 |             |      221184
+(1 row)
+
+SELECT * FROM hypertable_relation_size_pretty('compressed');
+ table_size | index_size | toast_size | total_size 
+------------+------------+------------+------------
+ 152 kB     | 64 kB      |            | 216 kB
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -39,6 +39,10 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug)
 #compression only for PG > 9
 if (${PG_VERSION_MAJOR} GREATER "9")
 
+  list(APPEND TEST_FILES
+    size_utils.sql
+  )
+
   list(APPEND TEST_FILES_DEBUG
     compress_table.sql
     compression.sql

--- a/tsl/test/sql/size_utils.sql
+++ b/tsl/test/sql/size_utils.sql
@@ -1,0 +1,36 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE TABLE compressed(time timestamptz NOT NULL);
+SELECT create_hypertable('compressed','time');
+
+-- test that empty hypertable is still included in result
+SELECT * FROM hypertable_approximate_row_count('compressed');
+
+-- create 5 chunks
+INSERT INTO compressed SELECT generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval);
+
+VACUUM compressed;
+
+-- row count should be 32
+SELECT * FROM hypertable_approximate_row_count('compressed');
+
+SELECT * FROM hypertable_relation_size('compressed');
+SELECT * FROM hypertable_relation_size_pretty('compressed');
+
+-- compress first 2 chunks
+ALTER TABLE compressed SET (timescaledb.compress);
+SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
+WHERE ht.table_name like 'compressed' ORDER BY c.id limit 2;
+
+VACUUM compressed;
+
+-- row count should be 32
+SELECT * FROM hypertable_approximate_row_count('compressed');
+
+SELECT * FROM hypertable_relation_size('compressed');
+SELECT * FROM hypertable_relation_size_pretty('compressed');
+


### PR DESCRIPTION
This patch adjusts hypertable_approximate_row_count to return
correct row estimates for hypertables that include compressed
chunks. It also fixes a bug that hypertables without chunks
would not be included in the result and fixes the schema handling
for that function.

This patch also adjusts hypertable_relation_size and
hypertable_relation_size_pretty to include information about
compressed chunks.

Fixes #1741 