### PR TITLE
Do not attempt to compress chunks that are dropped

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -147,7 +147,7 @@ ts_chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum
 								  bool include_chunks_marked_as_dropped);
 
 extern bool TSDLLEXPORT ts_chunk_contains_compressed_data(Chunk *chunk);
-extern TSDLLEXPORT bool ts_chunk_has_associated_compressed_chunk(int32 chunk_id);
+extern TSDLLEXPORT bool ts_chunk_can_be_compressed(int32 chunk_id);
 
 #define chunk_get_by_name(schema_name, table_name, num_constraints, fail_if_not_found)             \
 	ts_chunk_get_by_name_with_memory_context(schema_name,                                          \

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -791,7 +791,7 @@ dimension_slice_check_is_chunk_uncompressed_tuple_found(TupleInfo *ti, void *dat
 	foreach (lc, chunk_ids)
 	{
 		int32 chunk_id = lfirst_int(lc);
-		if (!ts_chunk_has_associated_compressed_chunk(chunk_id))
+		if (ts_chunk_can_be_compressed(chunk_id))
 		{
 			/* found a chunk that has not yet been compressed */
 			*((int32 *) data) = chunk_id;

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -126,6 +126,9 @@ select job_id as compressjob_id, hypertable_id, older_than from _timescaledb_con
 select test_compress_chunks_policy(:compressjob_id);
 ERROR:  job 1000 not found
 \set ON_ERROR_STOP 1
+-- We're done with the table, so drop it.
+DROP TABLE IF EXISTS conditions CASCADE;
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_2_4_chunk
 --TEST 7
 --compress chunks policy for integer based partition hypertable
 CREATE TABLE test_table_int(time bigint, val int);
@@ -205,3 +208,64 @@ ERROR:  permission denied to start compress_chunks background process as role "n
 \set ON_ERROR_STOP 1
 RESET ROLE;
 REVOKE NOLOGIN_ROLE FROM :ROLE_DEFAULT_PERM_USER;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE conditions(
+    time TIMESTAMPTZ NOT NULL,
+    device INTEGER,
+    temperature FLOAT
+);
+SELECT * FROM create_hypertable('conditions', 'time',
+                                chunk_time_interval => '1 day'::interval);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             7 | public      | conditions | t
+(1 row)
+
+INSERT INTO conditions
+SELECT time, (random()*30)::int, random()*80 - 40
+FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '10 min') AS time;
+CREATE VIEW conditions_summary
+WITH (timescaledb.continuous,
+      timescaledb.refresh_interval='1 minute',
+      timescaledb.max_interval_per_job = '60 days') AS
+SELECT device,
+       time_bucket(INTERVAL '1 hour', "time") AS day,
+       AVG(temperature) AS avg_temperature,
+       MAX(temperature) AS max_temperature,
+       MIN(temperature) AS min_temperature
+FROM conditions
+GROUP BY device, time_bucket(INTERVAL '1 hour', "time");
+NOTICE:  adding index _materialized_hypertable_8_device_day_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, day)
+REFRESH MATERIALIZED VIEW conditions_summary;
+WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
+ALTER TABLE conditions SET (timescaledb.compress);
+ALTER VIEW conditions_summary SET (
+      timescaledb.ignore_invalidation_older_than = '15 days'
+);
+SELECT COUNT(*) AS dropped_chunks_count
+  FROM drop_chunks(TIMESTAMPTZ '2018-12-15 00:00', 'conditions',
+                   cascade_to_materializations => FALSE);
+NOTICE:  making sure all invalidations for public.conditions_summary have been processed prior to dropping chunks
+ dropped_chunks_count 
+----------------------
+                   14
+(1 row)
+
+-- We need to have some chunks that are marked as dropped, otherwise
+-- we will not have a problem below.
+SELECT COUNT(*) AS dropped_chunks_count
+  FROM _timescaledb_catalog.chunk
+ WHERE dropped = TRUE;
+ dropped_chunks_count 
+----------------------
+                   14
+(1 row)
+
+SELECT add_compress_chunks_policy AS job_id
+  FROM add_compress_chunks_policy('conditions', INTERVAL '1 day') \gset
+SELECT test_compress_chunks_policy(:job_id);
+ test_compress_chunks_policy 
+-----------------------------
+ 
+(1 row)
+

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -69,6 +69,9 @@ select job_id as compressjob_id, hypertable_id, older_than from _timescaledb_con
 select test_compress_chunks_policy(:compressjob_id);
 \set ON_ERROR_STOP 1
 
+-- We're done with the table, so drop it.
+DROP TABLE IF EXISTS conditions CASCADE;
+
 --TEST 7
 --compress chunks policy for integer based partition hypertable
 CREATE TABLE test_table_int(time bigint, val int);
@@ -102,3 +105,50 @@ SELECT add_compress_chunks_policy('test_table_nologin', 2::int);
 \set ON_ERROR_STOP 1
 RESET ROLE;
 REVOKE NOLOGIN_ROLE FROM :ROLE_DEFAULT_PERM_USER;
+
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE conditions(
+    time TIMESTAMPTZ NOT NULL,
+    device INTEGER,
+    temperature FLOAT
+);
+SELECT * FROM create_hypertable('conditions', 'time',
+                                chunk_time_interval => '1 day'::interval);
+
+INSERT INTO conditions
+SELECT time, (random()*30)::int, random()*80 - 40
+FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '10 min') AS time;
+
+CREATE VIEW conditions_summary
+WITH (timescaledb.continuous,
+      timescaledb.refresh_interval='1 minute',
+      timescaledb.max_interval_per_job = '60 days') AS
+SELECT device,
+       time_bucket(INTERVAL '1 hour', "time") AS day,
+       AVG(temperature) AS avg_temperature,
+       MAX(temperature) AS max_temperature,
+       MIN(temperature) AS min_temperature
+FROM conditions
+GROUP BY device, time_bucket(INTERVAL '1 hour', "time");
+
+REFRESH MATERIALIZED VIEW conditions_summary;
+
+ALTER TABLE conditions SET (timescaledb.compress);
+ALTER VIEW conditions_summary SET (
+      timescaledb.ignore_invalidation_older_than = '15 days'
+);
+
+SELECT COUNT(*) AS dropped_chunks_count
+  FROM drop_chunks(TIMESTAMPTZ '2018-12-15 00:00', 'conditions',
+                   cascade_to_materializations => FALSE);
+
+-- We need to have some chunks that are marked as dropped, otherwise
+-- we will not have a problem below.
+SELECT COUNT(*) AS dropped_chunks_count
+  FROM _timescaledb_catalog.chunk
+ WHERE dropped = TRUE;
+
+SELECT add_compress_chunks_policy AS job_id
+  FROM add_compress_chunks_policy('conditions', INTERVAL '1 day') \gset
+SELECT test_compress_chunks_policy(:job_id);


### PR DESCRIPTION
The function `get_chunks_to_compress` return chunks that are not
compressed but that are dropped, meaning a lookup using
`ts_chunk_get_by_id` will fail to find the corresponding `table_id`,
which later leads to a null pointer when looking for the chunk. This
leads to a segmentation fault.

This commit fixes this by ignoring chunk that have are marked as
dropped in the chunk table when scanning for chunks to compress.

Part of timescale/timescaledb-private#673