### PR TITLE
Update Travis build fail notification with commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ notifications:
     template:
       - "<!here>"
       - "%{repository_slug} (%{build_number}) : %{message}"
+      - "Last commit: %{commit_subject} by %{author}"
       - "Build details: %{build_url}"
     rooms:
       - secure: "n4gHRucKsrlYNLVmoTxhsSbH780+8c+OjUCbaSxzyf7QYpbiD5HdCYAwBwJw6VkWPHQ+gXXy75szzcBmCOILEqx+m8WBLet+K9Kw1g3EE0r7lXT+OLWi0JJXvWBv/QdMwefilg7mC8P/USEwUSZfK/iW7tERvQc38ajGonqTsS4QWSg9zAlZZ1ZQJAALd4S4z+BJ/skAQNV+hAI1DLb8jf3A+Ex4/uMs9oAmfGiKqQTwmHlL698XFD83bv0XdxJYskkL8Eqt+19d0HD7lTCvez0yES2PCRXUWsWd2mIwTzGPYyDAU+5MifUvV2CaGDDAhIpzTYoZ4rl2SJc4uu6Fztat4UQB1GGc+TCNo5V8L3IdmzGjI2NSk88QItvpSiiNvtS0mr5As9dO8pIwuWwc4SL0u5bYw7Cq+y2s85huhKrYFVkdEptxjGInHjmq0KsuqpHoFE3E2DPD0fR0KhOekFkzobXg1cPubWHOmzm/PhVaMz3tFAtg83V2f+qg3UtfjMMgI84J/SsUdqv9J1G9R2iGxi56WKSWHHyMeloY8Pz2HFJzV0fPJQM+D5pJFpxQkSXyOMR72qJjeg0IZTiCndX9AEswbGQ3d/dwmYgbfzAah+OP37ZTYyEOsqJTEKvWq8GuJZTuhdJhhvA38Axv9jACcoQtxTKdKskOAUH3TWA="


### PR DESCRIPTION
Timescale is notified internally about failed builds on Travis. This
update adds information about the last commit.

PR note:
I propose this change to see if a failure is on a new commit or was seen previously in the channel, since there are some flaky tests still. 