### PR TITLE
Modify continuous_aggregate_stats view definition

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -154,14 +154,17 @@ CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregate_stats as
     cagg.job_id as job_id,
     bgw_job_stat.last_start as last_run_started_at,
     bgw_job_stat.last_successful_finish as last_successful_finish,
-    CASE when bgw_job_stat.last_run_success = 't' then 'Success'
-         when bgw_job_stat.last_run_success = 'f' then 'Failed'
-    END AS last_run_status,
-    case when bgw_job_stat.last_finish < '4714-11-24 00:00:00+00 BC' then 'running'
-       when bgw_job_stat.next_start is not null then 'scheduled'
-    end as job_status,
-    case when bgw_job_stat.last_finish > bgw_job_stat.last_start then (bgw_job_stat.last_finish - bgw_job_stat.last_start)
-    end as last_run_duration,
+    CASE WHEN bgw_job_stat.last_finish < '4714-11-24 00:00:00+00 BC' THEN NULL 
+         WHEN bgw_job_stat.last_finish IS NOT NULL THEN
+              CASE WHEN bgw_job_stat.last_run_success = 't' THEN 'Success'
+                   WHEN bgw_job_stat.last_run_success = 'f' THEN 'Failed'
+              END
+    END as last_run_status,
+    CASE WHEN bgw_job_stat.last_finish < '4714-11-24 00:00:00+00 BC' THEN 'Running'
+       WHEN bgw_job_stat.next_start IS NOT NULL THEN 'Scheduled'
+    END as job_status,
+    CASE WHEN bgw_job_stat.last_finish > bgw_job_stat.last_start THEN (bgw_job_stat.last_finish - bgw_job_stat.last_start)
+    END as last_run_duration,
     bgw_job_stat.next_start as next_scheduled_run,
     bgw_job_stat.total_runs,
     bgw_job_stat.total_successes,

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -481,7 +481,7 @@ select view_name, completed_threshold, invalidation_threshold, job_status, last_
 view_name              | test_continuous_agg_view
 completed_threshold    | 6
 invalidation_threshold | 6
-job_status             | scheduled
+job_status             | Scheduled
 last_run_duration      | 
 
 \x off


### PR DESCRIPTION
last_run_success value is reset when a job is started.
So mask the value if the status of a job is
running, otherwise it will show an incorrect state.

Fixes #1781 
For reviewers, here is the output from a running job and a scheduled job.  (the change in this PR is for the running job case).
test=# SELECT now(), * from timescaledb_information.continuous_aggregate_stats ;
              now              | view_name | completed_threshold | invalidation_threshold | job_id |     
 last_run_started_at      |    last_successful_finish     | **last_run_status | job_status** | last_run_durat
ion |      next_scheduled_run       | total_runs | total_successes | total_failures | total_crashes 
-------------------------------+-----------+---------------------+------------------------+--------+-----
--------------------------+-------------------------------+-----------------+------------+---------------
----+-------------------------------+------------+-----------------+----------------+---------------
 2020-03-30 15:45:19.330586-04 | mat_m1    |                     |                        |   1000 | 2020
-03-30 15:40:19.465616-04 | 2020-03-30 15:40:19.495706-04 | **Success         | scheduled  |** 00:00:00.03009
    | 2020-03-30 15:45:19.495706-04 |          1 |               1 |              0 |             0
(1 row)

test=# SELECT now(), * from timescaledb_information.continuous_aggregate_stats ;
              now              | view_name | completed_threshold | invalidation_threshold | job_id |     
 last_run_started_at      |    last_successful_finish     | **last_run_status | job_status** | last_run_durat
ion | next_scheduled_run | total_runs | total_successes | total_failures | total_crashes 
-------------------------------+-----------+---------------------+------------------------+--------+-----
--------------------------+-------------------------------+-----------------+------------+---------------
----+--------------------+------------+-----------------+----------------+---------------
 2020-03-30 15:45:21.833573-04 | mat_m1    | 21                  | 21                     |   1000 | 2020
-03-30 15:45:21.124055-04 | 2020-03-30 15:45:21.112443-04 |                 **| running**    |               
    | -infinity          |          3 |               2 |              0 |             1
(1 row)
