### PR TITLE
Add missing cast to cagg union view

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -78,7 +78,7 @@ extern Oid ts_lookup_proc_filtered(const char *schema, const char *funcname, Oid
 								   proc_filter filter, void *filter_arg);
 extern Oid ts_get_operator(const char *name, Oid namespace, Oid left, Oid right);
 
-extern Oid ts_get_cast_func(Oid source, Oid target);
+extern TSDLLEXPORT Oid ts_get_cast_func(Oid source, Oid target);
 
 extern void *ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size,
 										 size_t copy_size);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1907,8 +1907,19 @@ build_conversion_call(Oid type, FuncExpr *boundary)
 	{
 		case INT2OID:
 		case INT4OID:
+		{
+			/* since the boundary function returns int8 we need to cast to proper type here */
+			Oid cast_oid = ts_get_cast_func(INT8OID, type);
+
+			return makeFuncExpr(cast_oid,
+								type,
+								list_make1(boundary),
+								InvalidOid,
+								InvalidOid,
+								COERCE_IMPLICIT_CAST);
+		}
 		case INT8OID:
-			/* nothing to do for int types */
+			/* nothing to do for int8 */
 			return boundary;
 		case DATEOID:
 		case TIMESTAMPOID:

--- a/tsl/test/expected/continuous_aggs_union_view-10.out
+++ b/tsl/test/expected/continuous_aggs_union_view-10.out
@@ -311,8 +311,8 @@ SELECT _timescaledb_internal.cagg_watermark(5);
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket
@@ -323,13 +323,13 @@ SELECT _timescaledb_internal.cagg_watermark(5);
          ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
 (17 rows)
 
 -- result should have 4 rows
@@ -360,15 +360,15 @@ SELECT _timescaledb_internal.cagg_watermark(5);
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
-                     Index Cond: (time_bucket < COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: (time_bucket(10, boundary_test."time"))
          ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=2 loops=1)
                Chunks excluded during startup: 2
                ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
 (15 rows)
 
 -- result should have 4 rows

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -311,8 +311,8 @@ SELECT _timescaledb_internal.cagg_watermark(5);
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
    ->  HashAggregate (actual rows=0 loops=1)
          Group Key: time_bucket
@@ -323,13 +323,13 @@ SELECT _timescaledb_internal.cagg_watermark(5);
          ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
 (17 rows)
 
 -- result should have 4 rows
@@ -360,15 +360,15 @@ SELECT _timescaledb_internal.cagg_watermark(5);
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
-                     Index Cond: (time_bucket < COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: time_bucket(10, boundary_test."time")
          ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=2 loops=1)
                Chunks excluded during startup: 2
                ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
 (15 rows)
 
 -- result should have 4 rows

--- a/tsl/test/expected/continuous_aggs_union_view-9.6.out
+++ b/tsl/test/expected/continuous_aggs_union_view-9.6.out
@@ -311,8 +311,8 @@ SELECT _timescaledb_internal.cagg_watermark(5);
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
  Append
    ->  HashAggregate
          Group Key: time_bucket
@@ -323,13 +323,13 @@ SELECT _timescaledb_internal.cagg_watermark(5);
          ->  Custom Scan (ChunkAppend) on boundary_test
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
 (17 rows)
 
 -- result should have 4 rows
@@ -352,23 +352,23 @@ SELECT _timescaledb_internal.cagg_watermark(5);
 
 -- both sides of the UNION should return 2 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Append
    ->  HashAggregate
          Group Key: _materialized_hypertable_6.time_bucket
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk
-                     Index Cond: (time_bucket < COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
    ->  HashAggregate
          Group Key: (time_bucket(10, boundary_test."time"))
          ->  Custom Scan (ChunkAppend) on boundary_test
                Chunks excluded during startup: 2
                ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk
-                     Index Cond: ("time" >= COALESCE(_timescaledb_internal.cagg_watermark(5), '-2147483648'::integer))
+                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(5))::integer, '-2147483648'::integer))
 (15 rows)
 
 -- result should have 4 rows


### PR DESCRIPTION
The view definition for the union view was missing a cast from int8
to the actual int type used for hypertables with int partitioning
column this was not a problem on 64 bit systems but on 32 bit systems
int4 and int8 are represented differently.