### PR TITLE
Enable null pointer checks and warnings for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,14 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
   # These two flags generate too many errors currently, but we
   # probably want these optimizations enabled.
 
-  # TODO: -fdelete-null-pointer-checks -Wnull-dereference
-
   # This flag avoid some subtle bugs related to standard conversions,
   # but currently does not compile because we are using too many
   # implicit conversions that potentially lose precision.
 
   # TODO: -Wconversions
-  add_compile_options(-Wempty-body -Wvla)
+  add_compile_options(
+    -Wempty-body -Wvla
+    -Wnonnull -fdelete-null-pointer-checks -Wnull-dereference)
   if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "7")
     add_compile_options(-Wimplicit-fallthrough)
   endif()

--- a/src/chunk_dispatch_plan.c
+++ b/src/chunk_dispatch_plan.c
@@ -22,8 +22,7 @@
  * state that replaces the plan node as the plan moves from planning to
  * execution.
  */
-static Node *
-create_chunk_dispatch_state(CustomScan *cscan)
+ts_attribute_nonnull((1)) static Node *create_chunk_dispatch_state(CustomScan *cscan)
 {
 	return (Node *) ts_chunk_dispatch_state_create(linitial_oid(cscan->custom_private),
 												   linitial(cscan->custom_plans));
@@ -86,7 +85,7 @@ static CustomPathMethods chunk_dispatch_path_methods = {
 	.PlanCustomPath = chunk_dispatch_plan_create,
 };
 
-Path *
+Path *TS_RETURNS_NONNULL
 ts_chunk_dispatch_path_create(ModifyTablePath *mtpath, Path *subpath, Index hypertable_rti,
 							  Oid hypertable_relid)
 {

--- a/src/chunk_dispatch_state.c
+++ b/src/chunk_dispatch_state.c
@@ -20,8 +20,8 @@
 #include "dimension.h"
 #include "hypertable.h"
 
-static void
-chunk_dispatch_begin(CustomScanState *node, EState *estate, int eflags)
+ts_attribute_nonnull((1, 2)) static void chunk_dispatch_begin(CustomScanState *node, EState *estate,
+															  int eflags)
 {
 	ChunkDispatchState *state = (ChunkDispatchState *) node;
 	Hypertable *ht;
@@ -35,8 +35,7 @@ chunk_dispatch_begin(CustomScanState *node, EState *estate, int eflags)
 	node->custom_ps = list_make1(ps);
 }
 
-static TupleTableSlot *
-chunk_dispatch_exec(CustomScanState *node)
+ts_attribute_nonnull((1)) static TupleTableSlot *chunk_dispatch_exec(CustomScanState *node)
 {
 	ChunkDispatchState *state = (ChunkDispatchState *) node;
 	TupleTableSlot *slot;
@@ -141,8 +140,7 @@ chunk_dispatch_exec(CustomScanState *node)
 	return slot;
 }
 
-static void
-chunk_dispatch_end(CustomScanState *node)
+ts_attribute_nonnull((1)) static void chunk_dispatch_end(CustomScanState *node)
 {
 	ChunkDispatchState *state = (ChunkDispatchState *) node;
 	PlanState *substate = linitial(node->custom_ps);
@@ -152,8 +150,7 @@ chunk_dispatch_end(CustomScanState *node)
 	ts_cache_release(state->hypertable_cache);
 }
 
-static void
-chunk_dispatch_rescan(CustomScanState *node)
+ts_attribute_nonnull((1)) static void chunk_dispatch_rescan(CustomScanState *node)
 {
 	PlanState *substate = linitial(node->custom_ps);
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -616,6 +616,15 @@ extern int oid_cmp(const void *p1, const void *p2);
 #endif
 #endif
 
+/* function attributes */
+#ifdef __GNUC__
+#define ts_attribute_nonnull(ATTR) __attribute__((nonnull ATTR))
+#define TS_RETURNS_NONNULL __attribute__((returns_nonnull))
+#else
+#define ts_attribute_nonnull(ATTR)
+#define TS_RETURNS_NONNULL
+#endif
+
 /* backport pg_add_s64_overflow/pg_sub_s64_overflow */
 #if PG11_LT
 static inline bool


### PR DESCRIPTION
Enable option `-fdelete-null-pointer-checks`, `-Wnonnull` and
`-Wnull-dereference` to eliminate unnecessary checks of null pointers
and warn when potential null pointers are dereferenced.

The flags are enabled at `-O2`: this just enable it for debug builds.