### PR TITLE
Make compiler warnings into errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,17 @@ if (NOT CMAKE_C_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
    message(FATAL_ERROR "Unsupported compiler ${CMAKE_C_COMPILER_ID}. Supported compilers are: ${SUPPORTED_COMPILERS}")
 endif ()
 
+# Option to treat warnings as errors when compiling (default on)
+option(WARNINGS_AS_ERRORS "Make compiler warnings into errors (default ON)" ON)
+
+if (WARNINGS_AS_ERRORS)
+  if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    add_compile_options(-Werror)
+  elseif (CMAKE_C_COMPILER_ID MATCHES "MSVC")
+    add_compile_options(/WX)
+  endif ()
+endif (WARNINGS_AS_ERRORS)
+
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
   # These two flags generate too many errors currently, but we
   # probably want these optimizations enabled.
@@ -108,23 +119,18 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
   if (CC_SUPPORTS_IMPLICIT_FALLTHROUGH)
     add_compile_options(-Wimplicit-fallthrough)
   endif ()
-endif()
 
-# Check for supported platforms and compiler flags
-if (WIN32)
-  if (NOT CMAKE_CONFIGURATION_TYPES)
-    # Default to only include Release builds so MSBuild.exe 'just works'
-    set(CMAKE_CONFIGURATION_TYPES Release CACHE STRING "Semicolon separated list of supported configuration types, only supports Debug, Release, MinSizeRel, and RelWithDebInfo, anything else will be ignored." FORCE)
-  endif ()
-elseif (UNIX)
   # On UNIX, the compiler needs to support -fvisibility=hidden to hide symbols by default
   check_c_compiler_flag(-fvisibility=hidden CC_SUPPORTS_VISIBILITY_HIDDEN)
 
   if (NOT CC_SUPPORTS_VISIBILITY_HIDDEN)
     message(FATAL_ERROR "The compiler ${CMAKE_C_COMPILER_ID} does not support -fvisibility=hidden")
   endif (NOT CC_SUPPORTS_VISIBILITY_HIDDEN)
-else ()
-  message(FATAL_ERROR "Unsupported platform")
+endif()
+
+# On Windows, default to only include Release builds so MSBuild.exe 'just works'
+if (WIN32 AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_CONFIGURATION_TYPES Release CACHE STRING "Semicolon separated list of supported configuration types, only supports Debug, Release, MinSizeRel, and RelWithDebInfo, anything else will be ignored." FORCE)
 endif ()
 
 message(STATUS "Using compiler ${CMAKE_C_COMPILER_ID}")

--- a/src/compat.h
+++ b/src/compat.h
@@ -18,7 +18,6 @@
 #include <commands/explain.h>
 
 #include "export.h"
-#include "import/planner.h"
 
 #define is_supported_pg_version_96(version) ((version >= 90603) && (version < 100000))
 #define is_supported_pg_version_10(version) ((version >= 100002) && (version < 110000))

--- a/src/debug_guc.c
+++ b/src/debug_guc.c
@@ -4,14 +4,21 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <fmgr.h>
-#include "debug_guc.h"
-
 #include <utils/builtins.h>
 #include <utils/guc.h>
+#include <fmgr.h>
+
+#include "compat.h"
+#if PG12_GE
+#include <nodes/pathnodes.h>
+#else
+#include <nodes/relation.h>
+#endif
 #if PG10_GE
 #include <utils/varlena.h>
 #endif
+
+#include "debug_guc.h"
 
 TSDLLEXPORT DebugOptimizerFlags ts_debug_optimizer_flags;
 

--- a/src/import/allpaths.c
+++ b/src/import/allpaths.c
@@ -325,7 +325,7 @@ set_dummy_rel_pathlist(RelOptInfo *rel)
 void
 ts_set_dummy_rel_pathlist(RelOptInfo *rel)
 {
-	return set_dummy_rel_pathlist(rel);
+	set_dummy_rel_pathlist(rel);
 }
 
 /* copied from allpaths.c */

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3187,6 +3187,7 @@ process_altertable_reset_options(AlterTableCmd *cmd, Hypertable *ht)
 	Assert(IsA(cmd->def, List));
 	inpdef = (List *) cmd->def;
 	ts_with_clause_filter(inpdef, &compress_options, &pg_options);
+
 	if (compress_options)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,6 +12,11 @@
 #include <utils/datetime.h>
 
 #include "compat.h"
+#if PG12_GE
+#include <nodes/pathnodes.h>
+#else
+#include <nodes/relation.h>
+#endif
 
 #if PG11_GE
 #include <common/int.h>

--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -24,6 +24,7 @@
 #include <hypertable_cache.h>
 #include <planner.h>
 #include <import/allpaths.h>
+#include <import/planner.h>
 #include <func_cache.h>
 #include <dimension.h>
 #include <compat.h>


### PR DESCRIPTION
This change makes compiler warnings into errors by default on all
builds. This setting used to be applied on Travis builds, but was
removed (assumingly by accident) in a previous commit. The new
behavior can be disabled by including `-DWARNINGS_AS_ERRORS=OFF`
when running cmake.