### PR TITLE
Fix ts_hypertable_get_all for compressed tables

### DIFF
--- a/test/expected/chunk_utils_compression.out
+++ b/test/expected/chunk_utils_compression.out
@@ -1,0 +1,135 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+--------------------------------------------------------------------------
+-- show_chunks and drop_chunks functions on a compressed table 
+-- (issue https://github.com/timescale/timescaledb/issues/1535)
+-- create a table that will not be compressed
+CREATE TABLE public.uncompressed_table(time date NOT NULL, temp float8, device_id text);
+CREATE INDEX ON public.uncompressed_table(time DESC);
+SELECT create_hypertable('public.uncompressed_table', 'time', chunk_time_interval => interval '1 day');
+        create_hypertable        
+---------------------------------
+ (1,public,uncompressed_table,t)
+(1 row)
+
+INSERT INTO public.uncompressed_table VALUES('2020-03-01', 1.0, 'dev1');
+INSERT INTO public.uncompressed_table VALUES('2020-03-05', 2.0, 'dev1');
+INSERT INTO public.uncompressed_table VALUES('2020-03-07', 3.0, 'dev1');
+INSERT INTO public.uncompressed_table VALUES('2020-03-08', 4.0, 'dev7');
+INSERT INTO public.uncompressed_table VALUES('2020-03-09', 5.0, 'dev7');
+INSERT INTO public.uncompressed_table VALUES('2020-03-10', 6.0, 'dev7');
+-- create next table that is going to be compressed:
+CREATE TABLE public.table_to_compress (time date NOT NULL, acq_id bigint, value bigint);
+CREATE INDEX idx_table_to_compress_acq_id ON public.table_to_compress(acq_id);
+SELECT create_hypertable('public.table_to_compress', 'time', chunk_time_interval => interval '1 day');
+       create_hypertable        
+--------------------------------
+ (2,public,table_to_compress,t)
+(1 row)
+
+ALTER TABLE public.table_to_compress SET (timescaledb.compress, timescaledb.compress_segmentby = 'acq_id');
+NOTICE:  adding index _compressed_hypertable_3_acq_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_3 USING BTREE(acq_id, _ts_meta_sequence_num)
+INSERT INTO public.table_to_compress VALUES ('2020-01-01', 1234567, 777888);
+INSERT INTO public.table_to_compress VALUES ('2020-02-01', 567567, 890890);
+INSERT INTO public.table_to_compress VALUES ('2020-02-10', 1234, 5678);
+SELECT show_chunks('public.table_to_compress');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+
+SELECT show_chunks(hypertable=>'public.table_to_compress', older_than=>'1 day'::interval);
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+
+SELECT show_chunks(hypertable=>'public.table_to_compress', newer_than=>'1 day'::interval);
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT show_chunks(); -- across all hypertables
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(9 rows)
+
+-- compress all chunks of the table:
+SELECT compress_chunk(show_chunks(hypertable=>'public.table_to_compress'));
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+
+-- and run the queries again to make sure results are the same
+SELECT show_chunks('public.table_to_compress');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+
+SELECT show_chunks(hypertable=>'public.table_to_compress', older_than=>'1 day'::interval);
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(3 rows)
+
+SELECT show_chunks(hypertable=>'public.table_to_compress', newer_than=>'1 day'::interval);
+ show_chunks 
+-------------
+(0 rows)
+
+SELECT show_chunks(); 
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(9 rows)
+
+-- drop all hypertables' old chunks
+SELECT drop_chunks(older_than=>'1 day'::interval);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+(9 rows)
+
+SELECT show_chunks(); 
+ show_chunks 
+-------------
+(0 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -54,6 +54,7 @@ if(NOT APACHE_ONLY)
 if (${PG_VERSION_MAJOR} GREATER "9")
   list(APPEND TEST_FILES
     telemetry_compression.sql
+    chunk_utils_compression.sql
   )
 endif ()
 endif()

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -601,3 +601,4 @@ INSERT INTO try_schema.drop_chunk_test_date VALUES( '2020-02-10', 100, 'hello');
 SELECT show_chunks(hypertable=>'public.drop_chunk_test_date', older_than=>'1 day'::interval);
 SELECT show_chunks(hypertable=>'try_schema.drop_chunk_test_date', older_than=>'1 day'::interval);
 SELECT drop_chunks( older_than=> '1 day'::interval);
+

--- a/test/sql/chunk_utils_compression.sql
+++ b/test/sql/chunk_utils_compression.sql
@@ -1,0 +1,42 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+--------------------------------------------------------------------------
+-- show_chunks and drop_chunks functions on a compressed table 
+-- (issue https://github.com/timescale/timescaledb/issues/1535)
+
+-- create a table that will not be compressed
+CREATE TABLE public.uncompressed_table(time date NOT NULL, temp float8, device_id text);
+CREATE INDEX ON public.uncompressed_table(time DESC);
+SELECT create_hypertable('public.uncompressed_table', 'time', chunk_time_interval => interval '1 day');
+
+INSERT INTO public.uncompressed_table VALUES('2020-03-01', 1.0, 'dev1');
+INSERT INTO public.uncompressed_table VALUES('2020-03-05', 2.0, 'dev1');
+INSERT INTO public.uncompressed_table VALUES('2020-03-07', 3.0, 'dev1');
+INSERT INTO public.uncompressed_table VALUES('2020-03-08', 4.0, 'dev7');
+INSERT INTO public.uncompressed_table VALUES('2020-03-09', 5.0, 'dev7');
+INSERT INTO public.uncompressed_table VALUES('2020-03-10', 6.0, 'dev7');
+
+-- create next table that is going to be compressed:
+CREATE TABLE public.table_to_compress (time date NOT NULL, acq_id bigint, value bigint);
+CREATE INDEX idx_table_to_compress_acq_id ON public.table_to_compress(acq_id);
+SELECT create_hypertable('public.table_to_compress', 'time', chunk_time_interval => interval '1 day');
+ALTER TABLE public.table_to_compress SET (timescaledb.compress, timescaledb.compress_segmentby = 'acq_id');
+INSERT INTO public.table_to_compress VALUES ('2020-01-01', 1234567, 777888);
+INSERT INTO public.table_to_compress VALUES ('2020-02-01', 567567, 890890);
+INSERT INTO public.table_to_compress VALUES ('2020-02-10', 1234, 5678);
+SELECT show_chunks('public.table_to_compress');
+SELECT show_chunks(hypertable=>'public.table_to_compress', older_than=>'1 day'::interval);
+SELECT show_chunks(hypertable=>'public.table_to_compress', newer_than=>'1 day'::interval);
+SELECT show_chunks(); -- across all hypertables
+-- compress all chunks of the table:
+SELECT compress_chunk(show_chunks(hypertable=>'public.table_to_compress'));
+-- and run the queries again to make sure results are the same
+SELECT show_chunks('public.table_to_compress');
+SELECT show_chunks(hypertable=>'public.table_to_compress', older_than=>'1 day'::interval);
+SELECT show_chunks(hypertable=>'public.table_to_compress', newer_than=>'1 day'::interval);
+SELECT show_chunks(); 
+-- drop all hypertables' old chunks
+SELECT drop_chunks(older_than=>'1 day'::interval);
+SELECT show_chunks(); 


### PR DESCRIPTION
When calling show_chunks or drop_chunks without specifying
a particular hypertable TimescaleDB iterates through all
existing hypertables and builds a list. While doing this
it adds the internal '_compressed_hypertable_*' tables
which leads to incorrect behaviour of
ts_chunk_get_chunks_in_time_range function. This fix
filters out the internal compressed tables while scanning
at ts_hypertable_get_all function.

Fixes #1535 