### PR TITLE
Add logic to ignore dropped chunks in compressed_chunk_stats

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -206,7 +206,7 @@ WITH mapq as
   mapq.compressed_toast_bytes,
   mapq.compressed_total_bytes
   FROM _timescaledb_catalog.hypertable as srcht JOIN _timescaledb_catalog.chunk as srcch
-  ON srcht.id = srcch.hypertable_id and srcht.compressed_hypertable_id IS NOT NULL
+  ON srcht.id = srcch.hypertable_id and srcht.compressed_hypertable_id IS NOT NULL and srcch.dropped = false
   LEFT JOIN mapq
   ON srcch.id = mapq.chunk_id ;
 

--- a/test/expected/views.out
+++ b/test/expected/views.out
@@ -96,3 +96,34 @@ SELECT * FROM timescaledb_information.hypertable WHERE table_owner = 'super_user
  open         | open_ht    | super_user  |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB
 (2 rows)
 
+-- create hypertable with 2 chunks
+CREATE TABLE ht5(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('ht5','time');
+ create_hypertable 
+-------------------
+ (5,public,ht5,t)
+(1 row)
+
+INSERT INTO ht5 SELECT '2000-01-01'::TIMESTAMPTZ;
+INSERT INTO ht5 SELECT '2001-01-01'::TIMESTAMPTZ;
+-- compressed_chunk_stats should not show dropped chunks
+ALTER TABLE ht5 SET (timescaledb.compress);
+SELECT compress_chunk(i) FROM show_chunks('ht5') i;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_5_7_chunk
+ _timescaledb_internal._hyper_5_8_chunk
+(2 rows)
+
+SELECT drop_chunks(table_name => 'ht5', newer_than => '2000-01-01'::TIMESTAMPTZ);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_5_8_chunk
+(1 row)
+
+SELECT * FROM timescaledb_information.compressed_chunk_stats;
+ hypertable_name |               chunk_name               | compression_status | uncompressed_heap_bytes | uncompressed_index_bytes | uncompressed_toast_bytes | uncompressed_total_bytes | compressed_heap_bytes | compressed_index_bytes | compressed_toast_bytes | compressed_total_bytes 
+-----------------+----------------------------------------+--------------------+-------------------------+--------------------------+--------------------------+--------------------------+-----------------------+------------------------+------------------------+------------------------
+ ht5             | _timescaledb_internal._hyper_5_7_chunk | Compressed         | 8192 bytes              | 16 kB                    | 0 bytes                  | 24 kB                    | 8192 bytes            | 0 bytes                | 8192 bytes             | 16 kB
+(1 row)
+

--- a/test/sql/views.sql
+++ b/test/sql/views.sql
@@ -47,3 +47,14 @@ SELECT * FROM timescaledb_information.hypertable WHERE table_name = 'ht1' ORDER 
 -- filter by owner
 SELECT * FROM timescaledb_information.hypertable WHERE table_owner = 'super_user' ORDER BY table_schema,table_name;
 
+-- create hypertable with 2 chunks
+CREATE TABLE ht5(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('ht5','time');
+INSERT INTO ht5 SELECT '2000-01-01'::TIMESTAMPTZ;
+INSERT INTO ht5 SELECT '2001-01-01'::TIMESTAMPTZ;
+
+-- compressed_chunk_stats should not show dropped chunks
+ALTER TABLE ht5 SET (timescaledb.compress);
+SELECT compress_chunk(i) FROM show_chunks('ht5') i;
+SELECT drop_chunks(table_name => 'ht5', newer_than => '2000-01-01'::TIMESTAMPTZ);
+SELECT * FROM timescaledb_information.compressed_chunk_stats;


### PR DESCRIPTION
Similar to issue #1698 

After dropping a hypertable chunk that has been compressed, running timescaledb_information.compressed_chunk_stats fails with the error:
`ERROR:  relation "_timescaledb_internal._hyper_1584_89_chunk" does not exist`

This PR only looks for chunks that have not been dropped.