### PR TITLE
Record cagg view state in catalog

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -252,6 +252,7 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_agg (
     direct_view_name NAME NOT NULL,
     max_interval_per_job BIGINT NOT NULL,
     ignore_invalidation_older_than BIGINT NOT NULL DEFAULT BIGINT '9223372036854775807',
+    materialized_only BOOL NOT NULL DEFAULT false,
     UNIQUE(user_view_schema, user_view_name),
     UNIQUE(partial_view_schema, partial_view_name)
 );

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,12 @@
 
 DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;
 
+ALTER TABLE IF EXISTS _timescaledb_catalog.continuous_agg ADD COLUMN IF NOT EXISTS  materialized_only BOOL NOT NULL DEFAULT false;
+
+-- all continuous aggregrates created before this update had materialized only views
+UPDATE _timescaledb_catalog.continuous_agg SET materialized_only = true;
+
+-- rewrite catalog table to not break catalog scans on tables with missingval optimization
+CLUSTER  _timescaledb_catalog.continuous_agg USING continuous_agg_pkey;
+ALTER TABLE _timescaledb_catalog.continuous_agg SET WITHOUT CLUSTER;
+

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -114,6 +114,7 @@ CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregates as
           ELSE cagg.ignore_invalidation_older_than::TEXT
         END
     END AS ignore_invalidation_older_than,
+    cagg.materialized_only,
     format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as materialization_hypertable,
     directview.viewdefinition as view_definition
   FROM  _timescaledb_catalog.continuous_agg cagg,

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -834,6 +834,7 @@ typedef enum Anum_continuous_agg
 	Anum_continuous_agg_direct_view_name,
 	Anum_continuous_agg_max_interval_per_job,
 	Anum_continuous_agg_ignore_invalidation_older_than,
+	Anum_continuous_agg_materialize_only,
 	_Anum_continuous_agg_max,
 } Anum_continuous_agg;
 

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -155,6 +155,41 @@ update_refresh_lag(ContinuousAgg *agg, int64 new_lag)
 }
 
 static void
+update_materialized_only(ContinuousAgg *agg, bool materialized_only)
+{
+	ScanIterator iterator =
+		ts_scan_iterator_create(CONTINUOUS_AGG, RowExclusiveLock, CurrentMemoryContext);
+	iterator.ctx.index = catalog_get_index(ts_catalog_get(), CONTINUOUS_AGG, CONTINUOUS_AGG_PKEY);
+
+	ts_scan_iterator_scan_key_init(&iterator,
+								   Anum_continuous_agg_pkey_mat_hypertable_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(agg->data.mat_hypertable_id));
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		bool nulls[Natts_continuous_agg];
+		Datum values[Natts_continuous_agg];
+		bool repl[Natts_continuous_agg] = { false };
+		HeapTuple new;
+
+		heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
+
+		repl[AttrNumberGetAttrOffset(Anum_continuous_agg_materialize_only)] = true;
+		values[AttrNumberGetAttrOffset(Anum_continuous_agg_materialize_only)] =
+			BoolGetDatum(materialized_only);
+
+		new = heap_modify_tuple(ti->tuple, ti->desc, values, nulls, repl);
+
+		ts_catalog_update(ti->scanrel, new);
+		break;
+	}
+	ts_scan_iterator_close(&iterator);
+}
+
+static void
 update_max_interval_per_job(ContinuousAgg *agg, int64 new_max)
 {
 	ScanIterator iterator =
@@ -235,9 +270,12 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		Cache *hcache = ts_hypertable_cache_pin();
 		Hypertable *mat_ht =
 			ts_hypertable_cache_get_entry_by_id(hcache, agg->data.mat_hypertable_id);
+		bool materialized_only =
+			DatumGetBool(with_clause_options[ContinuousViewOptionMaterializedOnly].parsed);
 		Assert(mat_ht != NULL);
 
 		cagg_update_view_definition(agg, mat_ht, with_clause_options);
+		update_materialized_only(agg, materialized_only);
 		ts_cache_release(hcache);
 	}
 

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -63,8 +63,8 @@ SELECT * FROM timescaledb_information.policy_stats;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_agg;
- mat_hypertable_id | raw_hypertable_id | user_view_schema | user_view_name | partial_view_schema | partial_view_name | bucket_width | job_id | refresh_lag | direct_view_schema | direct_view_name | max_interval_per_job | ignore_invalidation_older_than 
--------------------+-------------------+------------------+----------------+---------------------+-------------------+--------------+--------+-------------+--------------------+------------------+----------------------+--------------------------------
+ mat_hypertable_id | raw_hypertable_id | user_view_schema | user_view_name | partial_view_schema | partial_view_name | bucket_width | job_id | refresh_lag | direct_view_schema | direct_view_name | max_interval_per_job | ignore_invalidation_older_than | materialized_only 
+-------------------+-------------------+------------------+----------------+---------------------+-------------------+--------------+--------+-------------+--------------------+------------------+----------------------+--------------------------------+-------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/continuous_aggs_union_view-10.out
+++ b/tsl/test/expected/continuous_aggs_union_view-10.out
@@ -36,6 +36,12 @@ AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
 ALTER TABLE metrics DROP COLUMN f2;
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -61,6 +67,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -78,6 +90,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- upgrade view to union view again
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -103,6 +121,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- try upgrade view to union view that is already union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -137,6 +161,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -161,6 +191,12 @@ CREATE VIEW metrics_summary
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -178,6 +214,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- upgrade view to union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -203,6 +245,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -225,6 +273,13 @@ CREATE VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- should be marked as materialized_only in catalog
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 -- query should not have results since cagg is materialized only and no refresh has happened yet
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
  time_bucket | avg 

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -36,6 +36,12 @@ AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
 ALTER TABLE metrics DROP COLUMN f2;
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -61,6 +67,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -78,6 +90,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- upgrade view to union view again
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -103,6 +121,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- try upgrade view to union view that is already union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -137,6 +161,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -161,6 +191,12 @@ CREATE VIEW metrics_summary
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -178,6 +214,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- upgrade view to union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -203,6 +245,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -225,6 +273,13 @@ CREATE VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- should be marked as materialized_only in catalog
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 -- query should not have results since cagg is materialized only and no refresh has happened yet
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
  time_bucket | avg 

--- a/tsl/test/expected/continuous_aggs_union_view-9.6.out
+++ b/tsl/test/expected/continuous_aggs_union_view-9.6.out
@@ -36,6 +36,12 @@ AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
 ALTER TABLE metrics DROP COLUMN f2;
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -61,6 +67,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -78,6 +90,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- upgrade view to union view again
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -103,6 +121,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- try upgrade view to union view that is already union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -137,6 +161,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -161,6 +191,12 @@ CREATE VIEW metrics_summary
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -178,6 +214,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- upgrade view to union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | f
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -203,6 +245,12 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 SELECT pg_get_viewdef('metrics_summary',true);
                                                                                           pg_get_viewdef                                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -225,6 +273,13 @@ CREATE VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+-- should be marked as materialized_only in catalog
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
+ user_view_name  | materialized_only 
+-----------------+-------------------
+ metrics_summary | t
+(1 row)
+
 -- query should not have results since cagg is materialized only and no refresh has happened yet
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
  time_bucket | avg 

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -74,6 +74,7 @@ refresh_lag                    | @ 2 hours
 refresh_interval               | @ 2 hours
 max_interval_per_job           | @ 60 days
 ignore_invalidation_older_than | 
+materialized_only              | t
 materialization_hypertable     | _timescaledb_internal._materialized_hypertable_2
 view_definition                |  SELECT time_bucket('@ 1 hour'::interval, device_readings.observation_time) AS bucket,                      +
                                |     device_readings.device_id,                                                                              +

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -35,24 +35,28 @@ AS
 ALTER TABLE metrics DROP COLUMN f2;
 
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- upgrade view to union view again
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- try upgrade view to union view that is already union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
@@ -64,6 +68,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 -- view should have results now after refresh
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -77,18 +82,21 @@ AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
 
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- upgrade view to union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- downgrade view to non-union view
 ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
@@ -102,6 +110,9 @@ CREATE VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+
+-- should be marked as materialized_only in catalog
+SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 
 -- query should not have results since cagg is materialized only and no refresh has happened yet
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;


### PR DESCRIPTION
Record materialized_only state of continuous aggregate view in
catalog and show state in timescaledb_information.continuous_aggregates.