### PR TITLE
Add test for INSERT in cached plans

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,9 +200,7 @@ endif ()
 
 message(STATUS "Compiling against PostgreSQL version ${PG_VERSION}")
 
-if ((${PG_VERSION} VERSION_LESS "9.6")
-    OR (${PG_VERSION} VERSION_EQUAL "13")
-    OR (${PG_VERSION} VERSION_GREATER "13"))
+if ((${PG_VERSION} VERSION_LESS "9.6") OR (${PG_VERSION_MAJOR} GREATER "12"))
   message(FATAL_ERROR "TimescaleDB only supports PostgreSQL 9.6, 10, 11 or 12")
 endif ()
 

--- a/test/expected/insert-10.out
+++ b/test/expected/insert-10.out
@@ -550,3 +550,39 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
                                  Index Cond: ("time" > '-infinity'::date)
 (9 rows)
 
+-- test INSERT with cached plans / plpgsql functions
+-- https://github.com/timescale/timescaledb/issues/1809
+CREATE TABLE status_table(a int, b int, last_ts timestamptz, UNIQUE(a,b));
+CREATE TABLE metrics(time timestamptz NOT NULL, value float);
+CREATE TABLE metrics2(time timestamptz NOT NULL, value float);
+SELECT (create_hypertable(t,'time')).table_name FROM (VALUES ('metrics'),('metrics2')) v(t);
+ table_name 
+------------
+ metrics
+ metrics2
+(2 rows)
+
+INSERT INTO metrics VALUES ('2000-01-01',random()), ('2000-02-01',random()), ('2000-03-01',random());
+CREATE OR REPLACE FUNCTION insert_test() RETURNS VOID LANGUAGE plpgsql AS
+$$
+  DECLARE
+    r RECORD;
+  BEGIN
+    FOR r IN
+      SELECT * FROM metrics
+    LOOP
+      WITH foo AS (
+        INSERT INTO metrics2 SELECT * FROM metrics RETURNING *
+      )
+      INSERT INTO status_table (a,b, last_ts)
+        VALUES (1,1, now())
+        ON CONFLICT (a,b) DO UPDATE SET last_ts=(SELECT max(time) FROM metrics);
+    END LOOP;
+  END;
+$$;
+SELECT insert_test(), insert_test(), insert_test();
+ insert_test | insert_test | insert_test 
+-------------+-------------+-------------
+             |             | 
+(1 row)
+

--- a/test/expected/insert-11.out
+++ b/test/expected/insert-11.out
@@ -550,3 +550,39 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
                                  Index Cond: ("time" > '-infinity'::date)
 (9 rows)
 
+-- test INSERT with cached plans / plpgsql functions
+-- https://github.com/timescale/timescaledb/issues/1809
+CREATE TABLE status_table(a int, b int, last_ts timestamptz, UNIQUE(a,b));
+CREATE TABLE metrics(time timestamptz NOT NULL, value float);
+CREATE TABLE metrics2(time timestamptz NOT NULL, value float);
+SELECT (create_hypertable(t,'time')).table_name FROM (VALUES ('metrics'),('metrics2')) v(t);
+ table_name 
+------------
+ metrics
+ metrics2
+(2 rows)
+
+INSERT INTO metrics VALUES ('2000-01-01',random()), ('2000-02-01',random()), ('2000-03-01',random());
+CREATE OR REPLACE FUNCTION insert_test() RETURNS VOID LANGUAGE plpgsql AS
+$$
+  DECLARE
+    r RECORD;
+  BEGIN
+    FOR r IN
+      SELECT * FROM metrics
+    LOOP
+      WITH foo AS (
+        INSERT INTO metrics2 SELECT * FROM metrics RETURNING *
+      )
+      INSERT INTO status_table (a,b, last_ts)
+        VALUES (1,1, now())
+        ON CONFLICT (a,b) DO UPDATE SET last_ts=(SELECT max(time) FROM metrics);
+    END LOOP;
+  END;
+$$;
+SELECT insert_test(), insert_test(), insert_test();
+ insert_test | insert_test | insert_test 
+-------------+-------------+-------------
+             |             | 
+(1 row)
+

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -549,3 +549,39 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
                                  Index Cond: ("time" > '-infinity'::date)
 (9 rows)
 
+-- test INSERT with cached plans / plpgsql functions
+-- https://github.com/timescale/timescaledb/issues/1809
+CREATE TABLE status_table(a int, b int, last_ts timestamptz, UNIQUE(a,b));
+CREATE TABLE metrics(time timestamptz NOT NULL, value float);
+CREATE TABLE metrics2(time timestamptz NOT NULL, value float);
+SELECT (create_hypertable(t,'time')).table_name FROM (VALUES ('metrics'),('metrics2')) v(t);
+ table_name 
+------------
+ metrics
+ metrics2
+(2 rows)
+
+INSERT INTO metrics VALUES ('2000-01-01',random()), ('2000-02-01',random()), ('2000-03-01',random());
+CREATE OR REPLACE FUNCTION insert_test() RETURNS VOID LANGUAGE plpgsql AS
+$$
+  DECLARE
+    r RECORD;
+  BEGIN
+    FOR r IN
+      SELECT * FROM metrics
+    LOOP
+      WITH foo AS (
+        INSERT INTO metrics2 SELECT * FROM metrics RETURNING *
+      )
+      INSERT INTO status_table (a,b, last_ts)
+        VALUES (1,1, now())
+        ON CONFLICT (a,b) DO UPDATE SET last_ts=(SELECT max(time) FROM metrics);
+    END LOOP;
+  END;
+$$;
+SELECT insert_test(), insert_test(), insert_test();
+ insert_test | insert_test | insert_test 
+-------------+-------------+-------------
+             |             | 
+(1 row)
+

--- a/test/expected/insert-9.6.out
+++ b/test/expected/insert-9.6.out
@@ -550,3 +550,39 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
                                  Index Cond: ("time" > '-infinity'::date)
 (9 rows)
 
+-- test INSERT with cached plans / plpgsql functions
+-- https://github.com/timescale/timescaledb/issues/1809
+CREATE TABLE status_table(a int, b int, last_ts timestamptz, UNIQUE(a,b));
+CREATE TABLE metrics(time timestamptz NOT NULL, value float);
+CREATE TABLE metrics2(time timestamptz NOT NULL, value float);
+SELECT (create_hypertable(t,'time')).table_name FROM (VALUES ('metrics'),('metrics2')) v(t);
+ table_name 
+------------
+ metrics
+ metrics2
+(2 rows)
+
+INSERT INTO metrics VALUES ('2000-01-01',random()), ('2000-02-01',random()), ('2000-03-01',random());
+CREATE OR REPLACE FUNCTION insert_test() RETURNS VOID LANGUAGE plpgsql AS
+$$
+  DECLARE
+    r RECORD;
+  BEGIN
+    FOR r IN
+      SELECT * FROM metrics
+    LOOP
+      WITH foo AS (
+        INSERT INTO metrics2 SELECT * FROM metrics RETURNING *
+      )
+      INSERT INTO status_table (a,b, last_ts)
+        VALUES (1,1, now())
+        ON CONFLICT (a,b) DO UPDATE SET last_ts=(SELECT max(time) FROM metrics);
+    END LOOP;
+  END;
+$$;
+SELECT insert_test(), insert_test(), insert_test();
+ insert_test | insert_test | insert_test 
+-------------+-------------+-------------
+             |             | 
+(1 row)
+

--- a/test/sql/insert.sql.in
+++ b/test/sql/insert.sql.in
@@ -118,3 +118,34 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time <= '-infinity' LIMIT 1;
 EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time > '-infinity' LIMIT 1;
+
+-- test INSERT with cached plans / plpgsql functions
+-- https://github.com/timescale/timescaledb/issues/1809
+CREATE TABLE status_table(a int, b int, last_ts timestamptz, UNIQUE(a,b));
+CREATE TABLE metrics(time timestamptz NOT NULL, value float);
+CREATE TABLE metrics2(time timestamptz NOT NULL, value float);
+SELECT (create_hypertable(t,'time')).table_name FROM (VALUES ('metrics'),('metrics2')) v(t);
+
+INSERT INTO metrics VALUES ('2000-01-01',random()), ('2000-02-01',random()), ('2000-03-01',random());
+
+CREATE OR REPLACE FUNCTION insert_test() RETURNS VOID LANGUAGE plpgsql AS
+$$
+  DECLARE
+    r RECORD;
+  BEGIN
+    FOR r IN
+      SELECT * FROM metrics
+    LOOP
+      WITH foo AS (
+        INSERT INTO metrics2 SELECT * FROM metrics RETURNING *
+      )
+      INSERT INTO status_table (a,b, last_ts)
+        VALUES (1,1, now())
+        ON CONFLICT (a,b) DO UPDATE SET last_ts=(SELECT max(time) FROM metrics);
+    END LOOP;
+  END;
+$$;
+
+SELECT insert_test(), insert_test(), insert_test();
+
+


### PR DESCRIPTION
This adds a test for INSERTs with cached plans. This test causes
a segfault before 1.7 but was fixed independantly by the refactoring
of the INSERT path when adding PG12 support.

Fixes #1809 