### PR TITLE
Fix null pointer deref in continuous aggregates

### DIFF
--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -523,7 +523,8 @@ drop_continuous_agg(ContinuousAgg *agg, bool drop_user_view)
 	/* lock catalogs */
 	LockRelationOid(catalog_get_table_id(catalog, BGW_JOB), RowExclusiveLock);
 	LockRelationOid(catalog_get_table_id(catalog, CONTINUOUS_AGG), RowExclusiveLock);
-	raw_hypertable_has_other_caggs = number_of_continuous_aggs_attached(raw_hypertable->fd.id) > 1;
+	raw_hypertable_has_other_caggs =
+		raw_hypertable_exists && number_of_continuous_aggs_attached(raw_hypertable->fd.id) > 1;
 	if (!raw_hypertable_has_other_caggs)
 		LockRelationOid(catalog_get_table_id(catalog, CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG),
 						RowExclusiveLock);


### PR DESCRIPTION
There is a potential null pointer dereference in that `raw_hypertable`
might be NULL when counting the number of continuous aggregates
attached. This commit fixes this by assuming that no continuous
aggregates are attached if `raw_hypertable` is NULL.

Found using `clang-tidy`.