### PR TITLE
Fix fkeylist compat module for PG11+

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -965,7 +965,6 @@ list_qsort(const List *list, list_qsort_comparator cmp)
  */
 #if PG11_LT
 #define RelationGetFKeyListCompat(rel) ts_relation_get_fk_list(rel)
-#define T_ForeignKeyCacheInfoCompat T_ForeignKeyCacheInfo
 typedef struct ForeignKeyCacheInfoCompat
 {
 	ForeignKeyCacheInfo base;

--- a/src/compat/fkeylist.c
+++ b/src/compat/fkeylist.c
@@ -46,7 +46,7 @@ ts_relation_get_fk_list(Relation relation)
 		if (constraint->contype != CONSTRAINT_FOREIGN)
 			continue;
 		info = (ForeignKeyCacheInfoCompat *) newNode(sizeof(ForeignKeyCacheInfoCompat),
-													 T_ForeignKeyCacheInfoCompat);
+													 T_ForeignKeyCacheInfo);
 		info->conoid = HeapTupleGetOid(htup);
 		result = lappend(result, info);
 	}


### PR DESCRIPTION
The symbol `T_ForeignKeyCacheInfoCompat` is not defined for PG11+ since
the setting in `compat.h` is guarded by a `PG11_LT`. Since
`T_ForeignKeyCacheInfo` exists in 9.6, 10, 11, and 12, the setting of
`T_ForeignKeyCacheInfoCompat` is removed and replaced with
`T_ForeignKeyCacheInfo` in the single use-case.

Found using `clang-tidy`.