### PR TITLE
Update build from source instructions for 1.7

### DIFF
--- a/docs/BuildSource.md
+++ b/docs/BuildSource.md
@@ -9,7 +9,7 @@ See the Releases tab for the latest release.
 
 **Prerequisites**:
 
-- A standard PostgreSQL 9.6, 10, or 11 installation with development
+- A standard PostgreSQL 12 or 11.4+ installation with development
 environment (header files) (e.g., `postgresql-server-dev-11 `package
 for Linux, Postgres.app for MacOS)
 - C compiler (e.g., gcc or clang)
@@ -18,8 +18,8 @@ for Linux, Postgres.app for MacOS)
 ```bash
 git clone git@github.com:timescale/timescaledb.git
 cd timescaledb
-# Find the latest release and checkout, e.g. for 1.3.0:
-git checkout 1.3.0
+# Find the latest release and checkout, e.g. for 1.7.0:
+git checkout 1.7.0
 # Bootstrap the build system
 ./bootstrap
 # To build the extension
@@ -42,7 +42,7 @@ See the Releases tab for the latest release.
 
 **Prerequisites**:
 
-- A standard [PostgreSQL 9.6, 10, or 11 64-bit installation](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
+- A standard [PostgreSQL 12 or 11.4+ 64-bit installation](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
 - OpenSSL for Windows
 - Microsoft Visual Studio 2017 with CMake and Git components
 - OR Visual Studio 2015/2016 with [CMake](https://cmake.org/) version 3.4 or greater and Git
@@ -58,8 +58,8 @@ be built in the following way:
 git clone git@github.com:timescale/timescaledb.git
 cd timescaledb
 
-# Find the latest release and checkout, e.g. for 1.3.0:
-git checkout 1.3.0
+# Find the latest release and checkout, e.g. for 1.7.0:
+git checkout 1.7.0
 # Bootstrap the build system
 bootstrap.bat
 # To build the extension from command line
@@ -70,3 +70,8 @@ cmake --build ./build --config Release --target install
 # Alternatively, build in Visual Studio via its built-in support for
 # CMake or by opening the generated build/timescaledb.sln solution file.
 ```
+
+#### Older PostgreSQL versions
+TimescaleDB can be installed with PostgreSQL 9.6.6+ and 10.9+ versions. Support for these 
+versions of PostgreSQL is deprecated and no future releases are planned for them. We 
+recommend to use PostgreSQL 12 or 11.4+.


### PR DESCRIPTION
PostgreSQL 12 is supported since 1.7, while 9.6 and 10 are deprecated.
This PR updates the building from source instruction with this change
and uses 1.7.0 in examples.