### PR TITLE
Improve handling of "dropped" chunks 

### DIFF
--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -40,7 +40,7 @@ extern TSDLLEXPORT void ts_chunk_index_create_all(int32 hypertable_id, Oid hyper
 												  int32 chunk_id, Oid chunkrelid);
 extern Oid ts_chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid,
 										   int32 hypertable_id, Oid hypertable_indexrelid);
-extern int ts_chunk_index_delete(Chunk *chunk, Oid chunk_indexrelid, bool drop_index);
+extern int ts_chunk_index_delete(int32 chunk_id, const char *indexname, bool drop_index);
 extern int ts_chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
 extern void ts_chunk_index_delete_by_name(const char *schema, const char *index_name,
 										  bool drop_index);

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -471,7 +471,7 @@ set_arbiter_indexes(ChunkInsertState *state, ChunkDispatch *dispatch)
 	foreach (lc, arbiter_indexes)
 	{
 		Oid hypertable_index = lfirst_oid(lc);
-		Chunk *chunk = ts_chunk_get_by_relid(RelationGetRelid(state->rel), 0, true);
+		Chunk *chunk = ts_chunk_get_by_relid(RelationGetRelid(state->rel), true);
 		ChunkIndexMapping cim;
 
 		if (ts_chunk_index_get_by_hypertable_indexrelid(chunk, hypertable_index, &cim) < 1)

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -360,7 +360,7 @@ hypertable_scan_limit_internal(ScanKeyData *scankey, int num_scankeys, int index
 							   tuple_filter_func filter)
 {
 	Catalog *catalog = ts_catalog_get();
-	ScannerCtx	scanctx = {
+	ScannerCtx scanctx = {
 		.table = catalog_get_table_id(catalog, HYPERTABLE),
 		.index = catalog_get_index(catalog, HYPERTABLE, indexid),
 		.nkeys = num_scankeys,
@@ -372,11 +372,6 @@ hypertable_scan_limit_internal(ScanKeyData *scankey, int num_scankeys, int index
 		.filter = filter,
 		.scandirection = ForwardScanDirection,
 		.result_mctx = mctx,
-		.tuplock = {
-			.waitpolicy = LockWaitBlock,
-			.lockmode = LockTupleExclusive,
-			.enabled = tuplock,
-		},
 	};
 
 	return ts_scanner_scan(&scanctx);
@@ -1013,6 +1008,7 @@ hypertable_get_chunk(Hypertable *h, Point *point, bool create_if_not_exists)
 {
 	Chunk *chunk;
 	ChunkStoreEntry *cse = ts_subspace_store_get(h->chunk_cache, point);
+
 	if (cse != NULL)
 	{
 		Assert(NULL != cse->chunk);
@@ -1024,7 +1020,7 @@ hypertable_get_chunk(Hypertable *h, Point *point, bool create_if_not_exists)
 	 * allocates a lot of transient data. We don't want this allocated on
 	 * the cache's memory context.
 	 */
-	chunk = ts_chunk_find(h->space, point, false);
+	chunk = ts_chunk_find(h, point);
 
 	if (NULL == chunk)
 	{
@@ -1115,7 +1111,7 @@ ts_hypertable_select_tablespace(Hypertable *ht, Chunk *chunk)
 	return &tspcs->tablespaces[i % tspcs->num_tablespaces];
 }
 
-char *
+const char *
 ts_hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk)
 {
 	Tablespace *tspc = ts_hypertable_select_tablespace(ht, chunk);

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -110,7 +110,7 @@ extern Oid ts_hypertable_relid(RangeVar *rv);
 extern TSDLLEXPORT bool ts_is_hypertable(Oid relid);
 extern bool ts_hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid);
 extern Tablespace *ts_hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
-extern char *ts_hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
+extern const char *ts_hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
 extern Tablespace *ts_hypertable_get_tablespace_at_offset_from(int32 hypertable_id,
 															   Oid tablespace_oid, int16 offset);
 extern bool ts_hypertable_has_tuples(Oid table_relid, LOCKMODE lockmode);

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -758,7 +758,7 @@ get_explicit_chunk_oids(CollectQualCtx *ctx, Hypertable *ht)
 		if (!isnull)
 		{
 			int32 chunk_id = DatumGetInt32(elem);
-			Chunk *chunk = ts_chunk_get_by_id(chunk_id, 0, false);
+			Chunk *chunk = ts_chunk_get_by_id(chunk_id, false);
 
 			if (chunk == NULL)
 				ereport(ERROR, (errmsg("chunk id %d not found", chunk_id)));

--- a/src/planner.c
+++ b/src/planner.c
@@ -404,7 +404,7 @@ classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable **p
 				 * reliably identify chunk BASERELs. We should, however, be able
 				 * to identify these in the query preprocessing and cache them
 				 * there if we need to speed this up. */
-				Chunk *chunk = ts_chunk_get_by_relid(rte->relid, 0, false);
+				Chunk *chunk = ts_chunk_get_by_relid(rte->relid, false);
 
 				if (NULL != chunk)
 				{
@@ -814,7 +814,7 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 			if (ts_guc_enable_transparent_decompression && TS_HYPERTABLE_HAS_COMPRESSION(ht))
 			{
 				RangeTblEntry *chunk_rte = planner_rt_fetch(rel->relid, root);
-				Chunk *chunk = ts_chunk_get_by_relid(chunk_rte->relid, 0, true);
+				Chunk *chunk = ts_chunk_get_by_relid(chunk_rte->relid, true);
 
 				if (chunk->fd.compressed_chunk_id > 0)
 				{

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -129,18 +129,18 @@ create_trigger_handler(Trigger *trigger, void *arg)
  * chunk.
  */
 void
-ts_trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk)
+ts_trigger_create_all_on_chunk(Chunk *chunk)
 {
 	int sec_ctx;
 	Oid saved_uid;
-	Oid owner = ts_rel_get_owner(ht->main_table_relid);
+	Oid owner = ts_rel_get_owner(chunk->hypertable_relid);
 
 	GetUserIdAndSecContext(&saved_uid, &sec_ctx);
 
 	if (saved_uid != owner)
 		SetUserIdAndSecContext(owner, sec_ctx | SECURITY_LOCAL_USERID_CHANGE);
 
-	for_each_trigger(ht->main_table_relid, create_trigger_handler, chunk);
+	for_each_trigger(chunk->hypertable_relid, create_trigger_handler, chunk);
 
 	if (saved_uid != owner)
 		SetUserIdAndSecContext(saved_uid, sec_ctx);

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -17,7 +17,7 @@
 
 extern void ts_trigger_create_on_chunk(Oid trigger_oid, char *chunk_schema_name,
 									   char *chunk_table_name);
-extern TSDLLEXPORT void ts_trigger_create_all_on_chunk(Hypertable *ht, Chunk *chunk);
+extern TSDLLEXPORT void ts_trigger_create_all_on_chunk(Chunk *chunk);
 extern bool ts_relation_has_transition_table_trigger(Oid relid);
 
 #endif /* TIMESCALEDB_TRIGGER_H */

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -140,7 +140,7 @@ execute_reorder_policy(BgwJob *job, reorder_func reorder, bool fast_continue)
 	 * function should translate this to the Oid of the index on the specific
 	 * chunk.
 	 */
-	chunk = ts_chunk_get_by_id(chunk_id, 0, false);
+	chunk = ts_chunk_get_by_id(chunk_id, false);
 	elog(LOG, "reordering chunk %s.%s", chunk->fd.schema_name.data, chunk->fd.table_name.data);
 	reorder(chunk->table_id,
 			get_relname_relid(NameStr(args->fd.hypertable_index_name),
@@ -326,7 +326,7 @@ execute_compress_chunks_policy(BgwJob *job)
 	}
 	else
 	{
-		chunk = ts_chunk_get_by_id(chunkid, 0, true);
+		chunk = ts_chunk_get_by_id(chunkid, true);
 		tsl_compress_chunk_wrapper(chunk->table_id, false);
 		elog(LOG,
 			 "completed compressing chunk %s.%s",

--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -184,7 +184,7 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing hyperspace for hypertable")));
 	/* refetch the srcchunk with all attributes filled in */
-	srcchunk = ts_chunk_get_by_relid(chunk_relid, srcht->space->num_dimensions, true);
+	srcchunk = ts_chunk_get_by_relid(chunk_relid, true);
 	cxt->srcht = srcht;
 	cxt->compress_ht = compress_ht;
 	cxt->srcht_chunk = srcchunk;
@@ -268,9 +268,7 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
 	if (compressed_hypertable == NULL)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing compressed hypertable")));
 
-	uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_relid,
-											   uncompressed_hypertable->space->num_dimensions,
-											   true);
+	uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_relid, true);
 	if (uncompressed_chunk == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
@@ -288,7 +286,7 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
 		return false;
 	}
 
-	compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, 0, true);
+	compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
 
 	/* acquire locks on src and compress hypertable and src chunk */
 	LockRelationOid(uncompressed_hypertable->main_table_relid, AccessShareLock);
@@ -315,7 +313,7 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
 bool
 tsl_compress_chunk_wrapper(Oid chunk_relid, bool if_not_compressed)
 {
-	Chunk *srcchunk = ts_chunk_get_by_relid(chunk_relid, 0, true);
+	Chunk *srcchunk = ts_chunk_get_by_relid(chunk_relid, true);
 	if (srcchunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
 	{
 		ereport((if_not_compressed ? NOTICE : ERROR),
@@ -343,7 +341,7 @@ tsl_decompress_chunk(PG_FUNCTION_ARGS)
 {
 	Oid uncompressed_chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	bool if_compressed = PG_ARGISNULL(1) ? false : PG_GETARG_BOOL(1);
-	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, 0, true);
+	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_chunk_id, true);
 	if (NULL == uncompressed_chunk)
 		elog(ERROR, "unknown chunk id %d", uncompressed_chunk_id);
 

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -572,6 +572,7 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 	CatalogSecurityContext sec_ctx;
 	Chunk *compress_chunk;
 	int namelen;
+	const char *tablespace;
 
 	/* Create a new chunk based on the hypercube */
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
@@ -614,10 +615,8 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 	 * on which to base this decision. We simply pick the same tablespace as the uncompressed chunk
 	 * for now.
 	 */
-	compress_chunk->table_id =
-		ts_chunk_create_table(compress_chunk,
-							  compress_ht,
-							  get_tablespace_name(get_rel_tablespace(src_chunk->table_id)));
+	tablespace = get_tablespace_name(get_rel_tablespace(src_chunk->table_id));
+	compress_chunk->table_id = ts_chunk_create_table(compress_chunk, compress_ht, tablespace);
 
 	if (!OidIsValid(compress_chunk->table_id))
 		elog(ERROR, "could not create compressed chunk table");
@@ -629,7 +628,7 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 								compress_chunk->hypertable_relid,
 								compress_chunk->fd.hypertable_id);
 
-	ts_trigger_create_all_on_chunk(compress_ht, compress_chunk);
+	ts_trigger_create_all_on_chunk(compress_chunk);
 
 	ts_chunk_index_create_all(compress_chunk->fd.hypertable_id,
 							  compress_chunk->hypertable_relid,

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -1,4 +1,3 @@
-
 /*
  * This file and its contents are licensed under the Timescale License.
  * Please see the included NOTICE for copyright information and
@@ -169,7 +168,7 @@ static inline void
 cache_entry_switch_to_chunk(ContinuousAggsCacheInvalEntry *cache_entry, Oid chunk_id,
 							Relation chunk_relation)
 {
-	Chunk *modified_tuple_chunk = ts_chunk_get_by_relid(chunk_id, 0, false);
+	Chunk *modified_tuple_chunk = ts_chunk_get_by_relid(chunk_id, false);
 	if (modified_tuple_chunk == NULL)
 		elog(ERROR, "continuous agg trigger function must be called on hypertable chunks only");
 

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -880,7 +880,7 @@ decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, Chunk
 {
 	ListCell *lc;
 	Index compressed_index = root->simple_rel_array_size;
-	Chunk *compressed_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, 0, true);
+	Chunk *compressed_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
 	Oid compressed_relid = compressed_chunk->table_id;
 	RelOptInfo *compressed_rel;
 

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -39,7 +39,7 @@ tsl_set_rel_pathlist_query(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeT
 		rel->reloptkind == RELOPT_OTHER_MEMBER_REL && TS_HYPERTABLE_HAS_COMPRESSION(ht) &&
 		rel->fdw_private != NULL && ((TimescaleDBPrivate *) rel->fdw_private)->compressed)
 	{
-		Chunk *chunk = ts_chunk_get_by_relid(rte->relid, 0, true);
+		Chunk *chunk = ts_chunk_get_by_relid(rte->relid, true);
 
 		if (chunk->fd.compressed_chunk_id > 0)
 			ts_decompress_chunk_generate_paths(root, rel, ht, chunk);
@@ -52,7 +52,7 @@ tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTbl
 	if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION(ht))
 	{
 		ListCell *lc;
-		Chunk *chunk = ts_chunk_get_by_relid(rte->relid, 0, true);
+		Chunk *chunk = ts_chunk_get_by_relid(rte->relid, true);
 		if (chunk->fd.compressed_chunk_id > 0)
 		{
 			foreach (lc, rel->pathlist)

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -171,7 +171,8 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("must provide a valid chunk to cluster")));
 
-	chunk = ts_chunk_get_by_relid(chunk_id, 0, false);
+	chunk = ts_chunk_get_by_relid(chunk_id, false);
+
 	if (NULL == chunk)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),


### PR DESCRIPTION
The internal chunk API is updated to avoid returning `Chunk` objects
that are marked `dropped=true` along with some refactoring, hardening,
and cleanup of the internal chunk APIs. In particular, chunks could
previously be returned in a partial state (without all fields set,
partial constraints, etc.) and this is no longer allowed. Further,
lock handling was unclear when joining chunk metadata from different
catalog tables. This is more clear now by having chunks built within
the scan loop so that proper locks are held when reading other
metadata (such as constraints).

This change also fixes issues with dropped chunks that caused chunk
metadata to be processed many times instead of just once, leading to
potential bugs or bad performance.

In particular, since the introduction of the “dropped” flag, chunk
metadata can exist in two states: 1. `dropped=false`
2. `dropped=true`. When dropping chunks (e.g., via `drop_chunks`,
`DROP TABLE <chunk>`, or `DROP TABLE <hypertable>`) there are also two
modes of dropping: 1. DELETE row and 2. UPDATE row and SET
dropped=true.

The deletion mode and the current state of chunk lead to a
cross-product resulting in 4 cases when dropping/deleting a chunk:

1. DELETE row when dropped=false
2. DELETE row when dropped=true
3. UPDATE row when dropped=false
4. UPDATE row when dropped=true

Unfortunately, the code didn't distinguish between these cases. In
particular, case (4) should not be able to happen, but since it did it
lead to a recursing loop where an UPDATE created a new tuple that then
is recursed to in the same loop, and so on.

To fix this recursing loop and make the code for dropping chunks less
error prone, a number of assertions have been added, including some
new light-weight scan functions to access chunk information without
building a full-blown chunk.