### PR TITLE
Fix segfault on COPY to hypertable

### DIFF
--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -138,6 +138,21 @@ SELECT * FROM trigger_test ORDER BY time;
    25 |  0.602348630782217
 (15 rows)
 
+-- Test that if we copy from stdin to a hypertable and violate a null
+-- constraint, it does not crash and generate an appropriate error
+-- message.
+CREATE TABLE test(a INT NOT NULL, b TIMESTAMPTZ);
+SELECT create_hypertable('test', 'b');
+NOTICE:  adding not-null constraint to column "b"
+ create_hypertable 
+-------------------
+ (5,public,test,t)
+(1 row)
+
+\set ON_ERROR_STOP 0
+COPY TEST (a,b) FROM STDIN (delimiter ',', null 'N');
+ERROR:  null value in column "a" violates not-null constraint
+\set ON_ERROR_STOP 1
 ----------------------------------------------------------------
 -- Testing COPY TO.
 ----------------------------------------------------------------

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -85,6 +85,17 @@ FOR EACH ROW EXECUTE PROCEDURE gt_10();
 \copy trigger_test from data/copy_data.csv with csv header ;
 SELECT * FROM trigger_test ORDER BY time;
 
+-- Test that if we copy from stdin to a hypertable and violate a null
+-- constraint, it does not crash and generate an appropriate error
+-- message.
+CREATE TABLE test(a INT NOT NULL, b TIMESTAMPTZ);
+SELECT create_hypertable('test', 'b');
+\set ON_ERROR_STOP 0
+COPY TEST (a,b) FROM STDIN (delimiter ',', null 'N');
+N,'2020-01-01'
+\.
+\set ON_ERROR_STOP 1
+
 ----------------------------------------------------------------
 -- Testing COPY TO.
 ----------------------------------------------------------------
@@ -99,3 +110,4 @@ COPY hyper TO STDOUT DELIMITER ',';
 -- COPY TO using a query should display all the tuples and not show a
 -- notice.
 COPY (SELECT * FROM hyper) TO STDOUT DELIMITER ',';
+


### PR DESCRIPTION
When copying from standard input the range table was not set up to
handle the constraints for the target table and instead is initialized
to null. In addition, the range table index was set to zero, causing an
underflow when executing the constraint check. This commit fixes this
by initializing the range table and setting the index correctly.

The code worked correctly for PG12, so the code is also refactored to
ensure that the range table and index is set the same way in all
versions.

Fixes #1840 