### PR TITLE
Validate job time to avoid error thrown by scheduler

### DIFF
--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -316,7 +316,8 @@ on_failure_to_start_job(ScheduledBgwJob *sjob)
 	else
 	{
 		/* restore the original next_start to maintain priority (it is unset during mark_start) */
-		ts_bgw_job_stat_set_next_start(&sjob->job, sjob->next_start);
+		if (sjob->next_start != DT_NOBEGIN)
+			ts_bgw_job_stat_set_next_start(&sjob->job, sjob->next_start);
 		mark_job_as_ended(sjob, JOB_FAILURE_TO_START);
 	}
 	scheduled_bgw_job_transition_state_to(sjob, JOB_STATE_SCHEDULED);


### PR DESCRIPTION
Trying to use an invalid time for a job raises an error.
This case should be checked  by the scheduler. Failure to
do so results in the scheduler being killed.

To reviewers:
This is related to a failure reported on support. Found this issue by looking at the logs.
I am not able to reliably reproduce this. So I don't have a test case in the regression suite. We would hit this case if we are running the job for the first time and the bgw fails to start.