### PR TITLE
Ignore Windows build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ typedef.list
 /.vs
 /compile_commands.json
 /.DS_Store
+
+/CMakeSettings.json
+/out/*


### PR DESCRIPTION
Adds build output on Windows and CMake settings for VS to gitignore.