### PR TITLE
Fix hypertable detection in subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #1850 Fix scheduler failure due to bad next_start_time for jobs
 * #1861 Fix qual pushodwn for compressed hypertables where quals have casts
+* #1875 Fix hypertable detection in subqueries
 
 **Thanks**
 * @frostwind for reporting issue with casts in where clauses on compressed hypertables
+* @fvannee for reporting an issue with hypertable detection in inlined SQL functions
 
 ## 1.7.0 (2020-04-16)
 

--- a/src/planner.c
+++ b/src/planner.c
@@ -392,7 +392,11 @@ classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable **p
 	{
 		case RELOPT_BASEREL:
 			rte = planner_rt_fetch(rel->relid, root);
-			ht = get_hypertable(rte->relid, CACHE_FLAG_CHECK);
+			/*
+			 * to correctly classify relations in subqueries we cannot call get_hypertable
+			 * with CACHE_FLAG_NOCREATE flag because the rel might not be in cache yet
+			 */
+			ht = get_hypertable(rte->relid, rte->inh ? CACHE_FLAG_MISSING_OK : CACHE_FLAG_CHECK);
 
 			if (NULL != ht)
 				reltype = TS_REL_HYPERTABLE;

--- a/test/expected/plan_hypertable_cache.out
+++ b/test/expected/plan_hypertable_cache.out
@@ -1,0 +1,46 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- test hypertable classification when hypertable is not in cache
+-- https://github.com/timescale/timescaledb/issues/1832
+\set PREFIX 'EXPLAIN (costs off)'
+CREATE TABLE test (a int, time timestamptz NOT NULL);
+SELECT create_hypertable('public.test', 'time');
+ create_hypertable 
+-------------------
+ (1,public,test,t)
+(1 row)
+
+INSERT INTO test SELECT i, current_date-10-i from generate_series(1,20) i;
+CREATE OR REPLACE FUNCTION test_f(_ts timestamptz)
+RETURNS SETOF test LANGUAGE SQL STABLE PARALLEL SAFE
+AS $f$
+   SELECT DISTINCT ON (a) * FROM test WHERE time >= _ts ORDER BY a, time DESC
+$f$;
+:PREFIX SELECT * FROM test_f(now());
+                   QUERY PLAN                    
+-------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: test.a, test."time" DESC
+         ->  Custom Scan (ChunkAppend) on test
+               Chunks excluded during startup: 4
+               ->  Seq Scan on test test_1
+                     Filter: ("time" >= now())
+(7 rows)
+
+-- create new session
+\c
+-- plan output should be identical to previous session
+:PREFIX SELECT * FROM test_f(now());
+                   QUERY PLAN                    
+-------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: test.a, test."time" DESC
+         ->  Custom Scan (ChunkAppend) on test
+               Chunks excluded during startup: 4
+               ->  Seq Scan on test test_1
+                     Filter: ("time" >= now())
+(7 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_FILES
   lateral.sql
   pg_dump.sql
   pg_dump_unprivileged.sql
+  plan_hypertable_cache.sql
   plain.sql
   reindex.sql
   relocate_extension.sql

--- a/test/sql/plan_hypertable_cache.sql
+++ b/test/sql/plan_hypertable_cache.sql
@@ -1,0 +1,26 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- test hypertable classification when hypertable is not in cache
+-- https://github.com/timescale/timescaledb/issues/1832
+
+\set PREFIX 'EXPLAIN (costs off)'
+
+CREATE TABLE test (a int, time timestamptz NOT NULL);
+SELECT create_hypertable('public.test', 'time');
+INSERT INTO test SELECT i, current_date-10-i from generate_series(1,20) i;
+
+CREATE OR REPLACE FUNCTION test_f(_ts timestamptz)
+RETURNS SETOF test LANGUAGE SQL STABLE PARALLEL SAFE
+AS $f$
+   SELECT DISTINCT ON (a) * FROM test WHERE time >= _ts ORDER BY a, time DESC
+$f$;
+
+:PREFIX SELECT * FROM test_f(now());
+
+-- create new session
+\c
+
+-- plan output should be identical to previous session
+:PREFIX SELECT * FROM test_f(now());


### PR DESCRIPTION
When classify_relation is called for relations of subqueries it
would not be able to correctly classify the relation unless it
was already in cache. This patch changes classify_relation to
call get_hypertable without CACHE_FLAG_NOCREATE when the RangeTblEntry
has the inheritance flag set.

Fixes #1832