### PR TITLE
Run Windows regression tests on PG12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
-image: Windows Server 2019
+image: Visual Studio 2019
 services:
-  - postgresql101
+  - postgresql12
   - docker
 build_script:
 - ps: >-
@@ -52,54 +52,58 @@ build_script:
 
     SET PGPASSWORD=Password12!
 
-    Write-Output "postgresql-x64-10 should start out running"
+    Write-Output "postgresql-x64-12 should start out running"
 
-    Get-Service -Name "postgresql-x64-10"
+    Get-Service -Name "postgresql-x64-12"
 
-    Write-Output "If the binary for postgres in not in 'C:\Program Files\postgresql\10' the rest of this script won't work"
+    Write-Output "If the binary for postgres in not in 'C:\Program Files\postgresql\12' the rest of this script won't work"
 
-    reg query "HKLM\System\CurrentControlSet\Services\postgresql-x64-10" /v "ImagePath"
+    reg query "HKLM\System\CurrentControlSet\Services\postgresql-x64-12" /v "ImagePath"
 
-    Stop-Service postgresql-x64-10
+    Stop-Service postgresql-x64-12
 
-    # postgresql-x64-10 should stop
+    # postgresql-x64-12 should stop
 
-    Get-Service -Name "postgresql-x64-10"
+    Get-Service -Name "postgresql-x64-12"
 
     # we preload timescale, and allow all netowrk connections to postgres
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "shared_preload_libraries = 'timescaledb'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "shared_preload_libraries = 'timescaledb'"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "log_directory = 'pg_log'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "logging_collector = on"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "log_line_prefix = '%u [%p] %d '"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "log_directory = 'pg_log'"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "max_worker_processes=16"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "log_line_prefix = '%u [%p] %d '"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "autovacuum=false"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "max_worker_processes=16"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "random_page_cost=1.0"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "autovacuum=false"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "random_page_cost=1.0"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.last_tuned_version='0.0.1'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "extra_float_digits=0"
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb_telemetry.cloud='ci'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'"
+
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.last_tuned_version='0.0.1'"
+
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb_telemetry.cloud='ci'"
 
     # TODO removing the following line causes a stack overflow on appveyor
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.telemetry_level='off'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.telemetry_level='off'"
 
-    # Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "log_min_messages='debug5'"
+    # Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "log_min_messages='debug5'"
 
 
-    Set-Content "C:\Program Files\postgresql\10\data\pg_hba.conf" "host    all             all             ::1/128            trust"
+    Set-Content "C:\Program Files\postgresql\12\data\pg_hba.conf" "host    all             all             ::1/128            trust"
 
-    Add-Content "C:\Program Files\postgresql\10\data\pg_hba.conf" "host    all             all             127.0.0.1/32            trust"
+    Add-Content "C:\Program Files\postgresql\12\data\pg_hba.conf" "host    all             all             127.0.0.1/32            trust"
 
     # build timescale
 
-     .\bootstrap -DUSE_OPENSSL=0 -DPG_PATH="C:\Program Files\PostgreSQL\10" -DREGRESS_CHECKS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CONFIGURATION_TYPES=Debug -DCMAKE_C_FLAGS=/MP
+     .\bootstrap -DUSE_OPENSSL=0 -DPG_PATH="C:\Program Files\PostgreSQL\12" -DREGRESS_CHECKS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CONFIGURATION_TYPES=Debug -DCMAKE_C_FLAGS=/MP
 
     cmake --build ./build --config Debug
 
@@ -107,29 +111,29 @@ build_script:
 
     # postgres should restart
 
-    Start-Service postgresql-x64-10
+    Start-Service postgresql-x64-12
 
-    Get-Service -Name "postgresql-x64-10"
+    Get-Service -Name "postgresql-x64-12"
 
     # create pg user root b/c docker will need it
 
-    & "C:\Program Files\PostgreSQL\10\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'CREATE USER root WITH SUPERUSER IN ROLE postgres;' -U postgres
+    & "C:\Program Files\PostgreSQL\12\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'CREATE USER root WITH SUPERUSER IN ROLE postgres;' -U postgres
 
-    & "C:\Program Files\PostgreSQL\10\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'CREATE USER super_user WITH SUPERUSER IN ROLE postgres;' -U postgres
+    & "C:\Program Files\PostgreSQL\12\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'CREATE USER super_user WITH SUPERUSER IN ROLE postgres;' -U postgres
 
-    & "C:\Program Files\PostgreSQL\10\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'show log_directory' -U postgres
+    & "C:\Program Files\PostgreSQL\12\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'show log_directory' -U postgres
 
-    & "C:\Program Files\PostgreSQL\10\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'show log_destination;' -U postgres
+    & "C:\Program Files\PostgreSQL\12\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'show log_destination;' -U postgres
 
-    & "C:\Program Files\PostgreSQL\10\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'show logging_collector;' -U postgres
+    & "C:\Program Files\PostgreSQL\12\bin\psql.exe" -a -e -E -v "VERBOSITY=verbose" -c 'show logging_collector;' -U postgres
 
     docker-switch-linux
 
-    # docker run -d --name pgregress -v c:/projects/timescaledb:/timescale timescaledev/postgresdev:exec_backend-10-alpine
+    docker run -d --name pgregress --env POSTGRES_HOST_AUTH_METHOD=trust postgres:12.2-alpine
 
-    docker run -d --name pgregress timescaledev/postgresdev:exec_backend-10-alpine
+    docker exec -it pgregress /bin/bash -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev findutils gcc libc-dev make util-linux-dev diffutils cmake bison flex curl git openssl-dev openssl postgresql-dev~=12.2"
 
-    docker exec -it pgregress /bin/bash -c "apk add cmake git diffutils"
+    docker exec -it pgregress /bin/bash -c "ln -s /usr/lib/postgresql/pgxs/src/test/regress/pg_regress /usr/local/bin/pg_regress"
 
     # we clone the current commit in the docker instance to ensure the correct tests run
     # (Ideally we'd use the same folder, but that's difficult to set up)
@@ -145,23 +149,23 @@ test_script:
 
     Set-PSDebug -Trace 1
 
-    Get-Service -Name "postgresql-x64-10"
+    Get-Service -Name "postgresql-x64-12"
 
     docker exec -it pgregress /bin/bash -c "psql -a -e -E -U postgres --host='docker.for.win.localhost' -v VERBOSITY=verbose -c'\dx;'"
 
     #right now we only run timescale regression tests, others will be set up later
 
-    docker exec -e IGNORES="bgw_db_scheduler" -e TEST_TABLESPACE1_PATH="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PATH="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
+    docker exec -e IGNORES="bgw_db_scheduler chunk_utils" -e TEST_TABLESPACE1_PATH="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PATH="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -e PG_REGRESS_OPTS="--bindir=/usr/local/bin/" -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
 
     $TESTS1 = $?
 
     # TODO can we switch these to file swapping?
 
-    Add-Content "C:\Program Files\postgresql\10\data\postgresql.conf" "timescaledb.license_key = 'E1eyJlbmRfdGltZSI6IjIwMTgtMTAtMDEgKzAwMDAiLCAic3RhcnRfdGltZSI6IjIwMTgtMDktMDEgKzAwMDAiLCAiaWQiOiI0OTBGQjI2MC1BMjkyLTRBRDktOUFBMi0wMzYwODM1NzkxQjgiLCAia2luZCI6InRyaWFsIn0K'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.license_key = 'E1eyJlbmRfdGltZSI6IjIwMTgtMTAtMDEgKzAwMDAiLCAic3RhcnRfdGltZSI6IjIwMTgtMDktMDEgKzAwMDAiLCAiaWQiOiI0OTBGQjI2MC1BMjkyLTRBRDktOUFBMi0wMzYwODM1NzkxQjgiLCAia2luZCI6InRyaWFsIn0K'"
 
-    Restart-Service postgresql-x64-10
+    Restart-Service postgresql-x64-12
 
-    docker exec -e IGNORES="bgw_db_scheduler" -e TEST_TABLESPACE1_PATH="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PATH="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal-t"
+    docker exec -e IGNORES="compression_algos continuous_aggs_bgw" -e TEST_TABLESPACE1_PATH="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PATH="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -e PG_REGRESS_OPTS="--bindir=/usr/local/bin/" -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal-t"
 
     if( -not $? -or -not $TESTS1 ) { exit 1 }
 
@@ -169,5 +173,5 @@ on_failure:
   - ps: >-
       docker exec -it pgregress cat /timescaledb/build/test/regression.diffs /timescaledb/build/tsl/test/regression.diffs /timescaledb/build/test/pgtest/regressions.diffs
 
-      Get-Content -Path "C:\Program Files\postgresql\10\data\pg_log\*"
+      Get-Content -Path "C:\Program Files\postgresql\12\data\pg_log\*"
 


### PR DESCRIPTION
Change appveyor script to run regression tests against PG12 on
Windows. It is short term solution with official PG alpine image.
No EXEC_BACKEND is enabled.