### PR TITLE
Remove DEBUG logging in extension check 

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -251,12 +251,6 @@ ts_extension_invalidate(Oid relid)
 bool
 ts_extension_is_loaded(void)
 {
-	elog(DEBUG1,
-		 "%s: timescaledb.restoring=%s, IsBinaryUpgrade=%s",
-		 __func__,
-		 ts_guc_restoring ? "on" : "off",
-		 IsBinaryUpgrade ? "yes" : "no");
-
 	/* When restoring deactivate extension.
 	 *
 	 * We are using IsBinaryUpgrade (and ts_guc_restoring).  If a user set


### PR DESCRIPTION
This change removes a `DEBUG1` level log message that was added to the
`ts_extension_is_loaded` check. The problem with this message is that
it is called very frequently, e.g., in planning, and it will flood the
output log.