### PR TITLE
Fix flaky hypertable cache plan test

### DIFF
--- a/test/expected/plan_hypertable_cache.out
+++ b/test/expected/plan_hypertable_cache.out
@@ -11,7 +11,7 @@ SELECT create_hypertable('public.test', 'time');
  (1,public,test,t)
 (1 row)
 
-INSERT INTO test SELECT i, current_date-10-i from generate_series(1,20) i;
+INSERT INTO test SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 CREATE OR REPLACE FUNCTION test_f(_ts timestamptz)
 RETURNS SETOF test LANGUAGE SQL STABLE PARALLEL SAFE
 AS $f$

--- a/test/sql/plan_hypertable_cache.sql
+++ b/test/sql/plan_hypertable_cache.sql
@@ -9,7 +9,7 @@
 
 CREATE TABLE test (a int, time timestamptz NOT NULL);
 SELECT create_hypertable('public.test', 'time');
-INSERT INTO test SELECT i, current_date-10-i from generate_series(1,20) i;
+INSERT INTO test SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 
 CREATE OR REPLACE FUNCTION test_f(_ts timestamptz)
 RETURNS SETOF test LANGUAGE SQL STABLE PARALLEL SAFE


### PR DESCRIPTION
The `plan_hypertable_cache` test used `current_date` to generate data,
which is inherently flaky since it can create a different number of
chunks depending on which date you start at. When the number of chunks
differ, the test output changes too.