### PR TITLE
Fix crash on SELECT WHERE NOT with empty table

### DIFF
--- a/test/expected/insert-10.out
+++ b/test/expected/insert-10.out
@@ -586,3 +586,53 @@ SELECT insert_test(), insert_test(), insert_test();
              |             | 
 (1 row)
 
+-- test Postgres crashes on INSERT ... SELECT ... WHERE NOT EXISTS with empty table
+-- https://github.com/timescale/timescaledb/issues/1883
+CREATE TABLE readings (
+	toe TIMESTAMPTZ NOT NULL,
+	sensor_id INT NOT NULL,
+	value INT NOT NULL
+);
+SELECT create_hypertable(
+	'readings',
+	'toe',
+	chunk_time_interval => interval '1 day',
+	if_not_exists => TRUE,
+	migrate_data => TRUE
+);
+   create_hypertable    
+------------------------
+ (11,public,readings,t)
+(1 row)
+
+EXPLAIN (costs off)
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on readings
+         ->  Custom Scan (ChunkDispatch)
+               ->  Subquery Scan on "*SELECT*"
+                     ->  Result
+                           One-Time Filter: (NOT $0)
+                           InitPlan 1 (returns $0)
+                             ->  Result
+                                   One-Time Filter: false
+(9 rows)
+
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+DROP TABLE readings;

--- a/test/expected/insert-11.out
+++ b/test/expected/insert-11.out
@@ -586,3 +586,53 @@ SELECT insert_test(), insert_test(), insert_test();
              |             | 
 (1 row)
 
+-- test Postgres crashes on INSERT ... SELECT ... WHERE NOT EXISTS with empty table
+-- https://github.com/timescale/timescaledb/issues/1883
+CREATE TABLE readings (
+	toe TIMESTAMPTZ NOT NULL,
+	sensor_id INT NOT NULL,
+	value INT NOT NULL
+);
+SELECT create_hypertable(
+	'readings',
+	'toe',
+	chunk_time_interval => interval '1 day',
+	if_not_exists => TRUE,
+	migrate_data => TRUE
+);
+   create_hypertable    
+------------------------
+ (11,public,readings,t)
+(1 row)
+
+EXPLAIN (costs off)
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on readings
+         ->  Custom Scan (ChunkDispatch)
+               ->  Subquery Scan on "*SELECT*"
+                     ->  Result
+                           One-Time Filter: (NOT $0)
+                           InitPlan 1 (returns $0)
+                             ->  Result
+                                   One-Time Filter: false
+(9 rows)
+
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+DROP TABLE readings;

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -585,3 +585,54 @@ SELECT insert_test(), insert_test(), insert_test();
              |             | 
 (1 row)
 
+-- test Postgres crashes on INSERT ... SELECT ... WHERE NOT EXISTS with empty table
+-- https://github.com/timescale/timescaledb/issues/1883
+CREATE TABLE readings (
+	toe TIMESTAMPTZ NOT NULL,
+	sensor_id INT NOT NULL,
+	value INT NOT NULL
+);
+SELECT create_hypertable(
+	'readings',
+	'toe',
+	chunk_time_interval => interval '1 day',
+	if_not_exists => TRUE,
+	migrate_data => TRUE
+);
+   create_hypertable    
+------------------------
+ (11,public,readings,t)
+(1 row)
+
+EXPLAIN (costs off)
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Custom Scan (HypertableInsert)
+   InitPlan 1 (returns $0)
+     ->  Result
+           One-Time Filter: false
+   ->  Insert on readings
+         ->  Result
+               One-Time Filter: (NOT $0)
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Result
+                           One-Time Filter: (NOT $0)
+(10 rows)
+
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+DROP TABLE readings;

--- a/test/expected/insert-9.6.out
+++ b/test/expected/insert-9.6.out
@@ -586,3 +586,53 @@ SELECT insert_test(), insert_test(), insert_test();
              |             | 
 (1 row)
 
+-- test Postgres crashes on INSERT ... SELECT ... WHERE NOT EXISTS with empty table
+-- https://github.com/timescale/timescaledb/issues/1883
+CREATE TABLE readings (
+	toe TIMESTAMPTZ NOT NULL,
+	sensor_id INT NOT NULL,
+	value INT NOT NULL
+);
+SELECT create_hypertable(
+	'readings',
+	'toe',
+	chunk_time_interval => interval '1 day',
+	if_not_exists => TRUE,
+	migrate_data => TRUE
+);
+   create_hypertable    
+------------------------
+ (11,public,readings,t)
+(1 row)
+
+EXPLAIN (costs off)
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Custom Scan (HypertableInsert)
+   ->  Insert on readings
+         ->  Custom Scan (ChunkDispatch)
+               ->  Subquery Scan on "*SELECT*"
+                     ->  Result
+                           One-Time Filter: (NOT $0)
+                           InitPlan 1 (returns $0)
+                             ->  Result
+                                   One-Time Filter: false
+(9 rows)
+
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+DROP TABLE readings;

--- a/test/sql/insert.sql.in
+++ b/test/sql/insert.sql.in
@@ -148,4 +148,35 @@ $$;
 
 SELECT insert_test(), insert_test(), insert_test();
 
-
+-- test Postgres crashes on INSERT ... SELECT ... WHERE NOT EXISTS with empty table
+-- https://github.com/timescale/timescaledb/issues/1883
+CREATE TABLE readings (
+	toe TIMESTAMPTZ NOT NULL,
+	sensor_id INT NOT NULL,
+	value INT NOT NULL
+);
+SELECT create_hypertable(
+	'readings',
+	'toe',
+	chunk_time_interval => interval '1 day',
+	if_not_exists => TRUE,
+	migrate_data => TRUE
+);
+EXPLAIN (costs off)
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+INSERT INTO readings 
+SELECT '2020-05-09 10:34:35.296288+00', 1, 0 
+WHERE NOT EXISTS (
+	SELECT 1 
+	FROM readings 
+	WHERE sensor_id = 1 
+		AND toe = '2020-05-09 10:34:35.296288+00'
+);
+DROP TABLE readings;


### PR DESCRIPTION
Apparently modify table state is not created with an empty tables, which lead to NULL pointer evaluation.

Fixes #1883.