### PR TITLE
Run Windows builds and tests using GitHub Actions

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -1,0 +1,57 @@
+# GitHub Actions configuration for TimescaleDB
+name: Build on Windows
+on:
+  push:
+    branches:
+      - prerelease_test
+  pull_request:
+jobs:
+  build:
+    name: PG${{ matrix.pg }} [${{ matrix.build_type }}]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        pg: [ 9, 10, 11, 12 ]
+        os: [ windows-2019 ]
+        build_type: [ Debug, Release ]
+    env:
+      # PostgreSQL configuration
+      PGPASSWORD: test
+      PGPORT: 6543
+      PGDATA: pgdata
+    steps:
+    - name: Checkout TimescaleDB source
+      uses: actions/checkout@v2
+      # Use a cache for the PostgreSQL installation to speed things up
+      # and avoid unnecessary package downloads. Since we only save
+      # the directory containing the binaries, the runs with a cache
+      # hit won't have PostgreSQL installed with a running service
+      # since the installer never runs. We therefore install with
+      # --extract-only and launch our own test instance, which is
+      # probably better anyway since it gives us more control.
+    - name: Cache PostgreSQL installation
+      uses: actions/cache@v1
+      id: cache-postgresql
+      with:
+        path: ~\PostgreSQL\${{ matrix.pg }}
+        key: ${{ runner.os }}-build-pg${{ matrix.pg }}
+    - name: Install PostgreSQL ${{ matrix.pg }}
+      if: steps.cache-postgresql.outputs.cache-hit != 'true'
+      run: choco install postgresql${{ matrix.pg }} -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
+    - name: Configure [${{ matrix.build_type }}]
+      run: cmake -B ${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREGRESS_CHECKS=OFF -DPG_PATH="$HOME/PostgreSQL/${{ matrix.pg }}" -DOPENSSL_ROOT_DIR="$HOME/PostgreSQL/${{ matrix.pg }}"
+      # Build step: could potentially speed things up with --parallel
+      # <num_cpu> or "-- -m:<num_cpu>", but MSBuild doesn't seem to be
+      # able to realize interdependencies between targets, which leads
+      # to linker failures when a target finished before another one
+      # it depends on.
+    - name: Build [${{ matrix.build_type }}]
+      run: cmake --build ${{ matrix.build_type }} --config ${{ matrix.build_type }}
+    - name: Install [${{ matrix.build_type }}]
+      run: cmake --install ${{ matrix.build_type }} --config ${{ matrix.build_type }}
+    - name: Create DB
+      run: ~/PostgreSQL/${{ matrix.pg }}/bin/initdb.exe -U postgres -A trust
+    - name: Start PostgreSQL
+      run: ~/PostgreSQL/${{ matrix.pg }}/bin/pg_ctl.exe start -o "-cshared_preload_libraries=timescaledb"
+    - name: Test CREATE EXTENSION
+      run: ; 'CREATE EXTENSION timescaledb' | ~/PostgreSQL/${{ matrix.pg }}/bin/psql -U postgres


### PR DESCRIPTION
Windows builds, for Debug and Release configurations, are now tested
using GitHub Actions. The build test covers all currently supported
PostgreSQL versions (9.6, 10, 11, 12) using a build matrix.

Currently, the TimescaleDB regression test suite is not run since it
requires a Windows-specific test client that we do not
support. Instead, the binaries are tested by doing a `CREATE
EXTENSION` to verify that they load and run without, e.g., missing
symbols or similar.

The test configuration is optimized for speed by using a cache for the
PostgreSQL installation. This avoids repeated downloads and
installations of PostgreSQL from EnterpriseDB's servers. But it also
means that we won't have a full installation on cache hits, which
means no running PostgreSQL service. This requires manual PostgreSQL
starts, which is what we want anyway since we need to preload our
extension.

It's anticipated that this build configuration can be extended to
produce release binaries in the future.