### PR TITLE
Cleanup TODOs and FIXMEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,14 +81,15 @@ endif ()
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
   # These two flags generate too many errors currently, but we
   # probably want these optimizations enabled.
-
-  # TODO: -fdelete-null-pointer-checks -Wnull-dereference
+  #
+  # -fdelete-null-pointer-checks -Wnull-dereference
 
   # This flag avoid some subtle bugs related to standard conversions,
   # but currently does not compile because we are using too many
   # implicit conversions that potentially lose precision.
+  #
+  # -Wconversions
 
-  # TODO: -Wconversions
   add_compile_options(-Wempty-body -Wvla)
   if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "7")
     add_compile_options(-Wimplicit-fallthrough)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,7 +90,7 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb_telemetry.cloud='ci'"
 
-    # TODO removing the following line causes a stack overflow on appveyor
+    # NOTE: Removing the following line causes a stack overflow on appveyor
 
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.telemetry_level='off'"
 
@@ -159,7 +159,8 @@ test_script:
 
     $TESTS1 = $?
 
-    # TODO can we switch these to file swapping?
+    # Normally we use different config files for apache and enterprise tests, but Windows was having problems with that
+    # Thus, just append the license key to the regular config file instead
 
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.license_key = 'E1eyJlbmRfdGltZSI6IjIwMTgtMTAtMDEgKzAwMDAiLCAic3RhcnRfdGltZSI6IjIwMTgtMDktMDEgKzAwMDAiLCAiaWQiOiI0OTBGQjI2MC1BMjkyLTRBRDktOUFBMi0wMzYwODM1NzkxQjgiLCAia2luZCI6InRyaWFsIn0K'"
 

--- a/sql/updates/0.6.1--0.7.0.sql
+++ b/sql/updates/0.6.1--0.7.0.sql
@@ -120,7 +120,7 @@ BEGIN
 
         return array_to_string(parts, 'AND');
     ELSE
-        --TODO: only works with time for now
+        -- only works with time for now
         IF _timescaledb_internal.time_literal_sql(dimension_slice_row.range_start, dimension_row.column_type) =
            _timescaledb_internal.time_literal_sql(dimension_slice_row.range_end, dimension_row.column_type) THEN
             RAISE 'Time based constraints have the same start and end values for column "%": %',

--- a/sql/updates/1.4.2--1.5.0.sql
+++ b/sql/updates/1.4.2--1.5.0.sql
@@ -20,7 +20,6 @@ CREATE TYPE _timescaledb_catalog.ts_interval AS (
     integer_interval        BIGINT
     );
 
--- q -- todo:: this is probably necessary if we keep the validation constraint in the table definition.
 CREATE OR REPLACE FUNCTION _timescaledb_internal.valid_ts_interval(invl _timescaledb_catalog.ts_interval)
 RETURNS BOOLEAN AS '@MODULE_PATHNAME@', 'ts_valid_ts_interval' LANGUAGE C VOLATILE STRICT;
 

--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -65,7 +65,7 @@ BEGIN
         END IF;
         return array_to_string(parts, 'AND');
     ELSE
-        --TODO: only works with time for now
+        -- only works with time for now
         IF _timescaledb_internal.time_literal_sql(dimension_slice_row.range_start, dimtype) =
            _timescaledb_internal.time_literal_sql(dimension_slice_row.range_end, dimtype) THEN
             RAISE 'time-based constraints have the same start and end values for column "%": %',

--- a/src/adts/simplehash.h
+++ b/src/adts/simplehash.h
@@ -208,7 +208,7 @@ SH_SCOPE void SH_STAT(SH_TYPE *tb);
 #ifndef SIMPLEHASH_H
 #define SIMPLEHASH_H
 
-/* FIXME: can we move these to a central location? */
+/* Ideally would like to move these to a central location? */
 
 /* calculate ceil(log base 2) of num */
 static inline uint64
@@ -624,11 +624,6 @@ restart:
 
 			/* shift forward, starting at last occupied element */
 
-			/*
-			 * TODO: This could be optimized to be one memcpy in may cases,
-			 * excepting wrapping around at the end of ->data. Hasn't shown up
-			 * in profiles so far though.
-			 */
 			moveelem = emptyelem;
 			while (moveelem != curelem)
 			{
@@ -696,13 +691,6 @@ SH_LOOKUP(SH_TYPE *tb, SH_KEY_TYPE key)
 
 		if (SH_COMPARE_KEYS(tb, hash, key, entry))
 			return entry;
-
-		/*
-		 * TODO: we could stop search based on distance. If the current
-		 * buckets's distance-from-optimal is smaller than what we've skipped
-		 * already, the entry doesn't exist. Probably only do so if
-		 * SH_STORE_HASH is defined, to avoid re-computing hashes?
-		 */
 
 		curelem = SH_NEXT(tb, curelem, startelem);
 	}
@@ -772,8 +760,6 @@ SH_DELETE(SH_TYPE *tb, SH_KEY_TYPE key)
 
 			return true;
 		}
-
-		/* TODO: return false; if distance too big */
 
 		curelem = SH_NEXT(tb, curelem, startelem);
 	}

--- a/src/adts/vec.h
+++ b/src/adts/vec.h
@@ -35,7 +35,6 @@
 #define VEC_TYPE VEC_MAKE_NAME(vec)
 
 /* function declarations */
-// TODO add INSERT for inserting into the middle of a vec
 #define VEC_INIT VEC_MAKE_NAME(vec_init)
 #define VEC_CREATE VEC_MAKE_NAME(vec_create)
 #define VEC_FREE_DATA VEC_MAKE_NAME(vec_free_data)
@@ -107,7 +106,7 @@ VEC_RESERVE(VEC_TYPE *vec, uint32 additional)
 	uint64 num_elements;
 	uint64 num_bytes;
 
-	// TODO handle overflow, huge allocations, if desired
+	/* this doesn't handle integer overflow or >4GB allocations */
 	if (num_new_elements == 0 || vec->num_elements + num_new_elements <= vec->max_elements)
 		return;
 

--- a/src/extension.c
+++ b/src/extension.c
@@ -308,6 +308,5 @@ ts_extension_is_loaded(void)
 char *
 ts_extension_get_so_name()
 {
-	/* TODO: after merge check whether this is the right place */
 	return EXTENSION_NAME "-" TIMESCALEDB_VERSION_MOD;
 }

--- a/src/plan_agg_bookend.c
+++ b/src/plan_agg_bookend.c
@@ -679,14 +679,16 @@ build_first_last_path(PlannerInfo *root, FirstLastAggInfo *fl_info, Oid eqop, Oi
 				Assert(rte->inh);
 				rte->inh = false;
 				/* query planner gets confused when entries in the
-				 * append_rel_list refer to entreis in the relarray that
-				 * don't exist. Since we need to rexpand hypertables in the
+				 * append_rel_list refer to entries in the relarray that
+				 * don't exist. Since we need to expand hypertables in the
 				 * subquery, all of the chunk entries will be invalid in
-				 * this manner, so we remove them from the list
+				 * this manner, so we remove them from the list.
 				 */
-				/* TODO this can be made non-quadratic by storing all the
-				 *      relids in a bitset, then iterating over the
-				 *      append_rel_list once
+				/*  Performance Enhancement: This can be made non-quadratic by:
+				 *  1) Loop once over all RTEs, storing the relid of any RTE that is a hypertable in
+				 * a bitset and setting its 'inh' flag to false 2) Loop over the append_rel_list,
+				 * removing any AppendRelInfo that has a parent relid which is in the previously
+				 * created bitset (i.e., is a hypertable)
 				 */
 				while (next != NULL)
 				{

--- a/src/planner.c
+++ b/src/planner.c
@@ -570,10 +570,11 @@ reenable_inheritance(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntr
 			Assert(ht != NULL && in_rel != NULL);
 			ts_plan_expand_hypertable_chunks(ht, root, in_rel);
 
-			/* TODO move this back into ts_plan_expand_hypertable_chunks */
 			in_rte->inh = true;
 			reenabled_inheritance = true;
-			/* FIXME redo set_rel_consider_parallel */
+			/* Redo set_rel_consider_parallel, as results of the call may no longer be valid here
+			 * (due to adding more tables to the set of tables under consideration here). This is
+			 * especially true if dealing with foreign data wrappers. */
 
 			/*
 			 * An entry of reloptkind RELOPT_OTHER_MEMBER_REL might still

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1101,7 +1101,7 @@ reindex_chunk(Hypertable *ht, Oid chunk_relid, void *arg)
 						 stmt->options
 #if PG12_GE
 						 ,
-						 stmt->concurrent /* TODO test */
+						 stmt->concurrent /* should test for deadlocks */
 #endif
 			);
 			break;
@@ -2739,7 +2739,7 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_ColumnDefault:
 		case AT_SetNotNull:
 #if PG12_GE
-		case AT_CheckNotNull: /*TODO test*/
+		case AT_CheckNotNull:
 #endif
 		case AT_DropNotNull:
 		case AT_AddOf:

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -18,7 +18,8 @@
 typedef struct TupleInfo
 {
 	Relation scanrel;
-	/* TODO in PG12+ we should not materialize a HeapTuple unless needed */
+	/* In PG12+, to avoid unnecessary materialization, we should use a TupleTableSlot (with type
+	 * pulled dynamically from the index) rather than a HeapTuple */
 	HeapTuple tuple;
 	TupleDesc desc;
 #if PG12_GE

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -532,7 +532,7 @@ TRUNCATE hyper_fk;
 --FOREIGN KEY references into a hypertable are currently broken.
 --The referencing table will never find the corresponding row in the hypertable
 --since it will only search the parent. Thus any insert will result in an ERROR
---TODO: block such foreign keys or fix. (Hard to block on create table so punting for now)
+--Block such foreign keys or fix. (Hard to block on create table so punting for now)
 CREATE TABLE hyper_for_ref (
   time BIGINT NOT NULL PRIMARY KEY,
   device_id TEXT NOT NULL,

--- a/test/expected/sql_query-10.out
+++ b/test/expected/sql_query-10.out
@@ -129,7 +129,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
          Index Cond: (_hyper_2_5_chunk.object_id = 1)
 (4 rows)
 
---TODO: handle this later?
+--Need to verify space partitions are currently pruned in this query
 --EXPLAIN (verbose ON, costs off) SELECT * FROM "two_Partitions" WHERE device_id IN ('dev2', 'dev21');
 \echo "The following shows non-aggregated queries with time desc using merge append"
 "The following shows non-aggregated queries with time desc using merge append"
@@ -231,7 +231,8 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                            Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
 (20 rows)
 
---TODO: time transform doesn't work
+--The query should still use the index on timeCustom, even though the GROUP BY/ORDER BY is on the transformed time 't'. 
+--However, current query plans show that it does not.
 EXPLAIN (verbose ON, costs off)SELECT "timeCustom"/10 t, min(series_0) FROM PUBLIC."two_Partitions" GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------

--- a/test/expected/sql_query-11.out
+++ b/test/expected/sql_query-11.out
@@ -129,7 +129,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
          Index Cond: (_hyper_2_5_chunk.object_id = 1)
 (4 rows)
 
---TODO: handle this later?
+--Need to verify space partitions are currently pruned in this query
 --EXPLAIN (verbose ON, costs off) SELECT * FROM "two_Partitions" WHERE device_id IN ('dev2', 'dev21');
 \echo "The following shows non-aggregated queries with time desc using merge append"
 "The following shows non-aggregated queries with time desc using merge append"
@@ -231,7 +231,8 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                            Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
 (20 rows)
 
---TODO: time transform doesn't work
+--The query should still use the index on timeCustom, even though the GROUP BY/ORDER BY is on the transformed time 't'. 
+--However, current query plans show that it does not.
 EXPLAIN (verbose ON, costs off)SELECT "timeCustom"/10 t, min(series_0) FROM PUBLIC."two_Partitions" GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------

--- a/test/expected/sql_query-12.out
+++ b/test/expected/sql_query-12.out
@@ -125,7 +125,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
    Index Cond: (_hyper_2_5_chunk.object_id = 1)
 (3 rows)
 
---TODO: handle this later?
+--Need to verify space partitions are currently pruned in this query
 --EXPLAIN (verbose ON, costs off) SELECT * FROM "two_Partitions" WHERE device_id IN ('dev2', 'dev21');
 \echo "The following shows non-aggregated queries with time desc using merge append"
 "The following shows non-aggregated queries with time desc using merge append"
@@ -227,7 +227,8 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                            Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
 (20 rows)
 
---TODO: time transform doesn't work
+--The query should still use the index on timeCustom, even though the GROUP BY/ORDER BY is on the transformed time 't'. 
+--However, current query plans show that it does not.
 EXPLAIN (verbose ON, costs off)SELECT "timeCustom"/10 t, min(series_0) FROM PUBLIC."two_Partitions" GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------

--- a/test/expected/sql_query-9.6.out
+++ b/test/expected/sql_query-9.6.out
@@ -129,7 +129,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
          Index Cond: (_hyper_2_5_chunk.object_id = 1)
 (4 rows)
 
---TODO: handle this later?
+--Need to verify space partitions are currently pruned in this query
 --EXPLAIN (verbose ON, costs off) SELECT * FROM "two_Partitions" WHERE device_id IN ('dev2', 'dev21');
 \echo "The following shows non-aggregated queries with time desc using merge append"
 "The following shows non-aggregated queries with time desc using merge append"
@@ -231,7 +231,8 @@ EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC.
                            Output: _hyper_1_1_chunk."timeCustom", _hyper_1_1_chunk.series_0
 (20 rows)
 
---TODO: time transform doesn't work
+--The query should still use the index on timeCustom, even though the GROUP BY/ORDER BY is on the transformed time 't'. 
+--However, current query plans show that it does not.
 EXPLAIN (verbose ON, costs off)SELECT "timeCustom"/10 t, min(series_0) FROM PUBLIC."two_Partitions" GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -361,8 +361,7 @@ SELECT * FROM color;
 (2 rows)
 
 -- switch back to default user to run some dropping tests
---TODO: currently default user is postgres, who is a superuser, potentially we should change that?
-\c :TEST_DBNAME :ROLE_SUPERUSER; 
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER; 
 \set ON_ERROR_STOP 0
 -- test that disable trigger is disallowed 
 ALTER TABLE location DISABLE TRIGGER create_vehicle_trigger;

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -372,7 +372,7 @@ TRUNCATE hyper_fk;
 --FOREIGN KEY references into a hypertable are currently broken.
 --The referencing table will never find the corresponding row in the hypertable
 --since it will only search the parent. Thus any insert will result in an ERROR
---TODO: block such foreign keys or fix. (Hard to block on create table so punting for now)
+--Block such foreign keys or fix. (Hard to block on create table so punting for now)
 CREATE TABLE hyper_for_ref (
   time BIGINT NOT NULL PRIMARY KEY,
   device_id TEXT NOT NULL,

--- a/test/sql/sql_query.sql.in
+++ b/test/sql/sql_query.sql.in
@@ -28,7 +28,7 @@ SELECT * FROM "int_part" WHERE object_id = 1;
 --make sure this touches only one partititon
 EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
 
---TODO: handle this later?
+--Need to verify space partitions are currently pruned in this query
 --EXPLAIN (verbose ON, costs off) SELECT * FROM "two_Partitions" WHERE device_id IN ('dev2', 'dev21');
 
 \echo "The following shows non-aggregated queries with time desc using merge append"
@@ -42,6 +42,7 @@ EXPLAIN (verbose ON, costs off)SELECT * FROM PUBLIC."two_Partitions" WHERE serie
 --note that without time transform things work too
 EXPLAIN (verbose ON, costs off)SELECT "timeCustom" t, min(series_0) FROM PUBLIC."two_Partitions" GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
 
---TODO: time transform doesn't work
+--The query should still use the index on timeCustom, even though the GROUP BY/ORDER BY is on the transformed time 't'. 
+--However, current query plans show that it does not.
 EXPLAIN (verbose ON, costs off)SELECT "timeCustom"/10 t, min(series_0) FROM PUBLIC."two_Partitions" GROUP BY t ORDER BY t DESC NULLS LAST limit 2;
 EXPLAIN (verbose ON, costs off)SELECT "timeCustom"%10 t, min(series_0) FROM PUBLIC."two_Partitions" GROUP BY t ORDER BY t DESC NULLS LAST limit 2;

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -278,8 +278,7 @@ SELECT * FROM vehicles;
 SELECT * FROM color;
 
 -- switch back to default user to run some dropping tests
---TODO: currently default user is postgres, who is a superuser, potentially we should change that?
-\c :TEST_DBNAME :ROLE_SUPERUSER; 
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER; 
 
 \set ON_ERROR_STOP 0
 -- test that disable trigger is disallowed 

--- a/test/src/bgw/params.c
+++ b/test/src/bgw/params.c
@@ -276,12 +276,12 @@ TS_FUNCTION_INFO_V1(ts_bgw_params_destroy);
 Datum
 ts_bgw_params_destroy(PG_FUNCTION_ARGS)
 {
-	/* no way to unpin in 9.6 and can fail in EXEC_BACKEND cases so forget it, should only affect
-	 * tests anyway */
-
 	/*
-	 * Removing for now because the EXEC_BACKEND compile-time flag is not correctly passed down.
-	 * TODO: Fix once we fix this compile-script issue (Or make work on EXEC_BACKEND boxes)
+	 * Removing shared memory segment unpin for now because:
+	 * 1) This can fail in EXEC_BACKEND cases.
+	 * 2) There's no way to unpin in PG9.6.
+	 * 3) The EXEC_BACKEND compile-time flag is not correctly passed down.
+	 * 4) This should only affect tests, not actual DB functionality.
 	 * #if PG10 && !defined(EXEC_BACKEND)
 	 *	dsm_unpin_segment(params_get_dsm_handle());
 	 * #endif

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -160,7 +160,7 @@ static BackgroundWorkerHandle *
 start_test_scheduler(char *params)
 {
 	/*
-	 * TODO this is where we would increment the number of bgw used, if we
+	 * This is where we would increment the number of bgw used, if we
 	 * decide to do so
 	 */
 	return ts_bgw_start_worker("ts_bgw_db_scheduler_test_main",

--- a/tsl/src/compression/dictionary.c
+++ b/tsl/src/compression/dictionary.c
@@ -74,8 +74,6 @@ struct DictionaryDecompressionIterator
 /// Compressor ///
 //////////////////
 
-// FIXME store (index + 1), and use 0 to mean NULL
-
 typedef struct DictionaryCompressor
 {
 	dictionary_hash *dictionary_items;
@@ -494,7 +492,6 @@ dictionary_decompression_iterator_try_next_reverse(DecompressionIterator *iter_b
 			.is_done = true,
 		};
 
-	// FIXME 0 should be a sentinel representing null
 	Assert(result.val < iter->compressed->num_distinct);
 	return (DecompressResult){
 		.val = iter->values[result.val],

--- a/tsl/src/compression/dictionary_hash.h
+++ b/tsl/src/compression/dictionary_hash.h
@@ -95,8 +95,10 @@ dictionary_hash_alloc(TypeCacheEntry *tentry)
 			 "invalid type for dictionary compression, type must have both a hash function and "
 			 "equality function");
 
-	/* TODO get collation from table? we need to think about backcompat,
-	 * and different collations should only affect compression ratios anyaway
+	/* May be more correct to get collation defined on the column, which may be different than the
+	 * collation defined on the type (what we're currently using). We need to think about
+	 * backwards compatibility, and different collations. Should only affect compression ratios
+	 * anyway.
 	 */
 	meta->eq_info = HEAP_FCINFO(2);
 	InitFunctionCallInfoData(*meta->eq_info, &tentry->eq_opr_finfo, 2, collation, NULL, NULL);

--- a/tsl/src/compression/gorilla.c
+++ b/tsl/src/compression/gorilla.c
@@ -409,10 +409,10 @@ gorilla_compressor_append_value(GorillaCompressor *compressor, uint64 val)
 		 */
 		int leading_zeros = xor != 0 ? 63 - pg_leftmost_one_pos64(xor) : 63;
 		int trailing_zeros = xor != 0 ? pg_rightmost_one_pos64(xor) : 1;
-		/*   TODO this can easily get stuck with a bad value for trailing_zeroes
-		 *   we use a new trailing_zeroes if th delta is too large, but the
-		 *   threshold was picked in a completely unprincipled manner.
-		 *   Needs benchmarking
+		/*   This can easily get stuck with a bad value for trailing_zeroes, leading to a bad
+		 * compressed size. We use a new trailing_zeroes if the delta is too large, but the
+		 *   threshold (12) was picked in a completely unprincipled manner.
+		 *   Needs benchmarking to determine an ideal threshold.
 		 */
 		bool reuse_bitsizes = has_values && leading_zeros >= compressor->prev_leading_zeroes &&
 							  trailing_zeros >= compressor->prev_trailing_zeros &&
@@ -667,7 +667,7 @@ gorilla_decompression_iterator_try_next_forward_internal(GorillaDecompressionIte
 	{
 		Simple8bRleDecompressResult null =
 			simple8brle_decompression_iterator_try_next_forward(&iter->nulls);
-		// FIXME we probably don't need to return a tail of non-null bits
+		/* Could slightly improve performance here by not returning a tail of non-null bits */
 		if (null.is_done)
 			return (DecompressResultInternal){
 				.is_done = true,

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -356,8 +356,6 @@ simple8brle_compressor_num_selectors(Simple8bRleCompressor *compressor)
 	return bit_array_num_bits(&compressor->selectors) / SIMPLE8B_BITS_PER_SELECTOR;
 }
 
-// TODO replace with simple8b_rle_compressor_finish_into(Simple8bRleCompressor *compressor,
-// simple8b_rle compressed)
 static Simple8bRleSerialized *
 simple8brle_compressor_finish(Simple8bRleCompressor *compressor)
 {
@@ -827,7 +825,7 @@ simple8brle_num_selector_slots_for_num_blocks(uint32 num_blocks)
 		   (num_blocks % SIMPLE8B_SELECTORS_PER_SELECTOR_SLOT != 0 ? 1 : 0);
 }
 
-// FIXME replace with count leading ones as in float.c
+/* Replacing this with count leading ones as in float.c would increase performance */
 static inline uint32
 simple8brle_bits_for_value(uint64 v)
 {

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -298,7 +298,8 @@ cagg_create_hypertable(int32 hypertable_id, Oid mat_tbloid, const char *matpartc
 												  Int64GetDatum(mat_tbltimecol_interval),
 												  INT8OID,
 												  InvalidOid);
-	// TODO fix this after change in C interface
+	/* Ideally would like to change/expand the API so setting the column name manually is
+	 * unnecessary, but not high priority */
 	chunk_sizing_info = ts_chunk_sizing_info_get_default_disabled(mat_tbloid);
 	chunk_sizing_info->colname = matpartcolname;
 	created = ts_hypertable_create_from_info(mat_tbloid,
@@ -965,9 +966,9 @@ get_finalize_aggref(Aggref *inp, Var *partial_state_var)
 	aggref->aggstar = false;
 	aggref->aggvariadic = false;
 	aggref->aggkind = AGGKIND_NORMAL;
-	aggref->aggsplit = AGGSPLIT_SIMPLE; // TODO make sure plannerdoes not change this ???
-	aggref->location = -1;				/*unknown */
-										/* construct the arguments */
+	aggref->aggsplit = AGGSPLIT_SIMPLE;
+	aggref->location = -1;
+	/* construct the arguments */
 	agggregate_signature = DatumGetCString(DirectFunctionCall1(regprocedureout, inp->aggfnoid));
 	aggregate_signature_const = makeConst(TEXTOID,
 										  -1,

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -1031,9 +1031,7 @@ continuous_agg_execute_materialization(int64 bucket_width, int32 hypertable_id,
 	materialization_table_name.schema = &materialization_table->fd.schema_name;
 	materialization_table_name.name = &materialization_table->fd.table_name;
 
-	/* lock the table's we will be inserting to now, to prevent deadlocks later on */
-	// TODO lock the materialization table, the and the completed_threshold with RowExclusive locks
-	// TODO decide lock ordering
+	/* to prevent deadlocks later on, lock the tables we will be inserting to now */
 
 	update_materializations(partial_view,
 							materialization_table_name,

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -381,9 +381,9 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 		DecompressChunkPath *path;
 
 		/*
-		 * filter out all paths that try to JOIN the compressed chunk on the
+		 * Filter out all paths that try to JOIN the compressed chunk on the
 		 * hypertable or the uncompressed chunk
-		 * TODO ideally we wouldn't create these paths in the first place...
+		 * Ideally, we wouldn't create these paths in the first place.
 		 */
 		if (child_path->param_info != NULL &&
 			(bms_is_member(chunk_rel->relid, child_path->param_info->ppi_req_outer) ||

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -382,26 +382,10 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 	}
 	else if (IsA(compressed_path, BitmapHeapPath))
 	{
-		// TODO we should remove quals that are redunant with the Bitmap scan
-		/* from create_bitmap_scan_plan */
-		// BitmapHeapPath *bpath = castNode(BitmapHeapPath, compressed_path);
-		// ListCell *l;
-		// foreach(l, clauses)
-		// {
-		// 	RestrictInfo *rinfo = lfirst_node(RestrictInfo, l);
-		// 	Node       *clause = (Node *) rinfo->clause;
-
-		// 	if (rinfo->pseudoconstant)
-		// 		continue;           /* we may drop pseudoconstants here */
-		// 	if (list_member(indexquals, clause))
-		// 		continue;           /* simple duplicate */
-		// 	if (rinfo->parent_ec && list_member_ptr(indexECs, rinfo->parent_ec))
-		// 		continue;           /* derived from same EquivalenceClass */
-		// 	if (!contain_mutable_functions(clause) &&
-		// 		predicate_implied_by(list_make1(clause), indexquals, false))
-		// 		continue;           /* provably implied by indexquals */
-		// 	qpqual = lappend(qpqual, rinfo);
-		// }
+		/* To increase performance, we should remove quals that are redundant with the Bitmap scan
+		 * Code from create_bitmap_scan_plan does something similar, and could be used as a starting
+		 * point.
+		 */
 		cscan->scan.plan.qual = get_actual_clauses(clauses);
 	}
 	else

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -1,5 +1,4 @@
-/*
- * This file and its contents are licensed under the Timescale License.
+/* * This file and its contents are licensed under the Timescale License.
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
@@ -230,7 +229,10 @@ pushdown_op_to_segment_meta_min_max(QualPushdownContext *context, List *expr_arg
 	else
 		return NULL;
 
-	/* todo think through the strict case */
+	/* May be able to allow non-strict operations as well.
+	 * Next steps: Think through edge cases, either allow and write tests or figure out why we must
+	 * block strict operations
+	 */
 	if (!OidIsValid(op_oid) || !op_strict(op_oid))
 		return NULL;
 

--- a/tsl/src/nodes/gapfill/planner.c
+++ b/tsl/src/nodes/gapfill/planner.c
@@ -441,7 +441,7 @@ plan_add_gapfill(PlannerInfo *root, RelOptInfo *group_rel)
 		group_rel->cheapest_startup_path = NULL;
 		group_rel->cheapest_unique_path = NULL;
 
-		/* TODO parameterized paths */
+		/* Parameterized paths pathlist is currently deleted instead of being processed */
 		list_free(group_rel->ppilist);
 		group_rel->ppilist = NULL;
 

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -251,7 +251,6 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 	 * transaction) to already have that mark set
 	 */
 	ts_chunk_index_mark_clustered(cim.chunkoid, cim.indexoid);
-	/* TODO allow users to set verbosity? */
 	timescale_reorder_rel(cim.chunkoid,
 						  cim.indexoid,
 						  verbose,

--- a/tsl/test/CMakeLists.txt
+++ b/tsl/test/CMakeLists.txt
@@ -1,7 +1,5 @@
 include("${PRIMARY_TEST_DIR}/test-defs.cmake")
 
-#TODO after we have isolation checks isolationcheck-t)
-
 set(_local_install_checks)
 set(_install_checks)
 

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -709,8 +709,7 @@ select remove_drop_chunks_policy('part_time_now_func');
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- todo:: this currently fails:
--- alter function dummy_now rename to dummy_now_renamed;
+alter function dummy_now() rename to dummy_now_renamed;
 alter schema public rename to new_public;
 select * from  _timescaledb_catalog.dimension;
  id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 

--- a/tsl/test/expected/compress_table.out
+++ b/tsl/test/expected/compress_table.out
@@ -69,7 +69,7 @@ CREATE TABLE compressed(
 \set gorilla    3
 \set deltadelta 4
 SELECT ARRAY[ord('time', :deltadelta, 0), seg('device', 0), com('data', :deltadelta), com('floats', :gorilla), com('nulls', :array), com('texts', :dictionary)]::_timescaledb_catalog.hypertable_compression[] AS "COMPRESSION_INFO" \gset
--- TODO NULL decompression doesn't quite work
+-- Can't actually decompress NULL. Used here as a placeholder to signal what type the first argument to 'decompress_forward' is.
 \set DECOMPRESS_FORWARD_CMD _timescaledb_internal.decompress_forward(time::_timescaledb_internal.compressed_data, NULL::INT) t, device, _timescaledb_internal.decompress_forward(data::_timescaledb_internal.compressed_data, NULL::INT) d, _timescaledb_internal.decompress_forward(floats::_timescaledb_internal.compressed_data, NULL::FLOAT(26)) f,  (NULL::text) n, _timescaledb_internal.decompress_forward(texts::_timescaledb_internal.compressed_data, NULL::TEXT) e
 INSERT INTO uncompressed
     SELECT generate_series( 1, 5), d, d % 3, d / 3.0, NULL, d

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -196,7 +196,7 @@ insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
 do update set b = excluded.b;
 ERROR:  insert/update/delete not permitted on chunk "_hyper_1_2_chunk"
---TEST2c dml directly on the chunk NOTE update/deletes don't get blocked (TODO)
+--TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12);
 ERROR:  insert/update/delete not permitted on chunk "_hyper_1_2_chunk"
 update _timescaledb_internal._hyper_1_2_chunk

--- a/tsl/test/expected/compression_algos.out
+++ b/tsl/test/expected/compression_algos.out
@@ -337,9 +337,6 @@ DROP TABLE base_ints;
 ------------------------
 -- INT Compression --
 ------------------------
---kinda silly test for now since compressed as bigint anyway
---TODO add proper int support
---TODO add proper smallint support and tests
 CREATE TABLE base_ints AS SELECT row_number() OVER() as rn, item::int FROM (select sub.item from (SELECT generate_series(1, 1000) item) as sub ORDER BY gen_rand_minstd()) sub;
 SELECT
   $$

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -829,18 +829,14 @@ SELECT set_integer_now_func('continuous_agg_extreme', 'integer_now_continuous_ag
  
 (1 row)
 
--- TODO we should be able to use time_bucket(5, ...) (note lack of '), but that is currently not
+-- We should be able to use time_bucket(5, ...) (note lack of '), but that is currently not
 --      recognized as a constant
 CREATE VIEW extreme_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('1', time), SUM(data) as value
         FROM continuous_agg_extreme
         GROUP BY 1;
---TODO this should be created as part of CREATE VIEW
 SELECT id as raw_table_id FROM _timescaledb_catalog.hypertable WHERE table_name='continuous_agg_extreme' \gset
-CREATE TRIGGER continuous_agg_insert_trigger
-    AFTER INSERT ON continuous_agg_extreme
-    FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.continuous_agg_invalidation_trigger(:raw_table_id);
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE raw_hypertable_id=:raw_table_id \gset
 -- EMPTY table should be a nop
 REFRESH MATERIALIZED VIEW extreme_view;

--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -109,7 +109,9 @@ FROM _timescaledb_catalog.hypertable ht
 	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics_space'
 \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- TODO this should change once we have a canonical way to create indexes on compressed tables
+-- Index created using query saved in variable used because there was 
+-- no standard way to create an index on a compressed table.
+-- Once a standard way exists, modify this test to use that method.
 CREATE INDEX c_index ON :METRICS_COMPRESSED(device_id);
 CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED(device_id);
 CREATE INDEX c_index_2 ON :METRICS_COMPRESSED(device_id, _ts_meta_count);

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -109,7 +109,9 @@ FROM _timescaledb_catalog.hypertable ht
 	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics_space'
 \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- TODO this should change once we have a canonical way to create indexes on compressed tables
+-- Index created using query saved in variable used because there was 
+-- no standard way to create an index on a compressed table.
+-- Once a standard way exists, modify this test to use that method.
 CREATE INDEX c_index ON :METRICS_COMPRESSED(device_id);
 CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED(device_id);
 CREATE INDEX c_index_2 ON :METRICS_COMPRESSED(device_id, _ts_meta_count);

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -109,7 +109,9 @@ FROM _timescaledb_catalog.hypertable ht
 	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics_space'
 \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- TODO this should change once we have a canonical way to create indexes on compressed tables
+-- Index created using query saved in variable used because there was 
+-- no standard way to create an index on a compressed table.
+-- Once a standard way exists, modify this test to use that method.
 CREATE INDEX c_index ON :METRICS_COMPRESSED(device_id);
 CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED(device_id);
 CREATE INDEX c_index_2 ON :METRICS_COMPRESSED(device_id, _ts_meta_count);

--- a/tsl/test/isolation/specs/reorder_deadlock.spec.in
+++ b/tsl/test/isolation/specs/reorder_deadlock.spec.in
@@ -35,7 +35,7 @@ session "B"
 setup		{ BEGIN; LOCK TABLE waiter; }
 step "Bc"   { ROLLBACK; }
 
-# TODO this fails in an unexpected manner, but isn't critical since the barrier should not be used in real code
+# This fails in an unexpected manner, but isn't critical since this barrier is only ever used in tests, and shouldn't exist in real code
 #permutation "S1" "R1" "S2" "Bc" "Rc" "Sc"
 
 #upgrade deadlocks should favor reorder

--- a/tsl/test/sql/bgw_policy.sql
+++ b/tsl/test/sql/bgw_policy.sql
@@ -341,8 +341,7 @@ select test_drop_chunks(:drop_chunks_job_id);
 select * from part_time_now_func;
 select remove_drop_chunks_policy('part_time_now_func');
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- todo:: this currently fails:
--- alter function dummy_now rename to dummy_now_renamed;
+alter function dummy_now() rename to dummy_now_renamed;
 alter schema public rename to new_public;
 select * from  _timescaledb_catalog.dimension;
 alter schema new_public rename to public;

--- a/tsl/test/sql/compress_table.sql
+++ b/tsl/test/sql/compress_table.sql
@@ -72,7 +72,7 @@ CREATE TABLE compressed(
 
 SELECT ARRAY[ord('time', :deltadelta, 0), seg('device', 0), com('data', :deltadelta), com('floats', :gorilla), com('nulls', :array), com('texts', :dictionary)]::_timescaledb_catalog.hypertable_compression[] AS "COMPRESSION_INFO" \gset
 
--- TODO NULL decompression doesn't quite work
+-- Can't actually decompress NULL. Used here as a placeholder to signal what type the first argument to 'decompress_forward' is.
 \set DECOMPRESS_FORWARD_CMD _timescaledb_internal.decompress_forward(time::_timescaledb_internal.compressed_data, NULL::INT) t, device, _timescaledb_internal.decompress_forward(data::_timescaledb_internal.compressed_data, NULL::INT) d, _timescaledb_internal.decompress_forward(floats::_timescaledb_internal.compressed_data, NULL::FLOAT(26)) f,  (NULL::text) n, _timescaledb_internal.decompress_forward(texts::_timescaledb_internal.compressed_data, NULL::TEXT) e
 
 INSERT INTO uncompressed

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -83,7 +83,7 @@ insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
 do update set b = excluded.b;
 
---TEST2c dml directly on the chunk NOTE update/deletes don't get blocked (TODO)
+--TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12);
 update _timescaledb_internal._hyper_1_2_chunk
 set b = 12;

--- a/tsl/test/sql/compression_algos.sql
+++ b/tsl/test/sql/compression_algos.sql
@@ -90,9 +90,6 @@ DROP TABLE base_ints;
 -- INT Compression --
 ------------------------
 
---kinda silly test for now since compressed as bigint anyway
---TODO add proper int support
---TODO add proper smallint support and tests
 CREATE TABLE base_ints AS SELECT row_number() OVER() as rn, item::int FROM (select sub.item from (SELECT generate_series(1, 1000) item) as sub ORDER BY gen_rand_minstd()) sub;
 SELECT
   $$

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -80,7 +80,9 @@ FROM _timescaledb_catalog.hypertable ht
 \gset
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- TODO this should change once we have a canonical way to create indexes on compressed tables
+-- Index created using query saved in variable used because there was 
+-- no standard way to create an index on a compressed table.
+-- Once a standard way exists, modify this test to use that method.
 CREATE INDEX c_index ON :METRICS_COMPRESSED(device_id);
 CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED(device_id);
 


### PR DESCRIPTION
This PR clarifies, removes, and otherwise cleans up all TODOs and FIXMEs accumulated across the TimescaleDB codebase until this point. 

Unless otherwise listed, the TODO was converted to a comment or put
into an issue tracker.

test/sql/
- triggers.sql: Made required change

tsl/test/
- CMakeLists.txt: TODO complete
- bgw_policy.sql: TODO complete
- continuous_aggs_materialize.sql: TODO complete
- compression.sql: TODO complete
- compression_algos.sql: TODO complete

tsl/src/
- compression/compression.c:
  - row_compressor_decompress_row: Expected complete
- compression/dictionary.c: FIXME complete
- materialize.c: TODO complete
- reorder.c: TODO complete
- simple8b_rle.h:
  - compressor_finish: Removed (obsolete)

src/
- extension.c: Removed due to age
- adts/simplehash.h: TODOs are from copied Postgres code
- adts/vec.h: TODO is non-significant
- planner.c: Removed
- process_utility.c
  - process_altertable_end_subcmd: Removed (PG will handle case)