### PR TITLE
Use test-specific assertions in C test code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ jobs:
         - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
         # Now run all tests
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -k -C /build/debug installcheck IGNORES='append-12 bgw_db_scheduler chunk_adaptive-12 ordered_append-12 parallel-12 transparent_decompression-12 compression_ddl continuous_aggs_insert continuous_aggs_multi' PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
-  
+
     # This runs tests on ARM32 emulation
     - if: branch = arm_test
       stage: test
@@ -261,7 +261,7 @@ jobs:
         - travis_wait 50 docker exec -u postgres docker_arm_emulator /bin/bash -c "cd /build && make installcheck IGNORES='multi_transaction_indexing bgw_db_scheduler bgw_job_delete continuous_aggs_insert continuous_aggs_bgw plan_ordered_append-12 parallel-12 compression_ddl continuous_aggs_insert continuous_aggs_multi'"
       after_script:
         - docker rm -f docker_arm_emulator
-  
+
     # to maximize code code coverage on PRs we run tests on earliest 9.6, latest 10 and earliest and latest 11
     # cron and prerelease runs regression tests on earliest and latest for each major version
     - if: (type = cron) OR (branch = prerelease_test)
@@ -303,9 +303,9 @@ jobs:
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test
       name: "CodeCov 12.0"
-      env: 
+      env:
         - PG_VERSION=12.0
-        - OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug  -DTS_COVERAGE_ONLY=TRUE -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'"
+        - OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'"
         - CODECOV_FLAGS="-F pr"
         - IGNORES="compression_ddl continuous_aggs_insert continuous_aggs_multi"
       after_success:
@@ -315,7 +315,7 @@ jobs:
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
       name: "CodeCov 9.6.17"
-      env: PG_VERSION=9.6.17 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug  -DTS_COVERAGE_ONLY=TRUE -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
+      env: PG_VERSION=9.6.17 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
@@ -323,7 +323,7 @@ jobs:
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
       name: "CodeCov 11.7"
-      env: PG_VERSION=11.7 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug  -DTS_COVERAGE_ONLY=TRUE -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
+      env: PG_VERSION=11.7 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
@@ -332,7 +332,7 @@ jobs:
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
       name: "CodeCov 10.12"
-      env: PG_VERSION=10.12 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug  -DTS_COVERAGE_ONLY=TRUE -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
+      env: PG_VERSION=10.12 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
@@ -430,7 +430,7 @@ jobs:
       after_script:
       script:
         - PG_MAJOR=12 PG_MINOR_COMPILE=0 bash -x ./scripts/docker-run-abi-test.sh
-  
+
     # ApacheOnly regression tests
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,6 @@ set(PROJECT_INSTALL_METHOD source CACHE STRING "Specify what install platform th
 is built for")
 message(STATUS "Install method is '${PROJECT_INSTALL_METHOD}'")
 
-option(TS_COVERAGE_ONLY "run in debug mode with assertions disabled to provide more accurate test-coverage info")
-
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   # CMAKE_BUILD_TYPE is set at CMake configuration type. But usage of CMAKE_C_FLAGS_DEBUG is
   # determined at build time by running cmake --build . --config Debug (at least on Windows).
@@ -71,9 +69,6 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
   # Debug. Then Debug enabled builds will only happen on Windows if both the configuration-
   # and build-time settings are Debug.
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG=1 -DTS_DEBUG=1")
-  if (NOT TS_COVERAGE_ONLY)
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DUSE_ASSERT_CHECKING=1")
-  endif()
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 set(SUPPORTED_COMPILERS "GNU" "Clang" "AppleClang" "MSVC")
@@ -314,6 +309,33 @@ endif()
 option(USE_OPENSSL "Enable use of OpenSSL if available" ON)
 option(SEND_TELEMETRY_DEFAULT "The default value for whether to send telemetry" ON)
 option(REGRESS_CHECKS "PostgreSQL regress checks through installcheck" ON)
+
+# Option to enable assertions. Note that if we include headers from a
+# PostgreSQL build that has assertions enabled, we might inherit that
+# setting without explicitly enabling assertions via the ASSERTIONS
+# option defined here. Thus, this option is mostly useful to enable
+# assertions when the PostgreSQL we compile against has it disabled.
+option(ASSERTIONS "Compile with assertion checks (default OFF)" OFF)
+
+if (NOT EXISTS ${PG_INCLUDEDIR}/pg_config.h)
+  message(FATAL_ERROR "Could not find pg_config.h in ${PG_INCLUDEDIR}. "
+    "Make sure PG_PATH points to a valid PostgreSQL installation that includes development headers.")
+endif ()
+
+file(READ ${PG_INCLUDEDIR}/pg_config.h PG_CONFIG_H)
+string(REGEX MATCH "#define USE_ASSERT_CHECKING 1" PG_USE_ASSERT_CHECKING ${PG_CONFIG_H})
+
+if (PG_USE_ASSERT_CHECKING AND NOT ASSERTIONS)
+  message(NOTICE "Assertion checks are OFF although enabled in PostgreSQL build (pg_config.h).\n"
+    "The PostgreSQL setting for assertions will take precedence.")
+elseif (ASSERTIONS)
+  message(STATUS "Assertion checks are ON")
+  add_compile_definitions(USE_ASSERT_CHECKING=1)
+elseif (CMAKE_BUILD_TYPE MATCHES Debug)
+  message(NOTICE "Assertion checks are OFF in Debug build. Set -DASSERTIONS=ON to enable assertions.")
+else ()
+  message(STATUS "Assertion checks are OFF")
+endif ()
 
 # Check if PostgreSQL has OpenSSL enabled by inspecting pg_config --configure.
 # Right now, a Postgres header will redefine an OpenSSL function if Postgres is not installed --with-openssl,

--- a/test/expected/test_utils.out
+++ b/test/expected/test_utils.out
@@ -1,0 +1,25 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION test.condition() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_condition' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION test.int64_eq() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_int64_eq' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION test.ptr_eq() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_ptr_eq' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION test.double_eq() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_double_eq' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+\c :TEST_DBNAME  :ROLE_DEFAULT_PERM_USER;
+-- We're testing that the test utils work and generate errors on
+-- failing conditions
+\set ON_ERROR_STOP 0
+SELECT test.condition();
+ERROR:  TestFailure @ test_utils.c ts_test_utils_condition:23 | (true_value == false_value)
+SELECT test.int64_eq();
+ERROR:  TestFailure @ test_utils.c ts_test_utils_int64_eq:33 | (big == small) [32532978 == 3242234]
+SELECT test.ptr_eq();
+ERROR:  TestFailure @ test_utils.c ts_test_utils_ptr_eq:47 | (true_ptr == false_ptr)
+SELECT test.double_eq();
+ERROR:  TestFailure @ test_utils.c ts_test_utils_double_eq:58 | (big_double == small_double) [923423478.324200 == 324.300000]
+\set ON_ERROR_STOP 1

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -83,7 +83,8 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
     metadata.sql
     net.sql
     symbol_conflict.sql
-    telemetry.sql)
+    telemetry.sql
+    test_utils.sql)
   if (USE_OPENSSL)
     list(APPEND TEST_FILES
       privacy.sql)

--- a/test/sql/test_utils.sql
+++ b/test/sql/test_utils.sql
@@ -1,0 +1,24 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION test.condition() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_condition' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION test.int64_eq() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_int64_eq' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION test.ptr_eq() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_ptr_eq' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION test.double_eq() RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_utils_double_eq' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+\c :TEST_DBNAME  :ROLE_DEFAULT_PERM_USER;
+
+-- We're testing that the test utils work and generate errors on
+-- failing conditions
+\set ON_ERROR_STOP 0
+SELECT test.condition();
+SELECT test.int64_eq();
+SELECT test.ptr_eq();
+SELECT test.double_eq();
+\set ON_ERROR_STOP 1

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
   symbol_conflict.c
   test_time_to_internal.c
   test_with_clause_parser.c
+  test_utils.c
 )
 
 include(${PROJECT_SOURCE_DIR}/src/build-defs.cmake)

--- a/test/src/adt_tests.c
+++ b/test/src/adt_tests.c
@@ -27,46 +27,47 @@ i32_vec_test(void)
 	int32_vec *vec = int32_vec_create(CurrentMemoryContext, 0);
 	int i;
 	uint32 old_capacity;
+
 	for (i = 0; i < 100; i++)
 		int32_vec_append(vec, i);
 
-	AssertInt64Eq(vec->num_elements, 100);
+	TestAssertInt64Eq(vec->num_elements, 100);
 
 	if (vec->max_elements < 100)
 		elog(ERROR, "vec capacity %d, should be at least 100", vec->max_elements);
 
 	for (i = 0; i < 100; i++)
-		AssertInt64Eq(*int32_vec_at(vec, i), i);
+		TestAssertInt64Eq(*int32_vec_at(vec, i), i);
 
-	AssertPtrEq(int32_vec_last(vec), int32_vec_at(vec, vec->num_elements - 1));
+	TestAssertPtrEq(int32_vec_last(vec), int32_vec_at(vec, vec->num_elements - 1));
 
 	old_capacity = vec->max_elements;
 	int32_vec_delete_range(vec, 30, 19);
-	AssertInt64Eq(vec->num_elements, 81);
-	AssertInt64Eq(vec->max_elements, old_capacity);
+	TestAssertInt64Eq(vec->num_elements, 81);
+	TestAssertInt64Eq(vec->max_elements, old_capacity);
 
 	for (i = 0; i < 30; i++)
-		AssertInt64Eq(*int32_vec_at(vec, i), i);
+		TestAssertInt64Eq(*int32_vec_at(vec, i), i);
 
 	for (; i < 51; i++)
-		AssertInt64Eq(*int32_vec_at(vec, i), i + 19);
+		TestAssertInt64Eq(*int32_vec_at(vec, i), i + 19);
 
-	AssertPtrEq(int32_vec_last(vec), int32_vec_at(vec, vec->num_elements - 1));
+	TestAssertPtrEq(int32_vec_last(vec), int32_vec_at(vec, vec->num_elements - 1));
 
 	int32_vec_clear(vec);
-	AssertInt64Eq(vec->num_elements, 0);
-	AssertInt64Eq(vec->max_elements, old_capacity);
+	TestAssertInt64Eq(vec->num_elements, 0);
+	TestAssertInt64Eq(vec->max_elements, old_capacity);
 
 	int32_vec_free_data(vec);
-	AssertInt64Eq(vec->num_elements, 0);
-	AssertInt64Eq(vec->max_elements, 0);
-	AssertPtrEq(vec->data, NULL);
+	TestAssertInt64Eq(vec->num_elements, 0);
+	TestAssertInt64Eq(vec->max_elements, 0);
+	TestAssertPtrEq(vec->data, NULL);
 
 	/* free_data is idempotent */
 	int32_vec_free_data(vec);
-	AssertInt64Eq(vec->num_elements, 0);
-	AssertInt64Eq(vec->max_elements, 0);
-	AssertPtrEq(vec->data, NULL);
+	TestAssertInt64Eq(vec->num_elements, 0);
+	TestAssertInt64Eq(vec->max_elements, 0);
+	TestAssertPtrEq(vec->data, NULL);
 
 	int32_vec_free(vec);
 }
@@ -81,15 +82,15 @@ uint64_vec_test(void)
 	for (i = 0; i < 30; i++)
 		uint64_vec_append(&vec, i + 3);
 
-	AssertInt64Eq(vec.num_elements, 30);
-	AssertInt64Eq(vec.max_elements, 100);
+	TestAssertInt64Eq(vec.num_elements, 30);
+	TestAssertInt64Eq(vec.max_elements, 100);
 	for (i = 0; i < 30; i++)
-		AssertInt64Eq(*uint64_vec_at(&vec, i), i + 3);
+		TestAssertInt64Eq(*uint64_vec_at(&vec, i), i + 3);
 
 	uint64_vec_free_data(&vec);
-	AssertInt64Eq(vec.num_elements, 0);
-	AssertInt64Eq(vec.max_elements, 0);
-	AssertPtrEq(vec.data, NULL);
+	TestAssertInt64Eq(vec.num_elements, 0);
+	TestAssertInt64Eq(vec.max_elements, 0);
+	TestAssertPtrEq(vec.data, NULL);
 }
 
 static void
@@ -112,24 +113,24 @@ bit_array_test(void)
 
 	bit_array_iterator_init(&iter, &bits);
 	for (i = 0; i < 65; i++)
-		AssertInt64Eq(bit_array_iter_next(&iter, i), i);
+		TestAssertInt64Eq(bit_array_iter_next(&iter, i), i);
 
-	AssertInt64Eq(bit_array_iter_next(&iter, 0), 0);
-	AssertInt64Eq(bit_array_iter_next(&iter, 0), 0);
-	AssertInt64Eq(bit_array_iter_next(&iter, 64), 0x9069060909009090);
-	AssertInt64Eq(bit_array_iter_next(&iter, 1), 0);
-	AssertInt64Eq(bit_array_iter_next(&iter, 64), ~0x9069060909009090);
-	AssertInt64Eq(bit_array_iter_next(&iter, 1), 1);
+	TestAssertInt64Eq(bit_array_iter_next(&iter, 0), 0);
+	TestAssertInt64Eq(bit_array_iter_next(&iter, 0), 0);
+	TestAssertInt64Eq(bit_array_iter_next(&iter, 64), 0x9069060909009090);
+	TestAssertInt64Eq(bit_array_iter_next(&iter, 1), 0);
+	TestAssertInt64Eq(bit_array_iter_next(&iter, 64), ~0x9069060909009090);
+	TestAssertInt64Eq(bit_array_iter_next(&iter, 1), 1);
 
 	bit_array_iterator_init_rev(&iter, &bits);
-	AssertInt64Eq(bit_array_iter_next_rev(&iter, 1), 1);
-	AssertInt64Eq(bit_array_iter_next_rev(&iter, 64), ~0x9069060909009090);
-	AssertInt64Eq(bit_array_iter_next_rev(&iter, 1), 0);
-	AssertInt64Eq(bit_array_iter_next_rev(&iter, 64), 0x9069060909009090);
-	AssertInt64Eq(bit_array_iter_next_rev(&iter, 0), 0);
-	AssertInt64Eq(bit_array_iter_next_rev(&iter, 0), 0);
+	TestAssertInt64Eq(bit_array_iter_next_rev(&iter, 1), 1);
+	TestAssertInt64Eq(bit_array_iter_next_rev(&iter, 64), ~0x9069060909009090);
+	TestAssertInt64Eq(bit_array_iter_next_rev(&iter, 1), 0);
+	TestAssertInt64Eq(bit_array_iter_next_rev(&iter, 64), 0x9069060909009090);
+	TestAssertInt64Eq(bit_array_iter_next_rev(&iter, 0), 0);
+	TestAssertInt64Eq(bit_array_iter_next_rev(&iter, 0), 0);
 	for (i = 64; i >= 0; i--)
-		AssertInt64Eq(bit_array_iter_next_rev(&iter, i), i);
+		TestAssertInt64Eq(bit_array_iter_next_rev(&iter, i), i);
 }
 
 Datum

--- a/test/src/bgw/params.c
+++ b/test/src/bgw/params.c
@@ -22,6 +22,7 @@
 
 #include "params.h"
 #include "timer_mock.h"
+#include "test_utils.h"
 #include "log.h"
 #include "scanner.h"
 #include "catalog.h"
@@ -75,7 +76,7 @@ params_load_dsm_handle()
 	rel = table_open(get_dsm_handle_table_oid(), RowExclusiveLock);
 	scan = table_beginscan(rel, SnapshotSelf, 0, NULL);
 	tuple = heap_getnext(scan, ForwardScanDirection);
-	Assert(tuple != NULL);
+	TestAssertTrue(tuple != NULL);
 	tuple = heap_copytuple(tuple);
 	fd = (FormData_bgw_dsm_handle *) GETSTRUCT(tuple);
 	handle = fd->handle;
@@ -123,11 +124,11 @@ params_open_wrapper()
 #endif
 	}
 
-	Assert(seg != NULL);
+	TestAssertTrue(seg != NULL);
 
 	wrapper = dsm_segment_address(seg);
 
-	Assert(wrapper != NULL);
+	TestAssertTrue(wrapper != NULL);
 
 	return wrapper;
 };
@@ -137,7 +138,7 @@ params_close_wrapper(TestParamsWrapper *wrapper)
 {
 	dsm_segment *seg = dsm_find_mapping(params_get_dsm_handle());
 
-	Assert(seg != NULL);
+	TestAssertTrue(seg != NULL);
 	dsm_detach(seg);
 }
 
@@ -147,7 +148,7 @@ ts_params_get()
 	TestParamsWrapper *wrapper = params_open_wrapper();
 	TestParams *res;
 
-	Assert(wrapper != NULL);
+	TestAssertTrue(wrapper != NULL);
 
 	res = palloc(sizeof(TestParams));
 
@@ -167,7 +168,7 @@ ts_params_set_time(int64 new_val, bool set_latch)
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 
-	Assert(wrapper != NULL);
+	TestAssertTrue(wrapper != NULL);
 
 	SpinLockAcquire(&wrapper->mutex);
 	wrapper->params.current_time = new_val;
@@ -184,7 +185,7 @@ ts_initialize_timer_latch()
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 
-	Assert(wrapper != NULL);
+	TestAssertTrue(wrapper != NULL);
 
 	SpinLockAcquire(&wrapper->mutex);
 
@@ -200,7 +201,7 @@ ts_reset_and_wait_timer_latch()
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 
-	Assert(wrapper != NULL);
+	TestAssertTrue(wrapper != NULL);
 
 	ResetLatch(&wrapper->params.timer_latch);
 	WaitLatchCompat(&wrapper->params.timer_latch,
@@ -215,7 +216,7 @@ params_set_mock_wait_type(MockWaitType new_val)
 {
 	TestParamsWrapper *wrapper = params_open_wrapper();
 
-	Assert(wrapper != NULL);
+	TestAssertTrue(wrapper != NULL);
 
 	SpinLockAcquire(&wrapper->mutex);
 
@@ -251,7 +252,7 @@ ts_bgw_params_create(PG_FUNCTION_ARGS)
 	dsm_segment *seg = dsm_create(sizeof(TestParamsWrapper), 0);
 	TestParamsWrapper *params;
 
-	Assert(seg != NULL);
+	TestAssertTrue(seg != NULL);
 
 	params = dsm_segment_address(seg);
 	*params = (TestParamsWrapper)

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -30,6 +30,7 @@
 #include "bgw/job_stat.h"
 #include "timer_mock.h"
 #include "params.h"
+#include "test_utils.h"
 
 TS_FUNCTION_INFO_V1(ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish);
 TS_FUNCTION_INFO_V1(ts_bgw_db_scheduler_test_run);
@@ -85,7 +86,7 @@ serialize_test_parameters(int32 ttl)
 
 	jb = JsonbValueToJsonb(result);
 	(void) JsonbToCString(jtext, &jb->root, VARSIZE(jb));
-	Assert(jtext->len < BGW_EXTRALEN);
+	TestAssertTrue(jtext->len < BGW_EXTRALEN);
 
 	return jtext->data;
 }
@@ -99,8 +100,8 @@ deserialize_test_parameters(char *params, int32 *ttl, Oid *user_oid)
 	Numeric ttl_numeric;
 	Numeric user_numeric;
 
-	Assert(ttl_v->type == jbvNumeric);
-	Assert(user_v->type == jbvNumeric);
+	TestAssertTrue(ttl_v->type == jbvNumeric);
+	TestAssertTrue(user_v->type == jbvNumeric);
 
 	ttl_numeric = ttl_v->val.numeric;
 	user_numeric = user_v->val.numeric;
@@ -179,12 +180,12 @@ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(PG_FUNCTION_ARGS)
 	if (worker_handle != NULL)
 	{
 		BgwHandleStatus status = WaitForBackgroundWorkerStartup(worker_handle, &pid);
-		Assert(BGWH_STARTED == status);
+		TestAssertTrue(BGWH_STARTED == status);
 		if (status != BGWH_STARTED)
 			elog(ERROR, "bgw not started");
 
 		status = WaitForBackgroundWorkerShutdown(worker_handle);
-		Assert(BGWH_STOPPED == status);
+		TestAssertTrue(BGWH_STOPPED == status);
 		if (status != BGWH_STOPPED)
 			elog(ERROR, "bgw not stopped");
 	}
@@ -207,7 +208,7 @@ ts_bgw_db_scheduler_test_run(PG_FUNCTION_ARGS)
 	MemoryContextSwitchTo(old_ctx);
 
 	status = WaitForBackgroundWorkerStartup(current_handle, &pid);
-	Assert(BGWH_STARTED == status);
+	TestAssertTrue(BGWH_STARTED == status);
 	if (status != BGWH_STARTED)
 		elog(ERROR, "bgw not started");
 
@@ -220,7 +221,7 @@ ts_bgw_db_scheduler_test_wait_for_scheduler_finish(PG_FUNCTION_ARGS)
 	if (current_handle != NULL)
 	{
 		BgwHandleStatus status = WaitForBackgroundWorkerShutdown(current_handle);
-		Assert(BGWH_STOPPED == status);
+		TestAssertTrue(BGWH_STOPPED == status);
 		if (status != BGWH_STOPPED)
 			elog(ERROR, "bgw not stopped");
 	}

--- a/test/src/net/test_http.c
+++ b/test/src/net/test_http.c
@@ -11,6 +11,7 @@
 
 #include "export.h"
 #include "net/http.h"
+#include "test_utils.h"
 
 #define MAX_REQUEST_SIZE 4096
 
@@ -96,7 +97,7 @@ ts_test_http_parsing(PG_FUNCTION_ARGS)
 
 			buf = ts_http_response_state_next_buffer(state, &bufsize);
 
-			Assert(bufsize >= bytes);
+			TestAssertTrue(bufsize >= bytes);
 
 			/* Copy part of the message into the parsing state */
 			memcpy(buf, TEST_RESPONSES[i], bytes);
@@ -104,13 +105,13 @@ ts_test_http_parsing(PG_FUNCTION_ARGS)
 			/* Now do the parse */
 			success = ts_http_response_state_parse(state, bytes);
 
-			Assert(success);
+			TestAssertTrue(success);
 			if (!success)
 				elog(ERROR, "could not parse http state");
 
 			success = ts_http_response_state_is_done(state);
 
-			Assert(bytes < strlen(TEST_RESPONSES[i]) ? !success : success);
+			TestAssertTrue(bytes < strlen(TEST_RESPONSES[i]) ? !success : success);
 
 			ts_http_response_state_destroy(state);
 		}
@@ -139,21 +140,21 @@ ts_test_http_parsing_full(PG_FUNCTION_ARGS)
 
 		bytes = strlen(TEST_RESPONSES[i]);
 
-		Assert(bufsize >= bytes);
+		TestAssertTrue(bufsize >= bytes);
 
 		/* Copy all of the message into the parsing state */
 		memcpy(buf, TEST_RESPONSES[i], bytes);
 
 		/* Now do the parse */
-		Assert(ts_http_response_state_parse(state, bytes));
+		TestAssertTrue(ts_http_response_state_parse(state, bytes));
 
-		Assert(ts_http_response_state_is_done(state));
-		Assert(ts_http_response_state_content_length(state) == TEST_LENGTHS[i]);
+		TestAssertTrue(ts_http_response_state_is_done(state));
+		TestAssertTrue(ts_http_response_state_content_length(state) == TEST_LENGTHS[i]);
 		/* Make sure we read the right message body */
 		cmp = !strncmp(MESSAGE_BODY[i],
 					   ts_http_response_state_body_start(state),
 					   ts_http_response_state_content_length(state));
-		Assert(cmp);
+		TestAssertTrue(cmp);
 		if (!cmp)
 			elog(ERROR, "bad message");
 
@@ -171,12 +172,12 @@ ts_test_http_parsing_full(PG_FUNCTION_ARGS)
 
 		bytes = strlen(BAD_RESPONSES[i]);
 
-		Assert(bufsize >= bytes);
+		TestAssertTrue(bufsize >= bytes);
 
 		memcpy(buf, BAD_RESPONSES[i], bytes);
 
-		Assert(!ts_http_response_state_parse(state, bytes) ||
-			   !ts_http_response_state_valid_status(state));
+		TestAssertTrue(!ts_http_response_state_parse(state, bytes) ||
+					   !ts_http_response_state_valid_status(state));
 
 		ts_http_response_state_destroy(state);
 	}
@@ -202,7 +203,7 @@ ts_test_http_request_build(PG_FUNCTION_ARGS)
 	serialized = ts_http_request_build(req, &request_len);
 
 	cmp_res = !strncmp(expected_response, serialized, request_len);
-	Assert(cmp_res);
+	TestAssertTrue(cmp_res);
 	if (!cmp_res)
 		elog(ERROR, "bad response");
 	ts_http_request_destroy(req);
@@ -220,7 +221,7 @@ ts_test_http_request_build(PG_FUNCTION_ARGS)
 
 	serialized = ts_http_request_build(req, &request_len);
 
-	Assert(!strncmp(expected_response, serialized, request_len));
+	TestAssertTrue(!strncmp(expected_response, serialized, request_len));
 	ts_http_request_destroy(req);
 
 	expected_response = "POST /tmp/status/1234 HTTP/1.1\r\n"
@@ -234,7 +235,7 @@ ts_test_http_request_build(PG_FUNCTION_ARGS)
 
 	serialized = ts_http_request_build(req, &request_len);
 
-	Assert(!strncmp(expected_response, serialized, request_len));
+	TestAssertTrue(!strncmp(expected_response, serialized, request_len));
 	ts_http_request_destroy(req);
 
 	/* Check that content-length checking works */
@@ -244,7 +245,7 @@ ts_test_http_request_build(PG_FUNCTION_ARGS)
 	ts_http_request_set_header(req, HTTP_HOST, host);
 	ts_http_request_set_header(req, HTTP_CONTENT_LENGTH, "9");
 
-	Assert(!ts_http_request_build(req, &request_len));
+	TestAssertTrue(!ts_http_request_build(req, &request_len));
 	ts_http_request_destroy(req);
 
 	PG_RETURN_NULL();

--- a/test/src/test_time_to_internal.c
+++ b/test/src/test_time_to_internal.c
@@ -30,121 +30,141 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 	/* int16 */
 	for (i16 = -100; i16 < 100; i16++)
 	{
-		AssertInt64Eq(i16, ts_time_value_to_internal(Int16GetDatum(i16), INT2OID));
-		AssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(i16, INT2OID)), i16);
+		TestAssertInt64Eq(i16, ts_time_value_to_internal(Int16GetDatum(i16), INT2OID));
+		TestAssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(i16, INT2OID)), i16);
 	}
 
-	AssertInt64Eq(PG_INT16_MAX, ts_time_value_to_internal(Int16GetDatum(PG_INT16_MAX), INT2OID));
-	AssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(PG_INT16_MAX, INT2OID)), PG_INT16_MAX);
+	TestAssertInt64Eq(PG_INT16_MAX,
+					  ts_time_value_to_internal(Int16GetDatum(PG_INT16_MAX), INT2OID));
+	TestAssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(PG_INT16_MAX, INT2OID)),
+					  PG_INT16_MAX);
 
-	AssertInt64Eq(PG_INT16_MIN, ts_time_value_to_internal(Int16GetDatum(PG_INT16_MIN), INT2OID));
-	AssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(PG_INT16_MIN, INT2OID)), PG_INT16_MIN);
+	TestAssertInt64Eq(PG_INT16_MIN,
+					  ts_time_value_to_internal(Int16GetDatum(PG_INT16_MIN), INT2OID));
+	TestAssertInt64Eq(DatumGetInt16(ts_internal_to_time_value(PG_INT16_MIN, INT2OID)),
+					  PG_INT16_MIN);
 
 	/* int32 */
 	for (i32 = -100; i32 < 100; i32++)
 	{
-		AssertInt64Eq(i32, ts_time_value_to_internal(Int32GetDatum(i32), INT4OID));
-		AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(i32, INT4OID)), i32);
+		TestAssertInt64Eq(i32, ts_time_value_to_internal(Int32GetDatum(i32), INT4OID));
+		TestAssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(i32, INT4OID)), i32);
 	}
 
-	AssertInt64Eq(PG_INT16_MAX, ts_time_value_to_internal(Int32GetDatum(PG_INT16_MAX), INT4OID));
-	AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT16_MAX, INT4OID)), PG_INT16_MAX);
+	TestAssertInt64Eq(PG_INT16_MAX,
+					  ts_time_value_to_internal(Int32GetDatum(PG_INT16_MAX), INT4OID));
+	TestAssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT16_MAX, INT4OID)),
+					  PG_INT16_MAX);
 
-	AssertInt64Eq(PG_INT32_MAX, ts_time_value_to_internal(Int32GetDatum(PG_INT32_MAX), INT4OID));
-	AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT32_MAX, INT4OID)), PG_INT32_MAX);
+	TestAssertInt64Eq(PG_INT32_MAX,
+					  ts_time_value_to_internal(Int32GetDatum(PG_INT32_MAX), INT4OID));
+	TestAssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT32_MAX, INT4OID)),
+					  PG_INT32_MAX);
 
-	AssertInt64Eq(PG_INT32_MIN, ts_time_value_to_internal(Int32GetDatum(PG_INT32_MIN), INT4OID));
-	AssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT32_MIN, INT4OID)), PG_INT32_MIN);
+	TestAssertInt64Eq(PG_INT32_MIN,
+					  ts_time_value_to_internal(Int32GetDatum(PG_INT32_MIN), INT4OID));
+	TestAssertInt64Eq(DatumGetInt32(ts_internal_to_time_value(PG_INT32_MIN, INT4OID)),
+					  PG_INT32_MIN);
 
 	/* int64 */
 	for (i64 = -100; i64 < 100; i64++)
 	{
-		AssertInt64Eq(i64, ts_time_value_to_internal(Int64GetDatum(i64), INT8OID));
-		AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(i64, INT8OID)), i64);
+		TestAssertInt64Eq(i64, ts_time_value_to_internal(Int64GetDatum(i64), INT8OID));
+		TestAssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(i64, INT8OID)), i64);
 	}
 
-	AssertInt64Eq(PG_INT16_MIN, ts_time_value_to_internal(Int64GetDatum(PG_INT16_MIN), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT16_MIN, INT8OID)), PG_INT16_MIN);
+	TestAssertInt64Eq(PG_INT16_MIN,
+					  ts_time_value_to_internal(Int64GetDatum(PG_INT16_MIN), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT16_MIN, INT8OID)),
+					  PG_INT16_MIN);
 
-	AssertInt64Eq(PG_INT32_MAX, ts_time_value_to_internal(Int64GetDatum(PG_INT32_MAX), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT32_MAX, INT8OID)), PG_INT32_MAX);
+	TestAssertInt64Eq(PG_INT32_MAX,
+					  ts_time_value_to_internal(Int64GetDatum(PG_INT32_MAX), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT32_MAX, INT8OID)),
+					  PG_INT32_MAX);
 
-	AssertInt64Eq(PG_INT64_MAX, ts_time_value_to_internal(Int64GetDatum(PG_INT64_MAX), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, INT8OID)), PG_INT64_MAX);
+	TestAssertInt64Eq(PG_INT64_MAX,
+					  ts_time_value_to_internal(Int64GetDatum(PG_INT64_MAX), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, INT8OID)),
+					  PG_INT64_MAX);
 
-	AssertInt64Eq(PG_INT64_MIN, ts_time_value_to_internal(Int64GetDatum(PG_INT64_MIN), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT64_MIN, INT8OID)), PG_INT64_MIN);
+	TestAssertInt64Eq(PG_INT64_MIN,
+					  ts_time_value_to_internal(Int64GetDatum(PG_INT64_MIN), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_time_value(PG_INT64_MIN, INT8OID)),
+					  PG_INT64_MIN);
 
 	/* test time values round trip */
 
 	/* TIMESTAMP */
 	for (i64 = -100; i64 < 100; i64++)
-		AssertInt64Eq(i64,
-					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
-												TIMESTAMPOID));
+		TestAssertInt64Eq(i64,
+						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
+													TIMESTAMPOID));
 
 	for (i64 = -10000000; i64 < 100000000; i64 += 1000000)
-		AssertInt64Eq(i64,
-					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
-												TIMESTAMPOID));
+		TestAssertInt64Eq(i64,
+						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
+													TIMESTAMPOID));
 
 	for (i64 = -1000000000; i64 < 10000000000; i64 += 100000000)
-		AssertInt64Eq(i64,
-					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
+		TestAssertInt64Eq(i64,
+						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
+													TIMESTAMPOID));
+
+	TestEnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPOID));
+	TestEnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPOID));
+
+	TestAssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
+					  ts_time_value_to_internal(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN,
+																		  TIMESTAMPOID),
 												TIMESTAMPOID));
 
-	EnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPOID));
-	EnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPOID));
-
-	AssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
-				  ts_time_value_to_internal(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN,
-																	  TIMESTAMPOID),
-											TIMESTAMPOID));
-
-	AssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
-				  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID)));
-	EnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID),
-										  TIMESTAMPOID));
+	TestAssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
+					  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID)));
+	TestEnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID),
+											  TIMESTAMPOID));
 
 	/* TIMESTAMPTZ */
 	for (i64 = -100; i64 < 100; i64++)
-		AssertInt64Eq(i64,
-					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
-												TIMESTAMPTZOID));
+		TestAssertInt64Eq(i64,
+						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
+													TIMESTAMPTZOID));
 
 	for (i64 = -10000000; i64 < 100000000; i64 += 1000000)
-		AssertInt64Eq(i64,
-					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
-												TIMESTAMPTZOID));
+		TestAssertInt64Eq(i64,
+						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
+													TIMESTAMPTZOID));
 
 	for (i64 = -1000000000; i64 < 10000000000; i64 += 100000000)
-		AssertInt64Eq(i64,
-					  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
+		TestAssertInt64Eq(i64,
+						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
+													TIMESTAMPTZOID));
+
+	TestEnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPTZOID));
+	TestEnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPTZOID));
+
+	TestAssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
+					  ts_time_value_to_internal(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN,
+																		  TIMESTAMPTZOID),
 												TIMESTAMPTZOID));
 
-	EnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPTZOID));
-	EnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPTZOID));
-
-	AssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
-				  ts_time_value_to_internal(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN,
-																	  TIMESTAMPTZOID),
-											TIMESTAMPTZOID));
-
-	AssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
-				  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID)));
-	EnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID),
-										  TIMESTAMPTZOID));
+	TestAssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
+					  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID)));
+	TestEnsureError(
+		ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID),
+								  TIMESTAMPTZOID));
 
 	/* DATE */
 	for (i64 = -100 * USECS_PER_DAY; i64 < 100 * USECS_PER_DAY; i64 += USECS_PER_DAY)
-		AssertInt64Eq(i64,
-					  ts_time_value_to_internal(ts_internal_to_time_value(i64, DATEOID), DATEOID));
+		TestAssertInt64Eq(i64,
+						  ts_time_value_to_internal(ts_internal_to_time_value(i64, DATEOID),
+													DATEOID));
 
-	EnsureError(ts_internal_to_time_value(PG_INT64_MIN, DATEOID));
-	AssertInt64Eq(106741034, DatumGetDateADT(ts_internal_to_time_value(PG_INT64_MAX, DATEOID)));
+	TestEnsureError(ts_internal_to_time_value(PG_INT64_MIN, DATEOID));
+	TestAssertInt64Eq(106741034, DatumGetDateADT(ts_internal_to_time_value(PG_INT64_MAX, DATEOID)));
 
-	EnsureError(ts_time_value_to_internal((DATEVAL_NOBEGIN + 1), DATEOID));
-	EnsureError(ts_time_value_to_internal((DATEVAL_NOEND - 1), DATEOID));
+	TestEnsureError(ts_time_value_to_internal((DATEVAL_NOBEGIN + 1), DATEOID));
+	TestEnsureError(ts_time_value_to_internal((DATEVAL_NOEND - 1), DATEOID));
 
 	PG_RETURN_VOID();
 };
@@ -161,93 +181,96 @@ ts_test_interval_to_internal_conversion(PG_FUNCTION_ARGS)
 	/* int16 */
 	for (i16 = -100; i16 < 100; i16++)
 	{
-		AssertInt64Eq(i16, ts_interval_value_to_internal(Int16GetDatum(i16), INT2OID));
-		AssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(i16, INT2OID)), i16);
+		TestAssertInt64Eq(i16, ts_interval_value_to_internal(Int16GetDatum(i16), INT2OID));
+		TestAssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(i16, INT2OID)), i16);
 	}
 
-	AssertInt64Eq(PG_INT16_MAX,
-				  ts_interval_value_to_internal(Int16GetDatum(PG_INT16_MAX), INT2OID));
-	AssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(PG_INT16_MAX, INT2OID)),
-				  PG_INT16_MAX);
+	TestAssertInt64Eq(PG_INT16_MAX,
+					  ts_interval_value_to_internal(Int16GetDatum(PG_INT16_MAX), INT2OID));
+	TestAssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(PG_INT16_MAX, INT2OID)),
+					  PG_INT16_MAX);
 
-	AssertInt64Eq(PG_INT16_MIN,
-				  ts_interval_value_to_internal(Int16GetDatum(PG_INT16_MIN), INT2OID));
-	AssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(PG_INT16_MIN, INT2OID)),
-				  PG_INT16_MIN);
+	TestAssertInt64Eq(PG_INT16_MIN,
+					  ts_interval_value_to_internal(Int16GetDatum(PG_INT16_MIN), INT2OID));
+	TestAssertInt64Eq(DatumGetInt16(ts_internal_to_interval_value(PG_INT16_MIN, INT2OID)),
+					  PG_INT16_MIN);
 
 	/* int32 */
 	for (i32 = -100; i32 < 100; i32++)
 	{
-		AssertInt64Eq(i32, ts_interval_value_to_internal(Int32GetDatum(i32), INT4OID));
-		AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(i32, INT4OID)), i32);
+		TestAssertInt64Eq(i32, ts_interval_value_to_internal(Int32GetDatum(i32), INT4OID));
+		TestAssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(i32, INT4OID)), i32);
 	}
 
-	AssertInt64Eq(PG_INT16_MAX,
-				  ts_interval_value_to_internal(Int32GetDatum(PG_INT16_MAX), INT4OID));
-	AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT16_MAX, INT4OID)),
-				  PG_INT16_MAX);
+	TestAssertInt64Eq(PG_INT16_MAX,
+					  ts_interval_value_to_internal(Int32GetDatum(PG_INT16_MAX), INT4OID));
+	TestAssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT16_MAX, INT4OID)),
+					  PG_INT16_MAX);
 
-	AssertInt64Eq(PG_INT32_MAX,
-				  ts_interval_value_to_internal(Int32GetDatum(PG_INT32_MAX), INT4OID));
-	AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT32_MAX, INT4OID)),
-				  PG_INT32_MAX);
+	TestAssertInt64Eq(PG_INT32_MAX,
+					  ts_interval_value_to_internal(Int32GetDatum(PG_INT32_MAX), INT4OID));
+	TestAssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT32_MAX, INT4OID)),
+					  PG_INT32_MAX);
 
-	AssertInt64Eq(PG_INT32_MIN,
-				  ts_interval_value_to_internal(Int32GetDatum(PG_INT32_MIN), INT4OID));
-	AssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT32_MIN, INT4OID)),
-				  PG_INT32_MIN);
+	TestAssertInt64Eq(PG_INT32_MIN,
+					  ts_interval_value_to_internal(Int32GetDatum(PG_INT32_MIN), INT4OID));
+	TestAssertInt64Eq(DatumGetInt32(ts_internal_to_interval_value(PG_INT32_MIN, INT4OID)),
+					  PG_INT32_MIN);
 
 	/* int64 */
 	for (i64 = -100; i64 < 100; i64++)
 	{
-		AssertInt64Eq(i64, ts_interval_value_to_internal(Int64GetDatum(i64), INT8OID));
-		AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(i64, INT8OID)), i64);
+		TestAssertInt64Eq(i64, ts_interval_value_to_internal(Int64GetDatum(i64), INT8OID));
+		TestAssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(i64, INT8OID)), i64);
 	}
 
-	AssertInt64Eq(PG_INT16_MIN,
-				  ts_interval_value_to_internal(Int64GetDatum(PG_INT16_MIN), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT16_MIN, INT8OID)),
-				  PG_INT16_MIN);
+	TestAssertInt64Eq(PG_INT16_MIN,
+					  ts_interval_value_to_internal(Int64GetDatum(PG_INT16_MIN), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT16_MIN, INT8OID)),
+					  PG_INT16_MIN);
 
-	AssertInt64Eq(PG_INT32_MAX,
-				  ts_interval_value_to_internal(Int64GetDatum(PG_INT32_MAX), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT32_MAX, INT8OID)),
-				  PG_INT32_MAX);
+	TestAssertInt64Eq(PG_INT32_MAX,
+					  ts_interval_value_to_internal(Int64GetDatum(PG_INT32_MAX), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT32_MAX, INT8OID)),
+					  PG_INT32_MAX);
 
-	AssertInt64Eq(PG_INT64_MAX,
-				  ts_interval_value_to_internal(Int64GetDatum(PG_INT64_MAX), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT64_MAX, INT8OID)),
-				  PG_INT64_MAX);
+	TestAssertInt64Eq(PG_INT64_MAX,
+					  ts_interval_value_to_internal(Int64GetDatum(PG_INT64_MAX), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT64_MAX, INT8OID)),
+					  PG_INT64_MAX);
 
-	AssertInt64Eq(PG_INT64_MIN,
-				  ts_interval_value_to_internal(Int64GetDatum(PG_INT64_MIN), INT8OID));
-	AssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT64_MIN, INT8OID)),
-				  PG_INT64_MIN);
+	TestAssertInt64Eq(PG_INT64_MIN,
+					  ts_interval_value_to_internal(Int64GetDatum(PG_INT64_MIN), INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_internal_to_interval_value(PG_INT64_MIN, INT8OID)),
+					  PG_INT64_MIN);
 
 	/* INTERVAL */
 	for (i64 = -100; i64 < 100; i64++)
-		AssertInt64Eq(i64,
-					  ts_interval_value_to_internal(ts_internal_to_interval_value(i64, INTERVALOID),
-													INTERVALOID));
+		TestAssertInt64Eq(i64,
+						  ts_interval_value_to_internal(ts_internal_to_interval_value(i64,
+																					  INTERVALOID),
+														INTERVALOID));
 
 	for (i64 = -10000000; i64 < 100000000; i64 += 1000000)
-		AssertInt64Eq(i64,
-					  ts_interval_value_to_internal(ts_internal_to_interval_value(i64, INTERVALOID),
-													INTERVALOID));
+		TestAssertInt64Eq(i64,
+						  ts_interval_value_to_internal(ts_internal_to_interval_value(i64,
+																					  INTERVALOID),
+														INTERVALOID));
 
 	for (i64 = -1000000000; i64 < 10000000000; i64 += 100000000)
-		AssertInt64Eq(i64,
-					  ts_interval_value_to_internal(ts_internal_to_interval_value(i64, INTERVALOID),
-													INTERVALOID));
+		TestAssertInt64Eq(i64,
+						  ts_interval_value_to_internal(ts_internal_to_interval_value(i64,
+																					  INTERVALOID),
+														INTERVALOID));
 
-	AssertInt64Eq(PG_INT64_MIN,
-				  ts_interval_value_to_internal(ts_internal_to_interval_value(PG_INT64_MIN,
-																			  INTERVALOID),
-												INTERVALOID));
-	AssertInt64Eq(PG_INT64_MAX,
-				  ts_interval_value_to_internal(ts_internal_to_interval_value(PG_INT64_MAX,
-																			  INTERVALOID),
-												INTERVALOID));
+	TestAssertInt64Eq(PG_INT64_MIN,
+					  ts_interval_value_to_internal(ts_internal_to_interval_value(PG_INT64_MIN,
+																				  INTERVALOID),
+													INTERVALOID));
+	TestAssertInt64Eq(PG_INT64_MAX,
+					  ts_interval_value_to_internal(ts_internal_to_interval_value(PG_INT64_MAX,
+																				  INTERVALOID),
+													INTERVALOID));
 
 	PG_RETURN_VOID();
 }

--- a/test/src/test_utils.c
+++ b/test/src/test_utils.c
@@ -1,0 +1,61 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+
+#include "test_utils.h"
+
+/*
+ * Test assertion macros.
+ *
+ * Errors are expected since we want to test that the macros work. For each
+ * macro, test one failing and one non-failing condition. The non-failing must
+ * come first since the failing one will abort the function.
+ */
+TS_TEST_FN(ts_test_utils_condition)
+{
+	bool true_value = true;
+	bool false_value = false;
+
+	TestAssertTrue(true_value == true_value);
+	TestAssertTrue(true_value == false_value);
+
+	PG_RETURN_VOID();
+}
+
+TS_TEST_FN(ts_test_utils_int64_eq)
+{
+	int64 big = 32532978;
+	int64 small = 3242234;
+
+	TestAssertInt64Eq(big, small);
+	TestAssertInt64Eq(big, big);
+
+	PG_RETURN_VOID();
+}
+
+TS_TEST_FN(ts_test_utils_ptr_eq)
+{
+	bool true_value = true;
+	bool false_value = false;
+	bool *true_ptr = &true_value;
+	bool *false_ptr = &false_value;
+
+	TestAssertPtrEq(true_ptr, true_ptr);
+	TestAssertPtrEq(true_ptr, false_ptr);
+
+	PG_RETURN_VOID();
+}
+
+TS_TEST_FN(ts_test_utils_double_eq)
+{
+	double big_double = 923423478.3242;
+	double small_double = 324.3;
+
+	TestAssertDoubleEq(big_double, big_double);
+	TestAssertDoubleEq(big_double, small_double);
+
+	PG_RETURN_VOID();
+}

--- a/test/src/test_with_clause_parser.c
+++ b/test/src/test_with_clause_parser.c
@@ -16,12 +16,8 @@
 #include <utils/memutils.h>
 
 #include "export.h"
-
+#include "test_utils.h"
 #include "with_clause_parser.h"
-
-#define TS_TEST_FN(name)                                                                           \
-	TS_FUNCTION_INFO_V1(name);                                                                     \
-	Datum name(PG_FUNCTION_ARGS)
 
 static DefElem *
 def_elem_from_texts(Datum *texts, int nelems)
@@ -65,7 +61,7 @@ def_elems_from_array(ArrayType *with_clause_array)
 		Datum *with_clause_fields;
 		int with_clause_elems;
 		ArrayType *with_clause = DatumGetArrayTypeP(with_clause_datum);
-		Assert(!with_clause_null);
+		TestAssertTrue(!with_clause_null);
 		deconstruct_array(with_clause,
 						  TEXTOID,
 						  with_clause_meta.typlen,
@@ -91,7 +87,7 @@ create_filter_tuple(TupleDesc tuple_desc, DefElem *d, bool within)
 	Datum *values = palloc0(sizeof(*values) * tuple_desc->natts);
 	bool *nulls = palloc0(sizeof(*nulls) * tuple_desc->natts);
 
-	Assert(tuple_desc->natts >= 4);
+	TestAssertTrue(tuple_desc->natts >= 4);
 
 	if (d->defnamespace != NULL)
 		values[0] = CStringGetTextDatum(d->defnamespace);

--- a/tsl/test/src/CMakeLists.txt
+++ b/tsl/test/src/CMakeLists.txt
@@ -13,5 +13,5 @@ add_library(${TSL_TESTS_LIB_NAME} OBJECT ${SOURCES})
 # module, it needs to be compiled as position-independent code
 # (e.g., the -fPIC compiler flag for GCC)
 set_target_properties(${TSL_TESTS_LIB_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
+target_include_directories(${TSL_TESTS_LIB_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/test/src)
 target_compile_definitions(${TSL_TESTS_LIB_NAME} PUBLIC TS_SUBMODULE)

--- a/tsl/test/src/test_ddl_hook.c
+++ b/tsl/test/src/test_ddl_hook.c
@@ -9,6 +9,7 @@
 #include <fmgr.h>
 
 #include "export.h"
+#include "test_utils.h"
 #include "process_utility.h"
 
 #include "compat.h"
@@ -186,7 +187,7 @@ test_sql_drop(List *dropped_objects)
 Datum
 ts_test_ddl_command_hook_reg(PG_FUNCTION_ARGS)
 {
-	Assert(ts_cm_functions->ddl_command_start == NULL);
+	TestAssertTrue(ts_cm_functions->ddl_command_start == NULL);
 	ts_cm_functions->ddl_command_start = test_ddl_command_start;
 	ts_cm_functions->ddl_command_end = test_ddl_command_end;
 	ts_cm_functions->sql_drop = test_sql_drop;
@@ -196,7 +197,7 @@ ts_test_ddl_command_hook_reg(PG_FUNCTION_ARGS)
 Datum
 ts_test_ddl_command_hook_unreg(PG_FUNCTION_ARGS)
 {
-	Assert(ts_cm_functions->ddl_command_start == test_ddl_command_start);
+	TestAssertTrue(ts_cm_functions->ddl_command_start == test_ddl_command_start);
 	ts_cm_functions->ddl_command_start = NULL;
 	ts_cm_functions->ddl_command_end = NULL;
 	ts_cm_functions->sql_drop = NULL;


### PR DESCRIPTION
Test code in C should use test-specific assertions that throw errors
instead of exiting the program with a signal (crash). Not only does
this provide more useful and easily accessible information of the
failing condition, but it also allows running the test suite without
assertions (`USE_ASSERT_CHECKING`) enabled. Having assertions disabled
during tests also provides more accurate test coverage numbers. Note
that these test-specific assertions are not intended to replace
regular assertions (`Assert`), which are used in non-test code.

The way to enable (or disable) assertions in CMake has also been
simplified and cleaned up. The option `-DASSERTIONS=[ON|OFF]` can be
used to enable assertions for a build, unless already enabled in the
PostgreSQL one is building against (in which case that setting takes
precedence). Note that the `ASSERTIONS` option defaults to `OFF` since
it is no longer necessary to have assertions enabled for tests.


NOTE: this cleanup will help the multinode rebase pass code coverage tests.