### PR TITLE
Add real-time aggregation test to update test

### DIFF
--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -1,0 +1,16 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\ir post.continuous_aggs.sql
+
+\d cagg.*
+
+SELECT * FROM cagg.realtime_mat ORDER BY bucket, location;
+
+REFRESH MATERIALIZED VIEW cagg.realtime_mat;
+
+SELECT * FROM cagg.realtime_mat ORDER BY bucket, location;
+
+SELECT view_name, refresh_lag, refresh_interval, max_interval_per_job, ignore_invalidation_older_than, materialized_only, materialization_hypertable FROM timescaledb_information.continuous_aggregates ORDER BY view_name::text;
+

--- a/test/sql/updates/post.v6-pg10.sql
+++ b/test/sql/updates/post.v6-pg10.sql
@@ -4,5 +4,5 @@
 
 \ir post.v2.sql
 \ir post.compression.sql
-\ir post.continuous_aggs.sql
+\ir post.continuous_aggs.v2.sql
 

--- a/test/sql/updates/post.v6-pg11.sql
+++ b/test/sql/updates/post.v6-pg11.sql
@@ -5,5 +5,5 @@
 \ir post.v2.sql
 \ir catalog_missing_columns.sql
 \ir post.compression.sql
-\ir post.continuous_aggs.sql
+\ir post.continuous_aggs.v2.sql
 

--- a/test/sql/updates/post.v6-pg12.sql
+++ b/test/sql/updates/post.v6-pg12.sql
@@ -5,4 +5,4 @@
 \ir post.v2.sql
 \ir catalog_missing_columns.sql
 \ir post.compression.sql
-\ir post.continuous_aggs.sql
+\ir post.continuous_aggs.v2.sql

--- a/test/sql/updates/post.v6-pg96.sql
+++ b/test/sql/updates/post.v6-pg96.sql
@@ -3,5 +3,5 @@
 -- LICENSE-APACHE for a copy of the license.
 
 \ir post.v2.sql
-\ir post.continuous_aggs.sql
+\ir post.continuous_aggs.v2.sql
 


### PR DESCRIPTION
This patch adds a continuous aggregate with real-time aggregation
enabled to the update test suite since we rebuild view definition
for real time aggregation during extension update.
The continuous aggregate is in its own schema because all view
definitions in the public schema are dumped and those view
definitions will change between versions.