### PR TITLE
Update tests to run on newest PG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,9 +95,9 @@ jobs:
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "Regression 9.6.17 32 bit"
+      name: "Regression 9.6.18 32 bit"
       env:
-        - PG_VERSION=9.6.17
+        - PG_VERSION=9.6.18
         - RETRY_PREFIX=""
       before_install:
         - docker run -d --name pgbuild --env POSTGRES_HOST_AUTH_METHOD=trust -v ${TRAVIS_BUILD_DIR}:/build i386/postgres:${PG_VERSION}-alpine
@@ -271,8 +271,8 @@ jobs:
 
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test
-      name: "Regression 9.6.17"
-      env: PG_VERSION=9.6.17
+      name: "Regression 9.6.18"
+      env: PG_VERSION=9.6.18
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
@@ -281,8 +281,8 @@ jobs:
 
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test
-      name: "Regression 10.12"
-      env: PG_VERSION=10.12
+      name: "Regression 10.13"
+      env: PG_VERSION=10.13
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
@@ -291,13 +291,13 @@ jobs:
 
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test
-      name: "Regression 11.7"
-      env: PG_VERSION=11.7
+      name: "Regression 11.8"
+      env: PG_VERSION=11.8
 
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
       stage: test
-      name: "Regression 12.2"
-      env: PG_VERSION=12.2
+      name: "Regression 12.3"
+      env: PG_VERSION=12.3
 
     #get codecov info, we only run 12.0 on PRs and the rest in cron
     - if: (type = pull_request) OR (type = cron) OR NOT (branch = master)
@@ -314,16 +314,16 @@ jobs:
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "CodeCov 9.6.17"
-      env: PG_VERSION=9.6.17 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
+      name: "CodeCov 9.6.18"
+      env: PG_VERSION=9.6.18 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "CodeCov 11.7"
-      env: PG_VERSION=11.7 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
+      name: "CodeCov 11.8"
+      env: PG_VERSION=11.8 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
@@ -331,8 +331,8 @@ jobs:
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "CodeCov 10.12"
-      env: PG_VERSION=10.12 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
+      name: "CodeCov 10.13"
+      env: PG_VERSION=10.13 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
@@ -455,23 +455,23 @@ jobs:
     # Release mode regression tests
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "Release regression tests 12.2"
-      env: PG_VERSION=12.2 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
+      name: "Release regression tests 12.3"
+      env: PG_VERSION=12.3 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "Release regression tests 11.7"
-      env: PG_VERSION=11.7 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
+      name: "Release regression tests 11.8"
+      env: PG_VERSION=11.8 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "Release regression tests 10.12"
-      env: PG_VERSION=10.12 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
+      name: "Release regression tests 10.13"
+      env: PG_VERSION=10.13 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
 
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
-      name: "Release regression tests 9.6.17"
-      env: PG_VERSION=9.6.17 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
+      name: "Release regression tests 9.6.18"
+      env: PG_VERSION=9.6.18 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE='Release'"
 
     # Memory spike test when running out of order random inserts into timescaledb database
     - if: (type = cron) OR (branch = prerelease_test)


### PR DESCRIPTION
PostgreSQL released 12.3, 11.8, 10.13 and 9.6.18. So tests, which uses
latest PostgreSQL, are updated to these versions.