### PR TITLE
Cleanup code coverage and make it work locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   # Run only telemetry test to see that it works without OpenSSL
   - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug-nossl installcheck TESTS=telemetry PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
   # Now build with OpenSSL
-  - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
+  - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DCODECOVERAGE=ON -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
   # Now run all tests
   - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -k -C /build/debug installcheck IGNORES='${IGNORES}' PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
   # Run the PG regression tests too
@@ -107,7 +107,7 @@ jobs:
         # Run only telemetry test to see that it works without OpenSSL
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug-nossl installcheck TESTS=telemetry PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
         # Now build with OpenSSL
-        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
+        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DCODECOVERAGE=ON -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
         # Now run all tests
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -k -C /build/debug installcheck IGNORES='bgw_db_scheduler chunk_adaptive-9.6' PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 
@@ -125,7 +125,7 @@ jobs:
         # Run only telemetry test to see that it works without OpenSSL
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug-nossl installcheck TESTS=telemetry PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
         # Now build with OpenSSL
-        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
+        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DCODECOVERAGE=ON -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
         # Now run all tests
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -k -C /build/debug installcheck IGNORES='append-10 bgw_db_scheduler chunk_adaptive-10 ordered_append-10 parallel-10 transparent_decompression-10 compression_ddl continuous_aggs_insert continuous_aggs_multi' PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 
@@ -143,7 +143,7 @@ jobs:
         # Run only telemetry test to see that it works without OpenSSL
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug-nossl installcheck TESTS=telemetry PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
         # Now build with OpenSSL
-        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
+        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DCODECOVERAGE=ON -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
         # Now run all tests
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -k -C /build/debug installcheck IGNORES='append-11 bgw_db_scheduler chunk_adaptive-11 ordered_append-11 parallel-11 transparent_decompression-11 compression_ddl continuous_aggs_insert continuous_aggs_multi' PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 
@@ -161,7 +161,7 @@ jobs:
         # Run only telemetry test to see that it works without OpenSSL
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -C /build/debug-nossl installcheck TESTS=telemetry PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
         # Now build with OpenSSL
-        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DENABLE_CODECOVERAGE=TRUE -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
+        - docker exec -it pgbuild /bin/sh -c "cd /build/debug &&  cmake .. -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENSSL=true -DCODECOVERAGE=ON -DPG_SOURCE_DIR=/postgres ${OTHER_CMAKE_FLAGS:-} && make install && chown -R postgres:postgres /build/debug/"
         # Now run all tests
         - ${RETRY_PREFIX} docker exec -u postgres -it pgbuild /bin/sh -c "make -k -C /build/debug installcheck IGNORES='append-12 bgw_db_scheduler chunk_adaptive-12 ordered_append-12 parallel-12 transparent_decompression-12 compression_ddl continuous_aggs_insert continuous_aggs_multi' PG_REGRESS_OPTS='--temp-instance=/tmp/pgdata'"
 
@@ -305,7 +305,7 @@ jobs:
       name: "CodeCov 12.0"
       env:
         - PG_VERSION=12.0
-        - OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'"
+        - OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'"
         - CODECOV_FLAGS="-F pr"
         - IGNORES="compression_ddl continuous_aggs_insert continuous_aggs_multi"
       after_success:
@@ -315,7 +315,7 @@ jobs:
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
       name: "CodeCov 9.6.17"
-      env: PG_VERSION=9.6.17 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
+      env: PG_VERSION=9.6.17 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
@@ -323,7 +323,7 @@ jobs:
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
       name: "CodeCov 11.7"
-      env: PG_VERSION=11.7 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
+      env: PG_VERSION=11.7 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "
@@ -332,7 +332,7 @@ jobs:
     - if: (type = cron) OR (branch = prerelease_test)
       stage: test
       name: "CodeCov 10.12"
-      env: PG_VERSION=10.12 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS='-O0 -coverage -fprofile-arcs -ftest-coverage -DNDEBUG'" CODECOV_FLAGS="-F cron"
+      env: PG_VERSION=10.12 OTHER_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DCODECOVERAGE=ON -DCMAKE_C_FLAGS='-DNDEBUG'" CODECOV_FLAGS="-F cron"
       after_success:
         - ci_env=`bash <(curl -s https://codecov.io/env)`
         - docker exec -it $ci_env pgbuild /bin/bash -c "cd /build/debug && bash <(curl -s https://codecov.io/bash) -c ${CODECOV_FLAGS} || echo \"Codecov did not collect coverage reports\" "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ set(PROJECT_INSTALL_METHOD source CACHE STRING "Specify what install platform th
 is built for")
 message(STATUS "Install method is '${PROJECT_INSTALL_METHOD}'")
 
+# Code coverage is optional and OFF by default
+option(CODECOVERAGE "Enable code coverage for the build" OFF)
+
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   # CMAKE_BUILD_TYPE is set at CMake configuration type. But usage of CMAKE_C_FLAGS_DEBUG is
   # determined at build time by running cmake --build . --config Debug (at least on Windows).
@@ -91,16 +94,11 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
   # -Wconversions
 
   add_compile_options(-Wempty-body -Wvla)
-  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "7")
-    add_compile_options(-Wimplicit-fallthrough)
-  endif()
+  check_c_compiler_flag(-Wimplicit-fallthrough CC_SUPPORTS_IMPLICIT_FALLTHROUGH)
 
-  # Not sure when it was added to Clang, but it is mentioned in the
-  # release notes for Clang 3.3
-  if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "3.3")
+  if (CC_SUPPORTS_IMPLICIT_FALLTHROUGH)
     add_compile_options(-Wimplicit-fallthrough)
-  endif()
-
+  endif ()
 endif()
 
 # Check for supported platforms and compiler flags
@@ -121,30 +119,6 @@ else ()
 endif ()
 
 message(STATUS "Using compiler ${CMAKE_C_COMPILER_ID}")
-
-if (ENABLE_CODECOVERAGE)
-  message(STATUS "Running code coverage")
-
-  if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
-  endif (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-
-  if (NOT DEFINED CODECOV_OUTPUTFILE)
-    set(CODECOV_OUTPUTFILE cmake_coverage.output)
-  endif (NOT DEFINED CODECOV_OUTPUTFILE)
-
-  if (NOT DEFINED CODECOV_HTMLOUTPUTDIR)
-    set(CODECOV_HTMLOUTPUTDIR coverage_results)
-  endif (NOT DEFINED CODECOV_HTMLOUTPUTDIR)
-
-  find_program(CODECOV_GCOV gcov)
-  find_program(CODECOV_LCOV lcov)
-  add_definitions(-fprofile-arcs -ftest-coverage -coverage)
-  link_libraries(gcov)
-  set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} --coverage -fprofile-arcs)
-  add_custom_target(coverage_init ALL ${CODECOV_LCOV} --base-directory . --directory ${CMAKE_BINARY_DIR} --output-file ${CODECOV_OUTPUTFILE} --capture --initial)
-
-endif (ENABLE_CODECOVERAGE)
 
 # Search paths for Postgres binaries
 if(WIN32)
@@ -378,6 +352,16 @@ if (USE_OPENSSL)
   message(STATUS "Using OpenSSL version ${OPENSSL_VERSION}")
 endif (USE_OPENSSL)
 
+if (CODECOVERAGE)
+  message(STATUS "Code coverage is enabled.")
+  # Note that --coverage is synonym for the necessary compiler and
+  # linker flags for the given compiler.  For example, with GCC,
+  # --coverage translates to -fprofile-arcs -ftest-coverage when
+  # compiling and -lgcov when linking
+  add_compile_options(--coverage -O0)
+  add_link_options(--coverage)
+endif (CODECOVERAGE)
+
 if (UNIX)
   add_subdirectory(scripts)
 endif (UNIX)
@@ -394,7 +378,13 @@ endif()
 
 add_custom_target(licensecheck
   COMMAND ${PROJECT_SOURCE_DIR}/scripts/check_license_all.sh
-)
+  )
+
+# This needs to be the last subdirectory so that other targets are
+# already defined
+if (CODECOVERAGE)
+  add_subdirectory(codecov)
+endif ()
 
 if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
   configure_file(${PROJECT_SOURCE_DIR}/scripts/githooks/commit_msg.py ${PROJECT_SOURCE_DIR}/.git/hooks/commit-msg COPYONLY)

--- a/codecov/CMakeLists.txt
+++ b/codecov/CMakeLists.txt
@@ -1,0 +1,115 @@
+# CMake targets for generating code coverage reports
+#
+# Note that the targets in here are not needed to enable code coverage
+# on builds. To have builds generate code coverage metadata, one only
+# has to enable the --coverage option for the compiler and this is
+# done in the top-level CMakeLists.txt so that the option covers all
+# build targets in the project.
+#
+# Given that all dependencies (lcov, genhtml) are installed, and CMake
+# is initialized with -DCODECOVERAGE=ON, it should be
+# possible to generate a code coverage report by running:
+#
+# $ make coverage
+#
+# The report is generated in REPORT_DIR and can be viewed in a web
+# browser.
+
+# Find lcov for html output
+find_program(LCOV lcov)
+
+if (LCOV)
+  # Final tracefile for code coverage
+  set(OUTPUT_FILE "timescaledb-codecov.info")
+
+  # Directory where to generate the HTML report
+  set(REPORT_DIR "codecov-report")
+
+
+  # The baseline run needs to run before tests to learn what zero
+  # coverage looks like
+  add_custom_command(
+    OUTPUT ${OUTPUT_FILE}.base
+    COMMENT "Generating code coverage base file"
+    COMMAND ${LCOV}
+    --capture
+    --initial # Initial run
+    --no-external # Do not include external source files
+    --base-directory ${CMAKE_SOURCE_DIR}
+    --directory ${CMAKE_BINARY_DIR}
+    --output-file ${OUTPUT_FILE}.base
+    DEPENDS timescaledb-tsl timescaledb timescaledb-loader)
+
+  add_custom_target(coverage_base
+    DEPENDS
+    timescaledb-tsl
+    timescaledb
+    timescaledb-loader
+    ${OUTPUT_FILE}.base)
+
+  # Ensure baseline file is generated before tests
+  add_dependencies(installcheck coverage_base)
+
+  # The test run needs to run after tests to analyze the test coverage
+  add_custom_command(
+    OUTPUT ${OUTPUT_FILE}.test
+    COMMENT "Generating code coverage test file"
+    COMMAND ${LCOV}
+    --capture
+    --no-external
+    --base-directory ${CMAKE_SOURCE_DIR}
+    --directory ${CMAKE_BINARY_DIR}
+    --output-file ${OUTPUT_FILE}.test
+    DEPENDS ${OUTPUT_FILE}.base coverage_base)
+
+  # Make sure coverage_test runs after tests (installcheck) finish
+  add_custom_target(coverage_test DEPENDS ${OUTPUT_FILE}.test)
+  add_dependencies(installcheck-post-hook coverage_test)
+
+  # Generate the final coverage file by combining the pre and post
+  # test tracefiles
+  add_custom_command(
+    OUTPUT ${OUTPUT_FILE}
+    COMMENT "Generating final code coverage file"
+    COMMAND ${LCOV}
+    --add-tracefile ${OUTPUT_FILE}.base
+    --add-tracefile ${OUTPUT_FILE}.test
+    --output-file ${OUTPUT_FILE}
+    DEPENDS ${OUTPUT_FILE}.test coverage_test)
+
+  add_custom_target(coverage_final DEPENDS ${OUTPUT_FILE})
+  add_dependencies(coverage_final coverage_test)
+
+  # Look for genhtml to produce HTML report. This tool is part of the
+  # lcov suite, so should be installed if lcov is installed. Thus,
+  # this is an over-cautious check just in case some distributions
+  # break these tools up in separate packages.
+  find_program(GENHTML genhtml)
+
+  if (GENHTML)
+    message(STATUS "Generate a code coverage report using the 'coverage' target after tests have run.")
+
+    add_custom_command(
+      OUTPUT ${REPORT_DIR}/index.html
+      COMMENT "Generating HTML code coverage report in ${CMAKE_CURRENT_BINARY_DIR}/${REPORT_DIR}"
+      COMMAND ${GENHTML}
+      --prefix ${CMAKE_SOURCE_DIR}
+      --ignore-errors source
+      --legend
+      --title "TimescaleDB"
+      --output-directory ${REPORT_DIR}
+      ${OUTPUT_FILE}
+      DEPENDS ${OUTPUT_FILE})
+    add_custom_target(coverage DEPENDS ${REPORT_DIR}/index.html)
+    add_dependencies(coverage coverage_final)
+
+    add_custom_command(
+      TARGET coverage
+      POST_BUILD
+      COMMENT "Open file://${CMAKE_CURRENT_BINARY_DIR}/${REPORT_DIR}/index.html in a browser to view the report")
+  else ()
+    message(STATUS "Install genhtml to generate code coverage reports")
+  endif (GENHTML)
+else ()
+  message(STATUS "Install lcov to generate code coverage reports")
+endif (LCOV)

--- a/codecov/README.md
+++ b/codecov/README.md
@@ -1,0 +1,38 @@
+# Code coverage for TimescaleDB
+
+Code coverage can be enabled for TimescaleDB builds by setting the
+option `-DCODECOVEAGE=ON` when running CMake (it is off by
+default). This enables the necessary compiler option (`--coverage`) to
+generate code coverage statistics and should be enough for CI build
+reports using, e.g., `codecov.io`. In addition, local code coverage
+reports can be generated with the `lcov` tool, when this tool is
+installed on the build system.
+
+
+## Generating local code coverage data files
+
+A code coverage report is generated in three steps using `lcov`:
+
+1. A pre test baseline run to learn what zero coverage looks like (the
+   `coverage_base` target).
+2. A post test run to learn the test coverage (the `coverage_test`
+   target).
+3. A final run to combine the pre test and post test output files into
+   a final data file (the `coverage_final` target).
+
+Each of these steps can be run manually using the mentioned targets,
+but should happen automatically as part of regular build and test
+steps. Optionally, this process can be extended with a filtering step
+to ignore certain paths that shouldn't be included in the final
+report.
+
+## Producing a HTML-based code coverage report
+
+Once the complete test suite has run (`installcheck` target), it is
+possible to produce a HTML-based code coverage report that can be
+viewed in a web browser. This is automated by the `coverage` target.
+Thus, the complete steps to produce a code coverage report are:
+
+1. `cmake --build`
+2. `cmake --build --target installcheck`
+3. `cmake --build --target coverage`

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,8 +94,18 @@ endif()
 
 if(_install_checks)
   add_custom_target(installcheck DEPENDS ${_install_checks})
+
+  # Define a post test hook that is invoked after the installcheck
+  # target finishes. One can use add_dependencies on post hook target
+  # to run other targets after tests complete. This is used, e.g., by
+  # code coverage.
+  add_custom_target(installcheck-post-hook COMMENT "Post test hook")
+  add_custom_command(
+    TARGET installcheck
+    POST_BUILD
+    COMMAND cmake --build ${CMAKE_CURRENT_BINARY_DIR} --target installcheck-post-hook)
 endif()
-  
+
 # installchecklocal tests against an existing postgres instance
 if(_local_install_checks)
   add_custom_target(installchecklocal DEPENDS ${_local_install_checks})


### PR DESCRIPTION
The code coverage options for CMake have been cleaned up and fixed
where they were broken. Build targets for local coverage reports now
work. The option to enable code coverage has been changed to
`-DCODECOVERAGE=ON` and local HTML-based reports can be generated
using the `lcov` program through the following steps:

1. `make install`
2. `make installcheck`
3. `make coverage`

The previous CMake options and targets didn't properly work, and often
included redundant and confusing options.

For instance, the only compiler option needed for code coverage is
`--coverage` as this is an alias for `-fprofile-arcs
-ftest-coverage`. Previously, however, these options were added
multiple times in various places, often all of them, but sometimes
only a subset for no apparent reason. They were also added using the
wrong CMake commands, for instance `add_definitions`, which is
deprecated and reserved for preprocessor definitions and not compiler
options.

The `lcov` program is used to generate local HTML-based code coverage
reports. Although CMake was setup to look for `lcov`, it didn't check
for failure cases in case it wasn't found and further had incomplete
target configurations that really didn't do much. No additional
documentation was provided on how to generate local coverage
reports. All of this has been fixed, including documentation in
`codecov/README.md`.