### PR TITLE
Check for database in extension_current_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## Unreleased
+
+**Bugfixes**
+* #1915 Check for database in extension_current_state
+
+**Thanks**
+* @dmitri191 for reporting an issue with failing background workers
+
 ## 1.7.1 (2020-05-18)
 
 This maintenance release contains bugfixes since the 1.7.0 release. We deem it medium

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -149,7 +149,7 @@ extension_current_state()
 	 * ready (which may result in an infinite loop). More concretely we need
 	 * RelationCacheInitializePhase3 to have been already called.
 	 */
-	if (!IsNormalProcessingMode() || !IsTransactionState())
+	if (!IsNormalProcessingMode() || !IsTransactionState() || !OidIsValid(MyDatabaseId))
 		return EXTENSION_STATE_UNKNOWN;
 
 	/*


### PR DESCRIPTION
The extension_current_state is called in the cache_invalidate_callback
which might be called in a background worker when the database has not
been initialized yet leading to a "cannot read pg_class without having
selected a database" error.
This patch adds a check for this condition to prevent this error.

Fixes #1847 