### PR TITLE
Unify chunk index creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #1915 Check for database in extension_current_state
+* #1918 Unify chunk index creation
 
 **Thanks**
 * @dmitri191 for reporting an issue with failing background workers
+* @nomanor for reporting an issue with expression index with table references
 
 ## 1.7.1 (2020-05-18)
 

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -402,44 +402,6 @@ ts_chunk_index_create_from_adjusted_index_info(int32 hypertable_id, Relation hyp
 					   get_rel_name(RelationGetRelid(hypertable_idxrel)));
 }
 
-/*
- * Create a new chunk index as a child of a parent hypertable index.
- *
- * The chunk index is created based on the statement that also creates the
- * parent index. This function is typically called when a new index is created
- * on the hypertable and we must add a corresponding index to each chunk.
- */
-Oid
-ts_chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid,
-								int32 hypertable_id, Oid hypertable_indexrelid)
-{
-	ObjectAddress idxobj;
-	char *hypertable_indexname = get_rel_name(hypertable_indexrelid);
-
-	if (hypertable_indexname == NULL)
-		return InvalidOid; /* oops, the root index is gone, lets stop */
-
-	if (NULL != stmt->idxname)
-		stmt->idxname = chunk_index_choose_name(get_rel_name(chunkrelid),
-												hypertable_indexname,
-												get_rel_namespace(chunkrelid));
-
-	idxobj = DefineIndexCompat(chunkrelid,
-							   stmt,
-							   InvalidOid,
-							   false, /* is alter table */
-							   true,  /* check rights */
-							   false, /* skip build */
-							   true); /* quiet */
-
-	chunk_index_insert(chunk_id,
-					   get_rel_name(idxobj.objectId),
-					   hypertable_id,
-					   hypertable_indexname);
-
-	return idxobj.objectId;
-}
-
 static inline Oid
 chunk_index_get_schemaid(Form_chunk_index chunk_index, bool missing_ok)
 {

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -38,8 +38,6 @@ extern void ts_chunk_index_create_from_adjusted_index_info(int32 hypertable_id,
 														   IndexInfo *indexinfo);
 extern TSDLLEXPORT void ts_chunk_index_create_all(int32 hypertable_id, Oid hypertable_relid,
 												  int32 chunk_id, Oid chunkrelid);
-extern Oid ts_chunk_index_create_from_stmt(IndexStmt *stmt, int32 chunk_id, Oid chunkrelid,
-										   int32 hypertable_id, Oid hypertable_indexrelid);
 extern int ts_chunk_index_delete(int32 chunk_id, const char *indexname, bool drop_index);
 extern int ts_chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
 extern void ts_chunk_index_delete_by_name(const char *schema, const char *index_name,

--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -81,12 +81,12 @@ INFO:  "_hyper_1_3_chunk": found 0 removable, 1 nonremovable row versions in 1 p
 SELECT indexrelid::regclass, indisclustered
 FROM pg_index
 WHERE indisclustered = true ORDER BY 1;
-                        indexrelid                        | indisclustered 
-----------------------------------------------------------+----------------
- cluster_test_time_location_idx                           | t
- _timescaledb_internal._hyper_1_1_chunk_time_location_idx | t
- _timescaledb_internal._hyper_1_2_chunk_time_location_idx | t
- _timescaledb_internal._hyper_1_3_chunk_time_location_idx | t
+                              indexrelid                               | indisclustered 
+-----------------------------------------------------------------------+----------------
+ cluster_test_time_location_idx                                        | t
+ _timescaledb_internal._hyper_1_1_chunk_cluster_test_time_location_idx | t
+ _timescaledb_internal._hyper_1_2_chunk_cluster_test_time_location_idx | t
+ _timescaledb_internal._hyper_1_3_chunk_cluster_test_time_location_idx | t
 (4 rows)
 
 --check the setting of cluster indexes on hypertables and chunks

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -143,7 +143,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
@@ -156,7 +156,7 @@ SELECT * FROM _timescaledb_catalog.chunk_index ORDER BY index_name, hypertable_i
         3 | _hyper_4_3_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
         3 | _hyper_4_3_chunk_index_test_time_device_idx |             4 | index_test_time_device_idx
         3 | _hyper_4_3_chunk_index_test_time_idx        |             4 | index_test_time_idx
-        3 | _hyper_4_3_chunk_time_temp_idx              |             4 | index_test_time_temp_idx
+        3 | _hyper_4_3_chunk_index_test_time_temp_idx   |             4 | index_test_time_temp_idx
         4 | _hyper_4_4_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
         4 | _hyper_4_4_chunk_index_test_time_device_idx |             4 | index_test_time_device_idx
         4 | _hyper_4_4_chunk_index_test_time_idx        |             4 | index_test_time_idx
@@ -180,7 +180,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx2       | {time}        |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_idx2       | {time}        |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_device_idx | {time,device} |      | t      | f       | f         | 
@@ -193,7 +193,7 @@ SELECT * FROM _timescaledb_catalog.chunk_index ORDER BY index_name, hypertable_i
         3 | _hyper_4_3_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
         3 | _hyper_4_3_chunk_index_test_time_device_idx |             4 | index_test_time_device_idx
         3 | _hyper_4_3_chunk_index_test_time_idx2       |             4 | index_test_time_idx2
-        3 | _hyper_4_3_chunk_time_temp_idx              |             4 | index_test_time_temp_idx
+        3 | _hyper_4_3_chunk_index_test_time_temp_idx   |             4 | index_test_time_temp_idx
         4 | _hyper_4_4_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
         4 | _hyper_4_4_chunk_index_test_time_device_idx |             4 | index_test_time_device_idx
         4 | _hyper_4_4_chunk_index_test_time_idx2       |             4 | index_test_time_idx2
@@ -214,7 +214,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
                  Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
 ----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
 (4 rows)
@@ -223,7 +223,7 @@ SELECT * FROM _timescaledb_catalog.chunk_index ORDER BY index_name, hypertable_i
  chunk_id |                 index_name                  | hypertable_id |   hypertable_index_name    
 ----------+---------------------------------------------+---------------+----------------------------
         3 | _hyper_4_3_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
-        3 | _hyper_4_3_chunk_time_temp_idx              |             4 | index_test_time_temp_idx
+        3 | _hyper_4_3_chunk_index_test_time_temp_idx   |             4 | index_test_time_temp_idx
         4 | _hyper_4_4_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
         4 | _hyper_4_4_chunk_index_test_time_temp_idx   |             4 | index_test_time_temp_idx
 (4 rows)
@@ -244,7 +244,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
                  Table                  |                                         Index                                         |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace 
 ----------------------------------------+---------------------------------------------------------------------------------------+---------------+------+--------+---------+-----------+------------
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx                     | {device,time} |      | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx                                  | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_temp_idx                       | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_a_hypertable_index_with_a_very_very_long_name_ | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_a_hypertable_index_with_a_very_very_long_nam_1 | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx                     | {device,time} |      | f      | f       | f         | 
@@ -282,7 +282,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
                  Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
@@ -305,7 +305,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
                  Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
@@ -327,7 +327,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
                  Table                  |                               Index                               |    Columns    | Expr | Unique | Primary | Exclusion | Tablespace  
 ----------------------------------------+-------------------------------------------------------------------+---------------+------+--------+---------+-----------+-------------
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
- _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | 
+ _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | 
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal._hyper_4_3_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace2
  _timescaledb_internal._hyper_4_3_chunk | _timescaledb_internal."3_1_index_test_time_device_key"            | {time,device} |      | t      | f       | f         | 
  _timescaledb_internal._hyper_4_4_chunk | _timescaledb_internal._hyper_4_4_chunk_index_test_device_time_idx | {device,time} |      | f      | f       | f         | 
@@ -344,7 +344,7 @@ SELECT * FROM _timescaledb_catalog.chunk_index ORDER BY index_name, hypertable_i
         4 | 4_2_index_test_time_device_key              |             4 | index_test_time_device_key
         3 | _hyper_4_3_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
         3 | _hyper_4_3_chunk_index_test_time_idx        |             4 | index_test_time_idx
-        3 | _hyper_4_3_chunk_time_temp_idx              |             4 | index_test_time_temp_idx
+        3 | _hyper_4_3_chunk_index_test_time_temp_idx   |             4 | index_test_time_temp_idx
         4 | _hyper_4_4_chunk_index_test_device_time_idx |             4 | index_test_device_time_idx
         4 | _hyper_4_4_chunk_index_test_time_idx        |             4 | index_test_time_idx
         4 | _hyper_4_4_chunk_index_test_time_temp_idx   |             4 | index_test_time_temp_idx
@@ -422,7 +422,7 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_idx        | {time}        |      | f      | f       | f         | tablespace1
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_device_idx | {time,device} |      | f      | f       | f         | tablespace2
  _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_device_idx      | {device}      |      | f      | f       | f         | tablespace1
- _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_time_temp_idx              | {time,temp}   |      | f      | f       | f         | tablespace2
+ _timescaledb_internal._hyper_5_5_chunk | _timescaledb_internal._hyper_5_5_chunk_index_test_time_temp_idx   | {time,temp}   |      | f      | f       | f         | tablespace2
 (4 rows)
 
 -- Cleanup
@@ -508,3 +508,21 @@ ALTER TABLE idx_predicate_test ADD COLUMN b1 bool;
 CREATE INDEX idx_predicate_test_b1 ON idx_predicate_test(b1) WHERE b1=true;
 INSERT INTO idx_predicate_test VALUES ('2000-01-01',true);
 DROP TABLE idx_predicate_test;
+-- test index with table references
+CREATE TABLE idx_tableref_test(time timestamptz);
+SELECT table_name FROM create_hypertable('idx_tableref_test', 'time');
+NOTICE:  adding not-null constraint to column "time"
+    table_name     
+-------------------
+ idx_tableref_test
+(1 row)
+
+-- we use security definer to prevent function inlining
+CREATE OR REPLACE FUNCTION tableref_func(t idx_tableref_test) RETURNS timestamptz LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $f$ SELECT t.time; $f$;
+-- try creating index with no existing chunks
+CREATE INDEX tableref_idx ON idx_tableref_test(tableref_func(idx_tableref_test));
+-- insert data to trigger chunk creation
+INSERT INTO idx_tableref_test SELECT '2000-01-01';
+DROP INDEX tableref_idx;
+-- try creating index on hypertable with existing chunks
+CREATE INDEX tableref_idx ON idx_tableref_test(tableref_func(idx_tableref_test));

--- a/tsl/test/expected/plan_gapfill-10.out
+++ b/tsl/test/expected/plan_gapfill-10.out
@@ -313,9 +313,9 @@ ORDER BY 2,1;
  Result
    ->  Merge Append
          Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
-         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
-         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
-         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+         ->  Index Only Scan using _hyper_1_1_chunk_gapfill_plan_test_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_gapfill_plan_test_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_gapfill_plan_test_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_gapfill_plan_test_value_time_idx on _hyper_1_4_chunk
 (7 rows)
 

--- a/tsl/test/expected/plan_gapfill-11.out
+++ b/tsl/test/expected/plan_gapfill-11.out
@@ -313,9 +313,9 @@ ORDER BY 2,1;
  Result
    ->  Merge Append
          Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
-         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
-         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
-         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+         ->  Index Only Scan using _hyper_1_1_chunk_gapfill_plan_test_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_gapfill_plan_test_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_gapfill_plan_test_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_gapfill_plan_test_value_time_idx on _hyper_1_4_chunk
 (7 rows)
 

--- a/tsl/test/expected/plan_gapfill-12.out
+++ b/tsl/test/expected/plan_gapfill-12.out
@@ -313,9 +313,9 @@ ORDER BY 2,1;
  Result
    ->  Merge Append
          Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
-         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
-         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
-         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+         ->  Index Only Scan using _hyper_1_1_chunk_gapfill_plan_test_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_gapfill_plan_test_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_gapfill_plan_test_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_gapfill_plan_test_value_time_idx on _hyper_1_4_chunk
 (7 rows)
 

--- a/tsl/test/expected/plan_gapfill-9.6.out
+++ b/tsl/test/expected/plan_gapfill-9.6.out
@@ -291,9 +291,9 @@ ORDER BY 2,1;
  Result
    ->  Merge Append
          Sort Key: _hyper_1_1_chunk.value, (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", NULL::timestamp with time zone, NULL::timestamp with time zone))
-         ->  Index Only Scan using _hyper_1_1_chunk_value_time_idx on _hyper_1_1_chunk
-         ->  Index Only Scan using _hyper_1_2_chunk_value_time_idx on _hyper_1_2_chunk
-         ->  Index Only Scan using _hyper_1_3_chunk_value_time_idx on _hyper_1_3_chunk
-         ->  Index Only Scan using _hyper_1_4_chunk_value_time_idx on _hyper_1_4_chunk
+         ->  Index Only Scan using _hyper_1_1_chunk_gapfill_plan_test_value_time_idx on _hyper_1_1_chunk
+         ->  Index Only Scan using _hyper_1_2_chunk_gapfill_plan_test_value_time_idx on _hyper_1_2_chunk
+         ->  Index Only Scan using _hyper_1_3_chunk_gapfill_plan_test_value_time_idx on _hyper_1_3_chunk
+         ->  Index Only Scan using _hyper_1_4_chunk_gapfill_plan_test_value_time_idx on _hyper_1_4_chunk
 (7 rows)
 

--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -1531,7 +1531,7 @@ DROP INDEX tmp_idx CASCADE;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1540,18 +1540,18 @@ DROP INDEX tmp_idx CASCADE;
                Rows Removed by Filter: 10080
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (19 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
          Output: _hyper_1_1_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1560,7 +1560,7 @@ DROP INDEX tmp_idx CASCADE;
          Rows Removed by Filter: 10080
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (15 rows)
@@ -1569,8 +1569,8 @@ DROP INDEX tmp_idx CASCADE;
 SET enable_seqscan TO true;
 SET enable_hashjoin TO false;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
@@ -1581,7 +1581,7 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = (1))
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1590,15 +1590,15 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 10080
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = (1))
 (22 rows)
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -1612,7 +1612,7 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=2)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=2)
                Output: _hyper_1_1_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=2)
@@ -1621,7 +1621,7 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 10080
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
 (25 rows)
@@ -2024,8 +2024,8 @@ DROP VIEW compressed_view;
 (28 rows)
 
 :PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -2055,11 +2055,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2069,7 +2069,7 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (45 rows)
 
@@ -2346,8 +2346,8 @@ set max_parallel_workers_per_gather = 0;
 set enable_hashjoin = false;
 set enable_mergejoin = false;
 :PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=27360 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
@@ -2356,14 +2356,14 @@ set enable_mergejoin = false;
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
    ->  Append (actual rows=0 loops=27360)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
@@ -2455,8 +2455,8 @@ set enable_mergejoin = true;
   'text' AS "text",
   :TEST_TABLE AS "RECORD"
 FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10944 loops=1)
    Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
    Sort Method: quicksort 
@@ -2471,7 +2471,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Rows Removed by Filter: 4
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
@@ -2505,8 +2505,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -2520,11 +2520,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 2
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2534,7 +2534,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 9
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
 (29 rows)
 
@@ -2728,8 +2728,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (28 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Sort (actual rows=0 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -2747,11 +2747,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 2
-               ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
-               ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2761,14 +2761,14 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 9
-               ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
 (33 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -2783,7 +2783,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Rows Removed by Filter: 4
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
@@ -3198,8 +3198,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Sort (actual rows=0 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -3220,11 +3220,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 2
-               ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
-               ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
@@ -3236,7 +3236,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 9
-               ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
 (38 rows)
 
@@ -3688,10 +3688,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
@@ -3714,10 +3714,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
@@ -3730,11 +3730,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
    ->  Merge Append (actual rows=100 loops=1)
          Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3758,11 +3758,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk."time"
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 100
@@ -3777,11 +3777,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
    ->  Merge Append (actual rows=100 loops=1)
          Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
-         ->  Index Only Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3805,11 +3805,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Only Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3822,11 +3822,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 2016
@@ -3850,11 +3850,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
@@ -3867,11 +3867,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 2016
@@ -3895,11 +3895,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
@@ -3949,10 +3949,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id DESC, _hyper_2_8_chunk.device_id_peer DESC, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
@@ -3975,10 +3975,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
@@ -4434,8 +4434,8 @@ SET enable_seqscan TO false;
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=5472 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_10_chunk.device_id
@@ -4449,15 +4449,15 @@ SET enable_seqscan TO false;
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
                Heap Fetches: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
          Heap Fetches: 2016
 (17 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    Output: count(*)
    ->  Append (actual rows=5472 loops=1)
@@ -4471,7 +4471,7 @@ SET enable_seqscan TO false;
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
                      Heap Fetches: 2
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
                Heap Fetches: 2016
 (16 rows)
@@ -4534,85 +4534,85 @@ DROP INDEX tmp_idx CASCADE;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
 (42 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
          Heap Fetches: 0
@@ -4622,8 +4622,8 @@ DROP INDEX tmp_idx CASCADE;
 SET enable_seqscan TO true;
 SET enable_hashjoin TO false;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
@@ -4634,17 +4634,17 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = (1))
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = (1))
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = (1))
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4661,12 +4661,12 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = (1))
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = (1))
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4677,8 +4677,8 @@ SET enable_hashjoin TO false;
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -4692,17 +4692,17 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=2)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=2)
                Output: _hyper_2_4_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=2)
                Output: _hyper_2_5_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
                Output: _hyper_2_6_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=2)
@@ -4719,12 +4719,12 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=2)
                Output: _hyper_2_10_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=2)
                Output: _hyper_2_11_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
@@ -4735,8 +4735,8 @@ SET enable_hashjoin TO false;
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=5472 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
@@ -4763,7 +4763,7 @@ RESET enable_hashjoin;
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Filter: ((1) = _hyper_2_7_chunk.device_id)
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Index Cond: (_hyper_2_8_chunk.device_id = (1))
                Heap Fetches: 0
@@ -4832,8 +4832,8 @@ RESET enable_hashjoin;
 
 SET seq_page_cost=100;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=10944 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -4860,15 +4860,15 @@ SET seq_page_cost=100;
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 0
@@ -4882,7 +4882,7 @@ SET seq_page_cost=100;
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=2 loops=2)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 0
@@ -4932,18 +4932,18 @@ set enable_seqscan TO false;
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Filter: ((1) = _hyper_2_7_chunk.device_id)
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=2016 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Recheck Cond: (_hyper_2_8_chunk.device_id = (1))
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=1)
                      Index Cond: (_hyper_2_8_chunk.device_id = (1))
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Filter: ((1) = _hyper_2_9_chunk.device_id)
                Rows Removed by Filter: 2016
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=2016 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Filter: ((1) = _hyper_2_10_chunk.device_id)
@@ -4966,7 +4966,7 @@ set enable_seqscan TO false;
                Filter: ((1) = _hyper_2_12_chunk.device_id)
                Rows Removed by Filter: 2016
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=2016 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=2016 loops=1)
 (72 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
@@ -5013,18 +5013,18 @@ set enable_seqscan TO false;
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Recheck Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=1008 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
                      Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Recheck Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
                Heap Blocks: exact=51
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=1008 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
                      Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Recheck Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=2)
                      Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
@@ -5047,7 +5047,7 @@ set enable_seqscan TO false;
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Recheck Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=0 loops=2)
                      Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
 (77 rows)
 
@@ -5302,8 +5302,8 @@ DROP VIEW compressed_view;
 (38 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -5342,11 +5342,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
@@ -5356,13 +5356,13 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (54 rows)
 
 :PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -5392,11 +5392,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -5406,7 +5406,7 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (45 rows)
 
@@ -5738,8 +5738,8 @@ set max_parallel_workers_per_gather = 0;
 set enable_hashjoin = false;
 set enable_mergejoin = false;
 :PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=27360 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
@@ -5748,14 +5748,14 @@ set enable_mergejoin = false;
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
    ->  Append (actual rows=0 loops=27360)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
@@ -7539,13 +7539,13 @@ EXPLAIN (costs off) SELECT * FROM metrics WHERE time > '2000-01-08' ORDER BY dev
 (10 rows)
 
 EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER BY device_id;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Merge Append
    Sort Key: _hyper_2_8_chunk.device_id
-   ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk
+   ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk
+   ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -7555,9 +7555,9 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk
+   ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (18 rows)
 

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -1551,7 +1551,7 @@ DROP INDEX tmp_idx CASCADE;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1560,18 +1560,18 @@ DROP INDEX tmp_idx CASCADE;
                Rows Removed by Filter: 10080
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (19 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
          Output: _hyper_1_1_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1580,7 +1580,7 @@ DROP INDEX tmp_idx CASCADE;
          Rows Removed by Filter: 10080
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (15 rows)
@@ -1589,8 +1589,8 @@ DROP INDEX tmp_idx CASCADE;
 SET enable_seqscan TO true;
 SET enable_hashjoin TO false;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
@@ -1601,7 +1601,7 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = (1))
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1610,15 +1610,15 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 10080
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = (1))
 (22 rows)
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -1632,7 +1632,7 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=2)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=2)
                Output: _hyper_1_1_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=2)
@@ -1641,7 +1641,7 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 10080
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
 (25 rows)
@@ -2099,8 +2099,8 @@ DROP VIEW compressed_view;
 (35 rows)
 
 :PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -2137,11 +2137,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2151,7 +2151,7 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
@@ -2456,8 +2456,8 @@ set max_parallel_workers_per_gather = 0;
 set enable_hashjoin = false;
 set enable_mergejoin = false;
 :PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=27360 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
@@ -2466,14 +2466,14 @@ set enable_mergejoin = false;
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
    ->  Append (actual rows=0 loops=27360)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
@@ -2565,8 +2565,8 @@ set enable_mergejoin = true;
   'text' AS "text",
   :TEST_TABLE AS "RECORD"
 FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10944 loops=1)
    Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
    Sort Method: quicksort 
@@ -2581,7 +2581,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Rows Removed by Filter: 4
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
@@ -2615,8 +2615,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -2630,11 +2630,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 2
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2644,7 +2644,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 9
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
 (29 rows)
 
@@ -2838,8 +2838,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (28 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Sort (actual rows=0 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -2857,11 +2857,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 2
-               ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
-               ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2871,14 +2871,14 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 9
-               ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
 (33 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -2893,7 +2893,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Rows Removed by Filter: 4
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
@@ -3308,8 +3308,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Sort (actual rows=0 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -3330,11 +3330,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 2
-               ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
-               ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
@@ -3346,7 +3346,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 9
-               ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
 (38 rows)
 
@@ -3798,10 +3798,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
@@ -3824,10 +3824,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
@@ -3840,11 +3840,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
    ->  Merge Append (actual rows=100 loops=1)
          Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3868,11 +3868,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk."time"
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 100
@@ -3887,11 +3887,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
    ->  Merge Append (actual rows=100 loops=1)
          Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
-         ->  Index Only Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3915,11 +3915,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Only Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3932,11 +3932,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 2016
@@ -3960,11 +3960,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
@@ -3977,11 +3977,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 2016
@@ -4005,11 +4005,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
@@ -4059,10 +4059,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id DESC, _hyper_2_8_chunk.device_id_peer DESC, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
@@ -4085,10 +4085,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
@@ -4544,8 +4544,8 @@ SET enable_seqscan TO false;
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=5472 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_10_chunk.device_id
@@ -4559,15 +4559,15 @@ SET enable_seqscan TO false;
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
                Heap Fetches: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
          Heap Fetches: 2016
 (17 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    Output: count(*)
    ->  Append (actual rows=5472 loops=1)
@@ -4581,7 +4581,7 @@ SET enable_seqscan TO false;
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
                      Heap Fetches: 2
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
                Heap Fetches: 2016
 (16 rows)
@@ -4644,85 +4644,85 @@ DROP INDEX tmp_idx CASCADE;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
 (42 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
          Heap Fetches: 0
@@ -4732,8 +4732,8 @@ DROP INDEX tmp_idx CASCADE;
 SET enable_seqscan TO true;
 SET enable_hashjoin TO false;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
@@ -4744,17 +4744,17 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = (1))
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = (1))
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = (1))
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
@@ -4771,12 +4771,12 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = (1))
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = (1))
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
@@ -4787,8 +4787,8 @@ SET enable_hashjoin TO false;
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -4802,17 +4802,17 @@ SET enable_hashjoin TO false;
    ->  Append (actual rows=0 loops=2)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=2)
                Output: _hyper_2_4_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=2)
                Output: _hyper_2_5_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
                Output: _hyper_2_6_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=2)
@@ -4829,12 +4829,12 @@ SET enable_hashjoin TO false;
                Rows Removed by Filter: 2016
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=2)
                Output: _hyper_2_10_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=2)
                Output: _hyper_2_11_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
@@ -4845,8 +4845,8 @@ SET enable_hashjoin TO false;
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=5472 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
@@ -4873,7 +4873,7 @@ RESET enable_hashjoin;
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Filter: ((1) = _hyper_2_7_chunk.device_id)
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Index Cond: (_hyper_2_8_chunk.device_id = (1))
                Heap Fetches: 0
@@ -4942,8 +4942,8 @@ RESET enable_hashjoin;
 
 SET seq_page_cost=100;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=10944 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -4970,15 +4970,15 @@ SET seq_page_cost=100;
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 0
@@ -4992,7 +4992,7 @@ SET seq_page_cost=100;
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=2 loops=2)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 0
@@ -5042,18 +5042,18 @@ set enable_seqscan TO false;
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Filter: ((1) = _hyper_2_7_chunk.device_id)
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=2016 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Recheck Cond: (_hyper_2_8_chunk.device_id = (1))
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=1)
                      Index Cond: (_hyper_2_8_chunk.device_id = (1))
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Filter: ((1) = _hyper_2_9_chunk.device_id)
                Rows Removed by Filter: 2016
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=2016 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Filter: ((1) = _hyper_2_10_chunk.device_id)
@@ -5076,7 +5076,7 @@ set enable_seqscan TO false;
                Filter: ((1) = _hyper_2_12_chunk.device_id)
                Rows Removed by Filter: 2016
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=2016 loops=1)
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=2016 loops=1)
 (72 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
@@ -5123,18 +5123,18 @@ set enable_seqscan TO false;
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Recheck Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=1008 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
                      Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Recheck Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
                Heap Blocks: exact=51
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=1008 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
                      Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Recheck Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=2)
                      Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
@@ -5157,7 +5157,7 @@ set enable_seqscan TO false;
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Recheck Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=0 loops=2)
                      Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
 (77 rows)
 
@@ -5412,8 +5412,8 @@ DROP VIEW compressed_view;
 (38 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -5452,11 +5452,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
@@ -5466,13 +5466,13 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (54 rows)
 
 :PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -5509,11 +5509,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -5523,7 +5523,7 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
@@ -5855,8 +5855,8 @@ set max_parallel_workers_per_gather = 0;
 set enable_hashjoin = false;
 set enable_mergejoin = false;
 :PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=27360 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
@@ -5865,14 +5865,14 @@ set enable_mergejoin = false;
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
    ->  Append (actual rows=0 loops=27360)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
@@ -7658,13 +7658,13 @@ EXPLAIN (costs off) SELECT * FROM metrics WHERE time > '2000-01-08' ORDER BY dev
 (10 rows)
 
 EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER BY device_id;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Merge Append
    Sort Key: _hyper_2_8_chunk.device_id
-   ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk
+   ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk
+   ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -7674,9 +7674,9 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk
+   ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (18 rows)
 

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -1537,7 +1537,7 @@ DROP INDEX tmp_idx CASCADE;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1546,18 +1546,18 @@ DROP INDEX tmp_idx CASCADE;
                Rows Removed by Filter: 10080
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (19 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
          Output: _hyper_1_1_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
    ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
@@ -1566,7 +1566,7 @@ DROP INDEX tmp_idx CASCADE;
          Rows Removed by Filter: 10080
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (15 rows)
@@ -1598,8 +1598,8 @@ SET enable_hashjoin TO false;
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -1614,7 +1614,7 @@ SET enable_hashjoin TO false;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=2)
                Output: _hyper_1_1_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_1_1_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_5_15_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=2)
@@ -1624,7 +1624,7 @@ SET enable_hashjoin TO false;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_5_16_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
 (27 rows)
@@ -2070,8 +2070,8 @@ DROP VIEW compressed_view;
 (35 rows)
 
 :PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -2108,11 +2108,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2122,7 +2122,7 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
@@ -2426,8 +2426,8 @@ set max_parallel_workers_per_gather = 0;
 set enable_hashjoin = false;
 set enable_mergejoin = false;
 :PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=27360 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
@@ -2436,14 +2436,14 @@ set enable_mergejoin = false;
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
    ->  Append (actual rows=0 loops=27360)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
@@ -2535,8 +2535,8 @@ set enable_mergejoin = true;
   'text' AS "text",
   :TEST_TABLE AS "RECORD"
 FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10944 loops=1)
    Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
    Sort Method: quicksort 
@@ -2551,7 +2551,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Rows Removed by Filter: 4
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
@@ -2585,8 +2585,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test empty resultset
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
@@ -2600,11 +2600,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 2
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2614,7 +2614,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
                Rows Removed by Filter: 9
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
 (29 rows)
 
@@ -2808,8 +2808,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (28 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Sort (actual rows=0 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -2827,11 +2827,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 2
-               ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
-               ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -2841,14 +2841,14 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
                            Rows Removed by Filter: 9
-               ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
 (33 rows)
 
 -- test IN (Const,Const)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -2863,7 +2863,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Rows Removed by Filter: 4
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
@@ -3278,8 +3278,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Sort (actual rows=0 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
@@ -3300,11 +3300,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 2
-               ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
-               ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
-               ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
@@ -3316,7 +3316,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
                            Rows Removed by Filter: 9
-               ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
 (38 rows)
 
@@ -3769,10 +3769,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
@@ -3795,10 +3795,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
@@ -3811,11 +3811,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
    ->  Merge Append (actual rows=100 loops=1)
          Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk."time"
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3839,11 +3839,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk."time"
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=100 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 100
@@ -3858,11 +3858,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
    ->  Merge Append (actual rows=100 loops=1)
          Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
-         ->  Index Only Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1 loops=1)
                Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer
                Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=1 loops=1)
                Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer
                Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3886,11 +3886,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Only Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
                Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer
                Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
-         ->  Index Only Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1 loops=1)
+         ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1 loops=1)
                Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer
                Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
                Heap Fetches: 1
@@ -3903,11 +3903,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 2016
@@ -3931,11 +3931,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
@@ -3948,11 +3948,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 2016
@@ -3976,11 +3976,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          Heap Fetches: 1343
@@ -4031,10 +4031,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Merge Append (actual rows=16795 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id DESC, _hyper_2_8_chunk.device_id_peer DESC, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
@@ -4057,10 +4057,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
@@ -4508,8 +4508,8 @@ SET enable_seqscan TO false;
 
 -- even when we select only a segmentby column, we still need count
 :PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=5472 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_10_chunk.device_id
@@ -4523,15 +4523,15 @@ SET enable_seqscan TO false;
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
                Heap Fetches: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
          Heap Fetches: 2016
 (17 rows)
 
 :PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    Output: count(*)
    ->  Append (actual rows=5472 loops=1)
@@ -4545,7 +4545,7 @@ SET enable_seqscan TO false;
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
                      Heap Fetches: 2
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
                Heap Fetches: 2016
 (16 rows)
@@ -4608,85 +4608,85 @@ DROP INDEX tmp_idx CASCADE;
    ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
 (42 rows)
 
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          Heap Fetches: 0
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
-         ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+         ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
          Heap Fetches: 0
@@ -4696,8 +4696,8 @@ DROP INDEX tmp_idx CASCADE;
 SET enable_seqscan TO true;
 SET enable_hashjoin TO false;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
-                                                                        QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
@@ -4717,15 +4717,15 @@ SET enable_hashjoin TO false;
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
                Rows Removed by Filter: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
          Output: _hyper_2_8_chunk.device_id_peer
          Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
          Heap Fetches: 0
-   ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
          Output: _hyper_2_9_chunk.device_id_peer
          Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          Heap Fetches: 0
@@ -4741,7 +4741,7 @@ SET enable_hashjoin TO false;
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                Filter: (compress_hyper_6_21_chunk.device_id_peer = 1)
                Rows Removed by Filter: 9
-   ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
          Heap Fetches: 0
@@ -4749,8 +4749,8 @@ SET enable_hashjoin TO false;
 
 --with multiple values can get a nested loop.
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -4765,19 +4765,19 @@ SET enable_hashjoin TO false;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=2)
                Output: _hyper_2_4_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_2_4_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_17_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=2)
                Output: _hyper_2_5_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_2_5_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_18_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
                Output: _hyper_2_6_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_2_6_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_19_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=2)
@@ -4795,13 +4795,13 @@ SET enable_hashjoin TO false;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=2)
                Output: _hyper_2_10_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_2_10_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_20_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=2)
                Output: _hyper_2_11_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_2_11_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_21_chunk_device_id_peer_idx on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = "*VALUES*".column1)
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
@@ -4875,8 +4875,8 @@ RESET enable_hashjoin;
 
 SET seq_page_cost=100;
 :PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=10944 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
@@ -4906,15 +4906,15 @@ SET seq_page_cost=100;
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 0
@@ -4930,7 +4930,7 @@ SET seq_page_cost=100;
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=2 loops=2)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
                Heap Fetches: 0
@@ -4964,7 +4964,7 @@ set enable_seqscan TO false;
          Output: _hyper_2_7_chunk.device_id_peer
          Recheck Cond: (_hyper_2_7_chunk.device_id = 1)
          Heap Blocks: exact=17
-         ->  Bitmap Index Scan on _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=2016 loops=1)
+         ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
 (23 rows)
 
@@ -5012,18 +5012,18 @@ set enable_seqscan TO false;
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Recheck Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=1008 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
                      Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Recheck Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
                Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=1008 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
                      Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Recheck Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=2)
                      Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1008 loops=2)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
@@ -5046,7 +5046,7 @@ set enable_seqscan TO false;
          ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Recheck Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 (actual rows=0 loops=2)
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=0 loops=2)
                      Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
 (77 rows)
 
@@ -5301,8 +5301,8 @@ DROP VIEW compressed_view;
 (38 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -5341,11 +5341,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
@@ -5355,13 +5355,13 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (54 rows)
 
 :PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
@@ -5398,11 +5398,11 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 2
-                           ->  Index Scan using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
@@ -5412,7 +5412,7 @@ DROP VIEW compressed_view;
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                                        Filter: (device_id = 2)
                                        Rows Removed by Filter: 6
-                           ->  Index Scan using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
+                           ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
@@ -5744,8 +5744,8 @@ set max_parallel_workers_per_gather = 0;
 set enable_hashjoin = false;
 set enable_mergejoin = false;
 :PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    ->  Append (actual rows=27360 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
@@ -5754,14 +5754,14 @@ set enable_mergejoin = false;
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
    ->  Append (actual rows=0 loops=27360)
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
@@ -7547,13 +7547,13 @@ EXPLAIN (costs off) SELECT * FROM metrics WHERE time > '2000-01-08' ORDER BY dev
 (10 rows)
 
 EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER BY device_id;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Merge Append
    Sort Key: _hyper_2_8_chunk.device_id
-   ->  Index Scan Backward using _hyper_2_8_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_8_chunk
+   ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_12_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_12_chunk
+   ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -7563,9 +7563,9 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
          Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk
                Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_9_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_9_chunk
+   ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan Backward using _hyper_2_7_chunk_device_id_device_id_peer_v0_v1_time_idx2 on _hyper_2_7_chunk
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk
          Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (18 rows)
 


### PR DESCRIPTION
This patch changes chunk index creation to use the same functions
for creating index in one transaction and using multiple transactions.
The single transaction index creation used to adjust the original
stmt and adjusted it for the chunk which lead to problems with table
references not being adjusted properly for the chunk.

Fixes #1866 