### PR TITLE
Change compression locking order

### DIFF
--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -564,6 +564,10 @@ create_compression_table(Oid owner, CompressColInfo *compress_cols)
 	return compress_hypertable_id;
 }
 
+/*
+ * Constraints and triggers are not created on the PG chunk table.
+ * Caller is expected to do this explicitly.
+ */
 Chunk *
 create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 {
@@ -622,15 +626,6 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 
 	if (!OidIsValid(compress_chunk->table_id))
 		elog(ERROR, "could not create compressed chunk table");
-
-	/* Create the chunk's constraints*/
-	ts_chunk_constraints_create(compress_chunk->constraints,
-								compress_chunk->table_id,
-								compress_chunk->fd.id,
-								compress_chunk->hypertable_relid,
-								compress_chunk->fd.hypertable_id);
-
-	ts_trigger_create_all_on_chunk(compress_chunk);
 
 	ts_chunk_index_create_all(compress_chunk->fd.hypertable_id,
 							  compress_chunk->hypertable_relid,


### PR DESCRIPTION
This patch changes the order in which locks are taken during
compression to avoid taking strong locks for long periods on referenced
tables.

Previously, constraints from the uncompressed chunk were copied to the
compressed chunk before compressing the data. When the uncompressed
chunk had foreign key constraints, this resulted in a
ShareRowExclusiveLock being held on the referenced table for the
remainder of the transaction, which includes the (potentially long)
period while the data is compressed, and prevented any
INSERTs/UPDATEs/DELETEs on the referenced table during the remainder of
the time it took the compression transaction to complete.

Copying constraints after completing the actual data compression does
not pose safety issues (as any updates to referenced keys are caught by
the FK constraint on the uncompressed chunk), and it enables the
compression job to minimize the time during which strong locks are held
on referenced tables.

Fixes #1614.
