### PR TITLE
Fix gapfill locf treat_null_as_missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #1915 Check for database in extension_current_state
 * #1918 Unify chunk index creation
+* #1938 Fix gapfill locf treat_null_as_missing
 
 **Thanks**
 * @dmitri191 for reporting an issue with failing background workers
 * @nomanor for reporting an issue with expression index with table references
+* @nicolai6120 for reporting an issue with locf and treat_null_as_missing
 
 ## 1.7.1 (2020-05-18)
 

--- a/tsl/src/nodes/gapfill/exec.c
+++ b/tsl/src/nodes/gapfill/exec.c
@@ -907,7 +907,8 @@ gapfill_state_return_subplan_slot(GapFillState *state)
 										   state->subslot_time,
 										   &state->subslot->tts_values[i],
 										   &state->subslot->tts_isnull[i]);
-					modified = !state->subslot->tts_isnull[i];
+					if (!state->subslot->tts_isnull[i])
+						modified = true;
 				}
 				else
 					gapfill_locf_tuple_returned(column.locf, value, isnull);
@@ -926,7 +927,7 @@ gapfill_state_return_subplan_slot(GapFillState *state)
 
 	/*
 	 * If we modified any values we need to make postgres treat this as virtual tuple
-	 * by removing references to the original tuple.
+	 * and remove references to the original tuple.
 	 */
 	if (modified)
 	{
@@ -944,6 +945,8 @@ gapfill_state_return_subplan_slot(GapFillState *state)
 			state->subslot->tts_shouldFreeMin = false;
 		}
 		state->subslot->tts_mintuple = NULL;
+
+		state->subslot->tts_nvalid = state->ncolumns;
 #endif
 	}
 


### PR DESCRIPTION
When using time_bucket_gapfill with the treat_null_as_missing
option we did not properly set the number of valid values when
generating our own virtual tuples leading to "cannot extract
attribute from empty tuple slot" when the number of values got
reset. This patch changes the gapfill code to always set
the number of valid values when generating virtual tuples.

Fixes #1937 