### PR TITLE
Improve linter support with clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ set(PROJECT_INSTALL_METHOD source CACHE STRING "Specify what install platform th
 is built for")
 message(STATUS "Install method is '${PROJECT_INSTALL_METHOD}'")
 
+# Build compilation database by default
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Code coverage is optional and OFF by default
 option(CODECOVERAGE "Enable code coverage for the build" OFF)
 
@@ -251,6 +254,12 @@ install(
 # in standard installation paths.
 find_program(CLANG_FORMAT
   NAMES clang-format-8 clang-format-7 clang-format
+  PATHS
+  /usr/bin
+  /usr/local/bin
+  /usr/local/opt/
+  /usr/local/opt/llvm/bin
+  /opt/bin
   DOC "The path to clang-format")
 
 if (CLANG_FORMAT)
@@ -287,20 +296,27 @@ else()
   )
 endif ()
 
-find_program(RUN_CLANG_TIDY run-clang-tidy DOC "The path to run-clang-tidy")
+# Linter support via clang-tidy. Enabled by default.
+option(LINTER "Enable linter support using clang-tidy (default ON)" ON)
 
-if(RUN_CLANG_TIDY)
-  message(STATUS "Found clang-tidy at ${RUN_CLANG_TIDY}")
-  if(CMAKE_EXPORT_COMPILE_COMMANDS)
-    add_custom_target(clang-tidy COMMAND ${RUN_CLANG_TIDY} -quiet)
-  else()
-    message(WARNING "You need to add -DCMAKE_EXPORT_COMPILE_COMMANDS=ON to use clang-tidy")
-    add_custom_target(clang-tidy
-      COMMAND ${CMAKE_COMMAND} -E echo "clang-tidy found but -DCMAKE_EXPORT_COMPILE_COMMAND was not set")
-  endif()
-else()
-  message(WARNING "Did not find clang-tidy, not defining clang-tidy target.")
-endif()
+if (LINTER)
+  find_program(CLANG_TIDY
+    clang-tidy
+    PATHS
+    /usr/bin
+    /usr/local/bin
+    /usr/local/opt/
+    /usr/local/opt/llvm/bin
+    /opt/bin
+    DOC "The path to the clang-tidy linter")
+
+  if (CLANG_TIDY)
+    message(STATUS "Linter support (clang-tidy) enabled")
+    set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")
+  else ()
+    message(STATUS "Install clang-tidy to enable code linting")
+  endif (CLANG_TIDY)
+endif (LINTER)
 
 option(USE_OPENSSL "Enable use of OpenSSL if available" ON)
 option(SEND_TELEMETRY_DEFAULT "The default value for whether to send telemetry" ON)

--- a/src/copy.c
+++ b/src/copy.c
@@ -144,7 +144,7 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 	BulkInsertState bistate;
 	uint64 processed = 0;
 #if PG12_GE
-	ExprState *qualexpr;
+	ExprState *qualexpr = NULL;
 #endif
 
 	Assert(range_table);
@@ -338,7 +338,7 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 			myslot = execute_attr_map_slot(cis->hyper_to_chunk_map->attrMap, myslot, cis->slot);
 
 #if PG12_GE
-		if (ccstate->where_clause)
+		if (qualexpr != NULL)
 		{
 			econtext->ecxt_scantuple = myslot;
 			if (!ExecQual(qualexpr, econtext))

--- a/tsl/src/compression/.clang-tidy
+++ b/tsl/src/compression/.clang-tidy
@@ -1,0 +1,8 @@
+# Disable warnings as errors on compression code since it currently
+# doesn't pass those tests
+---
+Checks:          '-*,clang-analyzer-core.*,clang-diagnostic-*'
+WarningsAsErrors: 'clang-analyzer-unix.*'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+...

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -569,6 +569,7 @@ simple8brle_decompression_iterator_max_elements(Simple8bRleDecompressionIterator
 	BitArrayIterator selectors;
 	uint32 max_stored = 0;
 	uint32 i;
+
 	Assert(compressed->num_blocks > 0);
 
 	bit_array_iterator_init(&selectors, iter->selectors.array);
@@ -578,7 +579,7 @@ simple8brle_decompression_iterator_max_elements(Simple8bRleDecompressionIterator
 		if (selector == 0)
 			elog(ERROR, "invalid selector 0");
 
-		if (simple8brle_selector_is_rle(selector))
+		if (simple8brle_selector_is_rle(selector) && iter->compressed_data)
 		{
 			Assert(simple8brle_rledata_repeatcount(iter->compressed_data[i]) > 0);
 			max_stored += simple8brle_rledata_repeatcount(iter->compressed_data[i]);

--- a/tsl/src/remote/cursor_fetcher.c
+++ b/tsl/src/remote/cursor_fetcher.c
@@ -55,7 +55,7 @@ static DataFetcherFuncs funcs = {
 static void
 cursor_create_req(CursorFetcher *cursor)
 {
-	AsyncRequest *volatile req;
+	AsyncRequest *volatile req = NULL;
 	StringInfoData buf;
 	MemoryContext oldcontext;
 
@@ -142,6 +142,7 @@ cursor_fetcher_create_for_rel(TSConnection *conn, Relation rel, List *retrieved_
 							  const char *stmt, StmtParams *params)
 {
 	CursorFetcher *cursor;
+
 	Assert(NULL != rel);
 
 	cursor = remote_cursor_init_with_params(conn,

--- a/tsl/src/remote/dist_commands.c
+++ b/tsl/src/remote/dist_commands.c
@@ -46,12 +46,14 @@ typedef struct DistCmdResult
 static DistCmdResult *
 ts_dist_cmd_collect_responses(List *requests)
 {
-	AsyncRequestSet *rs = async_request_set_create();
+	AsyncRequestSet *rs;
 	AsyncResponseResult *ar;
 	ListCell *lc;
-	DistCmdResult *results =
-		palloc0(sizeof(DistCmdResult) + requests->length * sizeof(DistCmdResponse));
+	DistCmdResult *results;
 	int i = 0;
+
+	rs = async_request_set_create();
+	results = palloc0(sizeof(DistCmdResult) + list_length(requests) * sizeof(DistCmdResponse));
 
 	foreach (lc, requests)
 		async_request_set_add(rs, lfirst(lc));
@@ -65,7 +67,7 @@ ts_dist_cmd_collect_responses(List *requests)
 		++i;
 	}
 
-	Assert(i == requests->length);
+	Assert(i == list_length(requests));
 	results->num_responses = i;
 	return results;
 }

--- a/tsl/src/remote/row_by_row_fetcher.c
+++ b/tsl/src/remote/row_by_row_fetcher.c
@@ -76,7 +76,7 @@ row_by_row_fetcher_reset(RowByRowFetcher *fetcher)
 static void
 row_by_row_fetcher_start(DataFetcher *df)
 {
-	AsyncRequest *volatile req;
+	AsyncRequest *volatile req = NULL;
 	MemoryContext oldcontext;
 	RowByRowFetcher *fetcher = cast_fetcher(RowByRowFetcher, df);
 


### PR DESCRIPTION
This change replaces the existing `clang-tidy` linter target with
CMake's built-in support for it. The old way of invoking the linter
relied on the `run-clang-tidy` wrapper script, which is not installed
by default on some platforms. Discovery of the `clang-tidy` tool has
also been improved to work with more installation locations.

As a result, linting now happens at compile time and is enabled
automatically when `clang-tidy` is installed and found.

In enabling `clang-tidy`, several non-trivial issues were discovered
in compression-related code. These might be false positives, but,
until a proper solution can be found, "warnings-as-errors" have been
disabled for that code to allow compilation to succeed with the linter
enabled.
