### PR TITLE
Set version in master to 2.0.0-dev

### DIFF
--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
-version = 2.0.0-beta5-dev
+version = 2.0.0-dev
 update_from_version = 1.7.1


### PR DESCRIPTION
We want to have the version in the master branch to be the
version of the next major release with a -dev suffix.
Actual release versions of the code will get their own respective
branches.