### PR TITLE
Make travis coverity run not depend on other tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ notifications:
       - "Build details: %{build_url}"
     rooms:
       - secure: "n4gHRucKsrlYNLVmoTxhsSbH780+8c+OjUCbaSxzyf7QYpbiD5HdCYAwBwJw6VkWPHQ+gXXy75szzcBmCOILEqx+m8WBLet+K9Kw1g3EE0r7lXT+OLWi0JJXvWBv/QdMwefilg7mC8P/USEwUSZfK/iW7tERvQc38ajGonqTsS4QWSg9zAlZZ1ZQJAALd4S4z+BJ/skAQNV+hAI1DLb8jf3A+Ex4/uMs9oAmfGiKqQTwmHlL698XFD83bv0XdxJYskkL8Eqt+19d0HD7lTCvez0yES2PCRXUWsWd2mIwTzGPYyDAU+5MifUvV2CaGDDAhIpzTYoZ4rl2SJc4uu6Fztat4UQB1GGc+TCNo5V8L3IdmzGjI2NSk88QItvpSiiNvtS0mr5As9dO8pIwuWwc4SL0u5bYw7Cq+y2s85huhKrYFVkdEptxjGInHjmq0KsuqpHoFE3E2DPD0fR0KhOekFkzobXg1cPubWHOmzm/PhVaMz3tFAtg83V2f+qg3UtfjMMgI84J/SsUdqv9J1G9R2iGxi56WKSWHHyMeloY8Pz2HFJzV0fPJQM+D5pJFpxQkSXyOMR72qJjeg0IZTiCndX9AEswbGQ3d/dwmYgbfzAah+OP37ZTYyEOsqJTEKvWq8GuJZTuhdJhhvA38Axv9jACcoQtxTKdKskOAUH3TWA="
-stages:
-  - test
-  - coverity12
-  - coverity11
 env:
   global:
     - RETRY_PREFIX=$(if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then echo "travis_retry"; else echo ""; fi)
@@ -279,12 +275,11 @@ jobs:
 
     # Coverity tests
 
-    - if: (branch = prerelease_test) OR (branch = coverity_scan)
-      stage: coverity11
+    - if: (branch = coverity_scan) OR (branch = coverity_scan_11)
+      stage: coverity
       name: "Coverity PG 11"
       env:
       before_install:
-        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
         - sudo apt-get install -y postgresql-11 postgresql-client-11 postgresql-contrib-11 postgresql-server-dev-11 cmake
       install:
       after_success:
@@ -299,14 +294,13 @@ jobs:
           notification_email: ci@timescale.com
           build_command_prepend: "./bootstrap -DCMAKE_BUILD_TYPE=Debug -DREGRESS_CHECKS=OFF && cd build"
           build_command: "make"
-          branch_pattern: coverity_scan|prerelease_test
+          branch_pattern: coverity_scan|coverity_scan_11
 
-    - if: (branch = prerelease_test) OR (branch = coverity_scan)
-      stage: coverity12
+    - if: (branch = coverity_scan) OR (branch = coverity_scan_12)
+      stage: coverity
       name: "Coverity PG 12"
       env:
       before_install:
-        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
         - sudo apt-get install -y postgresql-12 postgresql-client-12 postgresql-contrib-12 postgresql-server-dev-12 cmake
       install:
       after_success:
@@ -321,4 +315,4 @@ jobs:
           notification_email: ci@timescale.com
           build_command_prepend: "./bootstrap -DCMAKE_BUILD_TYPE=Debug -DREGRESS_CHECKS=OFF && cd build"
           build_command: "make"
-          branch_pattern: coverity_scan|prerelease_test
+          branch_pattern: coverity_scan|coverity_scan_12


### PR DESCRIPTION
This patch changes the travis configuration to make the coverity run
not depend on the result of other test runs and runs it on the
coverity_scan branch only since there is a quota on the number of
coverity runs we can do and we dont want to exceed it by multiple
pushes to prerelease_test.