### PR TITLE
Remove cascade option from drop_chunks

### DIFF
--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -21,9 +21,13 @@ INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedul
 (1, 'Telemetry Reporter', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h')
 ON CONFLICT (id) DO NOTHING;
 
-CREATE OR REPLACE FUNCTION add_drop_chunks_policy(hypertable REGCLASS, older_than "any", cascade BOOL = FALSE, if_not_exists BOOL = false, cascade_to_materializations BOOL = false)
-RETURNS INTEGER
-AS '@MODULE_PATHNAME@', 'ts_add_drop_chunks_policy'
+CREATE OR REPLACE FUNCTION add_drop_chunks_policy(
+       hypertable REGCLASS,
+       older_than "any",
+       if_not_exists BOOL = false,
+       cascade_to_materializations BOOL = false
+)
+RETURNS INTEGER AS '@MODULE_PATHNAME@', 'ts_add_drop_chunks_policy'
 LANGUAGE C VOLATILE STRICT;
 
 CREATE OR REPLACE FUNCTION add_reorder_policy(hypertable REGCLASS, index_name NAME, if_not_exists BOOL = false) RETURNS INTEGER

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -96,7 +96,6 @@ CREATE OR REPLACE FUNCTION drop_chunks(
     older_than "any" = NULL,
     table_name  NAME = NULL,
     schema_name NAME = NULL,
-    cascade  BOOLEAN = FALSE,
     newer_than "any" = NULL,
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -233,7 +233,6 @@ CREATE TABLE IF NOT EXISTS _timescaledb_config.bgw_policy_drop_chunks (
     job_id          		    INTEGER                 PRIMARY KEY REFERENCES _timescaledb_config.bgw_job(id) ON DELETE CASCADE,
     hypertable_id   		    INTEGER     UNIQUE      NOT NULL REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE,
     older_than	    _timescaledb_catalog.ts_interval    NOT NULL,
-	cascade					    BOOLEAN                 NOT NULL,
     cascade_to_materializations BOOLEAN,
     CONSTRAINT valid_older_than CHECK(_timescaledb_internal.valid_ts_interval(older_than))
 );

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -71,7 +71,7 @@ CREATE OR REPLACE VIEW timescaledb_information.license AS
          _timescaledb_internal.license_expiration_time() AS expiration_time;
 
 CREATE OR REPLACE VIEW timescaledb_information.drop_chunks_policies as
-  SELECT format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as hypertable, p.older_than, p.cascade, p.job_id, j.schedule_interval,
+  SELECT format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as hypertable, p.older_than, p.job_id, j.schedule_interval,
     j.max_runtime, j.max_retries, j.retry_period, p.cascade_to_materializations
   FROM _timescaledb_config.bgw_policy_drop_chunks p
     INNER JOIN _timescaledb_catalog.hypertable ht ON p.hypertable_id = ht.id

--- a/src/bgw_policy/drop_chunks.c
+++ b/src/bgw_policy/drop_chunks.c
@@ -49,10 +49,6 @@ bgw_policy_drop_chunks_tuple_found(TupleInfo *ti, void *const data)
 	(*policy)->older_than = *ts_interval_from_tuple(
 		values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_older_than)]);
 
-	Assert(!nulls[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade)]);
-	(*policy)->cascade =
-		DatumGetBool(values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade)]);
-
 	if (nulls[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade_to_materializations)])
 		(*policy)->cascade_to_materializations = CASCADE_TO_MATERIALIZATION_UNKNOWN;
 	else
@@ -160,8 +156,6 @@ ts_bgw_policy_drop_chunks_insert_with_relation(Relation rel, BgwPolicyDropChunks
 	values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_older_than)] =
 		HeapTupleGetDatum(ht_older_than);
 
-	values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade)] =
-		BoolGetDatum(policy->cascade);
 	if (policy->cascade_to_materializations == CASCADE_TO_MATERIALIZATION_UNKNOWN)
 	{
 		nulls[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade_to_materializations)] =

--- a/src/bgw_policy/drop_chunks.h
+++ b/src/bgw_policy/drop_chunks.h
@@ -16,7 +16,6 @@ typedef struct BgwPolicyDropChunks
 	int32 job_id;
 	int32 hypertable_id;
 	FormData_ts_interval older_than;
-	bool cascade;
 	CascadeToMaterializationOption cascade_to_materializations;
 } BgwPolicyDropChunks;
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -862,7 +862,6 @@ typedef enum Anum_bgw_policy_drop_chunks
 	Anum_bgw_policy_drop_chunks_job_id = 1,
 	Anum_bgw_policy_drop_chunks_hypertable_id,
 	Anum_bgw_policy_drop_chunks_older_than,
-	Anum_bgw_policy_drop_chunks_cascade,
 	Anum_bgw_policy_drop_chunks_cascade_to_materializations,
 	_Anum_bgw_policy_drop_chunks_max,
 } Anum_bgw_policy_drop_chunks;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -155,7 +155,7 @@ extern TSDLLEXPORT void ts_chunk_drop_preserve_catalog_row(Chunk *chunk, DropBeh
 														   int32 log_level);
 extern TSDLLEXPORT List *
 ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum, Datum newer_than_datum,
-						Oid older_than_type, Oid newer_than_type, bool cascade,
+						Oid older_than_type, Oid newer_than_type,
 						CascadeToMaterializationOption cascades_to_materializations,
 						int32 log_level, bool user_supplied_table_name, List **affected_data_nodes);
 extern TSDLLEXPORT Chunk *

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -520,7 +520,7 @@ static void
 continuous_agg_drop_chunks_by_chunk_id_default(int32 raw_hypertable_id, Chunk **chunks,
 											   Size num_chunks, Datum older_than_datum,
 											   Datum newer_than_datum, Oid older_than_type,
-											   Oid newer_than_type, bool cascade, int32 log_level,
+											   Oid newer_than_type, int32 log_level,
 											   bool user_supplied_table_name)
 {
 	error_no_default_fn_community();

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -78,11 +78,9 @@ typedef struct CrossModuleFunctions
 	bool (*process_cagg_viewstmt)(ViewStmt *stmt, const char *query_string, void *pstmt,
 								  WithClauseResult *with_clause_options);
 	void (*continuous_agg_drop_chunks_by_chunk_id)(int32 raw_hypertable_id, Chunk **chunks,
-												   Size num_chunks,
-
-												   Datum older_than_datum, Datum newer_than_datum,
-												   Oid older_than_type, Oid newer_than_type,
-												   bool cascade, int32 log_level,
+												   Size num_chunks, Datum older_than_datum,
+												   Datum newer_than_datum, Oid older_than_type,
+												   Oid newer_than_type, int32 log_level,
 												   bool user_supplied_table_name);
 	PGFunction continuous_agg_trigfn;
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -213,6 +213,7 @@ SELECT drop_chunks('haha', 'drop_chunk_test3');
 ERROR:  time constraint arguments of "drop_chunks" should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
 SELECT show_chunks('drop_chunk_test3', 'haha');
 ERROR:  time constraint arguments of "show_chunks" should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
+DROP VIEW dependent_view;
 -- should error because wrong time type
 SELECT drop_chunks(now(), 'drop_chunk_test3');
 ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
@@ -423,9 +424,8 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
 
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT show_chunks(older_than => 2)::TEXT'
-\set QUERY2 'SELECT drop_chunks(2, CASCADE=>true)::TEXT'
+\set QUERY2 'SELECT drop_chunks(older_than => 2)::TEXT'
 \set ECHO errors
-psql:include/query_result_test_equal.sql:14: NOTICE:  drop cascades to view dependent_view
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
               0 |                       2 |                       2
@@ -1358,12 +1358,13 @@ INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
 WHERE h.schema_name = 'public' AND h.table_name = 'drop_chunk_test3'
 ORDER BY c.id \gset
 create view dependent_view as SELECT * FROM :"chunk_schema".:"chunk_table";
+create view dependent_view2 as SELECT * FROM :"chunk_schema".:"chunk_table";
 ALTER TABLE drop_chunk_test3 OWNER TO :ROLE_DEFAULT_PERM_USER_2;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(table_name=>'drop_chunk_test1', older_than=>4, newer_than=>3);
 ERROR:  must be owner of hypertable "drop_chunk_test1"
-SELECT drop_chunks(2, CASCADE=>true, verbose => true);
+SELECT drop_chunks(2, verbose => true);
 ERROR:  must be owner of hypertable "drop_chunk_test1"
 --works with modified owner tables
 -- show_chunks and drop_chunks output should be the same
@@ -1375,21 +1376,18 @@ ERROR:  must be owner of hypertable "drop_chunk_test1"
               0 |                       1 |                       1
 (1 row)
 
---this fails because there is a dependent object
+\set VERBOSITY default
+--this fails because there are dependent objects
 SELECT drop_chunks(table_name=>'drop_chunk_test3', older_than=>100);
 ERROR:  cannot drop table _timescaledb_internal._hyper_3_34_chunk because other objects depend on it
---this will succeed even though there is a depenent object I don't have permission
---to drop. This matches PostgreSQL semantics.
--- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test3\', older_than=>100)::NAME'
-\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test3\', older_than=>100, cascade=>true)::NAME'
-\set ECHO errors
-psql:include/query_result_test_equal.sql:14: NOTICE:  drop cascades to view dependent_view
- Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
-----------------+-------------------------+-------------------------
-              0 |                       1 |                       1
-(1 row)
-
+DETAIL:  view dependent_view depends on table _timescaledb_internal._hyper_3_34_chunk
+view dependent_view2 depends on table _timescaledb_internal._hyper_3_34_chunk
+HINT:  Use DROP ... to drop the dependent objects.
+\set VERBOSITY terse
+\c  :TEST_DBNAME :ROLE_SUPERUSER
+DROP VIEW dependent_view;
+DROP VIEW dependent_view2;
+\c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 1
 --drop chunks from hypertable with same name in different schema
 -- order of schema in search_path matters --

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -126,11 +126,10 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	BgwPolicyDropChunks *existing;
 	Oid ht_oid = PG_GETARG_OID(0);
 	Datum older_than_datum = PG_GETARG_DATUM(1);
-	bool cascade = PG_GETARG_BOOL(2);
-	bool if_not_exists = PG_GETARG_BOOL(3);
+	bool if_not_exists = PG_GETARG_BOOL(2);
 	CascadeToMaterializationOption cascade_to_materializations =
-		(PG_ARGISNULL(4) ? CASCADE_TO_MATERIALIZATION_UNKNOWN :
-						   (PG_GETARG_BOOL(4) ? CASCADE_TO_MATERIALIZATION_TRUE :
+		(PG_ARGISNULL(3) ? CASCADE_TO_MATERIALIZATION_UNKNOWN :
+						   (PG_GETARG_BOOL(3) ? CASCADE_TO_MATERIALIZATION_TRUE :
 												CASCADE_TO_MATERIALIZATION_FALSE));
 	Oid older_than_type = PG_ARGISNULL(1) ? InvalidOid : get_fn_expr_argtype(fcinfo->flinfo, 1);
 	BgwPolicyDropChunks policy;
@@ -164,7 +163,7 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 							get_rel_name(ht_oid))));
 		}
 
-		if (ts_interval_equal(&existing->older_than, older_than) && existing->cascade == cascade &&
+		if (ts_interval_equal(&existing->older_than, older_than) &&
 			existing->cascade_to_materializations == cascade_to_materializations)
 		{
 			/* If all arguments are the same, do nothing */
@@ -200,7 +199,6 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 		.job_id = job_id,
 		.hypertable_id = ts_hypertable_relid_to_id(mapped_oid),
 		.older_than = *older_than,
-		.cascade = cascade,
 		.cascade_to_materializations = cascade_to_materializations,
 	};
 

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -240,7 +240,6 @@ execute_drop_chunks_policy(int32 job_id)
 										   &hypertable->fd.table_name,
 										   older_than,
 										   older_than_type,
-										   args->cascade,
 										   args->cascade_to_materializations);
 #else
 	num_dropped = list_length(ts_chunk_do_drop_chunks(table_relid,
@@ -248,7 +247,6 @@ execute_drop_chunks_policy(int32 job_id)
 													  (Datum) 0,
 													  older_than_type,
 													  InvalidOid,
-													  args->cascade,
 													  args->cascade_to_materializations,
 													  LOG,
 													  true /*user_supplied_table_name */,

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -178,7 +178,7 @@ chunk_set_default_data_node(PG_FUNCTION_ARGS)
 
 /* Should match definition in ddl_api.sql */
 #define DROP_CHUNKS_FUNCNAME "drop_chunks"
-#define DROP_CHUNKS_NARGS 7
+#define DROP_CHUNKS_NARGS 6
 
 /*
  * Invoke drop_chunks via fmgr so that the call can be deparsed and sent to
@@ -191,7 +191,7 @@ chunk_set_default_data_node(PG_FUNCTION_ARGS)
  */
 int
 chunk_invoke_drop_chunks(Name schema_name, Name table_name, Datum older_than, Datum older_than_type,
-						 bool cascade, bool cascade_to_materializations)
+						 bool cascade_to_materializations)
 {
 	EState *estate;
 	ExprContext *econtext;
@@ -223,7 +223,6 @@ chunk_invoke_drop_chunks(Name schema_name, Name table_name, Datum older_than, Da
 				  NameGetDatum(schema_name),
 				  false,
 				  false),
-		castNode(Const, makeBoolConst(cascade, false)),
 		makeNullConst(INT8OID, -1, InvalidOid),
 		castNode(Const, makeBoolConst(false, true)),
 		castNode(Const, makeBoolConst(cascade_to_materializations, false))

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -14,7 +14,6 @@
 extern void chunk_update_foreign_server_if_needed(int32 chunk_id, Oid existing_server_id);
 extern Datum chunk_set_default_data_node(PG_FUNCTION_ARGS);
 extern int chunk_invoke_drop_chunks(Name schema_name, Name table_name, Datum older_than,
-									Datum older_than_type, bool cascade,
-									bool cascade_to_materializations);
+									Datum older_than_type, bool cascade_to_materializations);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_H */

--- a/tsl/src/continuous_aggs/drop.c
+++ b/tsl/src/continuous_aggs/drop.c
@@ -23,7 +23,7 @@ void
 ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks_ptr,
 										  Size num_chunks, Datum older_than_datum,
 										  Datum newer_than_datum, Oid older_than_type,
-										  Oid newer_than_type, bool cascade, int32 log_level,
+										  Oid newer_than_type, int32 log_level,
 										  bool user_supplied_table_name)
 {
 	ListCell *lc;
@@ -50,7 +50,6 @@ ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunk
 								newer_than_datum,
 								older_than_type,
 								newer_than_type,
-								cascade,
 								CASCADE_TO_MATERIALIZATION_FALSE,
 								log_level,
 								user_supplied_table_name,

--- a/tsl/src/continuous_aggs/drop.h
+++ b/tsl/src/continuous_aggs/drop.h
@@ -10,10 +10,10 @@
 
 #include <chunk.h>
 
-extern void ts_continuous_agg_drop_chunks_by_chunk_id(
-	int32 raw_hypertable_id, Chunk **chunks_ptr, Size num_chunks,
-
-	Datum older_than_datum, Datum newer_than_datum, Oid older_than_type, Oid newer_than_type,
-	bool cascade, int32 log_level, bool user_supplied_table_name);
+extern void ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks_ptr,
+													  Size num_chunks, Datum older_than_datum,
+													  Datum newer_than_datum, Oid older_than_type,
+													  Oid newer_than_type, int32 log_level,
+													  bool user_supplied_table_name);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_DROP_H */

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -48,8 +48,8 @@ SELECT * FROM _timescaledb_config.bgw_job;
 (0 rows)
 
 SELECT * FROM timescaledb_information.drop_chunks_policies;
- hypertable | older_than | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
-------------+------------+---------+--------+-------------------+-------------+-------------+--------------+-----------------------------
+ hypertable | older_than | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
+------------+------------+--------+-------------------+-------------+-------------+--------------+-----------------------------
 (0 rows)
 
 SELECT * FROM timescaledb_information.reorder_policies;
@@ -432,9 +432,9 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
- job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
---------+---------------+-----------------+---------+-----------------------------
-   1001 |             2 | (t,"@ 4 mons",) | f       | f
+ job_id | hypertable_id |   older_than    | cascade_to_materializations 
+--------+---------------+-----------------+-----------------------------
+   1001 |             2 | (t,"@ 4 mons",) | f
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
@@ -592,9 +592,9 @@ SELECT show_chunks('test_drop_chunks_table');
 
 --test that views work
 SELECT * FROM timescaledb_information.drop_chunks_policies;
-       hypertable       |   older_than    | cascade | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
-------------------------+-----------------+---------+--------+-------------------+-------------+-------------+--------------+-----------------------------
- test_drop_chunks_table | (t,"@ 4 mons",) | f       |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | f
+       hypertable       |   older_than    | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
+------------------------+-----------------+--------+-------------------+-------------+-------------+--------------+-----------------------------
+ test_drop_chunks_table | (t,"@ 4 mons",) |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | f
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -87,9 +87,9 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
- job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
---------+---------------+-----------------+---------+-----------------------------
-   1000 |             1 | (t,"@ 4 mons",) | f       | f
+ job_id | hypertable_id |   older_than    | cascade_to_materializations 
+--------+---------------+-----------------+-----------------------------
+   1000 |             1 | (t,"@ 4 mons",) | f
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -328,12 +328,16 @@ INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = 
 WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 CREATE VIEW dependent_1 AS SELECT * FROM :COMPRESSED_CHUNK_NAME;
 \set ON_ERROR_STOP 0
+\set VERBOSITY default
 --errors due to dependent objects
 SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
 ERROR:  cannot drop table _timescaledb_internal.compress_hyper_2_37_chunk because other objects depend on it
+DETAIL:  view dependent_1 depends on table _timescaledb_internal.compress_hyper_2_37_chunk
+HINT:  Use DROP ... to drop the dependent objects.
+\set VERBOSITY terse
 \set ON_ERROR_STOP 1
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ, cascade=>true);
-NOTICE:  drop cascades to view dependent_1
+DROP VIEW dependent_1;
+SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
                drop_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_1_10_chunk

--- a/tsl/test/expected/deparse.out
+++ b/tsl/test/expected/deparse.out
@@ -10,28 +10,28 @@
 (1 row)
 
 -- test drop_chunks function deparsing
-SELECT * FROM tsl_test_deparse_drop_chunks('2019-01-01'::timestamptz, 'Test_table', 'test_schema', cascade => false, verbose => true);
-                                                                                                             tsl_test_deparse_drop_chunks                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone,table_name => 'Test_table',schema_name => 'test_schema',cascade => 'f',newer_than => NULL,verbose => 't',cascade_to_materializations => NULL)
+SELECT * FROM tsl_test_deparse_drop_chunks('2019-01-01'::timestamptz, 'Test_table', 'test_schema', verbose => true);
+                                                                                                      tsl_test_deparse_drop_chunks                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(older_than => 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone,table_name => 'Test_table',schema_name => 'test_schema',newer_than => NULL,verbose => 't',cascade_to_materializations => NULL)
 (1 row)
 
-SELECT * FROM tsl_test_deparse_drop_chunks(interval '1 day', table_name => 'weird nAme\\#^.', cascade_to_materializations => true, cascade => true);
-                                                                                          tsl_test_deparse_drop_chunks                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => '@ 1 day'::interval,table_name => E'weird nAme\\\\#^.',schema_name => NULL,cascade => 't',newer_than => NULL,verbose => 'f',cascade_to_materializations => 't')
+SELECT * FROM tsl_test_deparse_drop_chunks(interval '1 day', table_name => 'weird nAme\\#^.', cascade_to_materializations => true);
+                                                                                  tsl_test_deparse_drop_chunks                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(older_than => '@ 1 day'::interval,table_name => E'weird nAme\\\\#^.',schema_name => NULL,newer_than => NULL,verbose => 'f',cascade_to_materializations => 't')
 (1 row)
 
 SELECT * FROM tsl_test_deparse_drop_chunks(newer_than => 12345);
-                                                                                 tsl_test_deparse_drop_chunks                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => NULL,table_name => NULL,schema_name => NULL,cascade => 'f',newer_than => '12345'::integer,verbose => 'f',cascade_to_materializations => NULL)
+                                                                         tsl_test_deparse_drop_chunks                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(older_than => NULL,table_name => NULL,schema_name => NULL,newer_than => '12345'::integer,verbose => 'f',cascade_to_materializations => NULL)
 (1 row)
 
 SELECT * FROM tsl_test_deparse_drop_chunks(older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
-                                                                                                             tsl_test_deparse_drop_chunks                                                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => '@ 2 years'::interval,table_name => NULL,schema_name => NULL,cascade => 'f',newer_than => 'Thu Jan 01 00:00:00 2015'::timestamp without time zone,verbose => 'f',cascade_to_materializations => NULL)
+                                                                                                     tsl_test_deparse_drop_chunks                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(older_than => '@ 2 years'::interval,table_name => NULL,schema_name => NULL,newer_than => 'Thu Jan 01 00:00:00 2015'::timestamp without time zone,verbose => 'f',cascade_to_materializations => NULL)
 (1 row)
 
 -- test generalized deparsing function

--- a/tsl/test/expected/deparse_fail.out
+++ b/tsl/test/expected/deparse_fail.out
@@ -11,7 +11,6 @@ AS :TSL_MODULE_PATHNAME, 'ts_test_get_tabledef' LANGUAGE C VOLATILE STRICT;
 CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(older_than "any" = NULL,
     table_name  NAME = NULL,
     schema_name NAME = NULL,
-    cascade  BOOLEAN = FALSE,
     newer_than "any" = NULL,
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL) RETURNS TEXT

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -2903,8 +2903,8 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
  
 (1 row)
 
--- test passing newer_than as interval and cascade
-SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks', cascade => true);
+-- test passing newer_than as interval
+SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks');
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_10_30_chunk

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -2897,8 +2897,8 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
  
 (1 row)
 
--- test passing newer_than as interval and cascade
-SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks', cascade => true);
+-- test passing newer_than as interval
+SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks');
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_10_30_chunk

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -11,8 +11,8 @@ AS :TSL_MODULE_PATHNAME, 'ts_test_bgw_job_delete_by_id'
 LANGUAGE C VOLATILE STRICT;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
+ job_id | hypertable_id | older_than | cascade_to_materializations 
+--------+---------------+------------+-----------------------------
 (0 rows)
 
 select * from _timescaledb_config.bgw_policy_reorder;
@@ -125,16 +125,8 @@ select add_drop_chunks_policy('test_table', 'haha');
 ERROR:  invalid type for parameter older_than in add_drop_chunks_policy
 select add_drop_chunks_policy('test_table', 42);
 ERROR:  invalid parameter value for older_than
-select add_drop_chunks_policy('fake_table', INTERVAL '3 month', true);
-ERROR:  relation "fake_table" does not exist at character 31
 select add_drop_chunks_policy('fake_table', INTERVAL '3 month');
 ERROR:  relation "fake_table" does not exist at character 31
-select add_drop_chunks_policy('test_table', cascade=>true);
-ERROR:  function add_drop_chunks_policy(unknown, cascade => boolean) does not exist at character 8
-select add_drop_chunks_policy('test_table_int', INTERVAL '3 month', true);
-ERROR:  integer_now_func not set on hypertable "test_table_int"
-select add_drop_chunks_policy('test_table_int', 42, true);
-ERROR:  integer_now_func not set on hypertable "test_table_int"
 \set ON_ERROR_STOP 1
 select add_drop_chunks_policy('test_table', INTERVAL '3 month', true);
  add_drop_chunks_policy 
@@ -142,17 +134,9 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 month', true);
                    1002
 (1 row)
 
--- add_*_policy should be noop only for policies with the exact same parameters
-select add_drop_chunks_policy('test_table', INTERVAL '3 month', true, true);
-NOTICE:  drop chunks policy already exists on hypertable "test_table", skipping
- add_drop_chunks_policy 
-------------------------
-                     -1
-(1 row)
-
 -- Should not add new policy with different parameters
-select add_drop_chunks_policy('test_table', INTERVAL '3 month', false, true);
-WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
+select add_drop_chunks_policy('test_table', INTERVAL '3 month', true);
+NOTICE:  drop chunks policy already exists on hypertable "test_table", skipping
  add_drop_chunks_policy 
 ------------------------
                      -1
@@ -172,7 +156,7 @@ WARNING:  could not add drop chunks policy due to existing policy on hypertable 
                      -1
 (1 row)
 
-select add_drop_chunks_policy('test_table', INTERVAL '3 days', true, if_not_exists => true);
+select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true);
 WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
  add_drop_chunks_policy 
 ------------------------
@@ -187,33 +171,29 @@ WARNING:  could not add drop chunks policy due to existing policy on hypertable 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
---------+---------------+-----------------+---------+-----------------------------
-   1002 |             1 | (t,"@ 3 mons",) | t       | f
+ job_id | hypertable_id |   older_than    | cascade_to_materializations 
+--------+---------------+-----------------+-----------------------------
+   1002 |             1 | (t,"@ 3 mons",) | f
 (1 row)
 
 \set ON_ERROR_STOP 0
-select add_drop_chunks_policy('test_table', INTERVAL '3 month', false);
-ERROR:  drop chunks policy already exists for hypertable "test_table"
 select add_drop_chunks_policy('test_table', INTERVAL '1 year');
 ERROR:  drop chunks policy already exists for hypertable "test_table"
 select add_drop_chunks_policy('test_table', INTERVAL '3 days');
-ERROR:  drop chunks policy already exists for hypertable "test_table"
-select add_drop_chunks_policy('test_table', INTERVAL '3 days', true);
 ERROR:  drop chunks policy already exists for hypertable "test_table"
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', cascade_to_materializations => true);
 ERROR:  drop chunks policy already exists for hypertable "test_table"
 \set ON_ERROR_STOP 1
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
---------+---------------+-----------------+---------+-----------------------------
-   1002 |             1 | (t,"@ 3 mons",) | t       | f
+ job_id | hypertable_id |   older_than    | cascade_to_materializations 
+--------+---------------+-----------------+-----------------------------
+   1002 |             1 | (t,"@ 3 mons",) | f
 (1 row)
 
-select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
- job_id | hypertable_id |   older_than    | cascade 
---------+---------------+-----------------+---------
-   1002 |             1 | (t,"@ 3 mons",) | t
+select r.job_id,r.hypertable_id,r.older_than from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
+ job_id | hypertable_id |   older_than    
+--------+---------------+-----------------
+   1002 |             1 | (t,"@ 3 mons",)
 (1 row)
 
 select remove_drop_chunks_policy('test_table');
@@ -250,13 +230,13 @@ select * from _timescaledb_catalog.dimension;
 (2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
+ job_id | hypertable_id | older_than | cascade_to_materializations 
+--------+---------------+------------+-----------------------------
 (0 rows)
 
-select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
- job_id | hypertable_id | older_than | cascade 
---------+---------------+------------+---------
+select r.job_id,r.hypertable_id,r.older_than from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
+ job_id | hypertable_id | older_than 
+--------+---------------+------------
 (0 rows)
 
 select remove_reorder_policy('test_table');
@@ -282,9 +262,9 @@ select add_drop_chunks_policy('test_table', INTERVAL '3 month');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
---------+---------------+-----------------+---------+-----------------------------
-   1003 |             1 | (t,"@ 3 mons",) | f       | f
+ job_id | hypertable_id |   older_than    | cascade_to_materializations 
+--------+---------------+-----------------+-----------------------------
+   1003 |             1 | (t,"@ 3 mons",) | f
 (1 row)
 
 select remove_drop_chunks_policy('test_table');
@@ -294,8 +274,8 @@ select remove_drop_chunks_policy('test_table');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
+ job_id | hypertable_id | older_than | cascade_to_materializations 
+--------+---------------+------------+-----------------------------
 (0 rows)
 
 select add_drop_chunks_policy('test_table_int', 1);
@@ -305,27 +285,20 @@ select add_drop_chunks_policy('test_table_int', 1);
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
-   1004 |             2 | (f,,1)     | f       | f
+ job_id | hypertable_id | older_than | cascade_to_materializations 
+--------+---------------+------------+-----------------------------
+   1004 |             2 | (f,,1)     | f
 (1 row)
 
 -- Should not add new policy with different parameters
-select add_drop_chunks_policy('test_table_int', 2, false, true);
+select add_drop_chunks_policy('test_table_int', 2, true);
 WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
  add_drop_chunks_policy 
 ------------------------
                      -1
 (1 row)
 
-select add_drop_chunks_policy('test_table_int', 1, false, true, true);
-WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
- add_drop_chunks_policy 
-------------------------
-                     -1
-(1 row)
-
-select add_drop_chunks_policy('test_table_int', 1, true, true, false);
+select add_drop_chunks_policy('test_table_int', 1, true, true);
 WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
  add_drop_chunks_policy 
 ------------------------
@@ -339,8 +312,8 @@ select remove_drop_chunks_policy('test_table_int');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
+ job_id | hypertable_id | older_than | cascade_to_materializations 
+--------+---------------+------------+-----------------------------
 (0 rows)
 
 -- Make sure remove works when there's nothing to remove
@@ -566,10 +539,10 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade | cascade_to_materializations 
---------+---------------+-----------------+---------+-----------------------------
-   1009 |             4 | (t,"@ 2 days",) | f       | f
-   1010 |             5 | (t,"@ 1 day",)  | f       | f
+ job_id | hypertable_id |   older_than    | cascade_to_materializations 
+--------+---------------+-----------------+-----------------------------
+   1009 |             4 | (t,"@ 2 days",) | f
+   1010 |             5 | (t,"@ 1 day",)  | f
 (2 rows)
 
 DROP TABLE test_table;
@@ -581,9 +554,9 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than   | cascade | cascade_to_materializations 
---------+---------------+----------------+---------+-----------------------------
-   1010 |             5 | (t,"@ 1 day",) | f       | f
+ job_id | hypertable_id |   older_than   | cascade_to_materializations 
+--------+---------------+----------------+-----------------------------
+   1010 |             5 | (t,"@ 1 day",) | f
 (1 row)
 
 DROP TABLE test_table2;
@@ -593,8 +566,8 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (0 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade | cascade_to_materializations 
---------+---------------+------------+---------+-----------------------------
+ job_id | hypertable_id | older_than | cascade_to_materializations 
+--------+---------------+------------+-----------------------------
 (0 rows)
 
 -- Now test chunk_stat insertion
@@ -613,7 +586,7 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE _timescaledb_internal.bgw_policy_chunk_stats;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
--- Now test chunk_stat cascade deletion is correct
+-- Now test chunk_stat deletion is correct
 select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
  job_id | chunk_id | num_times_job_run 
 --------+----------+-------------------

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -235,12 +235,14 @@ WHERE hypertable.table_name like 'test1' ORDER BY chunk.id LIMIT 1 \gset
 CREATE VIEW dependent_1 AS SELECT * FROM :COMPRESSED_CHUNK_NAME;
 
 \set ON_ERROR_STOP 0
+\set VERBOSITY default
 --errors due to dependent objects
 SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
+\set VERBOSITY terse
 \set ON_ERROR_STOP 1
 
-
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ, cascade=>true);
+DROP VIEW dependent_1;
+SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
 
 --should decrease #chunks both compressed and decompressed
 SELECT count(*) as count_chunks_uncompressed

--- a/tsl/test/sql/deparse.sql
+++ b/tsl/test/sql/deparse.sql
@@ -31,8 +31,8 @@ SELECT 'TABLE DEPARSE TEST DONE';
 
 \set ECHO all
 -- test drop_chunks function deparsing
-SELECT * FROM tsl_test_deparse_drop_chunks('2019-01-01'::timestamptz, 'Test_table', 'test_schema', cascade => false, verbose => true);
-SELECT * FROM tsl_test_deparse_drop_chunks(interval '1 day', table_name => 'weird nAme\\#^.', cascade_to_materializations => true, cascade => true);
+SELECT * FROM tsl_test_deparse_drop_chunks('2019-01-01'::timestamptz, 'Test_table', 'test_schema', verbose => true);
+SELECT * FROM tsl_test_deparse_drop_chunks(interval '1 day', table_name => 'weird nAme\\#^.', cascade_to_materializations => true);
 SELECT * FROM tsl_test_deparse_drop_chunks(newer_than => 12345);
 SELECT * FROM tsl_test_deparse_drop_chunks(older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
 

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -843,8 +843,8 @@ SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
 FROM show_chunks('disttable_drop_chunks');
 $$);
 
--- test passing newer_than as interval and cascade
-SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks', cascade => true);
+-- test passing newer_than as interval
+SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks');
 SELECT * FROM disttable_drop_chunks;
 
 CREATE TABLE "weird nAme\\#^."(time bigint, device int CHECK (device > 0), color int, PRIMARY KEY (time,device));

--- a/tsl/test/sql/include/deparse_func.sql
+++ b/tsl/test/sql/include/deparse_func.sql
@@ -10,7 +10,6 @@ AS :TSL_MODULE_PATHNAME, 'ts_test_get_tabledef' LANGUAGE C VOLATILE STRICT;
 CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(older_than "any" = NULL,
     table_name  NAME = NULL,
     schema_name NAME = NULL,
-    cascade  BOOLEAN = FALSE,
     newer_than "any" = NULL,
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL) RETURNS TEXT

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -65,35 +65,27 @@ select add_drop_chunks_policy(INTERVAL '3 hours');
 select add_drop_chunks_policy('test_table', INTERVAL 'haha');
 select add_drop_chunks_policy('test_table', 'haha');
 select add_drop_chunks_policy('test_table', 42);
-select add_drop_chunks_policy('fake_table', INTERVAL '3 month', true);
 select add_drop_chunks_policy('fake_table', INTERVAL '3 month');
-select add_drop_chunks_policy('test_table', cascade=>true);
-select add_drop_chunks_policy('test_table_int', INTERVAL '3 month', true);
-select add_drop_chunks_policy('test_table_int', 42, true);
 \set ON_ERROR_STOP 1
 
 select add_drop_chunks_policy('test_table', INTERVAL '3 month', true);
--- add_*_policy should be noop only for policies with the exact same parameters
-select add_drop_chunks_policy('test_table', INTERVAL '3 month', true, true);
 -- Should not add new policy with different parameters
-select add_drop_chunks_policy('test_table', INTERVAL '3 month', false, true);
+select add_drop_chunks_policy('test_table', INTERVAL '3 month', true);
 select add_drop_chunks_policy('test_table', INTERVAL '1 year', if_not_exists => true);
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true);
-select add_drop_chunks_policy('test_table', INTERVAL '3 days', true, if_not_exists => true);
+select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true);
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', if_not_exists => true, cascade_to_materializations => true);
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
 
 \set ON_ERROR_STOP 0
-select add_drop_chunks_policy('test_table', INTERVAL '3 month', false);
 select add_drop_chunks_policy('test_table', INTERVAL '1 year');
 select add_drop_chunks_policy('test_table', INTERVAL '3 days');
-select add_drop_chunks_policy('test_table', INTERVAL '3 days', true);
 select add_drop_chunks_policy('test_table', INTERVAL '3 days', cascade_to_materializations => true);
 \set ON_ERROR_STOP 1
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
-select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
+select r.job_id,r.hypertable_id,r.older_than from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
 
 select remove_drop_chunks_policy('test_table');
 
@@ -113,7 +105,7 @@ select * from _timescaledb_catalog.dimension;
 
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
-select r.job_id,r.hypertable_id,r.older_than,r.cascade from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
+select r.job_id,r.hypertable_id,r.older_than from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
 select remove_reorder_policy('test_table');
 
 select * from _timescaledb_config.bgw_policy_reorder;
@@ -127,9 +119,8 @@ select * from _timescaledb_config.bgw_policy_drop_chunks;
 select add_drop_chunks_policy('test_table_int', 1);
 select * from _timescaledb_config.bgw_policy_drop_chunks;
 -- Should not add new policy with different parameters
-select add_drop_chunks_policy('test_table_int', 2, false, true);
-select add_drop_chunks_policy('test_table_int', 1, false, true, true);
-select add_drop_chunks_policy('test_table_int', 1, true, true, false);
+select add_drop_chunks_policy('test_table_int', 2, true);
+select add_drop_chunks_policy('test_table_int', 1, true, true);
 
 select remove_drop_chunks_policy('test_table_int');
 select * from _timescaledb_config.bgw_policy_drop_chunks;
@@ -236,7 +227,7 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 TRUNCATE _timescaledb_internal.bgw_policy_chunk_stats;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
--- Now test chunk_stat cascade deletion is correct
+-- Now test chunk_stat deletion is correct
 select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;
 
 CREATE TABLE test_table(time timestamptz, junk int);

--- a/tsl/test/src/deparse.c
+++ b/tsl/test/src/deparse.c
@@ -33,8 +33,11 @@ ts_test_deparse_drop_chunks(PG_FUNCTION_ARGS)
 {
 	FmgrInfo flinfo;
 	FunctionCallInfo fcinfo2 = palloc(SizeForFunctionCallInfo(fcinfo->nargs));
-	Oid argtypes[7] = { ANYOID, NAMEOID, NAMEOID, BOOLOID, ANYOID, BOOLOID, BOOLOID };
-	Oid funcid = ts_get_function_oid("drop_chunks", ts_extension_schema_name(), 7, argtypes);
+	Oid argtypes[] = { ANYOID, NAMEOID, NAMEOID, ANYOID, BOOLOID, BOOLOID };
+	Oid funcid = ts_get_function_oid("drop_chunks",
+									 ts_extension_schema_name(),
+									 sizeof(argtypes) / sizeof(*argtypes),
+									 argtypes);
 	const char *sql_cmd;
 	int i;
 


### PR DESCRIPTION
This commit removes the `cascade` option from the function `drop_chunks`
and `add_drop_chunk_policy`, which will now never cascade drops to
dependent objects.  The tests are fixed accordingly and verbosity
turned up to ensure that the dependent objects are printed in the error
details.

Fixes #timescale/timescaledb-private#786