### PR TITLE
Make table mandatory for drop_chunks

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -89,13 +89,11 @@ CREATE OR REPLACE FUNCTION  set_number_partitions(
     dimension_name          NAME = NULL
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_dimension_set_num_slices' LANGUAGE C VOLATILE;
 
--- Drop chunks older than the given timestamp. If a hypertable name is given,
--- drop only chunks associated with this table. Any of the first three arguments
--- can be NULL meaning "all values".
+-- Drop chunks older than the given timestamp for the specific
+-- hypertable or continuous aggregate.
 CREATE OR REPLACE FUNCTION drop_chunks(
+    hypertable_or_cagg  REGCLASS,
     older_than "any" = NULL,
-    table_name  NAME = NULL,
-    schema_name NAME = NULL,
     newer_than "any" = NULL,
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,7 +1,7 @@
 -- Add new function definitions, columns and tables for distributed hypertables
 DROP FUNCTION IF EXISTS create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc);
-DROP FUNCTION IF EXISTS add_drop_chunks_policy(regclass,"any",bool,bool,bool);
-DROP FUNCTION IF EXISTS drop_chunks("any",name,name,boolean,"any",boolean,boolean);
+DROP FUNCTION IF EXISTS add_drop_chunks_policy;
+DROP FUNCTION IF EXISTS drop_chunks;
 
 ALTER TABLE _timescaledb_catalog.hypertable ADD COLUMN replication_factor SMALLINT NULL CHECK (replication_factor > 0);
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -154,10 +154,10 @@ extern TSDLLEXPORT void ts_chunk_drop(Chunk *chunk, DropBehavior behavior, int32
 extern TSDLLEXPORT void ts_chunk_drop_preserve_catalog_row(Chunk *chunk, DropBehavior behavior,
 														   int32 log_level);
 extern TSDLLEXPORT List *
-ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum, Datum newer_than_datum,
+ts_chunk_do_drop_chunks(Hypertable *ht, Datum older_than_datum, Datum newer_than_datum,
 						Oid older_than_type, Oid newer_than_type,
 						CascadeToMaterializationOption cascades_to_materializations,
-						int32 log_level, bool user_supplied_table_name, List **affected_data_nodes);
+						int32 log_level, List **affected_data_nodes);
 extern TSDLLEXPORT Chunk *
 ts_chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum newer_than_datum,
 								  Oid older_than_type, Oid newer_than_type, char *caller_name,

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -527,8 +527,7 @@ static void
 continuous_agg_drop_chunks_by_chunk_id_default(int32 raw_hypertable_id, Chunk **chunks,
 											   Size num_chunks, Datum older_than_datum,
 											   Datum newer_than_datum, Oid older_than_type,
-											   Oid newer_than_type, int32 log_level,
-											   bool user_supplied_table_name)
+											   Oid newer_than_type, int32 log_level)
 {
 	error_no_default_fn_community();
 }

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -80,8 +80,7 @@ typedef struct CrossModuleFunctions
 	void (*continuous_agg_drop_chunks_by_chunk_id)(int32 raw_hypertable_id, Chunk **chunks,
 												   Size num_chunks, Datum older_than_datum,
 												   Datum newer_than_datum, Oid older_than_type,
-												   Oid newer_than_type, int32 log_level,
-												   bool user_supplied_table_name);
+												   Oid newer_than_type, int32 log_level);
 	PGFunction continuous_agg_trigfn;
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -304,7 +304,7 @@ ERROR:  tablespace "tablespace1" is still attached to 1 hypertables
 \set ON_ERROR_STOP 1
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT show_chunks(\'hyper_in_space\', 22)::NAME'
-\set QUERY2 'SELECT drop_chunks(22, \'hyper_in_space\')::NAME'
+\set QUERY2 'SELECT drop_chunks(\'hyper_in_space\', 22)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -14,16 +14,6 @@ $BODY$
     WHERE d.hypertable_id = dimension_get_time.hypertable_id AND
           d.interval_length IS NOT NULL
 $BODY$;
--- Make sure drop_chunks when there are no tables succeeds
--- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(older_than => INTERVAL \'1 hour\')::NAME'
-\set QUERY2 'SELECT drop_chunks(INTERVAL \'1 hour\', verbose => true)::NAME'
-\set ECHO errors
- Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
-----------------+-------------------------+-------------------------
-              0 |                       0 |                       0
-(1 row)
-
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test3(time bigint, temp float8, device_id text);
@@ -201,27 +191,31 @@ SELECT * FROM show_chunks('drop_chunk_test2');
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chunk;
 \set ON_ERROR_STOP 0
-SELECT drop_chunks();
+SELECT drop_chunks('drop_chunk_test1');
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
-SELECT drop_chunks(2);
+SELECT drop_chunks('drop_chunk_test1', older_than => 2);
 ERROR:  cannot drop table _timescaledb_internal._hyper_1_1_chunk because other objects depend on it
-SELECT drop_chunks(NULL::interval);
+SELECT drop_chunks('drop_chunk_test1', older_than => NULL::interval);
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
-SELECT drop_chunks(NULL::int);
+SELECT drop_chunks('drop_chunk_test1', older_than => NULL::int);
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
-SELECT drop_chunks('haha', 'drop_chunk_test3');
-ERROR:  time constraint arguments of "drop_chunks" should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
-SELECT show_chunks('drop_chunk_test3', 'haha');
+SELECT show_chunks('drop_chunk_test1', 'haha');
 ERROR:  time constraint arguments of "show_chunks" should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
 DROP VIEW dependent_view;
 -- should error because wrong time type
-SELECT drop_chunks(now(), 'drop_chunk_test3');
+SELECT drop_chunks('drop_chunk_test1', older_than => now());
 ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
 SELECT show_chunks('drop_chunk_test3', now());
 ERROR:  time constraint arguments of "show_chunks" should have same type as time column of the hypertable
 -- should error because of wrong relative order of time constraints
 SELECT show_chunks('drop_chunk_test1', older_than=>3, newer_than=>4);
 ERROR:  When both older_than and newer_than are specified, older_than must refer to a time that is more recent than newer_than so that a valid overlapping range is specified
+-- Should error because NULL was used for the table name.
+SELECT drop_chunks(NULL, older_than => 3);
+ERROR:  invalid hypertable or continuous aggregate
+-- should error because there is no relation with that OID.
+SELECT drop_chunks(3533, older_than => 3);
+ERROR:  OID 3533 does not refer to a table or view
 \set ON_ERROR_STOP 1
 --should always work regardless of time column types of hypertables
 SELECT show_chunks();
@@ -247,7 +241,8 @@ SELECT show_chunks();
  _timescaledb_internal._hyper_3_18_chunk
 (18 rows)
 
--- should work vecause so far all tables have time column type of bigint
+-- should work because so far all tables have time column type of
+-- bigint
 SELECT show_chunks(newer_than => 2);
                show_chunks               
 -----------------------------------------
@@ -422,14 +417,16 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  24 |            3 |                    6 |                   7
 (23 rows)
 
--- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(older_than => 2)::TEXT'
-\set QUERY2 'SELECT drop_chunks(older_than => 2)::TEXT'
-\set ECHO errors
- Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
-----------------+-------------------------+-------------------------
-              0 |                       2 |                       2
-(1 row)
+-- We drop all chunks older than timestamp 2 in all hypertable. This
+-- is added only to avoid making the diff for this commit larger than
+-- necessary and make reviews easier.
+SELECT drop_chunks(format('%1$I.%2$I', schema_name, table_name)::regclass, older_than => 2)
+  FROM _timescaledb_catalog.hypertable;
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_3_13_chunk
+(2 rows)
 
 SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
@@ -562,7 +559,7 @@ SELECT * FROM show_chunks('drop_chunk_test2');
 
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT show_chunks(\'drop_chunk_test1\', older_than => 3)::NAME'
-\set QUERY2 'SELECT drop_chunks(3, \'drop_chunk_test1\')::NAME'
+\set QUERY2 'SELECT drop_chunks(\'drop_chunk_test1\', older_than => 3)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -635,7 +632,7 @@ SELECT * FROM show_chunks('drop_chunk_test2');
 -- 2,147,483,647 is the largest int so this tests that BIGINTs work
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT show_chunks(\'drop_chunk_test3\', older_than => 2147483648)::NAME'
-\set QUERY2 'SELECT drop_chunks(2147483648, \'drop_chunk_test3\')::NAME'
+\set QUERY2 'SELECT drop_chunks(\'drop_chunk_test3\', older_than => 2147483648)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -680,8 +677,8 @@ ORDER BY c.id;
 
 \set ON_ERROR_STOP 0
 -- should error because no hypertable
-SELECT drop_chunks(5, 'drop_chunk_test4');
-ERROR:  "drop_chunk_test4" is not a hypertable or a continuous aggregate view
+SELECT drop_chunks('drop_chunk_test4', older_than => 5);
+ERROR:  relation "drop_chunk_test4" does not exist at character 20
 SELECT show_chunks('drop_chunk_test4');
 ERROR:  relation "drop_chunk_test4" does not exist at character 20
 SELECT show_chunks('drop_chunk_test4', 5);
@@ -724,8 +721,8 @@ ORDER BY c.id;
 
 -- newer_than tests
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test1\', newer_than=>5)::NAME'
-\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test1\', newer_than=>5, verbose => true)::NAME'
+\set QUERY1 'SELECT show_chunks(\'drop_chunk_test1\', newer_than=>5)::NAME'
+\set QUERY2 'SELECT drop_chunks(\'drop_chunk_test1\', newer_than=>5, verbose => true)::NAME'
 \set ECHO errors
 psql:include/query_result_test_equal.sql:14: INFO:  dropping chunk _timescaledb_internal._hyper_1_5_chunk
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
@@ -768,8 +765,8 @@ SELECT show_chunks('drop_chunk_test1');
 (7 rows)
 
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test1\', older_than=>4, newer_than=>3)::NAME'
-\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test1\', older_than=>4, newer_than=>3)::NAME'
+\set QUERY1 'SELECT show_chunks(\'drop_chunk_test1\', older_than=>4, newer_than=>3)::NAME'
+\set QUERY2 'SELECT drop_chunks(\'drop_chunk_test1\', older_than=>4, newer_than=>3)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -796,13 +793,6 @@ SELECT show_chunks('drop_chunk_test1');
  _timescaledb_internal._hyper_1_4_chunk
 (1 row)
 
--- testing drop_chunks when only schema is specified.
-\set ON_ERROR_STOP 0
-SELECT drop_chunks(schema_name=>'public');
-ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
-SELECT drop_chunks(null::bigint, schema_name=>'public');
-ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
-\set ON_ERROR_STOP 1
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
@@ -821,30 +811,13 @@ ORDER BY c.id;
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (6 rows)
 
--- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(older_than=>5, newer_than=>4)::NAME'
-\set QUERY2 'SELECT drop_chunks(5, schema_name=>\'public\', newer_than=>4)::NAME'
-\set ECHO errors
- Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
-----------------+-------------------------+-------------------------
-              0 |                       2 |                       2
-(1 row)
-
-SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
-FROM _timescaledb_catalog.chunk c
-INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
-INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
-INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
-WHERE h.schema_name = 'public'
-ORDER BY c.id;
- chunk_id | hypertable_id |     chunk_schema      |    chunk_table    | range_start | range_end 
-----------+---------------+-----------------------+-------------------+-------------+-----------
-        8 |             2 | _timescaledb_internal | _hyper_2_8_chunk  |           2 |         3
-        9 |             2 | _timescaledb_internal | _hyper_2_9_chunk  |           3 |         4
-       11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
-       12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
-(4 rows)
+SELECT drop_chunks(format('%1$I.%2$I', schema_name, table_name)::regclass, older_than => 5, newer_than => 4)
+  FROM _timescaledb_catalog.hypertable WHERE schema_name = 'public';
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+(2 rows)
 
 CREATE TABLE PUBLIC.drop_chunk_test_ts(time timestamp, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_ts', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
@@ -896,16 +869,16 @@ BEGIN;
 (1 row)
 
 -- show_chunks and drop_chunks output should be the same
-    \set QUERY1 'SELECT show_chunks(newer_than => interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(newer_than => interval \'1 minute\', table_name => \'drop_chunk_test_ts\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_ts\', newer_than => interval \'1 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_ts\', newer_than => interval \'1 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
               0 |                       1 |                       1
 (1 row)
 
-    \set QUERY1 'SELECT show_chunks(older_than => interval \'6 minute\', hypertable => \'drop_chunk_test_ts\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(older_than => interval \'6 minute\', table_name => \'drop_chunk_test_ts\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_ts\', older_than => interval \'6 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_ts\', older_than => interval \'6 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -918,8 +891,8 @@ BEGIN;
  _timescaledb_internal._hyper_4_19_chunk | 
 (1 row)
 
-    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_ts\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_ts\', older_than => interval \'1 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_ts\', interval \'1 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -957,7 +930,7 @@ BEGIN;
 (1 row)
 
     \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_tstz\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_tstz\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_tstz\', interval \'1 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -973,8 +946,8 @@ BEGIN;
 ROLLBACK;
 BEGIN;
 -- show_chunks and drop_chunks output should be the same
-    \set QUERY1 'SELECT show_chunks(newer_than => interval \'6 minute\', hypertable => \'drop_chunk_test_ts\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(newer_than => interval \'6 minute\', table_name => \'drop_chunk_test_ts\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_ts\', newer_than => interval \'6 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_ts\', newer_than => interval \'6 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -989,8 +962,8 @@ BEGIN;
 ROLLBACK;
 BEGIN;
 -- show_chunks and drop_chunks output should be the same
-    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_ts\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_ts\', older_than => interval \'1 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_ts\', older_than => interval \'1 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1003,8 +976,8 @@ BEGIN;
  _timescaledb_internal._hyper_4_20_chunk | 
 (1 row)
 
-    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 minute\', hypertable => \'drop_chunk_test_tstz\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(interval \'1 minute\', \'drop_chunk_test_tstz\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_tstz\', older_than => interval \'1 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_tstz\', older_than => interval \'1 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1020,8 +993,8 @@ BEGIN;
 ROLLBACK;
 BEGIN;
 -- show_chunks and drop_chunks output should be the same
-    \set QUERY1 'SELECT show_chunks(older_than => now()::timestamp-interval \'1 minute\', hypertable => \'drop_chunk_test_ts\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(now()::timestamp-interval \'1 minute\', \'drop_chunk_test_ts\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_ts\', older_than => now()::timestamp-interval \'1 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_ts\', older_than => now()::timestamp-interval \'1 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1034,8 +1007,8 @@ BEGIN;
  _timescaledb_internal._hyper_4_20_chunk | 
 (1 row)
 
-    \set QUERY1 'SELECT show_chunks(older_than => now()-interval \'1 minute\', hypertable => \'drop_chunk_test_tstz\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(now()-interval \'1 minute\', \'drop_chunk_test_tstz\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_tstz\', older_than => now()-interval \'1 minute\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_tstz\', older_than => now()-interval \'1 minute\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1077,20 +1050,16 @@ SELECT show_chunks();
 (8 rows)
 
 \set ON_ERROR_STOP 0
-SELECT show_chunks(older_than=>4);
-ERROR:  cannot call "show_chunks" on all hypertables when all hypertables do not have the same time dimension type
-SELECT drop_chunks(4);
-ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
 SELECT drop_chunks(interval '1 minute');
+ERROR:  function drop_chunks(interval) does not exist at character 8
+SELECT drop_chunks('drop_chunk_test3', interval '1 minute');
 ERROR:  can only use "drop_chunks" with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
-SELECT drop_chunks(interval '1 minute', 'drop_chunk_test3');
-ERROR:  can only use "drop_chunks" with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
-SELECT drop_chunks(now()-interval '1 minute', 'drop_chunk_test_ts');
+SELECT drop_chunks('drop_chunk_test_ts', (now()-interval '1 minute'));
 ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
-SELECT drop_chunks(now()::timestamp-interval '1 minute', 'drop_chunk_test_tstz');
+SELECT drop_chunks('drop_chunk_test_tstz', now()::timestamp-interval '1 minute');
 ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
-SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
-ERROR:  time constraint arguments of "drop_chunks" should have same type as time column of the hypertable
+SELECT drop_chunks('drop_chunk_test3', verbose => true);
+ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
 \set ON_ERROR_STOP 1
 \dt "_timescaledb_internal"._hyper*
                            List of relations
@@ -1118,8 +1087,8 @@ SET timezone = '+100';
 INSERT INTO PUBLIC.drop_chunk_test_date VALUES(now()-INTERVAL '2 day', 1.0, 'dev1');
 BEGIN;
 -- show_chunks and drop_chunks output should be the same
-    \set QUERY1 'SELECT show_chunks(older_than => interval \'1 day\', hypertable => \'drop_chunk_test_date\')::NAME'
-    \set QUERY2 'SELECT drop_chunks(interval \'1 day\', \'drop_chunk_test_date\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_date\', older_than => interval \'1 day\')::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_date\', older_than => interval \'1 day\')::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1134,8 +1103,8 @@ BEGIN;
 ROLLBACK;
 BEGIN;
 -- show_chunks and drop_chunks output should be the same
-    \set QUERY1 'SELECT show_chunks(older_than => (now()-interval \'1 day\')::date, hypertable => \'drop_chunk_test_date\')::NAME'
-    \set QUERY2 'SELECT drop_chunks((now()-interval \'1 day\')::date, \'drop_chunk_test_date\')::NAME'
+    \set QUERY1 'SELECT show_chunks(\'drop_chunk_test_date\', older_than => (now()-interval \'1 day\')::date)::NAME'
+    \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test_date\', older_than => (now()-interval \'1 day\')::date)::NAME'
     \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1221,8 +1190,8 @@ SELECT show_chunks(hypertable => 'test_weird_type', older_than=>'2019/06/06 10:0
 (2 rows)
 
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(older_than => \'2019/06/06 5:00+0\'::TIMESTAMPTZ, hypertable => \'test_weird_type\')::NAME'
-\set QUERY2 'SELECT drop_chunks(\'2019/06/06 5:00+0\'::TIMESTAMPTZ, \'test_weird_type\')::NAME'
+\set QUERY1 'SELECT show_chunks(\'test_weird_type\', older_than => \'2019/06/06 5:00+0\'::TIMESTAMPTZ)::NAME'
+\set QUERY2 'SELECT drop_chunks(\'test_weird_type\', older_than => \'2019/06/06 5:00+0\'::TIMESTAMPTZ)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1247,8 +1216,8 @@ SELECT show_chunks('test_weird_type', older_than=>'2019/06/06 10:00+0'::TIMESTAM
 (1 row)
 
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(older_than => \'2019/06/06 6:00+0\'::TIMESTAMPTZ, hypertable => \'test_weird_type\')::NAME'
-\set QUERY2 'SELECT drop_chunks(\'2019/06/06 6:00+0\'::TIMESTAMPTZ, \'test_weird_type\')::NAME'
+\set QUERY1 'SELECT show_chunks(\'test_weird_type\', older_than => \'2019/06/06 6:00+0\'::TIMESTAMPTZ)::NAME'
+\set QUERY2 'SELECT drop_chunks(\'test_weird_type\', older_than => \'2019/06/06 6:00+0\'::TIMESTAMPTZ)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1302,8 +1271,8 @@ SELECT show_chunks('test_weird_type_i', older_than=>10);
 (2 rows)
 
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(older_than=>5, hypertable => \'test_weird_type_i\')::NAME'
-\set QUERY2 'SELECT drop_chunks(5, \'test_weird_type_i\')::NAME'
+\set QUERY1 'SELECT show_chunks(\'test_weird_type_i\', older_than=>5)::NAME'
+\set QUERY2 'SELECT drop_chunks(\'test_weird_type_i\', older_than => 5)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1328,8 +1297,8 @@ SELECT show_chunks('test_weird_type_i', older_than=>10);
 (1 row)
 
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(older_than=>10, hypertable => \'test_weird_type_i\')::NAME'
-\set QUERY2 'SELECT drop_chunks(10, \'test_weird_type_i\')::NAME'
+\set QUERY1 'SELECT show_chunks(\'test_weird_type_i\', older_than=>10)::NAME'
+\set QUERY2 'SELECT drop_chunks(\'test_weird_type_i\', older_than => 10)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1362,14 +1331,12 @@ create view dependent_view2 as SELECT * FROM :"chunk_schema".:"chunk_table";
 ALTER TABLE drop_chunk_test3 OWNER TO :ROLE_DEFAULT_PERM_USER_2;
 \c  :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 \set ON_ERROR_STOP 0
-SELECT drop_chunks(table_name=>'drop_chunk_test1', older_than=>4, newer_than=>3);
-ERROR:  must be owner of hypertable "drop_chunk_test1"
-SELECT drop_chunks(2, verbose => true);
+SELECT drop_chunks('drop_chunk_test1', older_than=>4, newer_than=>3);
 ERROR:  must be owner of hypertable "drop_chunk_test1"
 --works with modified owner tables
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(hypertable=>\'drop_chunk_test2\', older_than=>4, newer_than=>3)::NAME'
-\set QUERY2 'SELECT drop_chunks(table_name=>\'drop_chunk_test2\', older_than=>4, newer_than=>3)::NAME'
+\set QUERY1 'SELECT show_chunks(\'drop_chunk_test2\', older_than=>4, newer_than=>3)::NAME'
+\set QUERY2 'SELECT drop_chunks(\'drop_chunk_test2\', older_than=>4, newer_than=>3)::NAME'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -1378,7 +1345,7 @@ ERROR:  must be owner of hypertable "drop_chunk_test1"
 
 \set VERBOSITY default
 --this fails because there are dependent objects
-SELECT drop_chunks(table_name=>'drop_chunk_test3', older_than=>100);
+SELECT drop_chunks('drop_chunk_test3', older_than=>100);
 ERROR:  cannot drop table _timescaledb_internal._hyper_3_34_chunk because other objects depend on it
 DETAIL:  view dependent_view depends on table _timescaledb_internal._hyper_3_34_chunk
 view dependent_view2 depends on table _timescaledb_internal._hyper_3_34_chunk
@@ -1426,32 +1393,10 @@ SELECT show_chunks(hypertable=>'try_schema.drop_chunk_test_date', older_than=>'1
  _timescaledb_internal._hyper_11_36_chunk
 (1 row)
 
-SELECT drop_chunks(table_name=>'drop_chunk_test_date', older_than=> '1 day'::interval);
+SELECT drop_chunks('drop_chunk_test_date', older_than=> '1 day'::interval);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_11_36_chunk
-(1 row)
-
---drop_chunks without schema_name and table_name
-INSERT INTO public.drop_chunk_test_date VALUES( '2020-02-11', 100, 'hello');
-INSERT INTO try_schema.drop_chunk_test_date VALUES( '2020-02-10', 100, 'hello');
-SELECT show_chunks(hypertable=>'public.drop_chunk_test_date', older_than=>'1 day'::interval);
-               show_chunks               
------------------------------------------
- _timescaledb_internal._hyper_6_35_chunk
- _timescaledb_internal._hyper_6_37_chunk
-(2 rows)
-
-SELECT show_chunks(hypertable=>'try_schema.drop_chunk_test_date', older_than=>'1 day'::interval);
-               show_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_11_38_chunk
-(1 row)
-
-SELECT drop_chunks(older_than=> '1 day'::interval);
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_11_38_chunk
 (1 row)
 
 -- test drop chunks across two tables within the same schema
@@ -1473,22 +1418,17 @@ NOTICE:  adding not-null constraint to column "time"
 
 INSERT INTO test1.hyper1 VALUES (10, 0.5);
 INSERT INTO test1.hyper2 VALUES (10, 0.7);
-SELECT drop_chunks(schema_name=>'test1', older_than => 100);
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_12_39_chunk
- _timescaledb_internal._hyper_13_40_chunk
-(2 rows)
-
 SELECT show_chunks('test1.hyper1');
- show_chunks 
--------------
-(0 rows)
+               show_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_12_37_chunk
+(1 row)
 
 SELECT show_chunks('test1.hyper2');
- show_chunks 
--------------
-(0 rows)
+               show_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_13_38_chunk
+(1 row)
 
 -- test drop chunks for given table name across all schemas
 CREATE TABLE test2.hyperx (time bigint, temp float);
@@ -1512,21 +1452,21 @@ INSERT INTO test3.hyperx VALUES (10, 0.7);
 SELECT show_chunks('test2.hyperx');
                show_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_14_41_chunk
+ _timescaledb_internal._hyper_14_39_chunk
 (1 row)
 
 SELECT show_chunks('test3.hyperx');
                show_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_15_42_chunk
+ _timescaledb_internal._hyper_15_40_chunk
 (1 row)
 
 -- This will only drop from one of the tables since the one that is
 -- first in the search path will hide the other one.
-SELECT drop_chunks(table_name=>'hyperx', older_than => 100);
+SELECT drop_chunks('hyperx', older_than => 100);
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_14_41_chunk
+ _timescaledb_internal._hyper_14_39_chunk
 (1 row)
 
 SELECT show_chunks('test2.hyperx');
@@ -1537,6 +1477,6 @@ SELECT show_chunks('test2.hyperx');
 SELECT show_chunks('test3.hyperx');
                show_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_15_42_chunk
+ _timescaledb_internal._hyper_15_40_chunk
 (1 row)
 

--- a/test/expected/chunk_utils_compression.out
+++ b/test/expected/chunk_utils_compression.out
@@ -114,7 +114,10 @@ SELECT show_chunks();
 (9 rows)
 
 -- drop all hypertables' old chunks
-SELECT drop_chunks(older_than=>'1 day'::interval);
+SELECT drop_chunks(table_name::regclass, older_than=>'1 day'::interval)
+  FROM _timescaledb_catalog.hypertable
+ WHERE schema_name = current_schema()
+ORDER BY table_name DESC;
               drop_chunks               
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -113,7 +113,7 @@ SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '
 -- testing drop_chunks START
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT "testSchema0".show_chunks(older_than => \'2017-03-01\'::timestamp, hypertable => \'test_ts\')::REGCLASS::TEXT'
-\set QUERY2 'SELECT "testSchema0".drop_chunks(\'2017-03-01\'::timestamp, \'test_ts\')::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'test_ts\', \'2017-03-01\'::timestamp)::TEXT'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -130,7 +130,7 @@ SELECT * FROM test_ts ORDER BY time;
 (4 rows)
 
 \set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_tz\')::REGCLASS::TEXT'
-\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_tz\')::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'test_tz\', interval \'1 minutes\')::TEXT'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -143,7 +143,7 @@ SELECT * FROM test_tz ORDER BY time;
 (0 rows)
 
 \set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_dt\')::REGCLASS::TEXT'
-\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_dt\')::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'test_dt\', interval \'1 minutes\')::TEXT'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------

--- a/test/isolation/expected/deadlock_dropchunks_select.out
+++ b/test/isolation/expected/deadlock_dropchunks_select.out
@@ -1,7 +1,7 @@
 Parsed test spec with 2 sessions
 
 starting permutation: s1a s1b s2a s2b
-step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+step s1a: SELECT count (*) FROM drop_chunks('dt',  '2018-12-25 00:00'::timestamptz);
 count          
 
 24             
@@ -12,7 +12,7 @@ typ            loc            mtim
 step s2b: COMMIT;
 
 starting permutation: s1a s2a s1b s2b
-step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+step s1a: SELECT count (*) FROM drop_chunks('dt',  '2018-12-25 00:00'::timestamptz);
 count          
 
 24             
@@ -24,7 +24,7 @@ typ            loc            mtim
 step s2b: COMMIT;
 
 starting permutation: s1a s2a s2b s1b
-step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+step s1a: SELECT count (*) FROM drop_chunks('dt',  '2018-12-25 00:00'::timestamptz);
 count          
 
 24             
@@ -38,7 +38,7 @@ starting permutation: s2a s1a s1b s2b
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ;
 typ            loc            mtim           
 
-step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); <waiting ...>
+step s1a: SELECT count (*) FROM drop_chunks('dt',  '2018-12-25 00:00'::timestamptz); <waiting ...>
 step s1a: <... completed>
 ERROR:  canceling statement due to lock timeout
 step s1b: COMMIT;
@@ -48,7 +48,7 @@ starting permutation: s2a s1a s2b s1b
 step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.sid = DT.sid AND mtim >= '2018-12-01 03:00:00+00' AND mtim <= '2018-12-01 04:00:00+00' AND typ = 'T1' ;
 typ            loc            mtim           
 
-step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); <waiting ...>
+step s1a: SELECT count (*) FROM drop_chunks('dt',  '2018-12-25 00:00'::timestamptz); <waiting ...>
 step s2b: COMMIT;
 step s1a: <... completed>
 count          
@@ -61,7 +61,7 @@ step s2a: SELECT typ, loc, mtim FROM DT , SL , ST WHERE SL.lid = DT.lid AND ST.s
 typ            loc            mtim           
 
 step s2b: COMMIT;
-step s1a: SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt');
+step s1a: SELECT count (*) FROM drop_chunks('dt',  '2018-12-25 00:00'::timestamptz);
 count          
 
 24             

--- a/test/isolation/specs/deadlock_dropchunks_select.spec
+++ b/test/isolation/specs/deadlock_dropchunks_select.spec
@@ -17,7 +17,7 @@ teardown
 
 session "s1"
 setup	{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; SET LOCAL lock_timeout = '50ms'; SET LOCAL deadlock_timeout = '10ms'; }
-step "s1a"	{ SELECT count (*) FROM drop_chunks( '2018-12-25 00:00'::timestamptz, 'dt'); }
+step "s1a"	{ SELECT count (*) FROM drop_chunks('dt',  '2018-12-25 00:00'::timestamptz); }
 step "s1b"	{ COMMIT; }
 
 session "s2"

--- a/test/sql/alter.sql
+++ b/test/sql/alter.sql
@@ -168,7 +168,7 @@ DROP TABLESPACE tablespace1;
 
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT show_chunks(\'hyper_in_space\', 22)::NAME'
-\set QUERY2 'SELECT drop_chunks(22, \'hyper_in_space\')::NAME'
+\set QUERY2 'SELECT drop_chunks(\'hyper_in_space\', 22)::NAME'
 \set ECHO errors
 \ir :QUERY_RESULT_TEST_EQUAL_RELPATH
 \set ECHO all

--- a/test/sql/chunk_utils_compression.sql
+++ b/test/sql/chunk_utils_compression.sql
@@ -38,5 +38,8 @@ SELECT show_chunks(hypertable=>'public.table_to_compress', older_than=>'1 day'::
 SELECT show_chunks(hypertable=>'public.table_to_compress', newer_than=>'1 day'::interval);
 SELECT show_chunks(); 
 -- drop all hypertables' old chunks
-SELECT drop_chunks(older_than=>'1 day'::interval);
+SELECT drop_chunks(table_name::regclass, older_than=>'1 day'::interval)
+  FROM _timescaledb_catalog.hypertable
+ WHERE schema_name = current_schema()
+ORDER BY table_name DESC;
 SELECT show_chunks(); 

--- a/test/sql/relocate_extension.sql
+++ b/test/sql/relocate_extension.sql
@@ -53,19 +53,19 @@ SELECT AVG(temp) AS avg_tmp, "testSchema0".time_bucket('1 day', time, INTERVAL '
 -- testing drop_chunks START
 -- show_chunks and drop_chunks output should be the same
 \set QUERY1 'SELECT "testSchema0".show_chunks(older_than => \'2017-03-01\'::timestamp, hypertable => \'test_ts\')::REGCLASS::TEXT'
-\set QUERY2 'SELECT "testSchema0".drop_chunks(\'2017-03-01\'::timestamp, \'test_ts\')::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'test_ts\', \'2017-03-01\'::timestamp)::TEXT'
 \set ECHO errors
 \ir  :QUERY_RESULT_TEST_EQUAL_RELPATH
 \set ECHO all
 SELECT * FROM test_ts ORDER BY time;
 \set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_tz\')::REGCLASS::TEXT'
-\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_tz\')::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'test_tz\', interval \'1 minutes\')::TEXT'
 \set ECHO errors
 \ir  :QUERY_RESULT_TEST_EQUAL_RELPATH
 \set ECHO all
 SELECT * FROM test_tz ORDER BY time;
 \set QUERY1 'SELECT "testSchema0".show_chunks(older_than => interval \'1 minutes\', hypertable => \'test_dt\')::REGCLASS::TEXT'
-\set QUERY2 'SELECT "testSchema0".drop_chunks(interval \'1 minutes\', \'test_dt\')::TEXT'
+\set QUERY2 'SELECT "testSchema0".drop_chunks(\'test_dt\', interval \'1 minutes\')::TEXT'
 \set ECHO errors
 \ir  :QUERY_RESULT_TEST_EQUAL_RELPATH
 \set ECHO all

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -13,7 +13,7 @@
 
 extern void chunk_update_foreign_server_if_needed(int32 chunk_id, Oid existing_server_id);
 extern Datum chunk_set_default_data_node(PG_FUNCTION_ARGS);
-extern int chunk_invoke_drop_chunks(Name schema_name, Name table_name, Datum older_than,
-									Datum older_than_type, bool cascade_to_materializations);
+extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type,
+									bool cascade_to_materializations);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_H */

--- a/tsl/src/continuous_aggs/drop.c
+++ b/tsl/src/continuous_aggs/drop.c
@@ -23,8 +23,7 @@ void
 ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks_ptr,
 										  Size num_chunks, Datum older_than_datum,
 										  Datum newer_than_datum, Oid older_than_type,
-										  Oid newer_than_type, int32 log_level,
-										  bool user_supplied_table_name)
+										  Oid newer_than_type, int32 log_level)
 {
 	ListCell *lc;
 	Oid arg_type = INT4OID;
@@ -45,14 +44,13 @@ ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunk
 		ContinuousAgg *agg = lfirst(lc);
 		Hypertable *mat_table = ts_hypertable_get_by_id(agg->data.mat_hypertable_id);
 
-		ts_chunk_do_drop_chunks(mat_table->main_table_relid,
+		ts_chunk_do_drop_chunks(mat_table,
 								older_than_datum,
 								newer_than_datum,
 								older_than_type,
 								newer_than_type,
 								CASCADE_TO_MATERIALIZATION_FALSE,
 								log_level,
-								user_supplied_table_name,
 								NULL);
 
 		/* we might still have materialization chunks that have data that refer

--- a/tsl/src/continuous_aggs/drop.h
+++ b/tsl/src/continuous_aggs/drop.h
@@ -13,7 +13,6 @@
 extern void ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunks_ptr,
 													  Size num_chunks, Datum older_than_datum,
 													  Datum newer_than_datum, Oid older_than_type,
-													  Oid newer_than_type, int32 log_level,
-													  bool user_supplied_table_name);
+													  Oid newer_than_type, int32 log_level);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_DROP_H */

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1072,7 +1072,7 @@ SELECT compress_chunk(i) FROM show_chunks('ht5') i;
  _timescaledb_internal._hyper_20_46_chunk
 (2 rows)
 
-SELECT drop_chunks(table_name => 'ht5', newer_than => '2000-01-01'::TIMESTAMPTZ);
+SELECT drop_chunks('ht5', newer_than => '2000-01-01'::TIMESTAMPTZ);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_20_46_chunk

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -242,7 +242,7 @@ ALTER VIEW conditions_summary SET (
       timescaledb.ignore_invalidation_older_than = '15 days'
 );
 SELECT COUNT(*) AS dropped_chunks_count
-  FROM drop_chunks(TIMESTAMPTZ '2018-12-15 00:00', 'conditions',
+  FROM drop_chunks('conditions', TIMESTAMPTZ '2018-12-15 00:00',
                    cascade_to_materializations => FALSE);
 NOTICE:  making sure all invalidations for public.conditions_summary have been processed prior to dropping chunks
  dropped_chunks_count 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -237,7 +237,7 @@ WHERE uncomp_hyper.table_name like 'test1';
                       26
 (1 row)
 
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-10'::TIMESTAMPTZ);
+SELECT drop_chunks('test1', older_than => '2018-03-10'::TIMESTAMPTZ);
               drop_chunks               
 ----------------------------------------
  _timescaledb_internal._hyper_1_2_chunk
@@ -330,14 +330,14 @@ CREATE VIEW dependent_1 AS SELECT * FROM :COMPRESSED_CHUNK_NAME;
 \set ON_ERROR_STOP 0
 \set VERBOSITY default
 --errors due to dependent objects
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
+SELECT drop_chunks('test1', older_than => '2018-03-28'::TIMESTAMPTZ);
 ERROR:  cannot drop table _timescaledb_internal.compress_hyper_2_37_chunk because other objects depend on it
 DETAIL:  view dependent_1 depends on table _timescaledb_internal.compress_hyper_2_37_chunk
 HINT:  Use DROP ... to drop the dependent objects.
 \set VERBOSITY terse
 \set ON_ERROR_STOP 1
 DROP VIEW dependent_1;
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
+SELECT drop_chunks('test1', older_than => '2018-03-28'::TIMESTAMPTZ);
                drop_chunks               
 -----------------------------------------
  _timescaledb_internal._hyper_1_10_chunk

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -229,14 +229,11 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
 -- cannot drop directly from the materialization table without specifying
 -- cont. aggregate view name explicitly
 \set ON_ERROR_STOP 0
-SELECT drop_chunks(
+SELECT drop_chunks(:'drop_chunks_mat_table',
     newer_than => -20,
     verbose => true,
     cascade_to_materializations=>true);
-INFO:  dropping chunk _timescaledb_internal._hyper_4_1_chunk
-INFO:  dropping chunk _timescaledb_internal._hyper_4_2_chunk
-INFO:  dropping chunk _timescaledb_internal._hyper_4_3_chunk
-ERROR:  cannot drop chunks on a continuous aggregate materialization table
+ERROR:  cannot drop chunks on a continuous aggregate materialization hypertable
 \set ON_ERROR_STOP 1
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
@@ -260,7 +257,7 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
 
 -- cannot drop from the raw table without specifying cascade_to_materializations
 \set ON_ERROR_STOP 0
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 10);
+SELECT drop_chunks('drop_chunks_table', older_than => 10);
 ERROR:  cascade_to_materializations options must be set explicitly
 \set ON_ERROR_STOP 1
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
@@ -283,10 +280,6 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           10 |     5
 (3 rows)
 
-\set ON_ERROR_STOP 0
-SELECT drop_chunks(older_than => 200);
-ERROR:  cascade_to_materializations options must be set explicitly
-\set ON_ERROR_STOP 1
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
  count 
 -------
@@ -308,8 +301,8 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
 (3 rows)
 
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table\', older_than => 13)::REGCLASS::TEXT'
-\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set QUERY1 'SELECT show_chunks(\'drop_chunks_table\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(\'drop_chunks_table\', older_than => 13, cascade_to_materializations => true)::TEXT'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -391,8 +384,8 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
 (5 rows)
 
 -- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(hypertable => \'drop_chunks_table_u\', older_than => 13)::REGCLASS::TEXT'
-\set QUERY2 'SELECT drop_chunks(table_name => \'drop_chunks_table_u\', older_than => 13, cascade_to_materializations => true)::TEXT'
+\set QUERY1 'SELECT show_chunks(\'drop_chunks_table_u\', older_than => 13)::REGCLASS::TEXT'
+\set QUERY2 'SELECT drop_chunks(\'drop_chunks_table_u\', older_than => 13, cascade_to_materializations => true)::TEXT'
 \set ECHO errors
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
@@ -579,14 +572,14 @@ AS SELECT time_bucket('5', time), max(data)
     GROUP BY 1;
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 \set ON_ERROR_STOP 0
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 13, cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => 13, cascade_to_materializations => false);
 ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 ALTER VIEW drop_chunks_view SET (timescaledb.ignore_invalidation_older_than = 9);
 -- 9 is too small (less than timescaledb.ignore_invalidation_older_than)
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-8), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-8), cascade_to_materializations => false);
 ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 -- 10 works but we don't have the completion threshold far enough along
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
@@ -595,7 +588,7 @@ LOG:  materializing continuous aggregate public.drop_chunks_view: nothing to inv
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 \set ON_ERROR_STOP 0
 --still too far behind
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
@@ -605,7 +598,7 @@ WARNING:  REFRESH did not materialize the entire range since it was limited by t
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 LOG:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 25
 --now, this works
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, no new range
 LOG:  materializing continuous aggregate public.drop_chunks_view: no new range to materialize or invalidations found, exiting early
@@ -616,11 +609,11 @@ LOG:  materializing continuous aggregate public.drop_chunks_view: no new range t
 
 \set ON_ERROR_STOP 0
 --must have older_than set and no newer than
-SELECT drop_chunks(table_name => 'drop_chunks_table', cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', cascade_to_materializations => false);
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
-SELECT drop_chunks(table_name => 'drop_chunks_table', newer_than=>10, cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', newer_than=>10, cascade_to_materializations => false);
 ERROR:  cannot use newer_than parameter to drop_chunks with cascade_to_materializations
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => 20, newer_than=>10, cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => 20, newer_than=>10, cascade_to_materializations => false);
 ERROR:  cannot use newer_than parameter to drop_chunks with cascade_to_materializations
 \set ON_ERROR_STOP 1
 --test materialization of invalidation before drop
@@ -661,7 +654,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (8 rows)
 
 --dropping tables will cause the invalidation to be processed
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
                drop_chunks                
@@ -787,7 +780,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (8 rows)
 
 --should see multiple rounds of invalidation in the log messages
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
@@ -843,7 +836,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
            0 |   4
 (12 rows)
 
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
                drop_chunks                
@@ -934,7 +927,7 @@ SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_tablen,
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
     WHERE _timescaledb_catalog.continuous_agg.raw_hypertable_id = :drop_chunks_table_nid
         AND _timescaledb_catalog.hypertable.id = _timescaledb_catalog.continuous_agg.mat_hypertable_id \gset
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() + 200, cascade_to_materializations => true);
+SELECT drop_chunks('drop_chunks_table', older_than=>integer_now_test2() + 200, cascade_to_materializations => true);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_10_19_chunk
@@ -1008,7 +1001,7 @@ ORDER BY ranges;
 
 --1 chunk from the mat. hypertable will be dropped and the other will
 --need deletes when the chunks from the raw hypertable are dropped.
-SELECT drop_chunks(table_name => 'drop_chunks_table', older_than=>integer_now_test2() - 4 , cascade_to_materializations => true);
+SELECT drop_chunks('drop_chunks_table', older_than=>integer_now_test2() - 4 , cascade_to_materializations => true);
                drop_chunks                
 ------------------------------------------
  _timescaledb_internal._hyper_10_13_chunk
@@ -1037,8 +1030,7 @@ ORDER BY ranges;
 (1 row)
 
 -- TEST drop chunks from continuous aggregates by specifying view name
-SELECT drop_chunks(
-    table_name => 'drop_chunks_view',
+SELECT drop_chunks('drop_chunks_view',
     newer_than => -20,
     verbose => true);
 INFO:  dropping chunk _timescaledb_internal._hyper_11_22_chunk
@@ -1047,32 +1039,24 @@ INFO:  dropping chunk _timescaledb_internal._hyper_11_22_chunk
  _timescaledb_internal._hyper_11_22_chunk
 (1 row)
 
---can also drop chunks by specifying materialized hypertable name
+-- Test that we cannot drop chunks when specifying materialized
+-- hypertable
 INSERT INTO drop_chunks_table SELECT generate_series(45, 55), 500;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 LOG:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 55
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
-SELECT chunk_table, ranges FROM chunk_relation_size(:'drop_chunks_mat_tablen');
+SELECT chunk_table, ranges
+  FROM chunk_relation_size(:'drop_chunks_mat_tablen');
                chunk_table                |   ranges    
 ------------------------------------------+-------------
  _timescaledb_internal._hyper_11_24_chunk | {"[40,60)"}
 (1 row)
 
 \set ON_ERROR_STOP 0
-SELECT drop_chunks(
-    table_name => :'drop_chunks_mat_table_name',
-    older_than => 60,
-    verbose => true);
-ERROR:  "_materialized_hypertable_11" is not a hypertable or a continuous aggregate view
+\set VERBOSITY default
+SELECT drop_chunks(:'drop_chunks_mat_tablen', older_than => 60);
+ERROR:  cannot drop chunks on a continuous aggregate materialization hypertable
+DETAIL:  Hypertable "_materialized_hypertable_11" is a materialized hypertable.
+HINT:  Call drop_chunks on the continuous aggregate instead.
+\set VERBOSITY terse
 \set ON_ERROR_STOP 1
-SELECT drop_chunks(
-    schema_name => :'drop_chunks_mat_schema',
-    table_name => :'drop_chunks_mat_table_name',
-    older_than => 60,
-    verbose => true);
-INFO:  dropping chunk _timescaledb_internal._hyper_11_24_chunk
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_11_24_chunk
-(1 row)
-

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -413,7 +413,7 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 (6 rows)
 
 -- Dropping a chunk should also clean up data node mappings
-SELECT * FROM drop_chunks(older_than => '2019-05-22 17:18'::timestamptz);
+SELECT * FROM drop_chunks('disttable', older_than => '2019-05-22 17:18'::timestamptz);
                  drop_chunks                 
 ---------------------------------------------
  _timescaledb_internal._dist_hyper_3_2_chunk
@@ -1109,7 +1109,7 @@ SELECT * FROM detach_data_node('server_2', 'disttable', force => true);
 ERROR:  server "server_2" does not exist
 \set ON_ERROR_STOP 1
 -- drop all chunks
-SELECT * FROM drop_chunks(table_name => 'disttable', older_than => '2200-01-01 00:00'::timestamptz);
+SELECT * FROM drop_chunks('disttable', older_than => '2200-01-01 00:00'::timestamptz);
                  drop_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_5_5_chunk

--- a/tsl/test/expected/deparse.out
+++ b/tsl/test/expected/deparse.out
@@ -10,28 +10,28 @@
 (1 row)
 
 -- test drop_chunks function deparsing
-SELECT * FROM tsl_test_deparse_drop_chunks('2019-01-01'::timestamptz, 'Test_table', 'test_schema', verbose => true);
-                                                                                                      tsl_test_deparse_drop_chunks                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone,table_name => 'Test_table',schema_name => 'test_schema',newer_than => NULL,verbose => 't',cascade_to_materializations => NULL)
+SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', '2019-01-01'::timestamptz, verbose => true);
+                                                                                              tsl_test_deparse_drop_chunks                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'myschema.table10',older_than => 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone,newer_than => NULL,verbose => 't',cascade_to_materializations => NULL)
 (1 row)
 
-SELECT * FROM tsl_test_deparse_drop_chunks(interval '1 day', table_name => 'weird nAme\\#^.', cascade_to_materializations => true);
-                                                                                  tsl_test_deparse_drop_chunks                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => '@ 1 day'::interval,table_name => E'weird nAme\\\\#^.',schema_name => NULL,newer_than => NULL,verbose => 'f',cascade_to_materializations => 't')
+SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', interval '1 day', cascade_to_materializations => true);
+                                                                           tsl_test_deparse_drop_chunks                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'myschema.table10',older_than => '@ 1 day'::interval,newer_than => NULL,verbose => 'f',cascade_to_materializations => 't')
 (1 row)
 
-SELECT * FROM tsl_test_deparse_drop_chunks(newer_than => 12345);
-                                                                         tsl_test_deparse_drop_chunks                                                                          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => NULL,table_name => NULL,schema_name => NULL,newer_than => '12345'::integer,verbose => 'f',cascade_to_materializations => NULL)
+SELECT * FROM tsl_test_deparse_drop_chunks('table1', newer_than => 12345);
+                                                                         tsl_test_deparse_drop_chunks                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'public.table1',older_than => NULL,newer_than => '12345'::integer,verbose => 'f',cascade_to_materializations => NULL)
 (1 row)
 
-SELECT * FROM tsl_test_deparse_drop_chunks(older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
-                                                                                                     tsl_test_deparse_drop_chunks                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(older_than => '@ 2 years'::interval,table_name => NULL,schema_name => NULL,newer_than => 'Thu Jan 01 00:00:00 2015'::timestamp without time zone,verbose => 'f',cascade_to_materializations => NULL)
+SELECT * FROM tsl_test_deparse_drop_chunks('table1', older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
+                                                                                                     tsl_test_deparse_drop_chunks                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'public.table1',older_than => '@ 2 years'::interval,newer_than => 'Thu Jan 01 00:00:00 2015'::timestamp without time zone,verbose => 'f',cascade_to_materializations => NULL)
 (1 row)
 
 -- test generalized deparsing function

--- a/tsl/test/expected/deparse_fail.out
+++ b/tsl/test/expected/deparse_fail.out
@@ -8,9 +8,9 @@
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_tabledef(tbl REGCLASS) RETURNS TEXT
 AS :TSL_MODULE_PATHNAME, 'ts_test_get_tabledef' LANGUAGE C VOLATILE STRICT;
-CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(older_than "any" = NULL,
-    table_name  NAME = NULL,
-    schema_name NAME = NULL,
+CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(
+    table_name REGCLASS,
+    older_than "any" = NULL,
     newer_than "any" = NULL,
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL) RETURNS TEXT

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -2834,8 +2834,7 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
  
 (1 row)
 
--- test passing older_than and schema name
-SELECT * FROM drop_chunks(older_than => '2018-01-01'::timestamptz, table_name => 'disttable_drop_chunks', schema_name => 'public');
+SELECT * FROM drop_chunks('disttable_drop_chunks', older_than => '2018-01-01'::timestamptz);
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_10_27_chunk
@@ -2904,7 +2903,7 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
 (1 row)
 
 -- test passing newer_than as interval
-SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks');
+SELECT * FROM drop_chunks('disttable_drop_chunks', newer_than => interval '10 years');
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_10_30_chunk
@@ -2937,7 +2936,7 @@ SELECT * FROM "weird nAme\\#^.";
 (3 rows)
 
 -- drop chunks using bigint as time
-SELECT * FROM drop_chunks(older_than => 1000, table_name => 'weird nAme\\#^.');
+SELECT * FROM drop_chunks('"weird nAme\\#^."', older_than => 1000);
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_11_33_chunk

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -2815,8 +2815,7 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
  
 (1 row)
 
--- test passing older_than and schema name
-SELECT * FROM drop_chunks(older_than => '2018-01-01'::timestamptz, table_name => 'disttable_drop_chunks', schema_name => 'public');
+SELECT * FROM drop_chunks('disttable_drop_chunks', older_than => '2018-01-01'::timestamptz);
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_10_27_chunk
@@ -2885,7 +2884,7 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
 (1 row)
 
 -- test passing newer_than as interval
-SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks');
+SELECT * FROM drop_chunks('disttable_drop_chunks', newer_than => interval '10 years');
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_10_30_chunk
@@ -2918,7 +2917,7 @@ SELECT * FROM "weird nAme\\#^.";
 (3 rows)
 
 -- drop chunks using bigint as time
-SELECT * FROM drop_chunks(older_than => 1000, table_name => 'weird nAme\\#^.');
+SELECT * FROM drop_chunks('"weird nAme\\#^."', older_than => 1000);
                   drop_chunks                  
 -----------------------------------------------
  _timescaledb_internal._dist_hyper_11_33_chunk

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -428,7 +428,7 @@ INSERT INTO ht5 SELECT '2001-01-01'::TIMESTAMPTZ;
 -- compressed_chunk_stats should not show dropped chunks
 ALTER TABLE ht5 SET (timescaledb.compress);
 SELECT compress_chunk(i) FROM show_chunks('ht5') i;
-SELECT drop_chunks(table_name => 'ht5', newer_than => '2000-01-01'::TIMESTAMPTZ);
+SELECT drop_chunks('ht5', newer_than => '2000-01-01'::TIMESTAMPTZ);
 SELECT chunk_name
 FROM timescaledb_information.compressed_chunk_stats
 WHERE hypertable_name = 'ht5'::regclass;

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -140,7 +140,7 @@ ALTER VIEW conditions_summary SET (
 );
 
 SELECT COUNT(*) AS dropped_chunks_count
-  FROM drop_chunks(TIMESTAMPTZ '2018-12-15 00:00', 'conditions',
+  FROM drop_chunks('conditions', TIMESTAMPTZ '2018-12-15 00:00',
                    cascade_to_materializations => FALSE);
 
 -- We need to have some chunks that are marked as dropped, otherwise

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -164,7 +164,7 @@ INNER JOIN _timescaledb_catalog.hypertable comp_hyper ON (chunk.hypertable_id = 
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'test1';
 
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-10'::TIMESTAMPTZ);
+SELECT drop_chunks('test1', older_than => '2018-03-10'::TIMESTAMPTZ);
 
 --should decrease #chunks both compressed and decompressed
 SELECT count(*) as count_chunks_uncompressed
@@ -237,12 +237,12 @@ CREATE VIEW dependent_1 AS SELECT * FROM :COMPRESSED_CHUNK_NAME;
 \set ON_ERROR_STOP 0
 \set VERBOSITY default
 --errors due to dependent objects
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
+SELECT drop_chunks('test1', older_than => '2018-03-28'::TIMESTAMPTZ);
 \set VERBOSITY terse
 \set ON_ERROR_STOP 1
 
 DROP VIEW dependent_1;
-SELECT drop_chunks(table_name=>'test1', older_than => '2018-03-28'::TIMESTAMPTZ);
+SELECT drop_chunks('test1', older_than => '2018-03-28'::TIMESTAMPTZ);
 
 --should decrease #chunks both compressed and decompressed
 SELECT count(*) as count_chunks_uncompressed

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -225,7 +225,7 @@ SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
 
 -- Dropping a chunk should also clean up data node mappings
-SELECT * FROM drop_chunks(older_than => '2019-05-22 17:18'::timestamptz);
+SELECT * FROM drop_chunks('disttable', older_than => '2019-05-22 17:18'::timestamptz);
 
 SELECT * FROM test.show_subtables('disttable');
 SELECT foreign_table_name, foreign_server_name
@@ -542,7 +542,7 @@ SELECT * FROM detach_data_node('server_2', 'disttable', force => true);
 \set ON_ERROR_STOP 1
 
 -- drop all chunks
-SELECT * FROM drop_chunks(table_name => 'disttable', older_than => '2200-01-01 00:00'::timestamptz);
+SELECT * FROM drop_chunks('disttable', older_than => '2200-01-01 00:00'::timestamptz);
 SELECT foreign_table_name, foreign_server_name
 FROM information_schema.foreign_tables
 ORDER BY foreign_table_name;

--- a/tsl/test/sql/deparse.sql
+++ b/tsl/test/sql/deparse.sql
@@ -31,10 +31,10 @@ SELECT 'TABLE DEPARSE TEST DONE';
 
 \set ECHO all
 -- test drop_chunks function deparsing
-SELECT * FROM tsl_test_deparse_drop_chunks('2019-01-01'::timestamptz, 'Test_table', 'test_schema', verbose => true);
-SELECT * FROM tsl_test_deparse_drop_chunks(interval '1 day', table_name => 'weird nAme\\#^.', cascade_to_materializations => true);
-SELECT * FROM tsl_test_deparse_drop_chunks(newer_than => 12345);
-SELECT * FROM tsl_test_deparse_drop_chunks(older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
+SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', '2019-01-01'::timestamptz, verbose => true);
+SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', interval '1 day', cascade_to_materializations => true);
+SELECT * FROM tsl_test_deparse_drop_chunks('table1', newer_than => 12345);
+SELECT * FROM tsl_test_deparse_drop_chunks('table1', older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
 
 -- test generalized deparsing function
 SELECT * FROM tsl_test_deparse_scalar_func(schema_name => 'Foo', table_name => 'bar', option => false, "time" => timestamp '2019-09-10 11:08', message => 'This is a test message.');

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -830,8 +830,7 @@ SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
 FROM show_chunks('disttable_drop_chunks');
 $$);
 
--- test passing older_than and schema name
-SELECT * FROM drop_chunks(older_than => '2018-01-01'::timestamptz, table_name => 'disttable_drop_chunks', schema_name => 'public');
+SELECT * FROM drop_chunks('disttable_drop_chunks', older_than => '2018-01-01'::timestamptz);
 
 SELECT * FROM disttable_drop_chunks;
 
@@ -844,7 +843,7 @@ FROM show_chunks('disttable_drop_chunks');
 $$);
 
 -- test passing newer_than as interval
-SELECT * FROM drop_chunks(newer_than => interval '10 years', table_name => 'disttable_drop_chunks');
+SELECT * FROM drop_chunks('disttable_drop_chunks', newer_than => interval '10 years');
 SELECT * FROM disttable_drop_chunks;
 
 CREATE TABLE "weird nAme\\#^."(time bigint, device int CHECK (device > 0), color int, PRIMARY KEY (time,device));
@@ -857,7 +856,7 @@ INSERT INTO "weird nAme\\#^." VALUES
 
 SELECT * FROM "weird nAme\\#^.";
 -- drop chunks using bigint as time
-SELECT * FROM drop_chunks(older_than => 1000, table_name => 'weird nAme\\#^.');
+SELECT * FROM drop_chunks('"weird nAme\\#^."', older_than => 1000);
 SELECT * FROM "weird nAme\\#^.";
 
 -----------------------------------------------------------------------------------------

--- a/tsl/test/sql/include/deparse_func.sql
+++ b/tsl/test/sql/include/deparse_func.sql
@@ -7,9 +7,9 @@
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_tabledef(tbl REGCLASS) RETURNS TEXT
 AS :TSL_MODULE_PATHNAME, 'ts_test_get_tabledef' LANGUAGE C VOLATILE STRICT;
 
-CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(older_than "any" = NULL,
-    table_name  NAME = NULL,
-    schema_name NAME = NULL,
+CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(
+    table_name REGCLASS,
+    older_than "any" = NULL,
     newer_than "any" = NULL,
     verbose BOOLEAN = FALSE,
     cascade_to_materializations BOOLEAN = NULL) RETURNS TEXT

--- a/tsl/test/src/deparse.c
+++ b/tsl/test/src/deparse.c
@@ -33,7 +33,7 @@ ts_test_deparse_drop_chunks(PG_FUNCTION_ARGS)
 {
 	FmgrInfo flinfo;
 	FunctionCallInfo fcinfo2 = palloc(SizeForFunctionCallInfo(fcinfo->nargs));
-	Oid argtypes[] = { ANYOID, NAMEOID, NAMEOID, ANYOID, BOOLOID, BOOLOID };
+	Oid argtypes[] = { REGCLASSOID, ANYOID, ANYOID, BOOLOID, BOOLOID };
 	Oid funcid = ts_get_function_oid("drop_chunks",
 									 ts_extension_schema_name(),
 									 sizeof(argtypes) / sizeof(*argtypes),


### PR DESCRIPTION
    Make table mandatory for drop_chunks
    
    The `drop_chunks` function is refactored to make table name mandatory
    for the function. As a result, the function was also refactored to
    accept the `regclass` type instead of table name plus schema name and
    the parameters were reordered to match the order for `show_chunks`.
    
    The commit also refactor the code to pass the hypertable structure
    between internal functions rather than the hypertable relid and moving
    error checks to the PostgreSQL function.  This allow the internal
    functions to avoid some lookups and use the information in the
    structure directly and also give errors earlier instead of first
    dropping chunks and then error and roll back the transaction.

Fixes timescale/timescaledb-private#785 timescale/timescaledb-private#591