### PR TITLE
Fix license check return code

### DIFF
--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -18,7 +18,7 @@ check_file() {
         SUFFIX1='*.h'
     else
         SUFFIX0='*.sql'
-        SUFFIX1='*.sql'
+        SUFFIX1='*.sql.in'
     fi
 
     find $2 -type f \( -name "${SUFFIX0}" -or -name "${SUFFIX1}" \) -and -not -path "${SRC_DIR}/sql/updates/*.sql" -and -not -path "${SRC_DIR}/test/sql/dump/*.sql" -and -not -path "${SRC_DIR}/src/chunk_adaptive.*" -print0 | xargs -0 -n1 $(dirname ${0})/check_file_license.sh ${1}

--- a/scripts/check_license_all.sh
+++ b/scripts/check_license_all.sh
@@ -7,4 +7,7 @@ exit_apache=$?
 SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -e ${BASE_DIR}/tsl/src -u ${BASE_DIR}/tsl/test/sql -e ${BASE_DIR}/tsl/test/src
 exit_tsl=$?
 
-exit ${exit_apache} || ${exit_tsl}
+if [ ${exit_apache} -ne 0 ] || [ ${exit_tsl} -ne 0 ]; then
+  exit 1
+fi
+

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -1,6 +1,6 @@
--- This file and its contents are licensed under the Apache License 2.0.
+-- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
--- LICENSE-APACHE for a copy of the license.
+-- LICENSE-TIMESCALE for a copy of the license.
 -- disable background workers to make results reproducible
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_internal.stop_background_workers();

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -1,6 +1,6 @@
--- This file and its contents are licensed under the Apache License 2.0.
+-- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
--- LICENSE-APACHE for a copy of the license.
+-- LICENSE-TIMESCALE for a copy of the license.
 -- disable background workers to make results reproducible
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT _timescaledb_internal.stop_background_workers();

--- a/tsl/test/expected/jit-11.out
+++ b/tsl/test/expected/jit-11.out
@@ -58,7 +58,7 @@ SELECT
 FROM
   jit_test_contagg
 GROUP BY bucket, device_id;
-psql:include/jit_load.sql:29: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
+psql:include/jit_load.sql:30: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
 INSERT INTO jit_test_contagg

--- a/tsl/test/expected/jit-12.out
+++ b/tsl/test/expected/jit-12.out
@@ -58,7 +58,7 @@ SELECT
 FROM
   jit_test_contagg
 GROUP BY bucket, device_id;
-psql:include/jit_load.sql:29: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
+psql:include/jit_load.sql:30: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
 INSERT INTO jit_test_contagg

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -1,6 +1,6 @@
--- This file and its contents are licensed under the Apache License 2.0.
+-- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
--- LICENSE-APACHE for a copy of the license.
+-- LICENSE-TIMESCALE for a copy of the license.
 
 -- disable background workers to make results reproducible
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/tsl/test/sql/include/jit_load.sql
+++ b/tsl/test/sql/include/jit_load.sql
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+
 CREATE TABLE jit_test(time timestamp NOT NULL, device int, temp float);
 SELECT create_hypertable('jit_test', 'time');
 ALTER TABLE jit_test DROP COLUMN device;


### PR DESCRIPTION
This patch fixes the return code of the license check, previously
it would always return the return code of the apache license check.
This patch also adds a missing newline to the jit_load.sql file
so the license check properly detects the license.