### PR TITLE
Use EXECUTE FUNCTION instead of EXECUTE PROCEDURE

### DIFF
--- a/sql/ddl_triggers.sql
+++ b/sql/ddl_triggers.sql
@@ -10,8 +10,8 @@ AS '@MODULE_PATHNAME@', 'ts_timescaledb_process_ddl_event' LANGUAGE C;
 --EVENT TRIGGER MUST exclude the ALTER EXTENSION tag.
 CREATE EVENT TRIGGER timescaledb_ddl_command_end ON ddl_command_end
 WHEN TAG IN ('ALTER TABLE','CREATE TRIGGER','CREATE TABLE','CREATE INDEX','ALTER INDEX', 'DROP TABLE', 'DROP INDEX', 'DROP SCHEMA')
-EXECUTE PROCEDURE _timescaledb_internal.process_ddl_event();
+EXECUTE FUNCTION _timescaledb_internal.process_ddl_event();
 
 DROP EVENT TRIGGER IF EXISTS timescaledb_ddl_sql_drop;
 CREATE EVENT TRIGGER timescaledb_ddl_sql_drop ON sql_drop
-EXECUTE PROCEDURE _timescaledb_internal.process_ddl_event();
+EXECUTE FUNCTION _timescaledb_internal.process_ddl_event();

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -396,7 +396,7 @@ BEGIN
 END
 $BODY$;
 CREATE TRIGGER test_trigger BEFORE UPDATE OR DELETE ON PUBLIC."Hypertable_1"
-FOR EACH STATEMENT EXECUTE PROCEDURE empty_trigger_func();
+FOR EACH STATEMENT EXECUTE FUNCTION empty_trigger_func();
 ALTER TABLE PUBLIC."Hypertable_1" ALTER COLUMN sensor_2_renamed SET DATA TYPE int;
 ALTER INDEX "ind_humidity" RENAME TO "ind_humdity2";
 -- Change should be reflected here

--- a/test/expected/copy.out
+++ b/test/expected/copy.out
@@ -116,7 +116,7 @@ SELECT create_hypertable('trigger_test', 'time', chunk_time_interval => 10);
 (1 row)
 
 CREATE TRIGGER check_time BEFORE INSERT ON trigger_test
-FOR EACH ROW EXECUTE PROCEDURE gt_10();
+FOR EACH ROW EXECUTE FUNCTION gt_10();
 \copy trigger_test from data/copy_data.csv with csv header ;
 SELECT * FROM trigger_test ORDER BY time;
  time |       value        

--- a/test/expected/ddl-11.out
+++ b/test/expected/ddl-11.out
@@ -334,7 +334,7 @@ BEGIN
 END
 $BODY$;
 CREATE TRIGGER test_trigger BEFORE UPDATE OR DELETE ON PUBLIC."Hypertable_1"
-FOR EACH STATEMENT EXECUTE PROCEDURE empty_trigger_func();
+FOR EACH STATEMENT EXECUTE FUNCTION empty_trigger_func();
 ALTER TABLE PUBLIC."Hypertable_1" ALTER COLUMN sensor_2_renamed SET DATA TYPE int;
 ALTER INDEX "ind_humidity" RENAME TO "ind_humdity2";
 -- Change should be reflected here

--- a/test/expected/ddl-12.out
+++ b/test/expected/ddl-12.out
@@ -333,7 +333,7 @@ BEGIN
 END
 $BODY$;
 CREATE TRIGGER test_trigger BEFORE UPDATE OR DELETE ON PUBLIC."Hypertable_1"
-FOR EACH STATEMENT EXECUTE PROCEDURE empty_trigger_func();
+FOR EACH STATEMENT EXECUTE FUNCTION empty_trigger_func();
 ALTER TABLE PUBLIC."Hypertable_1" ALTER COLUMN sensor_2_renamed SET DATA TYPE int;
 ALTER INDEX "ind_humidity" RENAME TO "ind_humdity2";
 -- Change should be reflected here

--- a/test/expected/ddl_single-11.out
+++ b/test/expected/ddl_single-11.out
@@ -297,7 +297,7 @@ BEGIN
 END
 $BODY$;
 CREATE TRIGGER test_trigger BEFORE UPDATE OR DELETE ON PUBLIC."Hypertable_1"
-FOR EACH STATEMENT EXECUTE PROCEDURE empty_trigger_func();
+FOR EACH STATEMENT EXECUTE FUNCTION empty_trigger_func();
 ALTER TABLE PUBLIC."Hypertable_1" ALTER COLUMN sensor_2_renamed SET DATA TYPE int;
 ALTER INDEX "ind_humidity" RENAME TO "ind_humdity2";
 -- Change should be reflected here

--- a/test/expected/ddl_single-12.out
+++ b/test/expected/ddl_single-12.out
@@ -296,7 +296,7 @@ BEGIN
 END
 $BODY$;
 CREATE TRIGGER test_trigger BEFORE UPDATE OR DELETE ON PUBLIC."Hypertable_1"
-FOR EACH STATEMENT EXECUTE PROCEDURE empty_trigger_func();
+FOR EACH STATEMENT EXECUTE FUNCTION empty_trigger_func();
 ALTER TABLE PUBLIC."Hypertable_1" ALTER COLUMN sensor_2_renamed SET DATA TYPE int;
 ALTER INDEX "ind_humidity" RENAME TO "ind_humdity2";
 -- Change should be reflected here

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -85,7 +85,7 @@ FROM pg_proc WHERE proname = 'custom_calculate_chunk_interval';
 (1 row)
 
 CREATE TRIGGER restore_trigger BEFORE INSERT ON "test_schema"."two_Partitions"
-FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+FOR EACH ROW EXECUTE FUNCTION test_trigger();
 -- Save the number of dependent objects so we can make sure we have the same number later
 SELECT count(*) as num_dependent_objects
   FROM pg_depend

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -25,54 +25,54 @@ $BODY$;
 -- row triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert
     BEFORE INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update
     BEFORE UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete
     BEFORE delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER z_test_trigger_all
     BEFORE INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 -- row triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_after
     AFTER INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_insert_after_when_dev1
     AFTER INSERT ON hyper
     FOR EACH ROW
     WHEN (NEW.device_id = 'dev1')
-    EXECUTE PROCEDURE test_trigger();
+    EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update_after
     AFTER UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete_after
     AFTER delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER z_test_trigger_all_after
     AFTER INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 -- statement triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert_s_before
     BEFORE INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update_s_before
     BEFORE UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete_s_before
     BEFORE DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 -- statement triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_s_after
     AFTER INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update_s_after
     AFTER UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete_s_after
     AFTER DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 SELECT * FROM create_hypertable('hyper', 'time', chunk_time_interval => 10);
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
@@ -175,49 +175,49 @@ DROP TRIGGER z_test_trigger_all_after ON hyper;
 -- row triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert
     BEFORE INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update
     BEFORE UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete
     BEFORE delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER z_test_trigger_all
     BEFORE INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 -- row triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_after
     AFTER INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update_after
     AFTER UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete_after
     AFTER delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER z_test_trigger_all_after
     AFTER INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 -- statement triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert_s_before
     BEFORE INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update_s_before
     BEFORE UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete_s_before
     BEFORE DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 -- statement triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_s_after
     AFTER INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_update_s_after
     AFTER UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _0_test_trigger_delete_s_after
     AFTER DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 INSERT INTO hyper(time, device_id,sensor_1) VALUES
 (1257987600000000000, 'dev1', 1);
 WARNING:  FIRING trigger when: BEFORE level: STATEMENT op: INSERT cnt: 0 trigger_name _0_test_trigger_insert_s_before
@@ -308,7 +308,7 @@ END
 $BODY$;
 CREATE TRIGGER create_color_trigger
     BEFORE INSERT OR UPDATE ON location
-    FOR EACH ROW EXECUTE PROCEDURE create_color_trigger_fn();
+    FOR EACH ROW EXECUTE FUNCTION create_color_trigger_fn();
 SELECT create_hypertable('location', 'time');
    create_hypertable   
 -----------------------
@@ -329,7 +329,7 @@ GRANT SELECT, INSERT, UPDATE ON vehicles TO :ROLE_DEFAULT_PERM_USER_2;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2;
 CREATE TRIGGER create_vehicle_trigger
     BEFORE INSERT OR UPDATE ON location
-    FOR EACH ROW EXECUTE PROCEDURE create_vehicle_trigger_fn();
+    FOR EACH ROW EXECUTE FUNCTION create_vehicle_trigger_fn();
 INSERT INTO location VALUES('2017-01-01 01:02:03', 1, 1, 40.7493226,-73.9771259);
 INSERT INTO location VALUES('2017-01-01 01:02:04', 1, 20, 24.7493226,-73.9771259);
 INSERT INTO location VALUES('2017-01-01 01:02:03', 23, 1, 40.7493226,-73.9771269);

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -130,10 +130,10 @@ $BODY$;
 -- test truncate on a chunk
 CREATE TRIGGER _test_truncate_before
     BEFORE TRUNCATE ON _timescaledb_internal._hyper_1_5_chunk
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 CREATE TRIGGER _test_truncate_after
     AFTER TRUNCATE ON _timescaledb_internal._hyper_1_5_chunk
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 \set ON_ERROR_STOP 0
 TRUNCATE "two_Partitions";
 WARNING:  FIRING trigger when: BEFORE level: STATEMENT op: TRUNCATE cnt: <NULL> trigger_name _test_truncate_before

--- a/test/sql/copy.sql
+++ b/test/sql/copy.sql
@@ -80,7 +80,7 @@ CREATE TABLE "trigger_test" (
 );
 SELECT create_hypertable('trigger_test', 'time', chunk_time_interval => 10);
 CREATE TRIGGER check_time BEFORE INSERT ON trigger_test
-FOR EACH ROW EXECUTE PROCEDURE gt_10();
+FOR EACH ROW EXECUTE FUNCTION gt_10();
 
 \copy trigger_test from data/copy_data.csv with csv header ;
 SELECT * FROM trigger_test ORDER BY time;

--- a/test/sql/include/ddl_ops_2.sql
+++ b/test/sql/include/ddl_ops_2.sql
@@ -23,7 +23,7 @@ END
 $BODY$;
 
 CREATE TRIGGER test_trigger BEFORE UPDATE OR DELETE ON PUBLIC."Hypertable_1"
-FOR EACH STATEMENT EXECUTE PROCEDURE empty_trigger_func();
+FOR EACH STATEMENT EXECUTE FUNCTION empty_trigger_func();
 
 ALTER TABLE PUBLIC."Hypertable_1" ALTER COLUMN sensor_2_renamed SET DATA TYPE int;
 ALTER INDEX "ind_humidity" RENAME TO "ind_humdity2";

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -47,7 +47,7 @@ FROM pg_proc WHERE proname = 'custom_calculate_chunk_interval';
 
 CREATE TRIGGER restore_trigger BEFORE INSERT ON "test_schema"."two_Partitions"
 
-FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 -- Save the number of dependent objects so we can make sure we have the same number later
 SELECT count(*) as num_dependent_objects

--- a/test/sql/triggers.sql
+++ b/test/sql/triggers.sql
@@ -28,68 +28,68 @@ $BODY$;
 -- row triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert
     BEFORE INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update
     BEFORE UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete
     BEFORE delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER z_test_trigger_all
     BEFORE INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 -- row triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_after
     AFTER INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_insert_after_when_dev1
     AFTER INSERT ON hyper
     FOR EACH ROW
     WHEN (NEW.device_id = 'dev1')
-    EXECUTE PROCEDURE test_trigger();
+    EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update_after
     AFTER UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete_after
     AFTER delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER z_test_trigger_all_after
     AFTER INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 -- statement triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert_s_before
     BEFORE INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update_s_before
     BEFORE UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete_s_before
     BEFORE DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 -- statement triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_s_after
     AFTER INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update_s_after
     AFTER UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete_s_after
     AFTER DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 
 SELECT * FROM create_hypertable('hyper', 'time', chunk_time_interval => 10);
@@ -135,62 +135,62 @@ DROP TRIGGER z_test_trigger_all_after ON hyper;
 -- row triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert
     BEFORE INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update
     BEFORE UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete
     BEFORE delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER z_test_trigger_all
     BEFORE INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 -- row triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_after
     AFTER INSERT ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update_after
     AFTER UPDATE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete_after
     AFTER delete ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER z_test_trigger_all_after
     AFTER INSERT OR UPDATE OR DELETE ON hyper
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 -- statement triggers: BEFORE
 CREATE TRIGGER _0_test_trigger_insert_s_before
     BEFORE INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update_s_before
     BEFORE UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete_s_before
     BEFORE DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 -- statement triggers: AFTER
 CREATE TRIGGER _0_test_trigger_insert_s_after
     AFTER INSERT ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_update_s_after
     AFTER UPDATE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _0_test_trigger_delete_s_after
     AFTER DELETE ON hyper
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 
 INSERT INTO hyper(time, device_id,sensor_1) VALUES
@@ -249,7 +249,7 @@ $BODY$;
 
 CREATE TRIGGER create_color_trigger
     BEFORE INSERT OR UPDATE ON location
-    FOR EACH ROW EXECUTE PROCEDURE create_color_trigger_fn();
+    FOR EACH ROW EXECUTE FUNCTION create_color_trigger_fn();
 
 SELECT create_hypertable('location', 'time');
 
@@ -264,7 +264,7 @@ GRANT SELECT, INSERT, UPDATE ON vehicles TO :ROLE_DEFAULT_PERM_USER_2;
 
 CREATE TRIGGER create_vehicle_trigger
     BEFORE INSERT OR UPDATE ON location
-    FOR EACH ROW EXECUTE PROCEDURE create_vehicle_trigger_fn();
+    FOR EACH ROW EXECUTE FUNCTION create_vehicle_trigger_fn();
 
 INSERT INTO location VALUES('2017-01-01 01:02:03', 1, 1, 40.7493226,-73.9771259);
 INSERT INTO location VALUES('2017-01-01 01:02:04', 1, 20, 24.7493226,-73.9771259);

--- a/test/sql/truncate.sql
+++ b/test/sql/truncate.sql
@@ -49,11 +49,11 @@ $BODY$;
 -- test truncate on a chunk
 CREATE TRIGGER _test_truncate_before
     BEFORE TRUNCATE ON _timescaledb_internal._hyper_1_5_chunk
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 CREATE TRIGGER _test_truncate_after
     AFTER TRUNCATE ON _timescaledb_internal._hyper_1_5_chunk
-    FOR EACH STATEMENT EXECUTE PROCEDURE test_trigger();
+    FOR EACH STATEMENT EXECUTE FUNCTION test_trigger();
 
 \set ON_ERROR_STOP 0
 TRUNCATE "two_Partitions";

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -609,13 +609,13 @@ END;
 $BODY$;
 CREATE TRIGGER test1_trigger
 BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON test1
-FOR EACH STATEMENT EXECUTE PROCEDURE test1_print_func();
+FOR EACH STATEMENT EXECUTE FUNCTION test1_print_func();
 INSERT INTO test1 SELECT generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 1:00', '1 hour') , 1 ;
 NOTICE:   raise notice test1_print_trigger called 
 -- add a row trigger too --
 CREATE TRIGGER test1_trigger2
 BEFORE INSERT OR UPDATE OR DELETE ON test1
-FOR EACH ROW EXECUTE PROCEDURE test1_print_func();
+FOR EACH ROW EXECUTE FUNCTION test1_print_func();
 INSERT INTO test1 SELECT '2018-03-02 1:05'::TIMESTAMPTZ, 2;
 NOTICE:   raise notice test1_print_trigger called 
 NOTICE:   raise notice test1_print_trigger called 

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -54,7 +54,7 @@ INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,2,0,
 -- create the trigger
 CREATE TRIGGER continuous_agg_insert_trigger
     AFTER INSERT ON continuous_agg_test
-    FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.continuous_agg_invalidation_trigger(1);
+    FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.continuous_agg_invalidation_trigger(1);
 -- inserting into the table still doesn't change the watermark since there's no
 -- continuous_aggs_invalidation_threshold. We treat that case as a invalidation_watermark of
 -- BIG_INT_MIN, since the first run of the aggregation will need to scan the

--- a/tsl/test/expected/ddl_hook.out
+++ b/tsl/test/expected/ddl_hook.out
@@ -136,10 +136,10 @@ END
 $BODY$;
 CREATE TRIGGER htable_trigger_test
 BEFORE INSERT ON htable
-FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+FOR EACH ROW EXECUTE FUNCTION test_trigger();
 NOTICE:  test_ddl_command_start: 1 hypertables, query: CREATE TRIGGER htable_trigger_test
 BEFORE INSERT ON htable
-FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+FOR EACH ROW EXECUTE FUNCTION test_trigger();
 NOTICE:  test_ddl_command_start: public.htable
 DROP TRIGGER htable_trigger_test on htable;
 NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TRIGGER htable_trigger_test on htable;

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -509,7 +509,7 @@ END
 $BODY$;
 CREATE TRIGGER disttable_trigger_test
 BEFORE INSERT ON disttable
-FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+FOR EACH ROW EXECUTE FUNCTION test_trigger();
 DROP TRIGGER disttable_trigger_test on disttable;
 DROP FUNCTION test_trigger;
 -- DROP INDEX
@@ -1690,7 +1690,7 @@ $$;
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 CREATE EVENT TRIGGER test_event_trigger_sqldrop ON sql_drop
     WHEN TAG IN ('drop table')
-    EXECUTE PROCEDURE test_event_trigger_sql_drop_function();
+    EXECUTE FUNCTION test_event_trigger_sql_drop_function();
 SET ROLE :ROLE_1;
 -- Test DROP inside event trigger on local table (should not crash)
 CREATE TABLE non_htable (id int PRIMARY KEY);

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -119,7 +119,7 @@ END
 $BODY$;
 CREATE TRIGGER _0_test_trigger_insert
     BEFORE INSERT ON disttable
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
  hypertable_id | node_hypertable_id |  node_name  | block_chunks 
 ---------------+--------------------+-------------+--------------
@@ -915,7 +915,7 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 -- Adding a new trigger should not recurse to foreign chunks
 CREATE TRIGGER _1_test_trigger_insert
     AFTER INSERT ON disttable
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 SELECT st."Child" as chunk_relid, test.show_triggers((st)."Child")
 FROM test.show_subtables('disttable') st;
  chunk_relid | show_triggers 

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -119,7 +119,7 @@ END
 $BODY$;
 CREATE TRIGGER _0_test_trigger_insert
     BEFORE INSERT ON disttable
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
  hypertable_id | node_hypertable_id |  node_name  | block_chunks 
 ---------------+--------------------+-------------+--------------
@@ -915,7 +915,7 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 -- Adding a new trigger should not recurse to foreign chunks
 CREATE TRIGGER _1_test_trigger_insert
     AFTER INSERT ON disttable
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 SELECT st."Child" as chunk_relid, test.show_triggers((st)."Child")
 FROM test.show_subtables('disttable') st;
  chunk_relid | show_triggers 

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -404,13 +404,13 @@ END;
 $BODY$;
 CREATE TRIGGER test1_trigger
 BEFORE INSERT OR UPDATE OR DELETE OR TRUNCATE ON test1
-FOR EACH STATEMENT EXECUTE PROCEDURE test1_print_func();
+FOR EACH STATEMENT EXECUTE FUNCTION test1_print_func();
 
 INSERT INTO test1 SELECT generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 1:00', '1 hour') , 1 ;
 -- add a row trigger too --
 CREATE TRIGGER test1_trigger2
 BEFORE INSERT OR UPDATE OR DELETE ON test1
-FOR EACH ROW EXECUTE PROCEDURE test1_print_func();
+FOR EACH ROW EXECUTE FUNCTION test1_print_func();
 INSERT INTO test1 SELECT '2018-03-02 1:05'::TIMESTAMPTZ, 2;
 
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_orderby = '"Time" DESC');

--- a/tsl/test/sql/continuous_aggs_watermark.sql
+++ b/tsl/test/sql/continuous_aggs_watermark.sql
@@ -27,7 +27,7 @@ INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,2,0,
 -- create the trigger
 CREATE TRIGGER continuous_agg_insert_trigger
     AFTER INSERT ON continuous_agg_test
-    FOR EACH ROW EXECUTE PROCEDURE _timescaledb_internal.continuous_agg_invalidation_trigger(1);
+    FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.continuous_agg_invalidation_trigger(1);
 
 -- inserting into the table still doesn't change the watermark since there's no
 -- continuous_aggs_invalidation_threshold. We treat that case as a invalidation_watermark of

--- a/tsl/test/sql/ddl_hook.sql
+++ b/tsl/test/sql/ddl_hook.sql
@@ -63,7 +63,7 @@ $BODY$;
 
 CREATE TRIGGER htable_trigger_test
 BEFORE INSERT ON htable
-FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 DROP TRIGGER htable_trigger_test on htable;
 DROP FUNCTION test_trigger();

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -151,7 +151,7 @@ $BODY$;
 
 CREATE TRIGGER disttable_trigger_test
 BEFORE INSERT ON disttable
-FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 DROP TRIGGER disttable_trigger_test on disttable;
 DROP FUNCTION test_trigger;
@@ -419,7 +419,7 @@ $$;
 
 CREATE EVENT TRIGGER test_event_trigger_sqldrop ON sql_drop
     WHEN TAG IN ('drop table')
-    EXECUTE PROCEDURE test_event_trigger_sql_drop_function();
+    EXECUTE FUNCTION test_event_trigger_sql_drop_function();
 
 SET ROLE :ROLE_1;
 

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -101,7 +101,7 @@ $BODY$;
 
 CREATE TRIGGER _0_test_trigger_insert
     BEFORE INSERT ON disttable
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
@@ -296,7 +296,7 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 -- Adding a new trigger should not recurse to foreign chunks
 CREATE TRIGGER _1_test_trigger_insert
     AFTER INSERT ON disttable
-    FOR EACH ROW EXECUTE PROCEDURE test_trigger();
+    FOR EACH ROW EXECUTE FUNCTION test_trigger();
 
 SELECT st."Child" as chunk_relid, test.show_triggers((st)."Child")
 FROM test.show_subtables('disttable') st;

--- a/tsl/test/sql/include/deparse_create.sql
+++ b/tsl/test/sql/include/deparse_create.sql
@@ -39,7 +39,7 @@ CREATE TABLE table7(t TIMESTAMP, v INT);
 CREATE TABLE table8(id INT, status device_status);
 
 CREATE TRIGGER test_trigger BEFORE UPDATE OR DELETE ON table8
-FOR EACH STATEMENT EXECUTE PROCEDURE test.empty_trigger_func();
+FOR EACH STATEMENT EXECUTE FUNCTION test.empty_trigger_func();
 
 CREATE RULE notify_me AS ON UPDATE TO table8 DO ALSO NOTIFY table8;
 


### PR DESCRIPTION
Replace EXECUTE PROCEDURE with EXECUTE FUNCTION because the former
is deprecated in PG11+. Unfortunately some test output will still
have EXECUTE PROCEDURE because pg_get_triggerdef in PG11 still
generates a definition with EXECUTE PROCEDURE.