### PR TITLE
Enable linter only for clang compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,8 +290,14 @@ else()
   )
 endif ()
 
-# Linter support via clang-tidy. Enabled by default.
-option(LINTER "Enable linter support using clang-tidy (default ON)" ON)
+if(CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+  set(LINTER_DEFAULT ON)
+else()
+  set(LINTER_DEFAULT OFF)
+endif()
+
+# Linter support via clang-tidy. Enabled when using clang as compiler
+option(LINTER "Enable linter support using clang-tidy (ON when using clang)" ${LINTER_DEFAULT})
 
 if (LINTER)
   find_program(CLANG_TIDY

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -50,13 +50,8 @@ set(SOURCE_FILES
   partialize_finalize.sql
   restoring.sql
   timescaledb_fdw.sql
+  remote_txn.sql
 )
-
-if (NOT ${PG_VERSION} VERSION_LESS "10")
-  list(APPEND SOURCE_FILES
-    remote_txn.sql
-  )
-endif()
 
 # These files should be pre-pended to update scripts so that they are
 # executed before anything else during updates
@@ -65,7 +60,7 @@ set(PRE_UPDATE_FILES
 )
 
 # The POST_UPDATE_FILES should be executed as the last part of
-# the update script. 
+# the update script.
 # sets state for executing POST_UPDATE_FILES during ALTER EXTENSION
 set(SET_POST_UPDATE_STAGE updates/set_post_update_stage.sql)
 set(UNSET_UPDATE_STAGE updates/unset_update_stage.sql)


### PR DESCRIPTION
Enabling clang-tidy on builds not using clang compiler will not
compile due to incompatible compiler flags, so this patch
changes the current behaviour to only enable clang-tidy when
using clang compiler. You can still overwrite the behaviour
by passing -DLINTER=ON when not using clang.