### PR TITLE
Improve connection handling during transactions

### DIFF
--- a/sql/dist_internal.sql
+++ b/sql/dist_internal.sql
@@ -39,5 +39,7 @@ RETURNS TABLE (
     backend_pid         int,
     connection_status   text,
     transaction_status  text,
-    processing          boolean)
+    transaction_depth   int,
+    processing          boolean,
+    invalidated         boolean)
 AS '@MODULE_PATHNAME@', 'ts_remote_connection_cache_show' LANGUAGE C VOLATILE STRICT;

--- a/sql/dist_internal.sql
+++ b/sql/dist_internal.sql
@@ -28,3 +28,16 @@ AS '@MODULE_PATHNAME@', 'ts_dist_remote_hypertable_info' LANGUAGE C VOLATILE STR
 -- a data node. Throws error if validation fails.
 CREATE OR REPLACE FUNCTION _timescaledb_internal.validate_as_data_node() RETURNS void
 AS '@MODULE_PATHNAME@', 'ts_dist_validate_as_data_node' LANGUAGE C VOLATILE STRICT;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.show_connection_cache()
+RETURNS TABLE (
+    node_name           name,
+    user_name           name,
+    host                text,
+    port                int,
+    database            name,
+    backend_pid         int,
+    connection_status   text,
+    transaction_status  text,
+    processing          boolean)
+AS '@MODULE_PATHNAME@', 'ts_remote_connection_cache_show' LANGUAGE C VOLATILE STRICT;

--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -106,7 +106,6 @@ static void
 cache_invalidate_syscache_callback(Datum arg, int cacheid, uint32 hashvalue)
 {
 	Assert(cacheid == FOREIGNSERVEROID);
-
 	ts_cm_functions->cache_syscache_invalidate(arg, cacheid, hashvalue);
 }
 

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -60,6 +60,7 @@ TS_FUNCTION_INFO_V1(ts_timescaledb_fdw_validator);
 TS_FUNCTION_INFO_V1(ts_remote_txn_id_in);
 TS_FUNCTION_INFO_V1(ts_remote_txn_id_out);
 TS_FUNCTION_INFO_V1(ts_remote_txn_heal_data_node);
+TS_FUNCTION_INFO_V1(ts_remote_connection_cache_show);
 TS_FUNCTION_INFO_V1(ts_dist_set_id);
 TS_FUNCTION_INFO_V1(ts_dist_set_peer_id);
 TS_FUNCTION_INFO_V1(ts_dist_remote_hypertable_info);
@@ -215,6 +216,12 @@ Datum
 ts_remote_txn_heal_data_node(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_DATUM(ts_cm_functions->remote_txn_heal_data_node(fcinfo));
+}
+
+Datum
+ts_remote_connection_cache_show(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_DATUM(ts_cm_functions->remote_connection_cache_show(fcinfo));
 }
 
 Datum
@@ -656,6 +663,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.remote_txn_id_in = error_no_default_fn_pg_community,
 	.remote_txn_id_out = error_no_default_fn_pg_community,
 	.remote_txn_heal_data_node = error_no_default_fn_pg_community,
+	.remote_connection_cache_show = error_no_default_fn_pg_community,
 	.data_node_dispatch_path_create = data_node_dispatch_path_create_default,
 	.distributed_copy = distributed_copy_default,
 	.set_distributed_id = set_distributed_id_default,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -128,6 +128,7 @@ typedef struct CrossModuleFunctions
 	PGFunction remote_txn_id_in;
 	PGFunction remote_txn_id_out;
 	PGFunction remote_txn_heal_data_node;
+	PGFunction remote_connection_cache_show;
 	void (*create_chunk_on_data_nodes)(Chunk *chunk, Hypertable *ht);
 	Path *(*data_node_dispatch_path_create)(PlannerInfo *root, ModifyTablePath *mtpath,
 											Index hypertable_rti, int subpath_index);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -68,12 +68,7 @@ static bool check_tsl_loaded(void);
 static void
 cache_syscache_invalidate(Datum arg, int cacheid, uint32 hashvalue)
 {
-	/*
-	 * Using hash_value it is possible to do more fine grained validation in
-	 * the future see `postgres_fdw` connection management for an example. For
-	 * now, invalidate the entire cache.
-	 */
-	remote_connection_cache_invalidate_callback();
+	remote_connection_cache_invalidate_callback(arg, cacheid, hashvalue);
 }
 
 /*

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -157,6 +157,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.remote_txn_id_in = remote_txn_id_in_pg,
 	.remote_txn_id_out = remote_txn_id_out_pg,
 	.remote_txn_heal_data_node = remote_txn_heal_data_node,
+	.remote_connection_cache_show = remote_connection_cache_show,
 	.set_rel_pathlist = tsl_set_rel_pathlist,
 	.data_node_dispatch_path_create = data_node_dispatch_path_create,
 	.distributed_copy = remote_distributed_copy,

--- a/tsl/src/process_utility.c
+++ b/tsl/src/process_utility.c
@@ -10,11 +10,18 @@
 
 #include "process_utility.h"
 #include "remote/dist_commands.h"
+#include "remote/connection_cache.h"
 #include "remote/dist_ddl.h"
 
 void
 tsl_ddl_command_start(ProcessUtilityArgs *args)
 {
+	if (IsA(args->parsetree, DropdbStmt))
+	{
+		DropdbStmt *stmt = castNode(DropdbStmt, args->parsetree);
+		remote_connection_cache_dropped_db_callback(stmt->dbname);
+	}
+
 	dist_ddl_start(args);
 }
 

--- a/tsl/src/remote/async.h
+++ b/tsl/src/remote/async.h
@@ -54,6 +54,8 @@ typedef struct PreparedStmt PreparedStmt;
 
 /* Async Request */
 
+typedef void (*async_response_callback)(AsyncRequest *m, AsyncResponse *, void *data);
+
 #define TS_NO_TIMEOUT DT_NOBEGIN
 
 extern AsyncRequest *async_request_send_with_stmt_params_elevel_res_format(
@@ -95,7 +97,10 @@ extern AsyncRequest *async_request_send_prepared_stmt_with_params(PreparedStmt *
 																  int res_format);
 
 extern void async_request_attach_user_data(AsyncRequest *req, void *user_data);
+extern void async_request_set_response_callback(AsyncRequest *req, async_response_callback cb,
+												void *user_data);
 extern bool async_request_set_single_row_mode(AsyncRequest *req);
+extern TSConnection *async_request_get_connection(AsyncRequest *req);
 extern AsyncResponseResult *async_request_wait_ok_result(AsyncRequest *request);
 extern AsyncResponseResult *async_request_wait_any_result(AsyncRequest *request);
 

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -44,6 +44,12 @@ extern TSConnection *remote_connection_open_by_id(TSConnectionId id);
 extern TSConnection *remote_connection_open(Oid server_id, Oid user_id);
 extern TSConnection *remote_connection_open_nothrow(Oid server_id, Oid user_id, char **errmsg);
 extern bool remote_connection_set_autoclose(TSConnection *conn, bool autoclose);
+extern int remote_connection_xact_depth_get(const TSConnection *conn);
+extern int remote_connection_xact_depth_inc(TSConnection *conn);
+extern int remote_connection_xact_depth_dec(TSConnection *conn);
+extern void remote_connection_xact_transition_begin(TSConnection *conn);
+extern void remote_connection_xact_transition_end(TSConnection *conn);
+extern bool remote_connection_xact_is_transitioning(const TSConnection *conn);
 extern bool remote_connection_ping(const char *node_name);
 extern void remote_connection_close(TSConnection *conn);
 extern PGresult *remote_connection_exec(TSConnection *conn, const char *cmd);
@@ -68,11 +74,11 @@ extern void remote_validate_extension_version(TSConnection *conn, const char *da
 
 extern bool remote_connection_cancel_query(TSConnection *conn);
 extern PGconn *remote_connection_get_pg_conn(TSConnection *conn);
-extern bool remote_connection_is_processing(TSConnection *conn);
+extern bool remote_connection_is_processing(const TSConnection *conn);
 extern void remote_connection_set_processing(TSConnection *conn, bool processing);
 extern bool remote_connection_configure_if_changed(TSConnection *conn);
 extern void remote_connection_elog(TSConnection *conn, int elevel);
-extern const char *remote_connection_node_name(TSConnection *conn);
+extern const char *remote_connection_node_name(const TSConnection *conn);
 extern bool remote_connection_set_single_row_mode(TSConnection *conn);
 
 /* Functions operating on PGresult objects */

--- a/tsl/src/remote/connection_cache.h
+++ b/tsl/src/remote/connection_cache.h
@@ -22,9 +22,10 @@ is used by xact callbacks.
 extern Cache *remote_connection_cache_pin(void);
 
 extern TSConnection *remote_connection_cache_get_connection(Cache *cache, TSConnectionId id);
-extern void remote_connection_cache_remove(Cache *cache, TSConnectionId id);
+extern bool remote_connection_cache_remove(Cache *cache, TSConnectionId id);
 
 extern void remote_connection_cache_invalidate_callback(void);
+extern Datum remote_connection_cache_show(PG_FUNCTION_ARGS);
 extern void _remote_connection_cache_init(void);
 extern void _remote_connection_cache_fini(void);
 

--- a/tsl/src/remote/connection_cache.h
+++ b/tsl/src/remote/connection_cache.h
@@ -19,10 +19,8 @@ That means unpinning on aborts has to be done by the caller. This is because thi
 is used by xact callbacks.
 */
 
-extern Cache *remote_connection_cache_pin(void);
-
-extern TSConnection *remote_connection_cache_get_connection(Cache *cache, TSConnectionId id);
-extern bool remote_connection_cache_remove(Cache *cache, TSConnectionId id);
+extern TSConnection *remote_connection_cache_get_connection(TSConnectionId id);
+extern bool remote_connection_cache_remove(TSConnectionId id);
 
 extern void remote_connection_cache_invalidate_callback(Datum arg, int cacheid, uint32 hashvalue);
 extern void remote_connection_cache_dropped_db_callback(const char *dbname);

--- a/tsl/src/remote/connection_cache.h
+++ b/tsl/src/remote/connection_cache.h
@@ -24,7 +24,8 @@ extern Cache *remote_connection_cache_pin(void);
 extern TSConnection *remote_connection_cache_get_connection(Cache *cache, TSConnectionId id);
 extern bool remote_connection_cache_remove(Cache *cache, TSConnectionId id);
 
-extern void remote_connection_cache_invalidate_callback(void);
+extern void remote_connection_cache_invalidate_callback(Datum arg, int cacheid, uint32 hashvalue);
+extern void remote_connection_cache_dropped_db_callback(const char *dbname);
 extern Datum remote_connection_cache_show(PG_FUNCTION_ARGS);
 extern void _remote_connection_cache_init(void);
 extern void _remote_connection_cache_fini(void);

--- a/tsl/src/remote/dist_commands.c
+++ b/tsl/src/remote/dist_commands.c
@@ -396,11 +396,15 @@ ts_dist_cmd_close_prepared_command(PreparedDistCmd *command)
 Datum
 ts_dist_cmd_exec(PG_FUNCTION_ARGS)
 {
-	const char *query = TextDatumGetCString(PG_GETARG_DATUM(0));
+	const char *query = PG_ARGISNULL(0) ? NULL : TextDatumGetCString(PG_GETARG_DATUM(0));
 	ArrayType *data_nodes = PG_ARGISNULL(1) ? NULL : PG_GETARG_ARRAYTYPE_P(1);
 	DistCmdResult *result;
 	List *data_node_list;
 	const char *search_path;
+
+	if (NULL == query)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("invalid command string")));
 
 	if (dist_util_membership() != DIST_MEMBER_ACCESS_NODE)
 		ereport(ERROR,

--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -232,7 +232,7 @@ dist_ddl_preprocess(ProcessUtilityArgs *args)
 		 */
 		if (tag == T_DropStmt)
 		{
-			DropStmt *stmt = (DropStmt *) args->parsetree;
+			DropStmt *stmt = castNode(DropStmt, args->parsetree);
 
 			if (stmt->removeType == OBJECT_TABLE || stmt->removeType == OBJECT_SCHEMA)
 				set_dist_exec_type(DIST_DDL_EXEC_ON_END);

--- a/tsl/src/remote/dist_txn.c
+++ b/tsl/src/remote/dist_txn.c
@@ -35,11 +35,6 @@ void (*testing_callback_call_hook)(const char *event) = NULL;
 	} while (0)
 #endif
 
-/* prototypes of private functions */
-static void dist_txn_xact_callback(XactEvent event, void *arg);
-static void dist_txn_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
-									  SubTransactionId parentSubid, void *arg);
-
 static RemoteTxnStore *store = NULL;
 
 /*

--- a/tsl/src/remote/dist_txn.c
+++ b/tsl/src/remote/dist_txn.c
@@ -198,6 +198,7 @@ dist_txn_xact_callback_abort()
 		{
 			if (remote_txn_is_ongoing(remote_txn))
 				elog(WARNING, "failure aborting remote transaction during local abort");
+
 			remote_txn_store_remove(state.store, remote_txn_get_connection_id(remote_txn));
 		}
 	}

--- a/tsl/src/remote/txn.h
+++ b/tsl/src/remote/txn.h
@@ -5,6 +5,7 @@
  */
 #ifndef TIMESCALEDB_TSL_REMOTE_TXN_H
 #define TIMESCALEDB_TSL_REMOTE_TXN_H
+
 #include <postgres.h>
 #include <access/xact.h>
 
@@ -22,6 +23,7 @@ typedef enum
 
 /* actions */
 extern void remote_txn_init(RemoteTxn *entry, TSConnection *conn);
+extern RemoteTxn *remote_txn_begin_on_connection(TSConnection *conn);
 extern void remote_txn_begin(RemoteTxn *entry, int txnlevel);
 extern bool remote_txn_abort(RemoteTxn *entry);
 extern void remote_txn_write_persistent_record(RemoteTxn *entry);

--- a/tsl/src/remote/txn_store.c
+++ b/tsl/src/remote/txn_store.c
@@ -30,7 +30,6 @@ remote_txn_store_create(MemoryContext mctx)
 								 &ctl,
 								 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT),
 		.mctx = mctx,
-		.cache = remote_connection_cache_pin(),
 	};
 	return store;
 }
@@ -53,7 +52,7 @@ remote_txn_store_get(RemoteTxnStore *store, TSConnectionId id, bool *found_out)
 		 * aren't remade for existing transactions. Always getting a connection
 		 * from the cache avoids having to redo the same checks here and we can
 		 * keep connection validation in one place. */
-		conn = remote_connection_cache_get_connection(store->cache, id);
+		conn = remote_connection_cache_get_connection(id);
 
 		if (found)
 		{
@@ -87,7 +86,7 @@ remote_txn_store_remove(RemoteTxnStore *store, TSConnectionId id)
 
 	hash_search(store->hashtable, &id, HASH_REMOVE, &found);
 	Assert(found);
-	remote_connection_cache_remove(store->cache, id);
+	remote_connection_cache_remove(id);
 }
 
 void
@@ -99,6 +98,4 @@ remote_txn_store_destroy(RemoteTxnStore *store)
 #endif
 	hash_destroy(store->hashtable);
 	store->hashtable = NULL;
-	ts_cache_release(store->cache);
-	store->cache = NULL;
 }

--- a/tsl/src/remote/txn_store.h
+++ b/tsl/src/remote/txn_store.h
@@ -22,8 +22,6 @@ typedef struct RemoteTxnStore
 	HTAB *hashtable;
 	MemoryContext mctx;
 	HASH_SEQ_STATUS scan;
-
-	Cache *cache;
 } RemoteTxnStore;
 
 extern RemoteTxnStore *remote_txn_store_create(MemoryContext mctx);

--- a/tsl/test/expected/remote_txn.out
+++ b/tsl/test/expected/remote_txn.out
@@ -85,10 +85,10 @@ SELECT test_remote_txn_persistent_record('loopback');
 --successfull transaction
 SET timescaledb.enable_2pc = false;
 --initially, there are no connections in the cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 BEGIN;
@@ -100,20 +100,20 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-0
 (1 row)
 
     --expect to see one connection in transaction state
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
 COMMIT;
 --connection should remain, idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | IDLE               | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
 (1 row)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20001;
@@ -132,20 +132,21 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20002,1,'bleh', '2001-01-0
 (1 row)
 
     --existing connection, in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
 ROLLBACK;
 --connection should remain, in idle state after rollback
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20002;
  count 
@@ -160,11 +161,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-0
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
 -- Connection should remain after conflict, in idle state
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 --the next few statements inject faults before the commit. They should all fail
 --and be rolled back with no unresolved state
@@ -187,10 +189,10 @@ WARNING:  kill event: pre-commit
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: terminating connection due to administrator command
 -- Failed connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20003;
@@ -220,11 +222,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20004,1,'bleh', '2001-01-0
 (1 row)
 
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
 COMMIT;
@@ -232,10 +234,10 @@ WARNING:  kill event: waiting-commit
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: terminating connection due to administrator command
 --connection failed during commit, so should be cleared from the cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 --during waiting-commit the data node process could die before or after
@@ -264,11 +266,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-0
 (1 row)
 
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
 ROLLBACK;
@@ -289,10 +291,10 @@ SELECT count(*) FROM pg_prepared_xacts;
 (1 row)
 
 --the failed connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 --block preparing transactions on the access node
@@ -312,11 +314,12 @@ ERROR:  cannot prepare a transaction that modified remote tables
 --undo changes from 1-pc tests
 DELETE FROM  "S 1"."T 1" where "C 1" >= 20000;
 SET timescaledb.enable_2pc = true;
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 --simple commit
 BEGIN;
@@ -328,20 +331,20 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-0
 (1 row)
 
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
 COMMIT;
 --connection should remain in idle state
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | IDLE               | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
 (1 row)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10001;
@@ -366,20 +369,21 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-0
 (1 row)
 
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, user_name, host, database, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | user_name  |   host    |   database    | connection_status | transaction_status | transaction_depth | processing 
+-----------+------------+-----------+---------------+-------------------+--------------------+-------------------+------------
+ loopback  | super_user | localhost | db_remote_txn | OK                | INTRANS            |                 1 | f
 (1 row)
 
 ROLLBACK;
 --rolled back transaction, but connection should remain in idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 11001;
  count 
@@ -400,11 +404,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-0
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
 --connection should remain in idle after constraint violation
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 --the next few statements inject faults before the commit. They should all fail
 --and be rolled back with no unresolved state
@@ -427,10 +432,10 @@ WARNING:  kill event: pre-prepare-transaction
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: SSL connection has been closed unexpectedly
 --the connection was killed, so should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10002;
@@ -464,10 +469,10 @@ WARNING:  kill event: waiting-prepare-transaction
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: SSL connection has been closed unexpectedly
 --the connection should be cleared from the cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10003;
@@ -518,12 +523,11 @@ WARNING:  [loopback]: terminating connection due to administrator command
 WARNING:  [loopback]: SSL connection has been closed unexpectedly
 WARNING:  error while performing second phase of 2-pc
 --connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | BAD               | UNKNOWN            | t
-(1 row)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+(0 rows)
 
 --unresolved state shown here
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10004;
@@ -543,10 +547,10 @@ BEGIN;
     SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
 ERROR:  remote_txn_heal_data_node cannot run inside a transaction block
 COMMIT;
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 select count(*) from _timescaledb_catalog.remote_txn;
@@ -600,12 +604,11 @@ WARNING:  kill event: pre-commit-prepared
 WARNING:  [loopback]: terminating connection due to administrator command
 WARNING:  [loopback]: SSL connection has been closed unexpectedly
 WARNING:  error while performing second phase of 2-pc
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | BAD               | UNKNOWN            | t
-(1 row)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+(0 rows)
 
 --unresolved state shown here
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10006;
@@ -645,12 +648,11 @@ select count(*) from _timescaledb_catalog.remote_txn;
      0
 (1 row)
 
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | BAD               | UNKNOWN            | t
-(1 row)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+(0 rows)
 
 BEGIN;
     SELECT remote_node_killer_set_event('waiting-commit-prepared','loopback');
@@ -681,12 +683,11 @@ SELECT true FROM _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FRO
 (1 row)
 
 --heal does not use the connection cache, so unaffected
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | BAD               | UNKNOWN            | t
-(1 row)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+(0 rows)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10005;
  count 
@@ -722,11 +723,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-0
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
 --unique constraint violation, connection should remain
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 BEGIN;
     SAVEPOINT save_1;
@@ -738,11 +740,11 @@ NOTICE:  [loopback]:  PREPARE prep_1 AS SELECT 1
 (1 row)
 
         --connection in transaction state
-        SELECT node_name, connection_status, transaction_status, processing
+        SELECT node_name, connection_status, transaction_status, transaction_depth, processing
         FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 2 | f
 (1 row)
 
         --generate a unique violation
@@ -752,22 +754,24 @@ ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
     ROLLBACK TO SAVEPOINT save_1;
     --for correctness, the connection must remain after rollback since
     --the transaction is still ongoing
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
+(1 row)
 
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (81,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (81,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
 --connection should remain and be idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 81;
  count 
@@ -790,20 +794,21 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-0
  
 (1 row)
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
 COMMIT;
+WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 --connection should be removed since PREPARE TRANSACTION failed
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 SELECT count(*) FROM pg_prepared_xacts;
@@ -832,22 +837,24 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-
 (1 row)
 
     --Both connections in transaction state
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
- loopback2 | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
+ loopback2 | OK                | INTRANS            |                 1 | f
 (2 rows)
 
 COMMIT;
+WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback2]: duplicate key value violates unique constraint "t1_pkey"
 --one connection should remain and be idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+(1 row)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10010;
  count 
@@ -888,22 +895,22 @@ BEGIN;
  
 (1 row)
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
- loopback2 | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
+ loopback2 | OK                | INTRANS            |                 1 | f
 (2 rows)
 
 COMMIT;
 ERROR:  [loopback2]: duplicate key value violates unique constraint "t1_pkey"
 RESET client_min_messages;
 --failed connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10011;
@@ -937,10 +944,10 @@ SELECT count(*) FROM pg_prepared_xacts;
 (1 row)
 
 --heal is not using the connection cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
 (0 rows)
 
 --test simple subtrans abort.
@@ -959,12 +966,12 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10013,1,'bleh', '2001-01-
  
 (1 row)
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
- loopback2 | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
+ loopback2 | OK                | INTRANS            |                 1 | f
 (2 rows)
 
     SAVEPOINT save_1;
@@ -975,14 +982,24 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-
  
 (1 row)
 
+        SELECT node_name, connection_status, transaction_status, transaction_depth, processing
+        FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
+ loopback2 | OK                | INTRANS            |                 2 | f
+(2 rows)
+
     ROLLBACK TO SAVEPOINT save_1;
     -- For correctness, both connections should remain in order to
     -- continue the transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
+ loopback2 | OK                | INTRANS            |                 1 | f
+(2 rows)
 
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10014,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10014,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
@@ -998,18 +1015,22 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10015,1,'bleh', '2001-01-
  
 (1 row)
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 2 | f
+ loopback2 | OK                | INTRANS            |                 2 | f
+(2 rows)
 
 COMMIT;
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | IDLE               |                 0 | f
+ loopback2 | OK                | IDLE               |                 0 | f
+(2 rows)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10011;
  count 
@@ -1055,20 +1076,22 @@ BEGIN;
  
 (1 row)
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
- loopback  | OK                | INTRANS            | f
- loopback2 | OK                | INTRANS            | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 2 | f
+ loopback2 | OK                | INTRANS            |                 1 | f
 (2 rows)
 
     ROLLBACK TO SAVEPOINT save_1;
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | BAD               | UNKNOWN            |                 1 | f
+ loopback2 | OK                | INTRANS            |                 1 | f
+(2 rows)
 
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10019,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 ERROR:  connection to data node "loopback" was lost
@@ -1076,11 +1099,12 @@ ERROR:  connection to data node "loopback" was lost
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
 RESET client_min_messages;
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | connection_status | transaction_status | processing 
------------+-------------------+--------------------+------------
-(0 rows)
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback2 | OK                | IDLE               |                 0 | f
+(1 row)
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10016;
  count 

--- a/tsl/test/expected/remote_txn.out
+++ b/tsl/test/expected/remote_txn.out
@@ -84,6 +84,13 @@ SELECT test_remote_txn_persistent_record('loopback');
 -- ===================================================================
 --successfull transaction
 SET timescaledb.enable_2pc = false;
+--initially, there are no connections in the cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
@@ -92,7 +99,23 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-0
  
 (1 row)
 
+    --expect to see one connection in transaction state
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
 COMMIT;
+--connection should remain, idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | IDLE               | f
+(1 row)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20001;
  count 
 -------
@@ -108,7 +131,22 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20002,1,'bleh', '2001-01-0
  
 (1 row)
 
+    --existing connection, in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
 ROLLBACK;
+--connection should remain, in idle state after rollback
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20002;
  count 
 -------
@@ -121,6 +159,13 @@ BEGIN;
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
+-- Connection should remain after conflict, in idle state
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 --the next few statements inject faults before the commit. They should all fail
 --and be rolled back with no unresolved state
 BEGIN;
@@ -141,6 +186,13 @@ COMMIT;
 WARNING:  kill event: pre-commit
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: terminating connection due to administrator command
+-- Failed connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20003;
  count 
 -------
@@ -167,10 +219,25 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20004,1,'bleh', '2001-01-0
  
 (1 row)
 
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
 COMMIT;
 WARNING:  kill event: waiting-commit
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: terminating connection due to administrator command
+--connection failed during commit, so should be cleared from the cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 --during waiting-commit the data node process could die before or after
 --executing the commit on the remote node. So the behaviour here is non-deterministic
 --this is the bad part of 1-pc transactions.
@@ -196,6 +263,14 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-0
  
 (1 row)
 
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
 ROLLBACK;
 WARNING:  kill event: pre-abort
 WARNING:  [loopback]: terminating connection due to administrator command
@@ -213,7 +288,14 @@ SELECT count(*) FROM pg_prepared_xacts;
      0
 (1 row)
 
---block preparing transactions on the frontend
+--the failed connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
+--block preparing transactions on the access node
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
@@ -230,6 +312,12 @@ ERROR:  cannot prepare a transaction that modified remote tables
 --undo changes from 1-pc tests
 DELETE FROM  "S 1"."T 1" where "C 1" >= 20000;
 SET timescaledb.enable_2pc = true;
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 --simple commit
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
@@ -239,7 +327,23 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-0
  
 (1 row)
 
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
 COMMIT;
+--connection should remain in idle state
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | IDLE               | f
+(1 row)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10001;
  count 
 -------
@@ -252,7 +356,7 @@ SELECT count(*) FROM pg_prepared_xacts;
      0
 (1 row)
 
---simple abort
+--simple
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
@@ -261,7 +365,22 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-0
  
 (1 row)
 
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
 ROLLBACK;
+--rolled back transaction, but connection should remain in idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 11001;
  count 
 -------
@@ -280,6 +399,13 @@ BEGIN;
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
+--connection should remain in idle after constraint violation
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 --the next few statements inject faults before the commit. They should all fail
 --and be rolled back with no unresolved state
 BEGIN;
@@ -300,6 +426,13 @@ COMMIT;
 WARNING:  kill event: pre-prepare-transaction
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: SSL connection has been closed unexpectedly
+--the connection was killed, so should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10002;
  count 
 -------
@@ -330,6 +463,13 @@ COMMIT;
 WARNING:  kill event: waiting-prepare-transaction
 WARNING:  failure aborting remote transaction during local abort
 ERROR:  [loopback]: SSL connection has been closed unexpectedly
+--the connection should be cleared from the cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10003;
  count 
 -------
@@ -377,6 +517,14 @@ WARNING:  kill event: post-prepare-transaction
 WARNING:  [loopback]: terminating connection due to administrator command
 WARNING:  [loopback]: SSL connection has been closed unexpectedly
 WARNING:  error while performing second phase of 2-pc
+--connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | BAD               | UNKNOWN            | t
+(1 row)
+
 --unresolved state shown here
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10004;
  count 
@@ -395,6 +543,12 @@ BEGIN;
     SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
 ERROR:  remote_txn_heal_data_node cannot run inside a transaction block
 COMMIT;
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 select count(*) from _timescaledb_catalog.remote_txn;
  count 
 -------
@@ -446,6 +600,13 @@ WARNING:  kill event: pre-commit-prepared
 WARNING:  [loopback]: terminating connection due to administrator command
 WARNING:  [loopback]: SSL connection has been closed unexpectedly
 WARNING:  error while performing second phase of 2-pc
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | BAD               | UNKNOWN            | t
+(1 row)
+
 --unresolved state shown here
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10006;
  count 
@@ -484,6 +645,13 @@ select count(*) from _timescaledb_catalog.remote_txn;
      0
 (1 row)
 
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | BAD               | UNKNOWN            | t
+(1 row)
+
 BEGIN;
     SELECT remote_node_killer_set_event('waiting-commit-prepared','loopback');
  remote_node_killer_set_event 
@@ -512,6 +680,14 @@ SELECT true FROM _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FRO
  t
 (1 row)
 
+--heal does not use the connection cache, so unaffected
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | BAD               | UNKNOWN            | t
+(1 row)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10005;
  count 
 -------
@@ -530,8 +706,9 @@ select count(*) from _timescaledb_catalog.remote_txn;
      0
 (1 row)
 
---test prepare transactions. Note that leaked prepared stmts should be detected by `remote_txn_check_for_leaked_prepared_statements`
---so we should be fine if we don't see any WARNINGS.
+--test prepare transactions. Note that leaked prepared stmts should be
+--detected by `remote_txn_check_for_leaked_prepared_statements` so we
+--should be fine if we don't see any WARNINGS.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ PREPARE prep_1 AS SELECT 1 $$);
 NOTICE:  [loopback]:  PREPARE prep_1 AS SELECT 1 
@@ -544,6 +721,13 @@ NOTICE:  [loopback]:  PREPARE prep_1 AS SELECT 1
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
+--unique constraint violation, connection should remain
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 BEGIN;
     SAVEPOINT save_1;
         SELECT test.remote_exec('{loopback}', $$ PREPARE prep_1 AS SELECT 1 $$);
@@ -553,14 +737,38 @@ NOTICE:  [loopback]:  PREPARE prep_1 AS SELECT 1
  
 (1 row)
 
+        --connection in transaction state
+        SELECT node_name, connection_status, transaction_status, processing
+        FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
+        --generate a unique violation
         SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
     ROLLBACK TO SAVEPOINT save_1;
+    --for correctness, the connection must remain after rollback since
+    --the transaction is still ongoing
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (81,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (81,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 COMMIT;
+--connection should remain and be idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 81;
  count 
 -------
@@ -573,7 +781,7 @@ SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 81;
 --but rather are deferred till PREPARE TRANSACTION happens.
 ALTER TABLE "S 1"."T 1" DROP CONSTRAINT t1_pkey,
 ADD CONSTRAINT t1_pkey PRIMARY KEY ("C 1") DEFERRABLE INITIALLY DEFERRED;
---test ABORT TRANSACTION on failure in PREPARE TRANSACTION.
+--test ROLLBACK TRANSACTION on failure in PREPARE TRANSACTION.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
@@ -582,8 +790,22 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-0
  
 (1 row)
 
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+(1 row)
+
 COMMIT;
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
+--connection should be removed since PREPARE TRANSACTION failed
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM pg_prepared_xacts;
  count 
 -------
@@ -592,8 +814,8 @@ SELECT count(*) FROM pg_prepared_xacts;
 
 --test ROLLBACK TRANSACTION
 --this has an error on the second connection. So should force conn1 to prepare transaction
---ok and then have the txn fail on conn2. Thus conn1 would do a ROLLBACK TRANSACTION.
---conn2 would do a ABORT TRANSACTION.
+--ok and then have the txn fail on conn2. Thus conn1 would do a ROLLBACK PREPARED.
+--conn2 would do a ROLLBACK TRANSACTION.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10010,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10010,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
@@ -609,8 +831,24 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-
  
 (1 row)
 
+    --Both connections in transaction state
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+ loopback2 | OK                | INTRANS            | f
+(2 rows)
+
 COMMIT;
 ERROR:  [loopback2]: duplicate key value violates unique constraint "t1_pkey"
+--one connection should remain and be idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10010;
  count 
 -------
@@ -650,9 +888,24 @@ BEGIN;
  
 (1 row)
 
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+ loopback2 | OK                | INTRANS            | f
+(2 rows)
+
 COMMIT;
 ERROR:  [loopback2]: duplicate key value violates unique constraint "t1_pkey"
 RESET client_min_messages;
+--failed connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10011;
  count 
 -------
@@ -683,6 +936,13 @@ SELECT count(*) FROM pg_prepared_xacts;
      0
 (1 row)
 
+--heal is not using the connection cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 --test simple subtrans abort.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10012,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
@@ -699,6 +959,14 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10013,1,'bleh', '2001-01-
  
 (1 row)
 
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+ loopback2 | OK                | INTRANS            | f
+(2 rows)
+
     SAVEPOINT save_1;
         SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
@@ -708,6 +976,14 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-
 (1 row)
 
     ROLLBACK TO SAVEPOINT save_1;
+    -- For correctness, both connections should remain in order to
+    -- continue the transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10014,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10014,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -722,7 +998,19 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10015,1,'bleh', '2001-01-
  
 (1 row)
 
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 COMMIT;
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10011;
  count 
 -------
@@ -767,13 +1055,33 @@ BEGIN;
  
 (1 row)
 
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+ loopback  | OK                | INTRANS            | f
+ loopback2 | OK                | INTRANS            | f
+(2 rows)
+
     ROLLBACK TO SAVEPOINT save_1;
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10019,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 ERROR:  connection to data node "loopback" was lost
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10020,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 COMMIT;
 RESET client_min_messages;
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+ node_name | connection_status | transaction_status | processing 
+-----------+-------------------+--------------------+------------
+(0 rows)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10016;
  count 
 -------

--- a/tsl/test/expected/remote_txn.out
+++ b/tsl/test/expected/remote_txn.out
@@ -186,7 +186,7 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20003,1,'bleh', '2001-01-0
 
 COMMIT;
 WARNING:  kill event: pre-commit
-WARNING:  failure aborting remote transaction during local abort
+WARNING:  transaction rollback on data node "loopback" failed
 ERROR:  [loopback]: terminating connection due to administrator command
 -- Failed connection should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -231,7 +231,7 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20004,1,'bleh', '2001-01-0
 
 COMMIT;
 WARNING:  kill event: waiting-commit
-WARNING:  failure aborting remote transaction during local abort
+WARNING:  transaction rollback on data node "loopback" failed
 ERROR:  [loopback]: terminating connection due to administrator command
 --connection failed during commit, so should be cleared from the cache
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -276,8 +276,7 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-0
 ROLLBACK;
 WARNING:  kill event: pre-abort
 WARNING:  [loopback]: terminating connection due to administrator command
-WARNING:  [loopback]: SSL connection has been closed unexpectedly
-WARNING:  failure aborting remote transaction during local abort
+WARNING:  transaction rollback on data node "loopback" failed
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20005;
  count 
 -------
@@ -429,7 +428,7 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10002,1,'bleh', '2001-01-0
 
 COMMIT;
 WARNING:  kill event: pre-prepare-transaction
-WARNING:  failure aborting remote transaction during local abort
+WARNING:  transaction rollback on data node "loopback" failed
 ERROR:  [loopback]: SSL connection has been closed unexpectedly
 --the connection was killed, so should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -466,7 +465,7 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10003,1,'bleh', '2001-01-0
 
 COMMIT;
 WARNING:  kill event: waiting-prepare-transaction
-WARNING:  failure aborting remote transaction during local abort
+WARNING:  transaction rollback on data node "loopback" failed
 ERROR:  [loopback]: SSL connection has been closed unexpectedly
 --the connection should be cleared from the cache
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -521,7 +520,6 @@ COMMIT;
 WARNING:  kill event: post-prepare-transaction
 WARNING:  [loopback]: terminating connection due to administrator command
 WARNING:  [loopback]: SSL connection has been closed unexpectedly
-WARNING:  error while performing second phase of 2-pc
 --connection should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -603,7 +601,6 @@ COMMIT;
 WARNING:  kill event: pre-commit-prepared
 WARNING:  [loopback]: terminating connection due to administrator command
 WARNING:  [loopback]: SSL connection has been closed unexpectedly
-WARNING:  error while performing second phase of 2-pc
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
  node_name | connection_status | transaction_status | transaction_depth | processing 
@@ -672,7 +669,6 @@ COMMIT;
 WARNING:  kill event: waiting-commit-prepared
 WARNING:  [loopback]: terminating connection due to administrator command
 WARNING:  [loopback]: SSL connection has been closed unexpectedly
-WARNING:  error while performing second phase of 2-pc
 --at this point the commit prepared might or might not have been executed before
 --the data node process was killed.
 --but in any case, healing the server will bring it into a known state
@@ -802,7 +798,7 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-0
 (1 row)
 
 COMMIT;
-WARNING:  failure aborting remote transaction during local abort
+WARNING:  transaction rollback on data node "loopback" failed
 ERROR:  [loopback]: duplicate key value violates unique constraint "t1_pkey"
 --connection should be removed since PREPARE TRANSACTION failed
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -846,7 +842,7 @@ NOTICE:  [loopback2]:  INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-
 (2 rows)
 
 COMMIT;
-WARNING:  failure aborting remote transaction during local abort
+WARNING:  transaction rollback on data node "loopback2" failed
 ERROR:  [loopback2]: duplicate key value violates unique constraint "t1_pkey"
 --one connection should remain and be idle
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing

--- a/tsl/test/sql/remote_txn.sql
+++ b/tsl/test/sql/remote_txn.sql
@@ -73,21 +73,44 @@ SELECT test_remote_txn_persistent_record('loopback');
 
 --successfull transaction
 SET timescaledb.enable_2pc = false;
+
+--initially, there are no connections in the cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    --expect to see one connection in transaction state
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
+
+--connection should remain, idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20001;
 
 --aborted transaction
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20002,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    --existing connection, in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 ROLLBACK;
+
+--connection should remain, in idle state after rollback
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20002;
 
 --constraint violation
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
+
+-- Connection should remain after conflict, in idle state
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --the next few statements inject faults before the commit. They should all fail
 --and be rolled back with no unresolved state
@@ -96,13 +119,24 @@ BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20003,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
 
+-- Failed connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20003;
 SELECT count(*) FROM pg_prepared_xacts;
 
 BEGIN;
     SELECT remote_node_killer_set_event('waiting-commit', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
+
+--connection failed during commit, so should be cleared from the cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --during waiting-commit the data node process could die before or after
 --executing the commit on the remote node. So the behaviour here is non-deterministic
@@ -114,11 +148,18 @@ SELECT count(*) FROM pg_prepared_xacts;
 BEGIN;
     SELECT remote_node_killer_set_event('pre-abort', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 ROLLBACK;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20005;
 SELECT count(*) FROM pg_prepared_xacts;
 
---block preparing transactions on the frontend
+--the failed connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
+--block preparing transactions on the access node
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 PREPARE TRANSACTION 'test-2';
@@ -131,17 +172,34 @@ PREPARE TRANSACTION 'test-2';
 DELETE FROM  "S 1"."T 1" where "C 1" >= 20000;
 SET timescaledb.enable_2pc = true;
 
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 --simple commit
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
+
+--connection should remain in idle state
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10001;
 SELECT count(*) FROM pg_prepared_xacts;
 
---simple abort
+--simple
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    --connection in transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 ROLLBACK;
+
+--rolled back transaction, but connection should remain in idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 11001;
 SELECT count(*) FROM pg_prepared_xacts;
 
@@ -150,12 +208,20 @@ BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
 
+--connection should remain in idle after constraint violation
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 --the next few statements inject faults before the commit. They should all fail
 --and be rolled back with no unresolved state
 BEGIN;
     SELECT remote_node_killer_set_event('pre-prepare-transaction', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10002,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
+
+--the connection was killed, so should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10002;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -164,6 +230,10 @@ BEGIN;
     SELECT remote_node_killer_set_event('waiting-prepare-transaction', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10003,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
+
+--the connection should be cleared from the cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10003;
 
@@ -180,6 +250,11 @@ BEGIN;
     SELECT remote_node_killer_set_event('post-prepare-transaction', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
+
+--connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 --unresolved state shown here
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10004;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -188,6 +263,9 @@ SELECT count(*) FROM pg_prepared_xacts;
 BEGIN;
     SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
 COMMIT;
+
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 select count(*) from _timescaledb_catalog.remote_txn;
 
@@ -202,6 +280,10 @@ BEGIN;
     SELECT remote_node_killer_set_event('pre-commit-prepared', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
+
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 --unresolved state shown here
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10006;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -211,6 +293,9 @@ SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10006;
 SELECT count(*) FROM pg_prepared_xacts;
 select count(*) from _timescaledb_catalog.remote_txn;
 
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 BEGIN;
     SELECT remote_node_killer_set_event('waiting-commit-prepared','loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
@@ -219,24 +304,48 @@ COMMIT;
 --the data node process was killed.
 --but in any case, healing the server will bring it into a known state
 SELECT true FROM _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
+
+--heal does not use the connection cache, so unaffected
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10005;
 SELECT count(*) FROM pg_prepared_xacts;
 select count(*) from _timescaledb_catalog.remote_txn;
 
---test prepare transactions. Note that leaked prepared stmts should be detected by `remote_txn_check_for_leaked_prepared_statements`
---so we should be fine if we don't see any WARNINGS.
+--test prepare transactions. Note that leaked prepared stmts should be
+--detected by `remote_txn_check_for_leaked_prepared_statements` so we
+--should be fine if we don't see any WARNINGS.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ PREPARE prep_1 AS SELECT 1 $$);
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
+--unique constraint violation, connection should remain
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 BEGIN;
     SAVEPOINT save_1;
         SELECT test.remote_exec('{loopback}', $$ PREPARE prep_1 AS SELECT 1 $$);
+
+        --connection in transaction state
+        SELECT node_name, connection_status, transaction_status, processing
+        FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+        --generate a unique violation
         SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+
     ROLLBACK TO SAVEPOINT save_1;
+
+    --for correctness, the connection must remain after rollback since
+    --the transaction is still ongoing
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (81,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
+
+--connection should remain and be idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 81;
 
 
@@ -247,20 +356,34 @@ SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 81;
 ALTER TABLE "S 1"."T 1" DROP CONSTRAINT t1_pkey,
 ADD CONSTRAINT t1_pkey PRIMARY KEY ("C 1") DEFERRABLE INITIALLY DEFERRED;
 
---test ABORT TRANSACTION on failure in PREPARE TRANSACTION.
+--test ROLLBACK TRANSACTION on failure in PREPARE TRANSACTION.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
+
+--connection should be removed since PREPARE TRANSACTION failed
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM pg_prepared_xacts;
 
 --test ROLLBACK TRANSACTION
 --this has an error on the second connection. So should force conn1 to prepare transaction
---ok and then have the txn fail on conn2. Thus conn1 would do a ROLLBACK TRANSACTION.
---conn2 would do a ABORT TRANSACTION.
+--ok and then have the txn fail on conn2. Thus conn1 would do a ROLLBACK PREPARED.
+--conn2 would do a ROLLBACK TRANSACTION.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10010,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+
+    --Both connections in transaction state
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
+
+--one connection should remain and be idle
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10010;
 SELECT count(*) FROM pg_prepared_xacts;
 
@@ -276,8 +399,15 @@ BEGIN;
     SELECT remote_node_killer_set_event('pre-abort', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10011,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 RESET client_min_messages;
+
+--failed connection should be cleared
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10011;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -285,17 +415,34 @@ SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_forei
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10011;
 SELECT count(*) FROM pg_prepared_xacts;
 
+--heal is not using the connection cache
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
 --test simple subtrans abort.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10012,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10013,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     SAVEPOINT save_1;
         SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     ROLLBACK TO SAVEPOINT save_1;
+
+    -- For correctness, both connections should remain in order to
+    -- continue the transaction
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10014,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10015,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10011;
 SELECT count(*) FROM pg_prepared_xacts;
 
@@ -311,12 +458,18 @@ BEGIN;
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10018,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SAVEPOINT save_1;
         SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     ROLLBACK TO SAVEPOINT save_1;
+    SELECT node_name, connection_status, transaction_status, processing
+    FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10019,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10020,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
 RESET client_min_messages;
 
+SELECT node_name, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10016;
 SELECT count(*) FROM pg_prepared_xacts;
 

--- a/tsl/test/sql/remote_txn.sql
+++ b/tsl/test/sql/remote_txn.sql
@@ -75,17 +75,17 @@ SELECT test_remote_txn_persistent_record('loopback');
 SET timescaledb.enable_2pc = false;
 
 --initially, there are no connections in the cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     --expect to see one connection in transaction state
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 
 --connection should remain, idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20001;
@@ -94,12 +94,12 @@ SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20001;
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20002,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     --existing connection, in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 ROLLBACK;
 
 --connection should remain, in idle state after rollback
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20002;
 
@@ -109,7 +109,7 @@ BEGIN;
 COMMIT;
 
 -- Connection should remain after conflict, in idle state
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --the next few statements inject faults before the commit. They should all fail
@@ -120,7 +120,7 @@ BEGIN;
 COMMIT;
 
 -- Failed connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20003;
@@ -130,12 +130,12 @@ BEGIN;
     SELECT remote_node_killer_set_event('waiting-commit', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 
 --connection failed during commit, so should be cleared from the cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --during waiting-commit the data node process could die before or after
@@ -149,14 +149,14 @@ BEGIN;
     SELECT remote_node_killer_set_event('pre-abort', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 ROLLBACK;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20005;
 SELECT count(*) FROM pg_prepared_xacts;
 
 --the failed connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --block preparing transactions on the access node
@@ -172,19 +172,19 @@ PREPARE TRANSACTION 'test-2';
 DELETE FROM  "S 1"."T 1" where "C 1" >= 20000;
 SET timescaledb.enable_2pc = true;
 
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --simple commit
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 
 --connection should remain in idle state
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10001;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -193,12 +193,12 @@ SELECT count(*) FROM pg_prepared_xacts;
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     --connection in transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, user_name, host, database, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 ROLLBACK;
 
 --rolled back transaction, but connection should remain in idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 11001;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -209,7 +209,7 @@ BEGIN;
 COMMIT;
 
 --connection should remain in idle after constraint violation
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --the next few statements inject faults before the commit. They should all fail
@@ -220,7 +220,7 @@ BEGIN;
 COMMIT;
 
 --the connection was killed, so should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10002;
@@ -232,7 +232,7 @@ BEGIN;
 COMMIT;
 
 --the connection should be cleared from the cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10003;
@@ -252,7 +252,7 @@ BEGIN;
 COMMIT;
 
 --connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --unresolved state shown here
@@ -264,7 +264,7 @@ BEGIN;
     SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
 COMMIT;
 
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 select count(*) from _timescaledb_catalog.remote_txn;
@@ -281,7 +281,7 @@ BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
 
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --unresolved state shown here
@@ -293,7 +293,7 @@ SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10006;
 SELECT count(*) FROM pg_prepared_xacts;
 select count(*) from _timescaledb_catalog.remote_txn;
 
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 BEGIN;
@@ -306,7 +306,7 @@ COMMIT;
 SELECT true FROM _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
 
 --heal does not use the connection cache, so unaffected
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10005;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -320,7 +320,7 @@ BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
 --unique constraint violation, connection should remain
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 BEGIN;
@@ -328,7 +328,7 @@ BEGIN;
         SELECT test.remote_exec('{loopback}', $$ PREPARE prep_1 AS SELECT 1 $$);
 
         --connection in transaction state
-        SELECT node_name, connection_status, transaction_status, processing
+        SELECT node_name, connection_status, transaction_status, transaction_depth, processing
         FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
         --generate a unique violation
         SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
@@ -337,14 +337,14 @@ BEGIN;
 
     --for correctness, the connection must remain after rollback since
     --the transaction is still ongoing
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (81,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
 
 --connection should remain and be idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 81;
 
@@ -359,12 +359,12 @@ ADD CONSTRAINT t1_pkey PRIMARY KEY ("C 1") DEFERRABLE INITIALLY DEFERRED;
 --test ROLLBACK TRANSACTION on failure in PREPARE TRANSACTION.
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 
 --connection should be removed since PREPARE TRANSACTION failed
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM pg_prepared_xacts;
 
@@ -377,12 +377,12 @@ BEGIN;
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 
     --Both connections in transaction state
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 
 --one connection should remain and be idle
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10010;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -400,13 +400,13 @@ BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10011,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 RESET client_min_messages;
 
 --failed connection should be cleared
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10011;
@@ -416,7 +416,7 @@ SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 10011;
 SELECT count(*) FROM pg_prepared_xacts;
 
 --heal is not using the connection cache
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 
 --test simple subtrans abort.
@@ -424,24 +424,26 @@ BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10012,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10013,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     SAVEPOINT save_1;
         SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+        SELECT node_name, connection_status, transaction_status, transaction_depth, processing
+        FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     ROLLBACK TO SAVEPOINT save_1;
 
     -- For correctness, both connections should remain in order to
     -- continue the transaction
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10014,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10015,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 COMMIT;
 
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10011;
 SELECT count(*) FROM pg_prepared_xacts;
@@ -458,17 +460,17 @@ BEGIN;
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10018,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SAVEPOINT save_1;
         SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     ROLLBACK TO SAVEPOINT save_1;
-    SELECT node_name, connection_status, transaction_status, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10019,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     SELECT test.remote_exec('{loopback2}', $$ INSERT INTO "S 1"."T 1" VALUES (10020,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 COMMIT;
 RESET client_min_messages;
 
-SELECT node_name, connection_status, transaction_status, processing
+SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" > 10016;
 SELECT count(*) FROM pg_prepared_xacts;

--- a/tsl/test/src/remote/async.c
+++ b/tsl/test/src/remote/async.c
@@ -186,10 +186,10 @@ test_request_set()
 
 	set = async_request_set_create();
 	async_request_set_add_sql(set, conn, "SELECT 1");
-	response = async_request_set_wait_any_response_deadline(set, ERROR, TS_NO_TIMEOUT);
+	response = async_request_set_wait_any_response_deadline(set, TS_NO_TIMEOUT);
 	TestAssertTrue(async_response_get_type(response) == RESPONSE_RESULT);
 	async_response_close(response);
-	response = async_request_set_wait_any_response_deadline(set, ERROR, TS_NO_TIMEOUT);
+	response = async_request_set_wait_any_response_deadline(set, TS_NO_TIMEOUT);
 	TestAssertTrue(response == NULL);
 
 	remote_connection_close(conn);
@@ -211,7 +211,7 @@ test_node_death()
 	set = async_request_set_create();
 	async_request_set_add_sql(set, conn, "SELECT 1");
 	remote_node_killer_kill(rnk);
-	response = async_request_set_wait_any_response_deadline(set, ERROR, TS_NO_TIMEOUT);
+	response = async_request_set_wait_any_response_deadline(set, TS_NO_TIMEOUT);
 	TestAssertTrue(async_response_get_type(response) == RESPONSE_RESULT);
 	result = (AsyncResponseResult *) response;
 	pg_res = async_response_result_get_pg_result(result);
@@ -219,11 +219,11 @@ test_node_death()
 	async_response_close(response);
 
 	/* This will throw if elevel == ERROR so set to DEBUG1 */
-	response = async_request_set_wait_any_response_deadline(set, DEBUG1, TS_NO_TIMEOUT);
+	response = async_request_set_wait_any_response_deadline(set, TS_NO_TIMEOUT);
 	TestAssertTrue(async_response_get_type(response) == RESPONSE_COMMUNICATION_ERROR);
 	elog(WARNING, "Expect warning about communication error:");
 	async_response_report_error(response, WARNING);
-	response = async_request_set_wait_any_response_deadline(set, ERROR, TS_NO_TIMEOUT);
+	response = async_request_set_wait_any_response_deadline(set, TS_NO_TIMEOUT);
 	TestAssertTrue(response == NULL);
 	/* No socket error */
 	TestEnsureError(remote_connection_cancel_query(conn));
@@ -283,11 +283,11 @@ test_timeout()
 	set = async_request_set_create();
 	async_request_set_add_sql(set, conn, "LOCK \"S 1\".\"T 1\"");
 	response = async_request_set_wait_any_response_deadline(
-		set, DEBUG1, TimestampTzPlusMilliseconds(GetCurrentTimestamp(), 100));
+		set, TimestampTzPlusMilliseconds(GetCurrentTimestamp(), 100));
 	TestAssertTrue(async_response_get_type(response) == RESPONSE_TIMEOUT);
 
 	/* try again, use timeout instead of deadline interface */
-	response = async_request_set_wait_any_response_timeout(set, DEBUG1, 100);
+	response = async_request_set_wait_any_response_timeout(set, 100);
 	TestAssertTrue(async_response_get_type(response) == RESPONSE_TIMEOUT);
 
 	/* cancel the locked query and do another query */


### PR DESCRIPTION
This change refactors how connections are handled during remote
transactions. In particular, the connection cache now stays consistent
during transactions, even during rollbacks. Previously, the connection
cache was replaced on every rollback, even if the rollback was
intentional (i.e, not due to an error). This made it hard to debug
connections since the cache became completely empty.

Connections could also be left in the cache in a bad state after
failed transactions. This has been fixed by moving connection checks
to the cache and tying transaction state changes to each
connection. This ensures that such checks are done in one canonical
place instead of being spread out throughout the code.

Given how tightly coupled a remote transaction is with its connection,
it might make sense to remove the separate remote transaction store
and instead put this information in each connection. This is left to a
future change, however.

In addition to the above changes, this commit includes:

* Showing transaction depth and invalidation in the transaction store
* Invalidation on individual connections instead of replacing the
  whole cache
* Closing of connections to a local database that is being dropped to
  prevent "in use" errors.
* Ability to add callbacks to async requests that are executed when a
  response is received. This is used by remote transactions to mark
  connections as having successfully completed a transaction. Thus, on
  errors, it is easy to detect connections that are in bad states.
* Error checks on each connection instead of having global error
  tracking for each remote transaction. This change removes the global
  error state for distributed transactions.


Note that this is a multi-commit PR. In particular, the first commit just adds the ability to print the cache and this commit can be viewed by itself to see some of the oddness that occurs when printing the connection cache without any additional changes in the other commits.

