### PR TITLE
Initialize invalidation_range

### DIFF
--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -692,7 +692,7 @@ materialization_invalidation_log_get_range(int32 materialization_id, Oid type, i
 										   int64 invalidate_prior_to_time)
 {
 	bool found = false;
-	InternalTimeRange invalidation_range;
+	InternalTimeRange invalidation_range = { 0 };
 	ScanIterator iterator =
 		ts_scan_iterator_create(CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
 								AccessShareLock,


### PR DESCRIPTION
GCC 7.5 warns that invalidation_range may be used uninitialized.
This patch changes the code to always initialize invalidation_range.