### PR TITLE
Initialize variables complained about by older compilers

### DIFF
--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -195,7 +195,7 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 {
 	float8 jitter = calculate_jitter_percent();
 	/* consecutive failures includes this failure */
-	TimestampTz res;
+	TimestampTz res = 0;
 	volatile bool res_set = false;
 	TimestampTz last_finish = finish_time;
 	float8 multiplier = (consecutive_failures > MAX_FAILURES_MULTIPLIER ? MAX_FAILURES_MULTIPLIER :

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -692,7 +692,7 @@ materialization_invalidation_log_get_range(int32 materialization_id, Oid type, i
 										   int64 invalidate_prior_to_time)
 {
 	bool found = false;
-	InternalTimeRange invalidation_range;
+	InternalTimeRange invalidation_range = { 0 };
 	ScanIterator iterator =
 		ts_scan_iterator_create(CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
 								AccessShareLock,


### PR DESCRIPTION
GCC 7.5 warns that invalidation_range in continuous aggregate
materialization may be used uninitialized.
Older clang versons warn that res in calculate_next_start_on_failure
may be used uninitialized.
This patch changes the code to always initialize those two variables.