### PR TITLE
Fix bit array left shift count

### DIFF
--- a/src/adts/bit_array_impl.h
+++ b/src/adts/bit_array_impl.h
@@ -361,7 +361,7 @@ bit_array_append_bucket(BitArray *array, uint8 bits_used, uint64 bucket)
 static uint64
 bit_array_low_bits_mask(uint8 bits_used)
 {
-	if (bits_used == 64)
+	if (bits_used >= 64)
 		return PG_UINT64_MAX;
 	else
 		return (UINT64CONST(1) << bits_used) - UINT64CONST(1);


### PR DESCRIPTION
If `bits_used` is not exactly 64, a shift will be attempted, even when
`bits_used > 64`. According to the standard "[...] if the value of the
right operand is negative or is greater or equal to the number of bits
in the promoted left operand, the behavior is undefined."

Hence we change the code to return `PG_UINT64_MAX` if a request to
shift more bits than the number of bits in the type is requested,
otherwise we perform the shift.

Found using `clang-tidy`