### PR TITLE
Fix crash with create_distributed_hypertable

### DIFF
--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -4478,3 +4478,42 @@ EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
 (7 rows)
 
 DROP TABLE test_1702;
+--
+-- Test that creating a hypertable with a space dimension and
+-- if_not_exists works as expected, that is, the second call does not
+-- generate an error (and does not crash).
+--
+CREATE TABLE whatever (
+    timestamp TIMESTAMPTZ NOT NULL,
+    user_id   INT         NOT NULL,
+    data      JSONB
+);
+SELECT * FROM create_distributed_hypertable('whatever', 'timestamp', 'user_id',
+                                            if_not_exists => true, chunk_time_interval => INTERVAL '1 day');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            24 | public      | whatever   | t
+(1 row)
+
+-- Check the hypertable sequence before and after call to ensure that
+-- the hypertable sequence was not increased with the second call.
+SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
+ last_value | log_cnt | is_called 
+------------+---------+-----------
+         24 |      23 | t
+(1 row)
+
+SELECT * FROM create_distributed_hypertable('whatever', 'timestamp', 'user_id',
+                                            if_not_exists => true, chunk_time_interval => INTERVAL '1 day');
+NOTICE:  table "whatever" is already a hypertable, skipping
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            24 | public      | whatever   | f
+(1 row)
+
+SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
+ last_value | log_cnt | is_called 
+------------+---------+-----------
+         24 |      23 | t
+(1 row)
+

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -4458,3 +4458,42 @@ EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
 (7 rows)
 
 DROP TABLE test_1702;
+--
+-- Test that creating a hypertable with a space dimension and
+-- if_not_exists works as expected, that is, the second call does not
+-- generate an error (and does not crash).
+--
+CREATE TABLE whatever (
+    timestamp TIMESTAMPTZ NOT NULL,
+    user_id   INT         NOT NULL,
+    data      JSONB
+);
+SELECT * FROM create_distributed_hypertable('whatever', 'timestamp', 'user_id',
+                                            if_not_exists => true, chunk_time_interval => INTERVAL '1 day');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            24 | public      | whatever   | t
+(1 row)
+
+-- Check the hypertable sequence before and after call to ensure that
+-- the hypertable sequence was not increased with the second call.
+SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
+ last_value | log_cnt | is_called 
+------------+---------+-----------
+         24 |      23 | t
+(1 row)
+
+SELECT * FROM create_distributed_hypertable('whatever', 'timestamp', 'user_id',
+                                            if_not_exists => true, chunk_time_interval => INTERVAL '1 day');
+NOTICE:  table "whatever" is already a hypertable, skipping
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            24 | public      | whatever   | f
+(1 row)
+
+SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
+ last_value | log_cnt | is_called 
+------------+---------+-----------
+         24 |      23 | t
+(1 row)
+

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -1417,3 +1417,24 @@ SELECT create_distributed_hypertable('test_1702', 'time', 'id');
 EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
 
 DROP TABLE test_1702;
+
+--
+-- Test that creating a hypertable with a space dimension and
+-- if_not_exists works as expected, that is, the second call does not
+-- generate an error (and does not crash).
+--
+
+CREATE TABLE whatever (
+    timestamp TIMESTAMPTZ NOT NULL,
+    user_id   INT         NOT NULL,
+    data      JSONB
+);
+
+SELECT * FROM create_distributed_hypertable('whatever', 'timestamp', 'user_id',
+                                            if_not_exists => true, chunk_time_interval => INTERVAL '1 day');
+-- Check the hypertable sequence before and after call to ensure that
+-- the hypertable sequence was not increased with the second call.
+SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
+SELECT * FROM create_distributed_hypertable('whatever', 'timestamp', 'user_id',
+                                            if_not_exists => true, chunk_time_interval => INTERVAL '1 day');
+SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;


### PR DESCRIPTION
Function `ts_hypertable_create_from_info` will error if the hypertable
already exists unless the if-not-exists flag is not set.  If we reach
this point, either if-not-exists-flag was set or the hypertable did not
exist and was created above.

In `ts_hypertable_create_from_info`, a call to
`ts_dimension_info_validate` with `space_dim_info` will be made if (and
only if) the table did not exist. The function does not only validate
the dimension, it also set `dimension_id` field.

 If the table already existed, `created` will be false and the
`dimension_id` will be set to the invalid OID, which means that
`ts_hypertable_check_partitioning` will crash since it it expect a
proper OID to be passed.

This commit fixes that by checking if the hypertable exists prior to 
calling `ts_hypertable_create_from_info` in 
`ts_hypertable_create_internal` and aborting with an error if the 
hypertable already exists.

Fixes #1987
