### PR TITLE
Fix output in function to show connection cache

### DIFF
--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -374,7 +374,7 @@ create_tuple_from_conn_entry(const ConnectionCacheEntry *entry, const TupleDesc 
 		Int32GetDatum(remote_connection_xact_depth_get(entry->conn));
 	values[AttrNumberGetAttrOffset(Anum_show_conn_processing)] =
 		BoolGetDatum(remote_connection_is_processing(entry->conn));
-	values[AttrNumberGetAttrOffset(Anum_show_conn_processing)] = BoolGetDatum(entry->invalidated);
+	values[AttrNumberGetAttrOffset(Anum_show_conn_invalidated)] = BoolGetDatum(entry->invalidated);
 
 	return heap_form_tuple(tupdesc, values, nulls);
 }

--- a/tsl/test/expected/remote_txn.out
+++ b/tsl/test/expected/remote_txn.out
@@ -368,11 +368,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-0
 (1 row)
 
     --connection in transaction
-    SELECT node_name, user_name, host, database, connection_status, transaction_status, transaction_depth, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
- node_name | user_name  |   host    |   database    | connection_status | transaction_status | transaction_depth | processing 
------------+------------+-----------+---------------+-------------------+--------------------+-------------------+------------
- loopback  | super_user | localhost | db_remote_txn | OK                | INTRANS            |                 1 | f
+ node_name | connection_status | transaction_status | transaction_depth | processing 
+-----------+-------------------+--------------------+-------------------+------------
+ loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
 ROLLBACK;
@@ -1085,7 +1085,7 @@ BEGIN;
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
  node_name | connection_status | transaction_status | transaction_depth | processing 
 -----------+-------------------+--------------------+-------------------+------------
- loopback  | BAD               | UNKNOWN            |                 1 | f
+ loopback  | BAD               | UNKNOWN            |                 1 | t
  loopback2 | OK                | INTRANS            |                 1 | f
 (2 rows)
 

--- a/tsl/test/sql/remote_txn.sql
+++ b/tsl/test/sql/remote_txn.sql
@@ -193,7 +193,7 @@ SELECT count(*) FROM pg_prepared_xacts;
 BEGIN;
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (11001,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
     --connection in transaction
-    SELECT node_name, user_name, host, database, connection_status, transaction_status, transaction_depth, processing
+    SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 ROLLBACK;
 


### PR DESCRIPTION
The "invalidation" column was accidentally set as the "processing"
column in `show_connection_cache`. This made the output of these
columns show the wrong values. This change fixes this issue.