### PR TITLE
Remove flakiness of cagg materializaion test

### DIFF
--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -1436,9 +1436,9 @@ SELECT view_name, refresh_lag, max_interval_per_job
 (4 rows)
 
 -- test timezone is respected when materializing cagg with TIMESTAMP time column
-RESET timescaledb.current_timestamp_mock;
 RESET client_min_messages;
 SET SESSION timezone TO 'GMT+5';
+\set NOW_TEST 'timestamptz \'2019-09-09 01:01:01 UTC\''
 CREATE TABLE timezone_test(time timestamp NOT NULL);
 SELECT table_name FROM create_hypertable('timezone_test','time');
   table_name   
@@ -1446,7 +1446,10 @@ SELECT table_name FROM create_hypertable('timezone_test','time');
  timezone_test
 (1 row)
 
-INSERT INTO timezone_test VALUES (now() - '30m'::interval), (now()), (now() + '30m'::interval);
+INSERT INTO timezone_test VALUES
+    (:NOW_TEST - '30m'::interval),
+    (:NOW_TEST),
+    (:NOW_TEST + '30m'::interval);
 CREATE VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
@@ -1472,7 +1475,10 @@ SELECT table_name FROM create_hypertable('timezone_test','time');
  timezone_test
 (1 row)
 
-INSERT INTO timezone_test VALUES (now() - '30m'::interval), (now()), (now() + '30m'::interval);
+INSERT INTO timezone_test VALUES
+    (:NOW_TEST - '30m'::interval),
+    (:NOW_TEST),
+    (:NOW_TEST + '30m'::interval);
 CREATE VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
@@ -1489,6 +1495,8 @@ SELECT count(*) FROM timezone_test_summary;
 DROP TABLE timezone_test CASCADE;
 NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_23_44_chunk
+\unset NOW_TEST
+RESET timescaledb.current_timestamp_mock;
 -- TESTS for integer based table to verify watermark limited by max value of time column and not by now
 CREATE TABLE continuous_agg_int(time BIGINT, data BIGINT);
 SELECT create_hypertable('continuous_agg_int', 'time', chunk_time_interval=> 10);


### PR DESCRIPTION
Replaces now() with mocked timestamp value in
continuous_aggs_materialize test, so the test doesn't produce
unexpected result when now() is close to a chunk border.
