### PR TITLE
Fix paths to PG binaries in GH actions

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -48,6 +48,7 @@ jobs:
       run: cmake --build ${{ matrix.build_type }} --config ${{ matrix.build_type }}
     - name: Install [${{ matrix.build_type }}]
       run: cmake --install ${{ matrix.build_type }} --config ${{ matrix.build_type }}
+    - run: ls $HOME\PostgreSQL
     - name: Create DB
       run: $HOME\PostgreSQL\${{ matrix.pg }}\bin\initdb -U postgres -A trust
     - name: Start PostgreSQL

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -49,8 +49,8 @@ jobs:
     - name: Install [${{ matrix.build_type }}]
       run: cmake --install ${{ matrix.build_type }} --config ${{ matrix.build_type }}
     - name: Create DB
-      run: ~/PostgreSQL/${{ matrix.pg }}/bin/initdb -U postgres -A trust
+      run: $HOME\PostgreSQL\${{ matrix.pg }}\bin\initdb -U postgres -A trust
     - name: Start PostgreSQL
-      run: ~/PostgreSQL/${{ matrix.pg }}/bin/pg_ctl start -o "-cshared_preload_libraries=timescaledb"
+      run: $HOME\PostgreSQL\${{ matrix.pg }}\bin\pg_ctl start -o "-cshared_preload_libraries=timescaledb"
     - name: Test CREATE EXTENSION
-      run: ~/PostgreSQL/${{ matrix.pg }}/bin/psql -U postgres -d postgres -c 'CREATE EXTENSION timescaledb'
+      run: $HOME\PostgreSQL\${{ matrix.pg }}\bin\psql -U postgres -d postgres -c 'CREATE EXTENSION timescaledb'

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
         key: ${{ runner.os }}-build-pg${{ matrix.pg }}
     - name: Install PostgreSQL ${{ matrix.pg }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
-      run: choco install postgresql${{ matrix.pg }} -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
+      run: choco install postgresql${{ matrix.pg }} --force -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
     - name: Configure [${{ matrix.build_type }}]
       run: cmake -B ${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREGRESS_CHECKS=OFF -DPG_PATH="$HOME/PostgreSQL/${{ matrix.pg }}" -DOPENSSL_ROOT_DIR="$HOME/PostgreSQL/${{ matrix.pg }}"
       # Build step: could potentially speed things up with --parallel

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - prerelease_test
   pull_request:
+defaults:
+  run:
+    shell: cmd
 jobs:
   build:
     name: PG${{ matrix.pg }} [${{ matrix.build_type }}]
@@ -36,7 +39,7 @@ jobs:
         key: ${{ runner.os }}-build-pg${{ matrix.pg }}
     - name: Install PostgreSQL ${{ matrix.pg }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
-      run: choco install postgresql${{ matrix.pg }} --force -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
+      run: choco install postgresql${{ matrix.pg }} -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
     - name: Configure [${{ matrix.build_type }}]
       run: cmake -B ${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREGRESS_CHECKS=OFF -DPG_PATH="$HOME/PostgreSQL/${{ matrix.pg }}" -DOPENSSL_ROOT_DIR="$HOME/PostgreSQL/${{ matrix.pg }}"
       # Build step: could potentially speed things up with --parallel


### PR DESCRIPTION
Uses Windows notation for paths to PostgreSQL executables, so they can
be found during GitHub Actions workflow execution.