### PR TITLE
Force installing PostgreSQL in GH Actions on Windows

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
         key: ${{ runner.os }}-build-pg${{ matrix.pg }}
     - name: Install PostgreSQL ${{ matrix.pg }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
-      run: choco install postgresql${{ matrix.pg }} -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
+      run: choco install postgresql${{ matrix.pg }} --force -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
     - name: Configure [${{ matrix.build_type }}]
       run: cmake -B ${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREGRESS_CHECKS=OFF -DPG_PATH="$HOME/PostgreSQL/${{ matrix.pg }}" -DOPENSSL_ROOT_DIR="$HOME/PostgreSQL/${{ matrix.pg }}"
       # Build step: could potentially speed things up with --parallel


### PR DESCRIPTION
PostgreSQL 12 is preinstalled, while 11 is not. To unify different 
paths of PG 11 and 12 binaries, this commit implements workaround by 
forcing installation of PostgreSQL 12, so it is in the same path as 
PostgreSQL 11.