### PR TITLE
Add checks for read-only transactions

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3487,6 +3487,8 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 	List *data_node_oids = NIL;
 	Cache *hcache;
 
+	PreventCommandIfReadOnly("drop_chunks()");
+
 	/*
 	 * When past the first call of the SRF, dropping has already been completed,
 	 * so we just return the next chunk in the list of dropped chunks.

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -750,6 +750,8 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 	Datum values[2];
 	bool nulls[2] = { false, false };
 
+	PreventCommandIfReadOnly("set_adaptive_chunking()");
+
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1162,6 +1162,8 @@ ts_dimension_set_num_slices(PG_FUNCTION_ARGS)
 	int16 num_slices;
 	Hypertable *ht;
 
+	PreventCommandIfReadOnly("set_number_partitions()");
+
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
@@ -1212,6 +1214,8 @@ ts_dimension_set_interval(PG_FUNCTION_ARGS)
 	Name colname = PG_ARGISNULL(2) ? NULL : PG_GETARG_NAME(2);
 	Cache *hcache = ts_hypertable_cache_pin();
 	Hypertable *ht;
+
+	PreventCommandIfReadOnly("set_chunk_time_interval()");
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
@@ -1489,6 +1493,8 @@ ts_dimension_add(PG_FUNCTION_ARGS)
 		.if_not_exists = PG_ARGISNULL(5) ? false : PG_GETARG_BOOL(5),
 	};
 	Datum retval = 0;
+
+	PreventCommandIfReadOnly("add_dimension()");
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1848,6 +1848,9 @@ ts_hypertable_create_internal(PG_FUNCTION_ARGS, bool is_dist_call)
 	uint32 flags = 0;
 	List *data_nodes = NIL;
 
+	PreventCommandIfReadOnly(is_dist_call ? "create_distributed_hypertable()" :
+											"create_hypertable()");
+
 	if (!OidIsValid(table_relid))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -27,6 +27,8 @@ typedef struct ProcessUtilityArgs
 	char *completion_tag;
 } ProcessUtilityArgs;
 
+typedef bool (*ts_process_utility_handler_t)(ProcessUtilityArgs *args);
+
 extern void ts_process_utility_set_expect_chunk_modification(bool expect);
 
 #endif /* TIMESCALEDB_PROCESS_UTILITY_H */

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -434,6 +434,8 @@ ts_tablespace_attach(PG_FUNCTION_ARGS)
 	Oid hypertable_oid = PG_ARGISNULL(1) ? InvalidOid : PG_GETARG_OID(1);
 	bool if_not_attached = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 
+	PreventCommandIfReadOnly("attach_tablespace()");
+
 	if (PG_NARGS() < 2 || PG_NARGS() > 3)
 		elog(ERROR, "invalid number of arguments");
 
@@ -587,6 +589,8 @@ ts_tablespace_detach(PG_FUNCTION_ARGS)
 	Oid tspcoid;
 	int ret;
 
+	PreventCommandIfReadOnly("detach_tablespace()");
+
 	if (PG_NARGS() < 1 || PG_NARGS() > 3)
 		elog(ERROR, "invalid number of arguments");
 
@@ -617,6 +621,8 @@ TS_FUNCTION_INFO_V1(ts_tablespace_detach_all_from_hypertable);
 Datum
 ts_tablespace_detach_all_from_hypertable(PG_FUNCTION_ARGS)
 {
+	PreventCommandIfReadOnly("detach_tablespaces()");
+
 	if (PG_NARGS() != 1)
 		elog(ERROR, "invalid number of arguments");
 

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -638,6 +638,8 @@ data_node_add_internal(PG_FUNCTION_ARGS, bool set_distid)
 	bool PG_USED_FOR_ASSERTS_ONLY result;
 	DbInfo database;
 
+	PreventCommandIfReadOnly("add_data_node()");
+
 	namestrcpy(&database.name, dbname);
 
 	if (host == NULL)
@@ -780,6 +782,8 @@ data_node_attach(PG_FUNCTION_ARGS)
 	List *result;
 	int num_nodes;
 	ListCell *lc;
+
+	PreventCommandIfReadOnly("attach_data_node()");
 
 	if (PG_ARGISNULL(1))
 		ereport(ERROR,
@@ -1203,6 +1207,8 @@ data_node_allow_new_chunks(PG_FUNCTION_ARGS)
 	const char *node_name = PG_ARGISNULL(0) ? NULL : NameStr(*PG_GETARG_NAME(0));
 	Oid table_id = PG_ARGISNULL(1) ? InvalidOid : PG_GETARG_OID(1);
 
+	PreventCommandIfReadOnly("allow_new_chunks()");
+
 	return data_node_block_or_allow_new_chunks(node_name, table_id, false, false);
 }
 
@@ -1212,6 +1218,8 @@ data_node_block_new_chunks(PG_FUNCTION_ARGS)
 	const char *node_name = PG_ARGISNULL(0) ? NULL : NameStr(*PG_GETARG_NAME(0));
 	Oid table_id = PG_ARGISNULL(1) ? InvalidOid : PG_GETARG_OID(1);
 	bool force = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
+
+	PreventCommandIfReadOnly("block_new_chunks()");
 
 	return data_node_block_or_allow_new_chunks(node_name, table_id, force, true);
 }
@@ -1226,8 +1234,11 @@ data_node_detach(PG_FUNCTION_ARGS)
 	bool repartition = PG_ARGISNULL(3) ? false : PG_GETARG_BOOL(3);
 	int removed = 0;
 	List *hypertable_data_nodes = NIL;
-	ForeignServer *server = data_node_get_foreign_server(node_name, ACL_USAGE, true, false);
+	ForeignServer *server;
 
+	PreventCommandIfReadOnly("detach_data_node()");
+
+	server = data_node_get_foreign_server(node_name, ACL_USAGE, true, false);
 	Assert(NULL != server);
 
 	if (OidIsValid(table_id))
@@ -1274,6 +1285,8 @@ data_node_delete(PG_FUNCTION_ARGS)
 	Node *parsetree = NULL;
 	TSConnectionId cid;
 	ForeignServer *server;
+
+	PreventCommandIfReadOnly("delete_data_node()");
 
 	/* Need USAGE to detach. Further owner check done when executing the DROP
 	 * statement. */

--- a/tsl/src/hypertable.c
+++ b/tsl/src/hypertable.c
@@ -256,6 +256,8 @@ hypertable_set_replication_factor(PG_FUNCTION_ARGS)
 	Cache *hcache;
 	Hypertable *ht;
 
+	PreventCommandIfReadOnly("set_replication_factor()");
+
 	if (!OidIsValid(table_relid))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -1,0 +1,282 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+-- Following tests checks that API functions which modify data (including catalog)
+-- properly recognize read-only transaction state
+--
+-- create_hypertable()
+--
+CREATE TABLE test_table(time bigint NOT NULL, device int);
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable('test_table', 'time');
+ERROR:  cannot execute create_hypertable() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM create_hypertable('test_table', 'time', chunk_time_interval => 1000000::bigint);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | test_table | t
+(1 row)
+
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+-- set_chunk_time_interval()
+--
+SELECT * FROM set_chunk_time_interval('test_table', 2000000000::bigint);
+ERROR:  cannot execute set_chunk_time_interval() in a read-only transaction
+-- set_number_partitions()
+--
+SELECT * FROM set_number_partitions('test_table', 2);
+ERROR:  cannot execute set_number_partitions() in a read-only transaction
+-- set_adaptive_chunking()
+--
+SELECT * FROM set_adaptive_chunking('test_table', '2MB');
+ERROR:  cannot execute set_adaptive_chunking() in a read-only transaction
+-- drop_chunks()
+--
+SELECT * FROM drop_chunks('test_table', older_than => 10);
+ERROR:  cannot execute drop_chunks() in a read-only transaction
+SELECT * FROM drop_chunks('test_table', older_than => 10, cascade_to_materializations => true);
+ERROR:  cannot execute drop_chunks() in a read-only transaction
+-- add_dimension()
+--
+SELECT * FROM add_dimension('test_table', 'device', chunk_time_interval => 100);
+ERROR:  cannot execute add_dimension() in a read-only transaction
+\set ON_ERROR_STOP 1
+-- tablespaces
+--
+SET default_transaction_read_only TO off;
+SET client_min_messages TO error;
+DROP TABLESPACE IF EXISTS tablespace1;
+RESET client_min_messages;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_CLUSTER_SUPERUSER LOCATION :TEST_TABLESPACE1_PATH;
+SET default_transaction_read_only TO on;
+-- attach_tablespace()
+--
+\set ON_ERROR_STOP 0
+SELECT * FROM attach_tablespace('tablespace1', 'test_table');
+ERROR:  cannot execute attach_tablespace() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM attach_tablespace('tablespace1', 'test_table');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+-- detach_tablespace()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM detach_tablespace('tablespace1', 'test_table');
+ERROR:  cannot execute detach_tablespace() in a read-only transaction
+\set ON_ERROR_STOP 1
+-- detach_tablespaces()
+--
+\set ON_ERROR_STOP 0
+SELECT * FROM detach_tablespaces('test_table');
+ERROR:  cannot execute detach_tablespaces() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM detach_tablespaces('test_table');
+ detach_tablespaces 
+--------------------
+                  1
+(1 row)
+
+DROP TABLESPACE tablespace1;
+-- drop hypertable
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+DROP TABLE test_table;
+ERROR:  cannot execute DROP TABLE in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+DROP TABLE test_table;
+-- data nodes
+--
+CREATE TABLE disttable(time timestamptz NOT NULL, device int);
+-- add_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => 'data_node_1');
+ERROR:  cannot execute add_data_node() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => 'data_node_1');
+  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
+-------------+-----------+-------+-------------+--------------+------------------+-------------------
+ data_node_1 | localhost | 55432 | data_node_1 | t            | t                | t
+(1 row)
+
+SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => 'data_node_2');
+  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
+-------------+-----------+-------+-------------+--------------+------------------+-------------------
+ data_node_2 | localhost | 55432 | data_node_2 | t            | t                | t
+(1 row)
+
+-- create_distributed_hypertable()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', data_nodes => '{data_node_1}');
+ERROR:  cannot execute create_distributed_hypertable() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', data_nodes => '{data_node_1}');
+WARNING:  only one data node was assigned to the hypertable
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             2 | public      | disttable  | t
+(1 row)
+
+-- attach_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM attach_data_node('data_node_2', 'disttable');
+ERROR:  cannot execute attach_data_node() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM attach_data_node('data_node_2', 'disttable');
+NOTICE:  the number of partitions in dimension "device" was increased to 2
+ hypertable_id | node_hypertable_id |  node_name  
+---------------+--------------------+-------------
+             2 |                  1 | data_node_2
+(1 row)
+
+-- detach_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM detach_data_node('data_node_2', 'disttable');
+ERROR:  cannot execute detach_data_node() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM detach_data_node('data_node_2', 'disttable');
+NOTICE:  the number of partitions in dimension "device" was decreased to 1
+ detach_data_node 
+------------------
+                1
+(1 row)
+
+-- delete_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM delete_data_node('data_node_2');
+ERROR:  cannot execute delete_data_node() in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM delete_data_node('data_node_2');
+ delete_data_node 
+------------------
+ t
+(1 row)
+
+-- set_replication_factor()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM set_replication_factor('disttable', 2);
+ERROR:  cannot execute set_replication_factor() in a read-only transaction
+\set ON_ERROR_STOP 1
+-- drop distributed hypertable
+--
+\set ON_ERROR_STOP 0
+DROP TABLE disttable;
+ERROR:  cannot execute DROP TABLE in a read-only transaction
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+DROP TABLE disttable;
+-- Test some read-only cases of DDL operations
+-- 
+CREATE TABLE test_table(time bigint NOT NULL, device int);
+SELECT * FROM create_hypertable('test_table', 'time', chunk_time_interval => 1000000::bigint);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | test_table | t
+(1 row)
+
+INSERT INTO test_table VALUES (0, 1), (1, 1), (2, 2);
+SET default_transaction_read_only TO on;
+-- CREATE INDEX
+--
+\set ON_ERROR_STOP 0
+CREATE INDEX test_table_device_idx ON test_table(device);
+ERROR:  cannot execute CREATE INDEX in a read-only transaction
+\set ON_ERROR_STOP 1
+-- TRUNCATE
+--
+\set ON_ERROR_STOP 0
+TRUNCATE test_table;
+ERROR:  cannot execute TRUNCATE TABLE in a read-only transaction
+\set ON_ERROR_STOP 1
+-- ALTER TABLE
+--
+\set ON_ERROR_STOP 0
+ALTER TABLE test_table DROP COLUMN device;
+ERROR:  cannot execute ALTER TABLE in a read-only transaction
+ALTER TABLE test_table ADD CONSTRAINT device_check CHECK (device > 0);
+ERROR:  cannot execute ALTER TABLE in a read-only transaction
+\set ON_ERROR_STOP 1
+-- VACUUM
+--
+\set ON_ERROR_STOP 0
+VACUUM test_table;
+ERROR:  cannot execute VACUUM in a read-only transaction
+\set ON_ERROR_STOP 1
+-- CLUSTER
+--
+\set ON_ERROR_STOP 0
+CLUSTER test_table USING test_table_time_idx;
+ERROR:  cannot execute CLUSTER in a read-only transaction
+\set ON_ERROR_STOP 1
+-- COPY FROM
+--
+\set ON_ERROR_STOP 0
+COPY test_table (time, device) FROM STDIN DELIMITER ',';
+ERROR:  cannot execute COPY FROM in a read-only transaction
+\set ON_ERROR_STOP 1
+-- COPY TO (expect to be working in read-only mode)
+--
+COPY (SELECT * FROM test_Table ORDER BY time) TO STDOUT;
+0	1
+1	1
+2	2
+-- Test Continuous Aggregates
+-- 
+SET default_transaction_read_only TO off;
+CREATE TABLE test_contagg (
+  observation_time  TIMESTAMPTZ       NOT NULL,
+  device_id         TEXT              NOT NULL,
+  metric            DOUBLE PRECISION  NOT NULL,
+  PRIMARY KEY(observation_time, device_id)
+);
+SELECT create_hypertable('test_contagg', 'observation_time');
+     create_hypertable     
+---------------------------
+ (4,public,test_contagg,t)
+(1 row)
+
+SET default_transaction_read_only TO on;
+-- CREATE VIEW
+--
+\set ON_ERROR_STOP 0
+CREATE VIEW test_contagg_view
+WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  device_id,
+  avg(metric) as metric_avg,
+  max(metric)-min(metric) as metric_spread
+FROM
+  test_contagg
+GROUP BY bucket, device_id;
+ERROR:  cannot execute CREATE VIEW in a read-only transaction
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -54,6 +54,7 @@ set(TEST_FILES_DEBUG
   telemetry_distributed.sql
   transparent_decompression_queries.sql
   tsl_tables.sql
+  read_only.sql
 )
 
 set(TEST_TEMPLATES

--- a/tsl/test/sql/read_only.sql
+++ b/tsl/test/sql/read_only.sql
@@ -1,0 +1,245 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+
+-- Following tests checks that API functions which modify data (including catalog)
+-- properly recognize read-only transaction state
+--
+
+-- create_hypertable()
+--
+CREATE TABLE test_table(time bigint NOT NULL, device int);
+
+SET default_transaction_read_only TO on;
+
+\set ON_ERROR_STOP 0
+SELECT * FROM create_hypertable('test_table', 'time');
+\set ON_ERROR_STOP 1
+
+SET default_transaction_read_only TO off;
+SELECT * FROM create_hypertable('test_table', 'time', chunk_time_interval => 1000000::bigint);
+
+SET default_transaction_read_only TO on;
+
+\set ON_ERROR_STOP 0
+
+-- set_chunk_time_interval()
+--
+SELECT * FROM set_chunk_time_interval('test_table', 2000000000::bigint);
+
+-- set_number_partitions()
+--
+SELECT * FROM set_number_partitions('test_table', 2);
+
+-- set_adaptive_chunking()
+--
+SELECT * FROM set_adaptive_chunking('test_table', '2MB');
+
+-- drop_chunks()
+--
+SELECT * FROM drop_chunks('test_table', older_than => 10);
+SELECT * FROM drop_chunks('test_table', older_than => 10, cascade_to_materializations => true);
+
+-- add_dimension()
+--
+SELECT * FROM add_dimension('test_table', 'device', chunk_time_interval => 100);
+
+\set ON_ERROR_STOP 1
+
+-- tablespaces
+--
+SET default_transaction_read_only TO off;
+
+SET client_min_messages TO error;
+DROP TABLESPACE IF EXISTS tablespace1;
+RESET client_min_messages;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_CLUSTER_SUPERUSER LOCATION :TEST_TABLESPACE1_PATH;
+
+SET default_transaction_read_only TO on;
+
+-- attach_tablespace()
+--
+\set ON_ERROR_STOP 0
+SELECT * FROM attach_tablespace('tablespace1', 'test_table');
+\set ON_ERROR_STOP 1
+
+SET default_transaction_read_only TO off;
+SELECT * FROM attach_tablespace('tablespace1', 'test_table');
+
+-- detach_tablespace()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM detach_tablespace('tablespace1', 'test_table');
+\set ON_ERROR_STOP 1
+
+-- detach_tablespaces()
+--
+\set ON_ERROR_STOP 0
+SELECT * FROM detach_tablespaces('test_table');
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM detach_tablespaces('test_table');
+
+DROP TABLESPACE tablespace1;
+
+-- drop hypertable
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+DROP TABLE test_table;
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+DROP TABLE test_table;
+
+-- data nodes
+--
+CREATE TABLE disttable(time timestamptz NOT NULL, device int);
+
+-- add_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => 'data_node_1');
+\set ON_ERROR_STOP 1
+
+SET default_transaction_read_only TO off;
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => 'data_node_1');
+SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => 'data_node_2');
+
+-- create_distributed_hypertable()
+--
+SET default_transaction_read_only TO on;
+
+\set ON_ERROR_STOP 0
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', data_nodes => '{data_node_1}');
+\set ON_ERROR_STOP 1
+
+SET default_transaction_read_only TO off;
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', data_nodes => '{data_node_1}');
+
+-- attach_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM attach_data_node('data_node_2', 'disttable');
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM attach_data_node('data_node_2', 'disttable');
+
+-- detach_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM detach_data_node('data_node_2', 'disttable');
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM detach_data_node('data_node_2', 'disttable');
+
+-- delete_data_node()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM delete_data_node('data_node_2');
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+SELECT * FROM delete_data_node('data_node_2');
+
+-- set_replication_factor()
+--
+SET default_transaction_read_only TO on;
+\set ON_ERROR_STOP 0
+SELECT * FROM set_replication_factor('disttable', 2);
+\set ON_ERROR_STOP 1
+
+-- drop distributed hypertable
+--
+\set ON_ERROR_STOP 0
+DROP TABLE disttable;
+\set ON_ERROR_STOP 1
+SET default_transaction_read_only TO off;
+DROP TABLE disttable;
+
+-- Test some read-only cases of DDL operations
+-- 
+CREATE TABLE test_table(time bigint NOT NULL, device int);
+SELECT * FROM create_hypertable('test_table', 'time', chunk_time_interval => 1000000::bigint);
+INSERT INTO test_table VALUES (0, 1), (1, 1), (2, 2);
+
+SET default_transaction_read_only TO on;
+
+-- CREATE INDEX
+--
+\set ON_ERROR_STOP 0
+CREATE INDEX test_table_device_idx ON test_table(device);
+\set ON_ERROR_STOP 1
+
+-- TRUNCATE
+--
+\set ON_ERROR_STOP 0
+TRUNCATE test_table;
+\set ON_ERROR_STOP 1
+
+-- ALTER TABLE
+--
+\set ON_ERROR_STOP 0
+ALTER TABLE test_table DROP COLUMN device;
+ALTER TABLE test_table ADD CONSTRAINT device_check CHECK (device > 0);
+\set ON_ERROR_STOP 1
+
+-- VACUUM
+--
+\set ON_ERROR_STOP 0
+VACUUM test_table;
+\set ON_ERROR_STOP 1
+
+-- CLUSTER
+--
+\set ON_ERROR_STOP 0
+CLUSTER test_table USING test_table_time_idx;
+\set ON_ERROR_STOP 1
+
+-- COPY FROM
+--
+\set ON_ERROR_STOP 0
+COPY test_table (time, device) FROM STDIN DELIMITER ',';
+\set ON_ERROR_STOP 1
+
+-- COPY TO (expect to be working in read-only mode)
+--
+COPY (SELECT * FROM test_Table ORDER BY time) TO STDOUT;
+
+-- Test Continuous Aggregates
+-- 
+SET default_transaction_read_only TO off;
+
+CREATE TABLE test_contagg (
+  observation_time  TIMESTAMPTZ       NOT NULL,
+  device_id         TEXT              NOT NULL,
+  metric            DOUBLE PRECISION  NOT NULL,
+  PRIMARY KEY(observation_time, device_id)
+);
+
+SELECT create_hypertable('test_contagg', 'observation_time');
+
+SET default_transaction_read_only TO on;
+
+-- CREATE VIEW
+--
+\set ON_ERROR_STOP 0
+
+CREATE VIEW test_contagg_view
+WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1 hour', observation_time) as bucket,
+  device_id,
+  avg(metric) as metric_avg,
+  max(metric)-min(metric) as metric_spread
+FROM
+  test_contagg
+GROUP BY bucket, device_id;
+
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
This change ensures that API functions which modify data respects read-only transaction state set by
`default_transaction_read_only` option.

Related to https://github.com/timescale/timescaledb/issues/1912