### PR TITLE
Reset restoring gucs rather than explicitly setting 'off'

### DIFF
--- a/sql/restoring.sql
+++ b/sql/restoring.sql
@@ -25,8 +25,8 @@ DECLARE
     db text;
 BEGIN
     SELECT current_database() INTO db;
-    EXECUTE format($$ALTER DATABASE %I SET timescaledb.restoring ='off'$$, db);
-    SET SESSION timescaledb.restoring='off';
+    EXECUTE format($$ALTER DATABASE %I RESET timescaledb.restoring $$, db);
+    RESET timescaledb.restoring;
     PERFORM _timescaledb_internal.restart_background_workers();
 
     --try to restore the backed up uuid, if the restore did not set one


### PR DESCRIPTION
Setting the `timescaledb.restoring` guc explicitly to 'off'
for the db meant that the setting got exported in `pg_dumpall`
and some other cases where that setting would then conflict
with the setting set by the pre_restore function causing it to
be overridden and causing errors on restore. This changes to
`RESET` so that instead it will take the system default and not
be dumped separately as an override.