### PR TITLE
Remove dynamic version checks from SQL tests

### DIFF
--- a/test/expected/agg_bookends-11.out
+++ b/test/expected/agg_bookends-11.out
@@ -9,13 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \ir :TEST_LOAD_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/agg_bookends-12.out
+++ b/test/expected/agg_bookends-12.out
@@ -9,13 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \ir :TEST_LOAD_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -9,13 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \ir :TEST_LOAD_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/append-12.out
+++ b/test/expected/append-12.out
@@ -9,13 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \ir :TEST_LOAD_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/bgw_launcher.out
+++ b/test/expected/bgw_launcher.out
@@ -33,7 +33,7 @@ r INTEGER;
 BEGIN
 FOR i in 1..10
 LOOP
-SELECT COUNT(*) from worker_counts where (launcher = launcher_ct OR current_setting('server_version_num')::int < 100000)
+SELECT COUNT(*) from worker_counts where launcher = launcher_ct
 	AND single_scheduler = scheduler1_ct AND single_2_scheduler = scheduler2_ct and template1_scheduler = template1_ct into r;
 if(r < 1) THEN
   PERFORM pg_sleep(0.1);
@@ -317,11 +317,9 @@ SELECT backend_start as orig_backend_start
 FROM pg_stat_activity
 WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
-SELECT coalesce(
-  (SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher'),
-  (SELECT current_setting('server_version_num')::int < 100000));
- coalesce 
-----------
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher';
+ pg_cancel_backend 
+-------------------
  t
 (1 row)
 
@@ -331,7 +329,7 @@ SELECT wait_worker_counts(1,0,1,0);
  t
 (1 row)
 
-SELECT ((current_setting('server_version_num')::int < 100000) OR wait_greater(:'orig_backend_start', :'TEST_DBNAME_2')) as wait_greater;
+SELECT wait_greater(:'orig_backend_start', :'TEST_DBNAME_2');
  wait_greater 
 --------------
  t
@@ -459,7 +457,7 @@ r INTEGER;
 BEGIN
 FOR i in 1..10
 LOOP
-SELECT COUNT(*) from worker_counts where (launcher = launcher_ct OR current_setting('server_version_num')::int < 100000)
+SELECT COUNT(*) from worker_counts where launcher = launcher_ct
 	AND single_scheduler = scheduler1_ct AND single_2_scheduler = scheduler2_ct and template1_scheduler = template1_ct into r;
 if(r < 1) THEN
   PERFORM pg_sleep(0.1);

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -70,7 +70,7 @@ SELECT * FROM drop_test;
 --test drops thru cascades of other objects
 \c :TEST_DBNAME :ROLE_SUPERUSER
 drop schema public cascade;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
 \dn
   List of schemas
  Name |   Owner    

--- a/test/expected/plan_ordered_append.out
+++ b/test/expected/plan_ordered_append.out
@@ -14,15 +14,9 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
        format('%s/results/%s_results_optimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_OPTIMIZED",
        format('%s/results/%s_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNOPTIMIZED"
 \gset
-SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
+SELECT format('\! diff -u --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set PREFIX_NO_ANALYZE 'EXPLAIN (costs off)'
 \ir :TEST_LOAD_NAME
 -- This file and its contents are licensed under the Apache License 2.0.

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -69,7 +69,7 @@ cd ${EXE_DIR}/sql
 # create database and install timescaledb
 ${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d postgres -v ECHO=none -c "CREATE DATABASE \"${TEST_DBNAME}\";"
 ${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -c "SET client_min_messages=error; CREATE EXTENSION timescaledb; GRANT USAGE ON FOREIGN DATA WRAPPER timescaledb_fdw TO ${TEST_ROLE_1};"
-${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" < ${TEST_SUPPORT_FILE} >/dev/null 2>&1
+${PSQL} $@ -U $TEST_ROLE_SUPERUSER -d ${TEST_DBNAME} -v ECHO=none -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" < ${TEST_SUPPORT_FILE} >/dev/null 2>&1
 export TEST_DBNAME
 
 # we strip out any output between <exclude_from_test></exclude_from_test>

--- a/test/sql/agg_bookends.sql.in
+++ b/test/sql/agg_bookends.sql.in
@@ -11,14 +11,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
 
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
-
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \ir :TEST_LOAD_NAME
 \ir :TEST_QUERY_NAME
 

--- a/test/sql/append.sql.in
+++ b/test/sql/append.sql.in
@@ -11,13 +11,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
 
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 
 \ir :TEST_LOAD_NAME
 \ir :TEST_QUERY_NAME

--- a/test/sql/bgw_launcher.sql
+++ b/test/sql/bgw_launcher.sql
@@ -146,13 +146,11 @@ FROM pg_stat_activity
 WHERE application_name = 'TimescaleDB Background Worker Scheduler'
 AND datname = :'TEST_DBNAME_2' \gset
 
-SELECT coalesce(
-  (SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher'),
-  (SELECT current_setting('server_version_num')::int < 100000));
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE application_name = 'TimescaleDB Background Worker Launcher';
 
 SELECT wait_worker_counts(1,0,1,0);
 
-SELECT ((current_setting('server_version_num')::int < 100000) OR wait_greater(:'orig_backend_start', :'TEST_DBNAME_2')) as wait_greater;
+SELECT wait_greater(:'orig_backend_start', :'TEST_DBNAME_2');
 
 -- Make sure running pre_restore function stops background workers
 SELECT timescaledb_pre_restore();

--- a/test/sql/include/bgw_launcher_utils.sql
+++ b/test/sql/include/bgw_launcher_utils.sql
@@ -21,7 +21,7 @@ r INTEGER;
 BEGIN
 FOR i in 1..10
 LOOP
-SELECT COUNT(*) from worker_counts where (launcher = launcher_ct OR current_setting('server_version_num')::int < 100000)
+SELECT COUNT(*) from worker_counts where launcher = launcher_ct
 	AND single_scheduler = scheduler1_ct AND single_2_scheduler = scheduler2_ct and template1_scheduler = template1_ct into r;
 if(r < 1) THEN
   PERFORM pg_sleep(0.1);

--- a/test/sql/plan_ordered_append.sql
+++ b/test/sql/plan_ordered_append.sql
@@ -16,18 +16,10 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
        format('%s/results/%s_results_optimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_OPTIMIZED",
        format('%s/results/%s_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNOPTIMIZED"
 \gset
-SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
+SELECT format('\! diff -u --label "Unoptimized result" --label "Optimized result" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
 
-
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
-
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set PREFIX_NO_ANALYZE 'EXPLAIN (costs off)'
 
 \ir :TEST_LOAD_NAME

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -10,13 +10,7 @@ SELECT _timescaledb_internal.stop_background_workers();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
 SELECT create_hypertable('metrics','time');
   create_hypertable   

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -10,13 +10,7 @@ SELECT _timescaledb_internal.stop_background_workers();
 (1 row)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
 SELECT create_hypertable('metrics','time');
   create_hypertable   

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -127,17 +127,8 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
 SET max_parallel_workers_per_gather TO 0;
@@ -7735,17 +7726,8 @@ ORDER BY c.id;
 \set ECHO none 
 -- diff compressed and uncompressed results
 :DIFF_CMD_IDX
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
 SET max_parallel_workers_per_gather TO 0;

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -127,17 +127,8 @@ ANALYZE metrics_space;
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
 \set ECHO none
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
 SET max_parallel_workers_per_gather TO 0;
@@ -7624,17 +7615,8 @@ ORDER BY c.id;
 \set ECHO none 
 -- diff compressed and uncompressed results
 :DIFF_CMD_IDX
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
 SET max_parallel_workers_per_gather TO 0;

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -10,17 +10,8 @@ SELECT
 SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed results" %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') as "DIFF_CMD"
 \gset
 -- get EXPLAIN output for all variations
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
 \set TEST_TABLE 'metrics'

--- a/tsl/test/shared/expected/ordered_append-11.out
+++ b/tsl/test/shared/expected/ordered_append-11.out
@@ -9,17 +9,8 @@ SELECT
 SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed results" %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') as "DIFF_CMD"
 \gset
 -- get EXPLAIN output for all variations
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
 \set TEST_TABLE 'metrics'

--- a/tsl/test/shared/expected/ordered_append-12.out
+++ b/tsl/test/shared/expected/ordered_append-12.out
@@ -9,17 +9,8 @@ SELECT
 SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed results" %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') as "DIFF_CMD"
 \gset
 -- get EXPLAIN output for all variations
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
 \set TEST_TABLE 'metrics'

--- a/tsl/test/shared/sql/constraint_exclusion_prepared.sql
+++ b/tsl/test/shared/sql/constraint_exclusion_prepared.sql
@@ -12,17 +12,8 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \gset
 
 -- get EXPLAIN output for all variations
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 
 set work_mem to '64MB';
 

--- a/tsl/test/shared/sql/ordered_append.sql.in
+++ b/tsl/test/shared/sql/ordered_append.sql.in
@@ -11,17 +11,8 @@ SELECT format('\! diff -u --label "Uncompressed results" --label "Compressed res
 \gset
 
 -- get EXPLAIN output for all variations
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 
 set work_mem to '64MB';
 

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -7,14 +7,7 @@
 SELECT _timescaledb_internal.stop_background_workers();
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX"
-\gset
-
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 
 CREATE TABLE metrics(f1 int, f2 int, time timestamptz NOT NULL, device_id int, value float);
 SELECT create_hypertable('metrics','time');

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -113,17 +113,8 @@ SET client_min_messages TO error;
 RESET client_min_messages;
 \set ECHO all
 
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
@@ -201,17 +192,8 @@ RESET client_min_messages;
 :DIFF_CMD_IDX
 
 
--- look at postgres version to decide whether we run with analyze or without
-SELECT
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off)'
-    ELSE 'EXPLAIN (costs off)'
-  END AS "PREFIX",
-  CASE WHEN current_setting('server_version_num')::int >= 100000
-    THEN 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-    ELSE 'EXPLAIN (costs off, verbose)'
-  END AS "PREFIX_VERBOSE"
-\gset
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
 
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment


### PR DESCRIPTION
The sql tests still had version checks and would run EXPLAIN
with different parameters depending on postgres version. Since
all supported postgres versions now support all the parameters
we use we can safely remove the version check.