### PR TITLE
Replace Travis badge with GitHub badge

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -65,14 +65,14 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v1
       with:
-        name: Regression diff
+        name: Regression diff ${{ matrix.pg }}
         path: regression.diffs
 
     - name: Save postmaster.log
       if: failure()
       uses: actions/upload-artifact@v1
       with:
-        name: PostgreSQL log
+        name: PostgreSQL log ${{ matrix.pg }}
         path: postmaster.log
 
     - name: Slack Notification

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -111,14 +111,14 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v2
       with:
-        name: Regression diff
+        name: Regression diff ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: regression.log
 
     - name: Save postmaster.log
       if: failure()
       uses: actions/upload-artifact@v2
       with:
-        name: PostgreSQL log
+        name: PostgreSQL log ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: postgres.log
 
     - name: Stack trace

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 |Linux/macOS|Windows|Coverity|Code Coverage|
 |:---:|:---:|:---:|:---:|
-|[![Build Status](https://travis-ci.org/timescale/timescaledb.svg?branch=master)](https://travis-ci.org/timescale/timescaledb/builds)|[![Windows build status](https://ci.appveyor.com/api/projects/status/15sqkl900t04hywu/branch/master?svg=true)](https://ci.appveyor.com/project/timescale/timescaledb/branch/master)|[![Coverity Scan Build Status](https://scan.coverity.com/projects/timescale-timescaledb/badge.svg)](https://scan.coverity.com/projects/timescale-timescaledb)|[![Code Coverage](https://codecov.io/gh/timescale/timescaledb/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/timescale/timescaledb)
+|[![Build Status Linux/macOS](https://github.com/timescale/timescaledb/workflows/Regression/badge.svg?event=schedule)](https://github.com/timescale/timescaledb/actions?query=workflow%3ARegression+branch%3Amaster)|[![Windows build status](https://ci.appveyor.com/api/projects/status/15sqkl900t04hywu/branch/master?svg=true)](https://ci.appveyor.com/project/timescale/timescaledb/branch/master)|[![Coverity Scan Build Status](https://scan.coverity.com/projects/timescale-timescaledb/badge.svg)](https://scan.coverity.com/projects/timescale-timescaledb)|[![Code Coverage](https://codecov.io/gh/timescale/timescaledb/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/timescale/timescaledb)
 
 
 ## TimescaleDB

--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -85,10 +85,9 @@ function cleanup() {
   rm -rf ${EXE_DIR}/sql/dump
   rm -rf ${TEST_TABLESPACE1_PATH}
   rm -rf ${TEST_TABLESPACE2_PATH}
-  rm -f ${CURRENT_DIR}/.pg_init
-  rm -f ${TEMP_SCHEDULE}
   rm -rf ${TEST_TABLESPACE3_PATH}
-  rm -f ${TEST_OUTPUT_DIR}/.pg_init
+  rm -f ${TEMP_SCHEDULE}
+  rm -rf ${TEST_OUTPUT_DIR}/.pg_init
 }
 
 trap cleanup EXIT
@@ -99,7 +98,7 @@ TEST_TABLESPACE2_PATH=${TEST_TABLESPACE2_PATH:-$(mktemp -d 2>/dev/null || mktemp
 TEST_TABLESPACE3_PATH=${TEST_TABLESPACE3_PATH:-$(mktemp -d 2>/dev/null || mktemp -d -t 'timescaledb_regress')}
 export TEST_TABLESPACE1_PATH TEST_TABLESPACE2_PATH TEST_TABLESPACE3_PATH
 
-rm -f ${TEST_OUTPUT_DIR}/.pg_init
+rm -rf ${TEST_OUTPUT_DIR}/.pg_init
 mkdir -p ${EXE_DIR}/sql/dump
 
 export PG_REGRESS_DIFF_OPTS


### PR DESCRIPTION
Since most of our regression tests run on GitHub actions now this
patch replaces the build status badge from Travis with a GitHub
actions one.