### PR TITLE
Constify TIMESTAMPTZ OP INTERVAL in constraints

### DIFF
--- a/tsl/test/shared/expected/constify_timestamptz_op_interval-11.out
+++ b/tsl/test/shared/expected/constify_timestamptz_op_interval-11.out
@@ -1,0 +1,280 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (costs off)'
+-- we disable ChunkAppend and ConstraintAwareAppend here to make the exclusion easier to spot
+-- otherwise those would remove the chunks from the plan during execution
+SET timescaledb.enable_chunk_append TO FALSE;
+SET timescaledb.enable_constraint_aware_append TO FALSE;
+-- plan query on complete hypertable to get a list of the chunks
+:PREFIX
+SELECT time
+FROM metrics;
+             QUERY PLAN             
+------------------------------------
+ Append
+   ->  Seq Scan on _hyper_1_1_chunk
+   ->  Seq Scan on _hyper_1_2_chunk
+   ->  Seq Scan on _hyper_1_3_chunk
+(4 rows)
+
+-- all of these should have all chunk exclusion happening at plan time
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(3 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-01'::timestamptz + '6h'::interval;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone + '@ 6 hours'::interval))
+(3 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '6h'::interval + '2000-01-01'::timestamptz;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone + '@ 6 hours'::interval))
+(3 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-07'::timestamptz - '7 day 8 seconds'::interval;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone - '@ 7 days 8 secs'::interval))
+(3 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-03-01'::timestamptz - '60 day'::interval;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Wed Mar 01 00:00:00 2000 PST'::timestamp with time zone - '@ 60 days'::interval))
+(3 rows)
+
+-- test Var on right side of expression
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-01-01'::timestamptz - '6h'::interval > time;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(3 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-01-07'::timestamptz - '7 day'::interval > time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone - '@ 7 days'::interval))
+(3 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-03-01'::timestamptz - '60 day'::interval > time;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Wed Mar 01 00:00:00 2000 PST'::timestamp with time zone - '@ 60 days'::interval))
+(3 rows)
+
+-- test multiple constraints
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time > '2000-01-10'::timestamptz - '6h'::interval
+    AND time < '2000-01-10'::timestamptz + '6h'::interval;
+                                                                                                      QUERY PLAN                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: (("time" > ('Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval)) AND ("time" < ('Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone + '@ 6 hours'::interval)))
+(3 rows)
+
+-- test on space-partitioned hypertable
+:PREFIX
+SELECT time
+FROM metrics_space
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval
+    AND device_id = 1;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Scan using _hyper_2_4_chunk_metrics_space_time_idx on _hyper_2_4_chunk
+         Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+         Filter: (device_id = 1)
+(4 rows)
+
+-- test on compressed hypertable
+:PREFIX
+SELECT time
+FROM metrics_compressed
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (DecompressChunk) on _hyper_3_13_chunk
+         Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+         ->  Seq Scan on compress_hyper_4_18_chunk
+               Filter: (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(5 rows)
+
+-- test on space-partitioned compressed hypertable
+:PREFIX
+SELECT time
+FROM metrics_space_compressed
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval
+    AND device_id = 1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Custom Scan (DecompressChunk) on _hyper_5_19_chunk
+         Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+         ->  Seq Scan on compress_hyper_6_36_chunk
+               Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval)))
+(5 rows)
+
+-- month/year intervals are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month'::interval;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon'::interval))
+(7 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month - 1 day'::interval;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon -1 days'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon -1 days'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon -1 days'::interval))
+(7 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month + 1 day'::interval;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon 1 day'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon 1 day'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon 1 day'::interval))
+(7 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-02-01'::timestamptz - '1 year'::interval > time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 year'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 year'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 year'::interval))
+(7 rows)
+
+-- nested expressions are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '1 day' + '2000-02-01'::timestamptz - '1 month'::interval;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < (('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone + '@ 1 day'::interval) - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < (('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone + '@ 1 day'::interval) - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < (('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone + '@ 1 day'::interval) - '@ 1 mon'::interval))
+(7 rows)
+
+-- non-Const expressions are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time > now() - '6h'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" > (now() - '@ 6 hours'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" > (now() - '@ 6 hours'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" > (now() - '@ 6 hours'::interval))
+(7 rows)
+
+-- test NULL values
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - NULL::interval;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < NULL::timestamptz - NULL::interval;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+

--- a/tsl/test/shared/expected/constify_timestamptz_op_interval-12.out
+++ b/tsl/test/shared/expected/constify_timestamptz_op_interval-12.out
@@ -1,0 +1,268 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (costs off)'
+-- we disable ChunkAppend and ConstraintAwareAppend here to make the exclusion easier to spot
+-- otherwise those would remove the chunks from the plan during execution
+SET timescaledb.enable_chunk_append TO FALSE;
+SET timescaledb.enable_constraint_aware_append TO FALSE;
+-- plan query on complete hypertable to get a list of the chunks
+:PREFIX
+SELECT time
+FROM metrics;
+             QUERY PLAN             
+------------------------------------
+ Append
+   ->  Seq Scan on _hyper_1_1_chunk
+   ->  Seq Scan on _hyper_1_2_chunk
+   ->  Seq Scan on _hyper_1_3_chunk
+(4 rows)
+
+-- all of these should have all chunk exclusion happening at plan time
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-01'::timestamptz + '6h'::interval;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone + '@ 6 hours'::interval))
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '6h'::interval + '2000-01-01'::timestamptz;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone + '@ 6 hours'::interval))
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-07'::timestamptz - '7 day 8 seconds'::interval;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone - '@ 7 days 8 secs'::interval))
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-03-01'::timestamptz - '60 day'::interval;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Wed Mar 01 00:00:00 2000 PST'::timestamp with time zone - '@ 60 days'::interval))
+(2 rows)
+
+-- test Var on right side of expression
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-01-01'::timestamptz - '6h'::interval > time;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-01-07'::timestamptz - '7 day'::interval > time;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone - '@ 7 days'::interval))
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-03-01'::timestamptz - '60 day'::interval > time;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+   Index Cond: ("time" < ('Wed Mar 01 00:00:00 2000 PST'::timestamp with time zone - '@ 60 days'::interval))
+(2 rows)
+
+-- test multiple constraints
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time > '2000-01-10'::timestamptz - '6h'::interval
+    AND time < '2000-01-10'::timestamptz + '6h'::interval;
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+   Index Cond: (("time" > ('Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval)) AND ("time" < ('Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone + '@ 6 hours'::interval)))
+(2 rows)
+
+-- test on space-partitioned hypertable
+:PREFIX
+SELECT time
+FROM metrics_space
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval
+    AND device_id = 1;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Index Scan using _hyper_2_4_chunk_metrics_space_time_idx on _hyper_2_4_chunk
+   Index Cond: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+   Filter: (device_id = 1)
+(3 rows)
+
+-- test on compressed hypertable
+:PREFIX
+SELECT time
+FROM metrics_compressed
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_3_13_chunk
+   Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+   ->  Seq Scan on compress_hyper_4_18_chunk
+         Filter: (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(4 rows)
+
+-- test on space-partitioned compressed hypertable
+:PREFIX
+SELECT time
+FROM metrics_space_compressed
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval
+    AND device_id = 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_5_19_chunk
+   Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+   ->  Seq Scan on compress_hyper_6_36_chunk
+         Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval)))
+(4 rows)
+
+-- month/year intervals are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month'::interval;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon'::interval))
+(7 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month - 1 day'::interval;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon -1 days'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon -1 days'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon -1 days'::interval))
+(7 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month + 1 day'::interval;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon 1 day'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon 1 day'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 mon 1 day'::interval))
+(7 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-02-01'::timestamptz - '1 year'::interval > time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 year'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 year'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < ('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone - '@ 1 year'::interval))
+(7 rows)
+
+-- nested expressions are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '1 day' + '2000-02-01'::timestamptz - '1 month'::interval;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" < (('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone + '@ 1 day'::interval) - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" < (('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone + '@ 1 day'::interval) - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" < (('Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone + '@ 1 day'::interval) - '@ 1 mon'::interval))
+(7 rows)
+
+-- non-Const expressions are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time > now() - '6h'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_1_1_chunk_metrics_time_idx on _hyper_1_1_chunk
+         Index Cond: ("time" > (now() - '@ 6 hours'::interval))
+   ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk
+         Index Cond: ("time" > (now() - '@ 6 hours'::interval))
+   ->  Index Only Scan using _hyper_1_3_chunk_metrics_time_idx on _hyper_1_3_chunk
+         Index Cond: ("time" > (now() - '@ 6 hours'::interval))
+(7 rows)
+
+-- test NULL values
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - NULL::interval;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < NULL::timestamptz - NULL::interval;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+

--- a/tsl/test/shared/sql/.gitignore
+++ b/tsl/test/shared/sql/.gitignore
@@ -1,1 +1,2 @@
+/constify_timestamptz_op_interval-*.sql
 /ordered_append-*.sql

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_FILES_SHARED
 )
 
 set(TEST_TEMPLATES_SHARED
+  constify_timestamptz_op_interval.sql.in
   ordered_append.sql.in
 )
 

--- a/tsl/test/shared/sql/constify_timestamptz_op_interval.sql.in
+++ b/tsl/test/shared/sql/constify_timestamptz_op_interval.sql.in
@@ -1,0 +1,130 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set PREFIX 'EXPLAIN (costs off)'
+-- we disable ChunkAppend and ConstraintAwareAppend here to make the exclusion easier to spot
+-- otherwise those would remove the chunks from the plan during execution
+
+SET timescaledb.enable_chunk_append TO FALSE;
+
+SET timescaledb.enable_constraint_aware_append TO FALSE;
+
+-- plan query on complete hypertable to get a list of the chunks
+:PREFIX
+SELECT time
+FROM metrics;
+
+-- all of these should have all chunk exclusion happening at plan time
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-01'::timestamptz + '6h'::interval;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '6h'::interval + '2000-01-01'::timestamptz;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-01-07'::timestamptz - '7 day 8 seconds'::interval;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-03-01'::timestamptz - '60 day'::interval;
+
+-- test Var on right side of expression
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-01-01'::timestamptz - '6h'::interval > time;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-01-07'::timestamptz - '7 day'::interval > time;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-03-01'::timestamptz - '60 day'::interval > time;
+
+-- test multiple constraints
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time > '2000-01-10'::timestamptz - '6h'::interval
+    AND time < '2000-01-10'::timestamptz + '6h'::interval;
+
+-- test on space-partitioned hypertable
+:PREFIX
+SELECT time
+FROM metrics_space
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval
+    AND device_id = 1;
+
+-- test on compressed hypertable
+:PREFIX
+SELECT time
+FROM metrics_compressed
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval;
+
+-- test on space-partitioned compressed hypertable
+:PREFIX
+SELECT time
+FROM metrics_space_compressed
+WHERE time < '2000-01-01'::timestamptz - '6h'::interval
+    AND device_id = 1;
+
+-- month/year intervals are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month'::interval;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month - 1 day'::interval;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - '1 month + 1 day'::interval;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE '2000-02-01'::timestamptz - '1 year'::interval > time;
+
+-- nested expressions are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '1 day' + '2000-02-01'::timestamptz - '1 month'::interval;
+
+-- non-Const expressions are not constified
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time > now() - '6h'::interval;
+
+-- test NULL values
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < '2000-02-01'::timestamptz - NULL::interval;
+
+:PREFIX
+SELECT time
+FROM metrics
+WHERE time < NULL::timestamptz - NULL::interval;
+


### PR DESCRIPTION
Constify expressions of the following form in WHERE clause:

column OP timestamptz - interval
column OP timestamptz + interval
column OP interval + timestamptz

Iff interval has no month component.

Since the operators for timestamptz OP interval are marked
as stable they will not be constified during planning.
However, intervals without a month component can be safely
constified during planning as the result of those calculations
do not depend on the timezone setting.