### PR TITLE
Change testsupport.sql to not reference tsl code

### DIFF
--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -70,7 +70,7 @@ SELECT * FROM drop_test;
 --test drops thru cascades of other objects
 \c :TEST_DBNAME :ROLE_SUPERUSER
 drop schema public cascade;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 3 other objects
 \dn
   List of schemas
  Name |   Owner    

--- a/test/sql/utils/testsupport.sql
+++ b/test/sql/utils/testsupport.sql
@@ -280,5 +280,3 @@ BEGIN
 END
 $BODY$;
 
-CREATE OR REPLACE FUNCTION ts_test_override_current_timestamptz(new_value TIMESTAMPTZ) 
-RETURNS VOID AS :TSL_MODULE_PATHNAME, 'ts_test_override_current_timestamptz' LANGUAGE C VOLATILE STRICT;

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -6,7 +6,6 @@
 \unset ECHO
 psql:include/filter_exec.sql:5: NOTICE:  schema "test" already exists, skipping
 psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
-psql:utils/testsupport.sql:8: NOTICE:  schema "test" already exists, skipping
 -- Cleanup from other potential tests that created these databases
 SET client_min_messages TO ERROR;
 DROP DATABASE IF EXISTS data_node_1;
@@ -3289,9 +3288,9 @@ NOTICE:  adding not-null constraint to column "time"
 -- This will enable us to more easily see estimates per chunk
 SET timescaledb.enable_per_data_node_queries = false;
 -- Estimating chunk progress uses current timestamp so we override it for test purposes
-SELECT ts_test_override_current_timestamptz('2019-11-11 00:00'::timestamptz);
- ts_test_override_current_timestamptz 
---------------------------------------
+SELECT test.tsl_override_current_timestamptz('2019-11-11 00:00'::timestamptz);
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -6,7 +6,6 @@
 \unset ECHO
 psql:include/filter_exec.sql:5: NOTICE:  schema "test" already exists, skipping
 psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
-psql:utils/testsupport.sql:8: NOTICE:  schema "test" already exists, skipping
 -- Cleanup from other potential tests that created these databases
 SET client_min_messages TO ERROR;
 DROP DATABASE IF EXISTS data_node_1;
@@ -3269,9 +3268,9 @@ NOTICE:  adding not-null constraint to column "time"
 -- This will enable us to more easily see estimates per chunk
 SET timescaledb.enable_per_data_node_queries = false;
 -- Estimating chunk progress uses current timestamp so we override it for test purposes
-SELECT ts_test_override_current_timestamptz('2019-11-11 00:00'::timestamptz);
- ts_test_override_current_timestamptz 
---------------------------------------
+SELECT test.tsl_override_current_timestamptz('2019-11-11 00:00'::timestamptz);
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 

--- a/tsl/test/expected/dist_query-11.out
+++ b/tsl/test/expected/dist_query-11.out
@@ -24,6 +24,12 @@ SET client_min_messages TO notice;
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\ir debugsupport.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE OR REPLACE FUNCTION test.tsl_override_current_timestamptz(new_value TIMESTAMPTZ)
+RETURNS VOID AS :TSL_MODULE_PATHNAME, 'ts_test_override_current_timestamptz' LANGUAGE C VOLATILE STRICT;
 -- Cleanup from other tests that might have created these databases
 SET client_min_messages TO ERROR;
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
@@ -52,10 +58,6 @@ SELECT * FROM add_data_node('data_node_3', host => 'localhost',
 (1 row)
 
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
--- Function for testing push down of time-related functions (e.g., now())
-CREATE OR REPLACE FUNCTION test.override_current_timestamptz(new_value TIMESTAMPTZ) RETURNS VOID
-AS :TSL_MODULE_PATHNAME, 'ts_test_override_current_timestamptz'
-LANGUAGE C VOLATILE STRICT;
 SET ROLE :ROLE_1;
 -- Create a "normal" PG table as reference, one two-dimensional
 -- distributed hypertable, and a one-dimensional distributed
@@ -637,8 +639,8 @@ GROUP BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -696,8 +698,8 @@ GROUP BY 1,2
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (23 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -1493,8 +1495,8 @@ ORDER BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -1554,8 +1556,8 @@ ORDER BY 1,2
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (24 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -2188,8 +2190,8 @@ ORDER BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -2217,8 +2219,8 @@ ORDER BY 1,2
          Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
 (8 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -3021,8 +3023,8 @@ LIMIT 10
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -3082,8 +3084,8 @@ LIMIT 10
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (24 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -3916,8 +3918,8 @@ ORDER BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -3973,8 +3975,8 @@ ORDER BY 1,2
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (22 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -4806,8 +4808,8 @@ GROUP BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -4861,8 +4863,8 @@ GROUP BY 1,2
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (21 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 

--- a/tsl/test/expected/dist_query-12.out
+++ b/tsl/test/expected/dist_query-12.out
@@ -24,6 +24,12 @@ SET client_min_messages TO notice;
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\ir debugsupport.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE OR REPLACE FUNCTION test.tsl_override_current_timestamptz(new_value TIMESTAMPTZ)
+RETURNS VOID AS :TSL_MODULE_PATHNAME, 'ts_test_override_current_timestamptz' LANGUAGE C VOLATILE STRICT;
 -- Cleanup from other tests that might have created these databases
 SET client_min_messages TO ERROR;
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
@@ -52,10 +58,6 @@ SELECT * FROM add_data_node('data_node_3', host => 'localhost',
 (1 row)
 
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
--- Function for testing push down of time-related functions (e.g., now())
-CREATE OR REPLACE FUNCTION test.override_current_timestamptz(new_value TIMESTAMPTZ) RETURNS VOID
-AS :TSL_MODULE_PATHNAME, 'ts_test_override_current_timestamptz'
-LANGUAGE C VOLATILE STRICT;
 SET ROLE :ROLE_1;
 -- Create a "normal" PG table as reference, one two-dimensional
 -- distributed hypertable, and a one-dimensional distributed
@@ -637,8 +639,8 @@ GROUP BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -696,8 +698,8 @@ GROUP BY 1,2
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (23 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -1493,8 +1495,8 @@ ORDER BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -1554,8 +1556,8 @@ ORDER BY 1,2
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (24 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -2166,8 +2168,8 @@ ORDER BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -2191,8 +2193,8 @@ ORDER BY 1,2
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
 (6 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -2993,8 +2995,8 @@ LIMIT 10
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -3054,8 +3056,8 @@ LIMIT 10
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (24 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -3888,8 +3890,8 @@ ORDER BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -3945,8 +3947,8 @@ ORDER BY 1,2
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (22 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -4778,8 +4780,8 @@ GROUP BY 1,2
 
 ######### Constification and runtime push down of time-related functions
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 
@@ -4833,8 +4835,8 @@ GROUP BY 1,2
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (21 rows)
 
- override_current_timestamptz 
-------------------------------
+ tsl_override_current_timestamptz 
+----------------------------------
  
 (1 row)
 

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -7,9 +7,9 @@
 
 \unset ECHO
 \o /dev/null
+\ir include/debugsupport.sql
 \ir include/filter_exec.sql
 \ir include/remote_exec.sql
-\ir utils/testsupport.sql
 \o
 \set ECHO all
 
@@ -990,7 +990,7 @@ SELECT * FROM create_distributed_hypertable('hyper_estimate', 'time', 'device', 
 SET timescaledb.enable_per_data_node_queries = false;
 
 -- Estimating chunk progress uses current timestamp so we override it for test purposes
-SELECT ts_test_override_current_timestamptz('2019-11-11 00:00'::timestamptz);
+SELECT test.tsl_override_current_timestamptz('2019-11-11 00:00'::timestamptz);
 
 -- Test estimates when backfilling. 3 chunks should be historical and 3 should be considered current when estimating.
 -- Note that estimate numbers are way off since we are using shared buffer size as starting point. This will not be

--- a/tsl/test/sql/include/debugsupport.sql
+++ b/tsl/test/sql/include/debugsupport.sql
@@ -1,0 +1,6 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE OR REPLACE FUNCTION test.tsl_override_current_timestamptz(new_value TIMESTAMPTZ)
+RETURNS VOID AS :TSL_MODULE_PATHNAME, 'ts_test_override_current_timestamptz' LANGUAGE C VOLATILE STRICT;

--- a/tsl/test/sql/include/dist_query_load.sql
+++ b/tsl/test/sql/include/dist_query_load.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+\ir debugsupport.sql
+
 -- Cleanup from other tests that might have created these databases
 SET client_min_messages TO ERROR;
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
@@ -16,11 +18,6 @@ SELECT * FROM add_data_node('data_node_2', host => 'localhost',
 SELECT * FROM add_data_node('data_node_3', host => 'localhost',
                             database => 'data_node_3');
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
-
--- Function for testing push down of time-related functions (e.g., now())
-CREATE OR REPLACE FUNCTION test.override_current_timestamptz(new_value TIMESTAMPTZ) RETURNS VOID
-AS :TSL_MODULE_PATHNAME, 'ts_test_override_current_timestamptz'
-LANGUAGE C VOLATILE STRICT;
 
 SET ROLE :ROLE_1;
 

--- a/tsl/test/sql/include/dist_query_run.sql
+++ b/tsl/test/sql/include/dist_query_run.sql
@@ -165,7 +165,7 @@ GROUP BY 1,2
 -----------------------------------------------------------------
 \set TEST_DESC '\n######### Constification and runtime push down of time-related functions\n'
 \qecho :TEST_DESC
-SELECT test.override_current_timestamptz('2018-06-01 00:00'::timestamptz);
+SELECT test.tsl_override_current_timestamptz('2018-06-01 00:00'::timestamptz);
 
 :PREFIX
 SELECT time, device, avg(temp)
@@ -190,7 +190,7 @@ GROUP BY 1, 2
 
 :PREFIX
 EXECUTE :prepared_stmt;
-SELECT test.override_current_timestamptz('2019-10-15 00:00'::timestamptz);
+SELECT test.tsl_override_current_timestamptz('2019-10-15 00:00'::timestamptz);
 
 :PREFIX
 EXECUTE :prepared_stmt;


### PR DESCRIPTION
testsupport.sql had a reference to TSL code which will fail in
apache-only code since this file is included in every test run
for every build configuration.