### PR TITLE
Refactor process utility functions result type

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -509,7 +509,7 @@ error_no_default_fn_pg_enterprise(PG_FUNCTION_ARGS)
 	pg_unreachable();
 }
 
-static bool
+static DDLResult
 process_cagg_viewstmt_default(ViewStmt *stmt, const char *query_string, void *pstmt,
 							  WithClauseResult *with_clause_options)
 {

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -75,8 +75,8 @@ typedef struct CrossModuleFunctions
 	PGFunction partialize_agg;
 	PGFunction finalize_agg_sfunc;
 	PGFunction finalize_agg_ffunc;
-	bool (*process_cagg_viewstmt)(ViewStmt *stmt, const char *query_string, void *pstmt,
-								  WithClauseResult *with_clause_options);
+	DDLResult (*process_cagg_viewstmt)(ViewStmt *stmt, const char *query_string, void *pstmt,
+									   WithClauseResult *with_clause_options);
 	void (*continuous_agg_drop_chunks_by_chunk_id)(int32 raw_hypertable_id, Chunk **chunks,
 												   Size num_chunks, Datum older_than_datum,
 												   Datum newer_than_datum, Oid older_than_type,

--- a/src/process_utility.h
+++ b/src/process_utility.h
@@ -27,7 +27,13 @@ typedef struct ProcessUtilityArgs
 	char *completion_tag;
 } ProcessUtilityArgs;
 
-typedef bool (*ts_process_utility_handler_t)(ProcessUtilityArgs *args);
+typedef enum
+{
+	DDL_CONTINUE,
+	DDL_DONE
+} DDLResult;
+
+typedef DDLResult (*ts_process_utility_handler_t)(ProcessUtilityArgs *args);
 
 extern void ts_process_utility_set_expect_chunk_modification(bool expect);
 

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1754,7 +1754,7 @@ cagg_create(ViewStmt *stmt, Query *panquery, CAggTimebucketInfo *origquery_ht,
  * step 1 : validate query
  * step 2: create underlying tables and views
  */
-bool
+DDLResult
 tsl_process_continuous_agg_viewstmt(ViewStmt *stmt, const char *query_string, void *pstmt,
 									WithClauseResult *with_clause_options)
 {
@@ -1779,13 +1779,13 @@ tsl_process_continuous_agg_viewstmt(ViewStmt *stmt, const char *query_string, vo
 				 errmsg("continuous aggregate query \"%s\" already exists", stmt->view->relname),
 				 errhint("drop and recreate if needed.  This will drop the underlying "
 						 "materialization")));
-		return true;
+		return DDL_DONE;
 	}
 
 	timebucket_exprinfo = cagg_validate_query(query);
 
 	cagg_create(stmt, query, &timebucket_exprinfo, with_clause_options);
-	return true;
+	return DDL_DONE;
 }
 
 /*

--- a/tsl/src/continuous_aggs/create.h
+++ b/tsl/src/continuous_aggs/create.h
@@ -7,13 +7,14 @@
 #define TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_CREATE_H
 #include <postgres.h>
 
+#include <process_utility.h>
 #include "with_clause_parser.h"
 #include "continuous_agg.h"
 
 #define CONTINUOUS_AGG_CHUNK_ID_COL_NAME "chunk_id"
 
-bool tsl_process_continuous_agg_viewstmt(ViewStmt *stmt, const char *query_string, void *pstmt,
-										 WithClauseResult *with_clause_options);
+DDLResult tsl_process_continuous_agg_viewstmt(ViewStmt *stmt, const char *query_string, void *pstmt,
+											  WithClauseResult *with_clause_options);
 
 void cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht,
 								 WithClauseResult *with_clause_options);


### PR DESCRIPTION
Introduce and use explicit enum type for process utility functions return
value instead of using bool type.