### PR TITLE
Add assert errors in release build

### DIFF
--- a/src/debug_assert.h
+++ b/src/debug_assert.h
@@ -1,0 +1,30 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_DEBUG_ASSERT_H
+#define TIMESCALEDB_DEBUG_ASSERT_H
+
+#include <c.h>
+#include <postgres.h>
+
+/*
+ * Macro that expands to an assert in debug builds and to an ereport in
+ * release builds.
+ */
+#if DEBUG
+#define AssertOr(LEVEL, COND) Assert(COND)
+#else
+#define AssertOr(LEVEL, COND)                                                                      \
+	do                                                                                             \
+	{                                                                                              \
+		if (!(COND))                                                                               \
+			ereport((LEVEL),                                                                       \
+					(errcode(ERRCODE_INTERNAL_ERROR),                                              \
+					 errmsg("assertion failure"),                                                  \
+					 errdetail("Assertion '" #COND "' failed.")));                                 \
+	} while (0)
+#endif
+
+#endif /* TIMESCALEDB_DEBUG_ASSERT_H */

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -10,6 +10,7 @@
 #include "export.h"
 #include "hypercube.h"
 #include "dimension_vector.h"
+#include "debug_assert.h"
 
 /*
  * A hypercube represents the partition bounds of a hypertable chunk.
@@ -179,7 +180,8 @@ ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx)
 
 			Assert(hc->num_slices < constraints->num_dimension_constraints);
 			slice = ts_dimension_slice_scan_by_id(cc->fd.dimension_slice_id, mctx);
-			Assert(slice != NULL);
+			AssertOr(ERROR, slice != NULL);
+			AssertOr(ERROR, hc->num_slices < hc->capacity);
 			hc->slices[hc->num_slices++] = slice;
 		}
 	}


### PR DESCRIPTION
Assertions are used to verify the integrity of data and prevent
internal errors. However, in some situations, the assertions work fine
in debug builds, but are invalid in release builds for heavily loaded
systems causing crashes in rare situations because the assertion is
invalidated by bugs in the code.

This commit add support for assertions that work as normal assertions
in debug builds, but use `ereport` to generate an internal error
message in release builds.

The macro also takes a error level constant, allowing developer to
decide if an assertion violation should abort the current transaction,
generate a notice, or even shut down the process depending on how
serious the assertion violation is.