### PR TITLE
Ignore continuous_aggs_insert and continuous_aggs_multi on PG11.0

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -109,6 +109,7 @@ if event_type != "pull_request":
     "llvm_config": "/usr/bin/llvm-config-8",
     "clang": "clang-8",
     "extra_packages": "llvm-8 llvm-8-dev llvm-8-tools",
+    "installcheck_args": "IGNORES='continuous_aggs_insert continuous_aggs_multi'"
   }
   m["include"].append(build_debug_config(pg11_debug_earliest))
 


### PR DESCRIPTION
The log output in the isolation tests when running on PG 11.0 seems
to be suppressed and not be recorded leading to a diff in the test
output.