### PR TITLE
Refactor transparent_decompression test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,6 +82,8 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "autovacuum=false"
 
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "fsync=false"
+
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "random_page_cost=1.0"
 
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "extra_float_digits=0"

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -2,62 +2,139 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set TEST_BASE_NAME transparent_decompression
-SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
-       format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
-       format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED",
-       format('%s/results/%s_results_uncompressed_idx.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED_IDX",
-       format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESSED",
-       format('%s/results/%s_results_compressed_idx.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESSED_IDX"
-\gset
-SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') as "DIFF_CMD"
-\gset
-SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED_IDX', :'TEST_RESULTS_COMPRESSED_IDX') as "DIFF_CMD_IDX"
-\gset
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNCOMPRESSED",
+    format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_COMPRESSED" \gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
-CREATE TABLE metrics(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 int, v2 float, v3 float);
-SELECT create_hypertable('metrics','time');
+CREATE TABLE metrics (
+    filler_1 int,
+    filler_2 int,
+    filler_3 int,
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 int,
+    v2 float,
+    v3 float
+);
+SELECT create_hypertable ('metrics', 'time');
   create_hypertable   
 ----------------------
  (1,public,metrics,t)
 (1 row)
 
-ALTER TABLE metrics DROP COLUMN filler_1;
-INSERT INTO metrics(time,device_id, device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1,  device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics DROP COLUMN filler_2;
-INSERT INTO metrics(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id-1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics DROP COLUMN filler_3;
-INSERT INTO metrics(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ALTER TABLE metrics
+    DROP COLUMN filler_1;
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics
+    DROP COLUMN filler_2;
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id - 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-06 0:00:00+0'::timestamptz, '2000-01-12 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics
+    DROP COLUMN filler_3;
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-19 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
 ANALYZE metrics;
 -- create identical hypertable with space partitioning
-CREATE TABLE metrics_space(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 float, v2 float, v3 float);
-SELECT create_hypertable('metrics_space','time','device_id',3);
+CREATE TABLE metrics_space (
+    filler_1 int,
+    filler_2 int,
+    filler_3 int,
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 float,
+    v2 float,
+    v3 float
+);
+SELECT create_hypertable ('metrics_space', 'time', 'device_id', 3);
      create_hypertable      
 ----------------------------
  (2,public,metrics_space,t)
 (1 row)
 
-ALTER TABLE metrics_space DROP COLUMN filler_1;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics_space DROP COLUMN filler_2;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics_space DROP COLUMN filler_3;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ALTER TABLE metrics_space
+    DROP COLUMN filler_1;
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics_space
+    DROP COLUMN filler_2;
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-06 0:00:00+0'::timestamptz, '2000-01-12 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics_space
+    DROP COLUMN filler_3;
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-19 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
 ANALYZE metrics_space;
 -- run queries on uncompressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
+\set PREFIX_NO_ANALYZE ''
 \set ECHO none
 -- compress first and last chunk on the hypertable
-ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
+ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
 NOTICE:  adding index _compressed_hypertable_5_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_1_1_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_1_3_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_1_3_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_3_chunk
@@ -65,70 +142,70 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_3_chunk');
 
 -- compress some chunks on space partitioned hypertable
 -- we compress all chunks of first time slice, none of second, and 2 of the last time slice
-ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
+ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_6_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id, _ts_meta_sequence_num)
 NOTICE:  adding index _compressed_hypertable_6_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-SELECT compress_chunk('_timescaledb_internal._hyper_2_4_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_4_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_2_4_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_5_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_5_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_2_5_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_6_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_6_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_2_6_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_10_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_10_chunk');
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_2_10_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_11_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_11_chunk');
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_2_11_chunk
 (1 row)
 
-SELECT
-	ht.schema_name || '.' || ht.table_name AS "METRICS_COMPRESSED"
+SELECT ht.schema_name || '.' || ht.table_name AS "METRICS_COMPRESSED"
 FROM _timescaledb_catalog.hypertable ht
-	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics'
-\gset
-SELECT
-	ht.schema_name || '.' || ht.table_name AS "METRICS_SPACE_COMPRESSED"
+    INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id = ht2.compressed_hypertable_id
+        AND ht2.table_name = 'metrics' \gset
+SELECT ht.schema_name || '.' || ht.table_name AS "METRICS_SPACE_COMPRESSED"
 FROM _timescaledb_catalog.hypertable ht
-	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics_space'
-\gset
+    INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id = ht2.compressed_hypertable_id
+        AND ht2.table_name = 'metrics_space' \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- Index created using query saved in variable used because there was 
+-- Index created using query saved in variable used because there was
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
-CREATE INDEX c_index ON :METRICS_COMPRESSED(device_id);
-CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED(device_id);
-CREATE INDEX c_index_2 ON :METRICS_COMPRESSED(device_id, _ts_meta_count);
-CREATE INDEX c_space_index_2 ON :METRICS_SPACE_COMPRESSED(device_id, _ts_meta_count);
-CREATE INDEX ON :METRICS_COMPRESSED(device_id_peer);
-CREATE INDEX ON :METRICS_SPACE_COMPRESSED(device_id_peer);
+CREATE INDEX c_index ON :METRICS_COMPRESSED (device_id);
+CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED (device_id);
+CREATE INDEX c_index_2 ON :METRICS_COMPRESSED (device_id, _ts_meta_count);
+CREATE INDEX c_space_index_2 ON :METRICS_SPACE_COMPRESSED (device_id, _ts_meta_count);
+CREATE INDEX ON :METRICS_COMPRESSED (device_id_peer);
+CREATE INDEX ON :METRICS_SPACE_COMPRESSED (device_id_peer);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-CREATE INDEX ON metrics_space(device_id,device_id_peer, v0, v1 desc, time);
-CREATE INDEX ON metrics_space(device_id,device_id_peer DESC, v0, v1 desc, time);
-CREATE INDEX ON metrics_space(device_id DESC, device_id_peer DESC, v0, v1 desc, time);
+CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
+CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
+CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);
 ANALYZE metrics_space;
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
+\set PREFIX_NO_ANALYZE ''
 \set ECHO none
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
 SET max_parallel_workers_per_gather TO 0;
@@ -139,7 +216,12 @@ SET max_parallel_workers_per_gather TO 0;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- this should use DecompressChunk node
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time
+LIMIT 5;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
@@ -153,12 +235,12 @@ SET max_parallel_workers_per_gather TO 0;
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                      Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Filter: (compress_hyper_5_15_chunk.device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (never executed)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.device_id = 1)
@@ -173,167 +255,197 @@ SET max_parallel_workers_per_gather TO 0;
 (28 rows)
 
 -- test RECORD by itself
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics (actual rows=5472 loops=1)
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics (actual rows=1368 loops=1)
    Order: metrics."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Sort Key: _hyper_1_1_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (19 rows)
 
 -- test expressions
-:PREFIX SELECT
-  time_bucket('1d',time),
-  v1 + v2 AS "sum",
-  COALESCE(NULL,v1,v2) AS "coalesce",
-  NULL AS "NULL",
-  'text' AS "text",
-  :TEST_TABLE AS "RECORD"
-FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    :TEST_TABLE AS "RECORD"
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Sort (actual rows=10944 loops=1)
+ Sort (actual rows=2736 loops=1)
    Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
    Sort Method: quicksort 
-   ->  Result (actual rows=10944 loops=1)
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2880 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=4 loops=1)
+   ->  Result (actual rows=2736 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=4032 loops=1)
+                           Rows Removed by Filter: 3
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1008 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 6048
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=4032 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1512
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
 (16 rows)
 
 -- test empty targetlist
-:PREFIX SELECT FROM :TEST_TABLE;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Append (actual rows=27360 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-   ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+:PREFIX
+SELECT
+FROM :TEST_TABLE;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Append (actual rows=6840 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+   ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- test empty resultset
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < 0;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 10
+               Rows Removed by Filter: 5
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
          Filter: (device_id < 0)
-         Rows Removed by Filter: 10080
+         Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 15
+               Rows Removed by Filter: 5
 (12 rows)
 
 -- test targetlist not referencing columns
-:PREFIX SELECT 1 FROM :TEST_TABLE;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Result (actual rows=27360 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+:PREFIX
+SELECT 1
+FROM :TEST_TABLE;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Result (actual rows=6840 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test constraints not present in targetlist
-:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v1
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (15 rows)
 
 -- test order not present in targetlist
-:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v2
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (15 rows)
 
 -- test column with all NULL
-:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+:PREFIX
+SELECT v3
+FROM :TEST_TABLE
+WHERE device_id = 1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8
-   ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 4
+   ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 12
+               Rows Removed by Filter: 4
 (12 rows)
 
 --
 -- test qual pushdown
 --
 -- v3 is not segment by or order by column so should not be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE v3 > 10.0
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -344,23 +456,29 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Filter: (_hyper_1_1_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 7200
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=10 loops=1)
+               Rows Removed by Filter: 1800
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 10080
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 10080
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               Rows Removed by Filter: 2520
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
 (21 rows)
 
 -- device_id constraint should be pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -369,10 +487,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -383,25 +501,37 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (17 rows)
 
 -- test IS NULL / IS NOT NULL
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NOT NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (device_id IS NOT NULL)
 (13 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -412,40 +542,52 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id IS NULL)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (16 rows)
 
 -- test IN (Const,Const)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2880 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=4 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=4032 loops=1)
+                           Rows Removed by Filter: 3
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1008 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 6048
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=4032 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1512
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
 (16 rows)
 
 -- test cast pushdown
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = '1'::text::int
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -454,10 +596,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -468,7 +610,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (17 rows)
 
 --test var op var with two segment by
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = device_id_peer ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = device_id_peer
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -479,36 +627,48 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (16 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id_peer < device_id ORDER BY time, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (device_id_peer < device_id)
 (13 rows)
 
 -- test expressions
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id =  1 + 4/2 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1 + 4 / 2
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -517,10 +677,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 3)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 3)
          ->  Sort (never executed)
@@ -532,7 +692,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test function calls
 -- not yet pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(),1,3)) ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = length(substring(version(), 1, 3))
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -542,10 +708,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
                      Filter: (device_id = length("substring"(version(), 1, 3)))
-                     Rows Removed by Filter: 5760
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 1440
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = length("substring"(version(), 1, 3)))
          ->  Sort (never executed)
@@ -559,7 +725,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test segment meta pushdown
 --
 -- order by column and const
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time = '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                             QUERY PLAN                                                                                             
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
@@ -567,179 +739,230 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          Sort Key: _hyper_1_1_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=5 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 4995
+               Rows Removed by Filter: 1795
                ->  Sort (actual rows=5 loops=1)
                      Sort Key: compress_hyper_5_15_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                           Rows Removed by Filter: 5
-(12 rows)
+(11 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=60 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=60 loops=1)
+         Sort Method: quicksort 
+         ->  Append (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=15 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 4940
+                     Rows Removed by Filter: 1785
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
-(11 rows)
+(10 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time <= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=65 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=65 loops=1)
+         Sort Method: quicksort 
+         ->  Append (actual rows=20 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=20 loops=1)
                      Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 4935
+                     Rows Removed by Filter: 1780
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 5
-(11 rows)
+(10 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time >= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27300 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7140 loops=1)
+         ->  Append (actual rows=6825 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1785 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 60
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 15
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (16 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7135 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 65
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 20
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (16 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE '2000-01-01 1:00:00+0' < time
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7135 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 65
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 20
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (16 rows)
 
 --pushdowns between order by and segment by columns
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=2016 loops=1)
+         ->  Append (actual rows=504 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 10
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                           Rows Removed by Filter: 5
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                      Filter: (v0 < 1)
-                     Rows Removed by Filter: 8064
+                     Rows Removed by Filter: 2016
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (18 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=10080 loops=1)
+         ->  Append (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 10
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+                           Rows Removed by Filter: 5
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (v0 < device_id)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (17 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < v0
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=7200 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
+         ->  Append (actual rows=1800 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id < v0)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (device_id < v0)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (17 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v1 = device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -751,19 +974,25 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v1 = device_id)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (v1 = device_id)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v1 = device_id)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (18 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 = v1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -773,19 +1002,26 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      Filter: (v0 = v1)
-                     Rows Removed by Filter: 7200
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 1800
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (v0 = v1)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v0 = v1)
-                     Rows Removed by Filter: 10080
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     Rows Removed by Filter: 2520
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (16 rows)
 
 --pushdown of quals on order by and segment by cols anded together
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' and device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    AND device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -799,14 +1035,14 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=356 loops=1)
                      Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                      Filter: (_hyper_1_1_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Filter: ((compress_hyper_5_15_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_15_chunk.device_id = 1))
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (never executed)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Index Cond: (_hyper_1_2_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -823,47 +1059,64 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (32 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' or device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    OR device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27308 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7148 loops=1)
+         ->  Append (actual rows=6824 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1784 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     Rows Removed by Filter: 52
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+                     Rows Removed by Filter: 16
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (14 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < now()
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: metrics."time", metrics.device_id
          Sort Method: top-N heapsort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=27360 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics (actual rows=6840 loops=1)
                Chunks excluded during startup: 0
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
                      Filter: ("time" < now())
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ("time" < now())
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" < now())
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (14 rows)
 
 -- test sort optimization interaction
-:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+:PREFIX
+SELECT time
+FROM :TEST_TABLE
+ORDER BY time DESC
+LIMIT 10;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -872,8 +1125,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Heap Fetches: 0
          ->  Sort (never executed)
@@ -882,88 +1135,123 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_5_15_chunk (never executed)
 (14 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY time DESC,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
 (10 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY device_id,
+    time DESC
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk.device_id, _hyper_1_1_chunk."time" DESC
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (10 rows)
 
 --
 -- test ordered path
 --
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
    Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
 -- should produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
          Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- test order by columns not in targetlist
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time
+LIMIT 100;
                                                                                                                                                 QUERY PLAN                                                                                                                                                
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -974,10 +1262,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk."time"
                Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                      Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk."time"
                      Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 3365
+                     Rows Removed by Filter: 845
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1 loops=1)
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk."time"
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -985,14 +1273,21 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                      Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                            Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (22 rows)
 
 -- test ordering only by segmentby columns
 -- should produce ordered path and not have sequence number in targetlist of compressed scan
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer
+LIMIT 100;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -1003,10 +1298,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer
                Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                      Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer
                      Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 3365
+                     Rows Removed by Filter: 845
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1 loops=1)
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -1014,130 +1309,173 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                            Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (22 rows)
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0;
                                                                                                                               QUERY PLAN                                                                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
          Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0
                Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0, v1 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0, v1 desc;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0,
+    v1
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC;
                                                                                                                                              QUERY PLAN                                                                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1
          Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time,v3;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time,
+    v3;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time", _hyper_1_2_chunk.v3
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
 -- should produce ordered path
 -- ASC/DESC for segmentby columns can be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id DESC, _hyper_1_2_chunk.device_id_peer DESC, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
          Sort Key: _hyper_1_2_chunk.device_id DESC, _hyper_1_2_chunk.device_id_peer DESC, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                Sort Key: compress_hyper_5_16_chunk.device_id DESC, compress_hyper_5_16_chunk.device_id_peer DESC, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
    Sort Key: _hyper_1_2_chunk.device_id DESC, _hyper_1_2_chunk.device_id_peer DESC, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk."time"
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
@@ -1147,392 +1485,465 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 --
 -- test plan time exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=1675 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (11 rows)
 
 -- test runtime exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08'::text::timestamptz ORDER BY time, device_id;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'::text::timestamptz
+ORDER BY time,
+    device_id;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Sort Key: metrics."time", metrics.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=16795 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=4195 loops=1)
          Chunks excluded during startup: 1
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=1675 loops=1)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (10 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
    Sort Key: _hyper_1_1_chunk.device_id
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=5 loops=1)
          Group Key: _hyper_1_1_chunk.device_id
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (11 rows)
 
 -- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT sum(count(*)) OVER ()
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
    Sort Key: _hyper_1_1_chunk.device_id
    Sort Method: quicksort 
    ->  WindowAgg (actual rows=5 loops=1)
          ->  HashAggregate (actual rows=5 loops=1)
                Group Key: _hyper_1_1_chunk.device_id
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (12 rows)
 
 -- test CTE
-:PREFIX WITH
-q AS (SELECT v1 FROM :TEST_TABLE ORDER BY time)
-SELECT * FROM q ORDER BY v1;
-                                                        QUERY PLAN                                                         
----------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=27360 loops=1)
+:PREFIX WITH q AS (
+    SELECT v1
+    FROM :TEST_TABLE
+    ORDER BY time
+)
+SELECT *
+FROM q
+ORDER BY v1;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=6840 loops=1)
    Sort Key: q.v1
    Sort Method: quicksort 
    CTE q
-     ->  Custom Scan (ChunkAppend) on metrics (actual rows=27360 loops=1)
+     ->  Custom Scan (ChunkAppend) on metrics (actual rows=6840 loops=1)
            Order: metrics."time"
-           ->  Sort (actual rows=7200 loops=1)
+           ->  Sort (actual rows=1800 loops=1)
                  Sort Key: _hyper_1_1_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=10080 loops=1)
-           ->  Sort (actual rows=10080 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=2520 loops=1)
+           ->  Sort (actual rows=2520 loops=1)
                  Sort Key: _hyper_1_3_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-   ->  CTE Scan on q (actual rows=27360 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+   ->  CTE Scan on q (actual rows=6840 loops=1)
 (18 rows)
 
 -- test CTE join
-:PREFIX WITH
-q1 AS (SELECT time, v1 FROM :TEST_TABLE WHERE device_id=1 ORDER BY time),
-q2 AS (SELECT time, v2 FROM :TEST_TABLE WHERE device_id=2 ORDER BY time)
-SELECT * FROM q1 INNER JOIN q2 ON q1.time=q2.time ORDER BY q1.time;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join (actual rows=5472 loops=1)
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+)
+SELECT *
+FROM q1
+    INNER JOIN q2 ON q1.time = q2.time
+ORDER BY q1.time;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=1368 loops=1)
    Merge Cond: (q1."time" = q2."time")
    CTE q1
-     ->  Custom Scan (ChunkAppend) on metrics (actual rows=5472 loops=1)
+     ->  Custom Scan (ChunkAppend) on metrics (actual rows=1368 loops=1)
            Order: metrics."time"
-           ->  Sort (actual rows=1440 loops=1)
+           ->  Sort (actual rows=360 loops=1)
                  Sort Key: _hyper_1_1_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                              Filter: (device_id = 1)
-                             Rows Removed by Filter: 8
-           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                             Rows Removed by Filter: 4
+           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=504 loops=1)
                  Filter: (device_id = 1)
-                 Rows Removed by Filter: 8064
-           ->  Sort (actual rows=2016 loops=1)
+                 Rows Removed by Filter: 2016
+           ->  Sort (actual rows=504 loops=1)
                  Sort Key: _hyper_1_3_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                              Filter: (device_id = 1)
-                             Rows Removed by Filter: 12
+                             Rows Removed by Filter: 4
    CTE q2
-     ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=5472 loops=1)
+     ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=1368 loops=1)
            Order: metrics_1."time"
-           ->  Sort (actual rows=1440 loops=1)
+           ->  Sort (actual rows=360 loops=1)
                  Sort Key: _hyper_1_1_chunk_1."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=1440 loops=1)
-                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=2 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=360 loops=1)
+                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
                              Filter: (device_id = 2)
-                             Rows Removed by Filter: 8
-           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=2016 loops=1)
+                             Rows Removed by Filter: 4
+           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=504 loops=1)
                  Filter: (device_id = 2)
-                 Rows Removed by Filter: 8064
-           ->  Sort (actual rows=2016 loops=1)
+                 Rows Removed by Filter: 2016
+           ->  Sort (actual rows=504 loops=1)
                  Sort Key: _hyper_1_3_chunk_1."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=2016 loops=1)
-                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=3 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=504 loops=1)
+                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
                              Filter: (device_id = 2)
-                             Rows Removed by Filter: 12
-   ->  Sort (actual rows=5472 loops=1)
+                             Rows Removed by Filter: 4
+   ->  Sort (actual rows=1368 loops=1)
          Sort Key: q1."time"
          Sort Method: quicksort 
-         ->  CTE Scan on q1 (actual rows=5472 loops=1)
-   ->  Sort (actual rows=5472 loops=1)
+         ->  CTE Scan on q1 (actual rows=1368 loops=1)
+   ->  Sort (actual rows=1368 loops=1)
          Sort Key: q2."time"
          Sort Method: quicksort 
-         ->  CTE Scan on q2 (actual rows=5472 loops=1)
+         ->  CTE Scan on q2 (actual rows=1368 loops=1)
 (50 rows)
 
 -- test prepared statement
-PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+PREPARE prep AS
+SELECT count(time)
+FROM :TEST_TABLE
+WHERE device_id = 1;
 :PREFIX EXECUTE prep;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (13 rows)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 DEALLOCATE prep;
 --
 -- test indexes
 --
-SET enable_seqscan TO false;
+SET enable_seqscan TO FALSE;
 -- IndexScans should work
-:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Key: _hyper_1_1_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
 (24 rows)
 
 -- globs should not plan IndexOnlyScans
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
          Sort Key: _hyper_1_1_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
 (24 rows)
 
 -- whole row reference should work
-:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE as test_table WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT test_table
+FROM :TEST_TABLE AS test_table
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: test_table."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: ((test_table.*)::metrics), test_table.device_id, test_table."time"
          Sort Key: test_table."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk test_table (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk test_table (actual rows=360 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk test_table_1 (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk test_table_1 (actual rows=504 loops=1)
          Output: test_table_1.*, test_table_1.device_id, test_table_1."time"
          Filter: (test_table_1.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Output: ((test_table_2.*)::metrics), test_table_2.device_id, test_table_2."time"
          Sort Key: test_table_2."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk test_table_2 (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk test_table_2 (actual rows=504 loops=1)
                Output: test_table_2.*, test_table_2.device_id, test_table_2."time"
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
 (24 rows)
 
 -- even when we select only a segmentby column, we still need count
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id
                Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-               Heap Fetches: 2
-   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+               Heap Fetches: 1
+   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk.device_id
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id
                Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
-               Heap Fetches: 3
+               Heap Fetches: 1
 (17 rows)
 
-:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
+:PREFIX_VERBOSE
+SELECT count(*)
+FROM :TEST_TABLE
+WHERE device_id = 1;
                                                                        QUERY PLAN                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    Output: count(*)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-                     Heap Fetches: 2
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Heap Fetches: 1
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (_hyper_1_2_chunk.device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
-                     Heap Fetches: 3
+                     Heap Fetches: 1
 (16 rows)
 
 -- should be able to order using an index
-CREATE INDEX tmp_idx ON :TEST_TABLE(device_id);
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE ORDER BY device_id;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=27360 loops=1)
+CREATE INDEX tmp_idx ON :TEST_TABLE (device_id);
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+ORDER BY device_id;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Append (actual rows=6840 loops=1)
    Sort Key: _hyper_1_1_chunk.device_id
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=7200 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
          Output: _hyper_1_1_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id
-               Heap Fetches: 10
-   ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=10080 loops=1)
+               Heap Fetches: 5
+   ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_2_chunk.device_id
-         Heap Fetches: 10080
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+         Heap Fetches: 2520
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id
-               Heap Fetches: 15
+               Heap Fetches: 5
 (15 rows)
 
 DROP INDEX tmp_idx CASCADE;
 --use the peer index
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -1548,7 +1959,7 @@ DROP INDEX tmp_idx CASCADE;
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 10080
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
@@ -1556,7 +1967,11 @@ DROP INDEX tmp_idx CASCADE;
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (19 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
@@ -1568,7 +1983,7 @@ DROP INDEX tmp_idx CASCADE;
    ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
          Output: _hyper_1_2_chunk.device_id_peer
          Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 10080
+         Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
@@ -1577,9 +1992,13 @@ DROP INDEX tmp_idx CASCADE;
 (15 rows)
 
 --ensure that we can get a nested loop
-SET enable_seqscan TO true;
-SET enable_hashjoin TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1));
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
@@ -1598,7 +2017,7 @@ SET enable_hashjoin TO false;
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
                Output: _hyper_1_2_chunk.device_id_peer
                Filter: ((1) = _hyper_1_2_chunk.device_id_peer)
-               Rows Removed by Filter: 10080
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
@@ -1607,7 +2026,12 @@ SET enable_hashjoin TO false;
 (22 rows)
 
 --with multiple values can get a nested loop.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1),
+            (2));
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
@@ -1629,7 +2053,7 @@ SET enable_hashjoin TO false;
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=2)
                Output: _hyper_1_2_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id_peer)
-               Rows Removed by Filter: 10080
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
@@ -1638,38 +2062,47 @@ SET enable_hashjoin TO false;
 (25 rows)
 
 RESET enable_hashjoin;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=5472 loops=1)
+ Nested Loop (actual rows=1368 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
          Output: (1)
          Group Key: 1
          ->  Result (actual rows=1 loops=1)
                Output: 1
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id = (1))
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
                Filter: ((1) = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id = (1))
 (22 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+ Nested Loop (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
          Output: "*VALUES*".column1
@@ -1679,91 +2112,105 @@ RESET enable_hashjoin;
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                      Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=2)
+   ->  Append (actual rows=1368 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=2)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=2)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
 (25 rows)
 
-SET seq_page_cost=100;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+SET seq_page_cost = 100;
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join (actual rows=10944 loops=1)
+ Hash Semi Join
    Output: _hyper_1_1_chunk.device_id_peer
    Hash Cond: (_hyper_1_1_chunk.device_id = "*VALUES*".column1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=7200 loops=1)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=10 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=10080 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
-   ->  Hash (actual rows=2 loops=1)
+   ->  Hash
          Output: "*VALUES*".column1
-         Buckets: 1024  Batches: 1 
-         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+         ->  Values Scan on "*VALUES*"
                Output: "*VALUES*".column1
-(19 rows)
+(18 rows)
 
 RESET seq_page_cost;
 -- force a BitmapHeapScan
-SET enable_indexscan TO false;
-set enable_seqscan TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+SET enable_indexscan TO FALSE;
+SET enable_seqscan TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=5472 loops=1)
+ Nested Loop (actual rows=1368 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  HashAggregate (actual rows=1 loops=1)
          Output: (1)
          Group Key: 1
          ->  Result (actual rows=1 loops=1)
                Output: 1
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
                Filter: ((1) = _hyper_1_1_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                      Recheck Cond: (compress_hyper_5_15_chunk.device_id = (1))
                      Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=2 loops=1)
+                     ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=1 loops=1)
                            Index Cond: (compress_hyper_5_15_chunk.device_id = (1))
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
                Filter: ((1) = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Filter: ((1) = _hyper_1_3_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Recheck Cond: (compress_hyper_5_16_chunk.device_id = (1))
                      Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=3 loops=1)
+                     ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=1 loops=1)
                            Index Cond: (compress_hyper_5_16_chunk.device_id = (1))
 (30 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+ Nested Loop (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
          Output: "*VALUES*".column1
@@ -1773,36 +2220,46 @@ set enable_seqscan TO false;
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                      Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=2)
+   ->  Append (actual rows=1368 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_1_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=2)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                      Recheck Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
                      Heap Blocks: exact=2
-                     ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=2 loops=2)
+                     ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=1 loops=2)
                            Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=2)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=2)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Recheck Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
                      Heap Blocks: exact=2
-                     ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=3 loops=2)
+                     ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=1 loops=2)
                            Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
 (33 rows)
 
-SET enable_indexscan TO true;
-SET enable_seqscan TO true;
+SET enable_indexscan TO TRUE;
+SET enable_seqscan TO TRUE;
 -- test view
-CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
-:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+CREATE OR REPLACE VIEW compressed_view AS
+SELECT time,
+    device_id,
+    v1,
+    v2
+FROM :TEST_TABLE;
+:PREFIX
+SELECT *
+FROM compressed_view
+WHERE device_id = 1
+ORDER BY time DESC
+LIMIT 10;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -1811,10 +2268,10 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 12
+                           Rows Removed by Filter: 4
          ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -1826,48 +2283,64 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=27360 loops=1)
+         ->  Hash Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time AND m1.device_id=m2.device_id AND m3.device_id = 3 ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Merge Join (actual rows=10 loops=1)
          Merge Cond: (m1."time" = m3."time")
@@ -1876,58 +2349,68 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: m1."time", m1.device_id
                      Sort Method: quicksort 
-                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                            Order: m1."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m1_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: m2."time", m2.device_id
                      Sort Method: quicksort 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
          ->  Materialize (actual rows=10 loops=1)
                ->  Merge Append (actual rows=3 loops=1)
                      Sort Key: m3."time"
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: m3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
                                        Filter: (device_id = 3)
-                                       Rows Removed by Filter: 8
+                                       Rows Removed by Filter: 4
                      ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_1 (actual rows=1 loops=1)
                            Filter: (device_id = 3)
                            Rows Removed by Filter: 2
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: m3_2."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_2 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_2 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
                                        Filter: (device_id = 3)
-                                       Rows Removed by Filter: 12
+                                       Rows Removed by Filter: 4
 (57 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -1938,10 +2421,10 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
-                                 Rows Removed by Filter: 8
+                                 Rows Removed by Filter: 4
                ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
@@ -1955,10 +2438,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 8
+                                       Rows Removed by Filter: 4
                      ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
                            Filter: (device_id = 2)
                      ->  Sort (never executed)
@@ -1968,7 +2451,17 @@ DROP VIEW compressed_view;
                                        Filter: (device_id = 2)
 (36 rows)
 
-:PREFIX SELECT * FROM metrics m1 INNER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -1979,10 +2472,10 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
-                                 Rows Removed by Filter: 8
+                                 Rows Removed by Filter: 4
                ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
@@ -1996,10 +2489,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
                            Index Cond: (device_id = 2)
                      ->  Sort (never executed)
@@ -2010,223 +2503,277 @@ DROP VIEW compressed_view;
 (36 rows)
 
 -- test OUTER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
-                     Buckets: 8192 (originally 4096)  Batches: 1 (originally 1) 
-                     ->  Append (actual rows=5472 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
+                     Buckets: 4096  Batches: 1 
+                     ->  Append (actual rows=1368 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 8
-                           ->  Seq Scan on _hyper_1_2_chunk m2_1 (actual rows=2016 loops=1)
+                                       Rows Removed by Filter: 4
+                           ->  Seq Scan on _hyper_1_2_chunk m2_1 (actual rows=504 loops=1)
                                  Filter: (device_id = 2)
-                                 Rows Removed by Filter: 8064
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_2 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=3 loops=1)
+                                 Rows Removed by Filter: 2016
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_2 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 12
+                                       Rows Removed by Filter: 4
 (35 rows)
 
-:PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM metrics m1
+    LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
                      Buckets: 8192  Batches: 1 
-                     ->  Append (actual rows=5472 loops=1)
+                     ->  Append (actual rows=1368 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                            ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=504 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 6
+                                       Rows Removed by Filter: 2
                            ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
 -- test implicit self-join
-:PREFIX SELECT * FROM :TEST_TABLE m1, :TEST_TABLE m2 WHERE m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 20;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=20 loops=1)
    ->  Sort (actual rows=20 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
 -- test self-join with sub-query
-:PREFIX SELECT * FROM (SELECT * FROM :TEST_TABLE m1) m1 INNER JOIN (SELECT * FROM :TEST_TABLE m2) m2 ON m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
-:PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time LIMIT 1) m1 ON true;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -2236,24 +2783,30 @@ DROP VIEW compressed_view;
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
                ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
                      Heap Fetches: 7
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
-(20 rows)
+(18 rows)
 
 -- test prepared statement with params pushdown
-PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time AND device_id = $1 LIMIT 1) m1 ON true;
-:PREFIX EXECUTE param_prep(1);
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+:PREFIX EXECUTE param_prep (1);
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -2263,23 +2816,21 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
                ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
                      Filter: (device_id = 1)
                      Rows Removed by Filter: 4
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
-(21 rows)
+(19 rows)
 
-:PREFIX EXECUTE param_prep(2);
+:PREFIX EXECUTE param_prep (2);
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -2289,23 +2840,23 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
                      Filter: (device_id = 2)
                      Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
 (21 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2329,7 +2880,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2353,7 +2904,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2377,7 +2928,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2401,7 +2952,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2428,10 +2979,20 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket ('1d', time) AS time,
+    device_id,
+    avg(v1)
+FROM :TEST_TABLE
+WHERE device_id = 1
+GROUP BY 1,
+    2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-SELECT time FROM cagg_test ORDER BY time LIMIT 1;
+SELECT time
+FROM cagg_test
+ORDER BY time
+LIMIT 1;
              time             
 ------------------------------
  Fri Dec 31 16:00:00 1999 PST
@@ -2441,51 +3002,57 @@ DROP VIEW cagg_test CASCADE;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
-:PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SET enable_bitmapscan = FALSE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = FALSE;
+SET enable_mergejoin = FALSE;
+:PREFIX
+SELECT *
+FROM metrics,
+    metrics_space
+WHERE metrics.time > metrics_space.time
+    AND metrics.device_id = metrics_space.device_id
+    AND metrics.time < metrics_space.time;
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
-   ->  Append (actual rows=0 loops=27360)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+   ->  Append (actual rows=0 loops=6840)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 1440
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=2 loops=27360)
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=27360)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
                Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Filter: (_hyper_2_4_chunk.device_id = device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=27360)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 2016
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=3 loops=27360)
+               Rows Removed by Filter: 504
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = true;
-set enable_mergejoin = true;
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = TRUE;
+SET enable_mergejoin = TRUE;
 ---end github issue 1558
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
@@ -2493,7 +3060,12 @@ set enable_mergejoin = true;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- this should use DecompressChunk node
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time
+LIMIT 5;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
@@ -2507,9 +3079,9 @@ set enable_mergejoin = true;
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                      Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Filter: (compress_hyper_6_17_chunk.device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
@@ -2526,101 +3098,113 @@ set enable_mergejoin = true;
 (27 rows)
 
 -- test RECORD by itself
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics_space (actual rows=5472 loops=1)
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_space (actual rows=1368 loops=1)
    Order: metrics_space."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (16 rows)
 
 -- test expressions
-:PREFIX SELECT
-  time_bucket('1d',time),
-  v1 + v2 AS "sum",
-  COALESCE(NULL,v1,v2) AS "coalesce",
-  NULL AS "NULL",
-  'text' AS "text",
-  :TEST_TABLE AS "RECORD"
-FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10944 loops=1)
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    :TEST_TABLE AS "RECORD"
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2736 loops=1)
    Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
    Sort Method: quicksort 
-   ->  Result (actual rows=10944 loops=1)
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+   ->  Result (actual rows=2736 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 4
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=504 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 2
 (23 rows)
 
 -- test empty targetlist
-:PREFIX SELECT FROM :TEST_TABLE;
+:PREFIX
+SELECT
+FROM :TEST_TABLE;
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Append (actual rows=27360 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-   ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-   ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+ Append (actual rows=6840 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+   ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (15 rows)
 
 -- test empty resultset
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < 0;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 2
+               Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 6
+               Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 2
+               Rows Removed by Filter: 1
    ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
@@ -2630,85 +3214,98 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 3
+               Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 9
+               Rows Removed by Filter: 3
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
 (29 rows)
 
 -- test targetlist not referencing columns
-:PREFIX SELECT 1 FROM :TEST_TABLE;
+:PREFIX
+SELECT 1
+FROM :TEST_TABLE;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
- Result (actual rows=27360 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+ Result (actual rows=6840 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
 -- test constraints not present in targetlist
-:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v1
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
 (12 rows)
 
 -- test order not present in targetlist
-:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v2
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
 (12 rows)
 
 -- test column with all NULL
-:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+:PREFIX
+SELECT v3
+FROM :TEST_TABLE
+WHERE device_id = 1;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-   ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
 (9 rows)
 
@@ -2716,7 +3313,12 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test qual pushdown
 --
 -- v3 is not segment by or order by column so should not be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE v3 > 10.0
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -2727,53 +3329,59 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 1440
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               Rows Removed by Filter: 360
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 4320
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               Rows Removed by Filter: 1080
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 1440
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               Rows Removed by Filter: 360
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
+               Rows Removed by Filter: 504
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Filter: (_hyper_2_8_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 6048
+               Rows Removed by Filter: 1512
          ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
+               Rows Removed by Filter: 504
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 504
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 6048
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               Rows Removed by Filter: 1512
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
+               Rows Removed by Filter: 504
 (51 rows)
 
 -- device_id constraint should be pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -2782,8 +3390,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
@@ -2795,40 +3403,52 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (16 rows)
 
 -- test IS NULL / IS NOT NULL
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NOT NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (device_id IS NOT NULL)
 (28 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -2839,15 +3459,15 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
                ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
@@ -2857,46 +3477,58 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
 (33 rows)
 
 -- test IN (Const,Const)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 4
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=504 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 2
 (23 rows)
 
 -- test cast pushdown
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = '1'::text::int
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -2905,8 +3537,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
@@ -2918,7 +3550,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (16 rows)
 
 --test var op var with two segment by
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = device_id_peer ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = device_id_peer
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -2929,72 +3567,84 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (37 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id_peer < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (device_id_peer < device_id)
 (28 rows)
 
 -- test expressions
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id =  1 + 4/2 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1 + 4 / 2
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3003,8 +3653,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_6_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 3)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
                Filter: (device_id = 3)
@@ -3014,7 +3664,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test function calls
 -- not yet pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(),1,3)) ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = length(substring(version(), 1, 3))
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                               QUERY PLAN                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3030,8 +3686,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 Rows Removed by Filter: 1440
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                                 Rows Removed by Filter: 360
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -3040,17 +3696,17 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 Rows Removed by Filter: 4320
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                                 Rows Removed by Filter: 1080
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=1440 loops=1)
+                     ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (never executed)
@@ -3083,7 +3739,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test segment meta pushdown
 --
 -- order by column and const
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time = '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                             QUERY PLAN                                                                                             
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
@@ -3091,214 +3753,241 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          Sort Key: _hyper_2_4_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 999
+               Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_6_17_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                           Rows Removed by Filter: 1
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=3 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2997
+               Rows Removed by Filter: 1077
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: compress_hyper_6_18_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                           Rows Removed by Filter: 3
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 999
+               Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_6_19_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                           Rows Removed by Filter: 1
-(30 rows)
+(27 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=60 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=12 loops=1)
+         Sort Method: quicksort 
+         ->  Append (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 988
+                     Rows Removed by Filter: 357
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=36 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=9 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 2964
+                     Rows Removed by Filter: 1071
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 3
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=12 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 988
+                     Rows Removed by Filter: 357
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-(23 rows)
+(20 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time <= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+         Sort Method: quicksort 
+         ->  Append (actual rows=20 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=4 loops=1)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 356
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=12 loops=1)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1068
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=4 loops=1)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 356
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(20 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time >= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=65 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=13 loops=1)
-                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 987
+         ->  Append (actual rows=6825 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=357 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 3
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=39 loops=1)
-                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 2961
+                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1071 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 9
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 3
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=13 loops=1)
-                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 987
+                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=357 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 3
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-(23 rows)
-
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=27300 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1428 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 12
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4284 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 36
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1428 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 12
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (36 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1427 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4281 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 39
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 12
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (36 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE '2000-01-01 1:00:00+0' < time
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1427 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4281 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 39
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 12
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
 (36 rows)
 
 --pushdowns between order by and segment by columns
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3310,17 +3999,17 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
                ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
@@ -3331,17 +4020,23 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
 (38 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3353,80 +4048,92 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (42 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < v0
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (device_id < v0)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
 (33 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v1 = device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3436,40 +4143,46 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 4320
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1080
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     Rows Removed by Filter: 504
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 6048
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     Rows Removed by Filter: 1512
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (37 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 = v1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3479,40 +4192,47 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 4320
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1080
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     Rows Removed by Filter: 504
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 6048
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     Rows Removed by Filter: 1512
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (37 rows)
 
 --pushdown of quals on order by and segment by cols anded together
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' and device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    AND device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3526,11 +4246,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=356 loops=1)
                      Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                      Filter: (_hyper_2_4_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Filter: ((compress_hyper_6_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_17_chunk.device_id = 1))
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
@@ -3549,80 +4269,97 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (31 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' or device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    OR device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27308 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Append (actual rows=6824 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4281 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     Rows Removed by Filter: 39
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1427 loops=1)
+                     Rows Removed by Filter: 12
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
 (30 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < now()
+ORDER BY time,
+    device_id
+LIMIT 10;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: metrics_space."time", metrics_space.device_id
          Sort Method: top-N heapsort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=27360 loops=1)
-               ->  Merge Append (actual rows=7200 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=6840 loops=1)
+               ->  Merge Append (actual rows=1800 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Merge Append (actual rows=10080 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=2520 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
-                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                            Filter: ("time" < now())
-                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
-               ->  Merge Append (actual rows=10080 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Merge Append (actual rows=2520 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
 (31 rows)
 
 -- test sort optimization interaction
-:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+:PREFIX
+SELECT time
+FROM :TEST_TABLE
+ORDER BY time DESC
+LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3635,19 +4372,19 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_11_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=6048 loops=1)
+                     ->  Sort (actual rows=1512 loops=1)
                            Sort Key: _hyper_2_11_chunk."time" DESC
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_10_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=2016 loops=1)
+                     ->  Sort (actual rows=504 loops=1)
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -3678,31 +4415,43 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                                  ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
 (51 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY time DESC,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_12_chunk."time" DESC, _hyper_2_12_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
 (19 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY device_id,
+    time DESC
+LIMIT 10;
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3711,18 +4460,18 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_4_chunk.device_id, _hyper_2_4_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_5_chunk.device_id, _hyper_2_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_6_chunk.device_id, _hyper_2_6_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
@@ -3732,13 +4481,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
 (36 rows)
@@ -3747,84 +4496,108 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test ordered path
 --
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
    Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(31 rows)
+(32 rows)
 
 -- should produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
 
 -- test order by columns not in targetlist
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time
+LIMIT 100;
                                                                                                                                                 QUERY PLAN                                                                                                                                                
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -3846,7 +4619,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                      Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                            Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
@@ -3856,7 +4629,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                      Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
@@ -3871,7 +4644,14 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test ordering only by segmentby columns
 -- should produce ordered path and not have sequence number in targetlist of compressed scan
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer
+LIMIT 100;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -3893,7 +4673,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                      Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                            Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
@@ -3903,7 +4683,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
@@ -3918,305 +4698,369 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0;
                                                                                                                               QUERY PLAN                                                                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
-   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 1005
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 504
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0
                Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0
                Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+         Heap Fetches: 335
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
+         Heap Fetches: 335
 (38 rows)
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0, v1 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0, v1 desc;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0,
+    v1
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC;
                                                                                                                                              QUERY PLAN                                                                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC
-   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 1005
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 504
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+         Heap Fetches: 335
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
+         Heap Fetches: 335
 (38 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time,v3;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time,
+    v3;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time", _hyper_2_8_chunk.v3
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-(31 rows)
+               Rows Removed by Filter: 169
+(32 rows)
 
 -- should produce ordered path
 -- ASC/DESC for segmentby columns can be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id DESC, _hyper_2_8_chunk.device_id_peer DESC, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                Sort Key: compress_hyper_6_20_chunk.device_id DESC, compress_hyper_6_20_chunk.device_id_peer DESC, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                Sort Key: compress_hyper_6_21_chunk.device_id DESC, compress_hyper_6_21_chunk.device_id_peer DESC, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
    Sort Key: _hyper_2_8_chunk.device_id DESC, _hyper_2_8_chunk.device_id_peer DESC, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-(31 rows)
+               Rows Removed by Filter: 169
+(32 rows)
 
 --
 -- test constraint exclusion
 --
 -- test plan time exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
    Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=4029 loops=1)
-               Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _hyper_2_9_chunk (actual rows=1343 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1005 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(22 rows)
+(23 rows)
 
 -- test runtime exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08'::text::timestamptz ORDER BY time, device_id;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'::text::timestamptz
+ORDER BY time,
+    device_id;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Sort Key: metrics_space."time", metrics_space.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=16795 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=4195 loops=1)
          ->  Merge Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 4320
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1080
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Merge Append (actual rows=6715 loops=1)
-               ->  Index Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=1343 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=4029 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=1343 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-         ->  Merge Append (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1675 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+                     Rows Removed by Filter: 169
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1005 loops=1)
+                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 169
+         ->  Merge Append (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(33 rows)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+(35 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
 -- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
@@ -4224,25 +5068,29 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=5 loops=1)
          Group Key: _hyper_2_4_chunk.device_id
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (20 rows)
 
 -- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX
+SELECT sum(count(*)) OVER ()
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
@@ -4251,381 +5099,434 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    ->  WindowAgg (actual rows=5 loops=1)
          ->  HashAggregate (actual rows=5 loops=1)
                Group Key: _hyper_2_4_chunk.device_id
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (21 rows)
 
 -- test CTE
-:PREFIX WITH
-q AS (SELECT v1 FROM :TEST_TABLE ORDER BY time)
-SELECT * FROM q ORDER BY v1;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=27360 loops=1)
+:PREFIX WITH q AS (
+    SELECT v1
+    FROM :TEST_TABLE
+    ORDER BY time
+)
+SELECT *
+FROM q
+ORDER BY v1;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=6840 loops=1)
    Sort Key: q.v1
    Sort Method: quicksort 
    CTE q
-     ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=27360 loops=1)
+     ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=6840 loops=1)
            Order: metrics_space."time"
-           ->  Merge Append (actual rows=7200 loops=1)
+           ->  Merge Append (actual rows=1800 loops=1)
                  Sort Key: _hyper_2_4_chunk."time"
-                 ->  Sort (actual rows=1440 loops=1)
+                 ->  Sort (actual rows=360 loops=1)
                        Sort Key: _hyper_2_4_chunk."time"
                        Sort Method: quicksort 
-                       ->  Sort (actual rows=1440 loops=1)
+                       ->  Sort (actual rows=360 loops=1)
                              Sort Key: _hyper_2_4_chunk."time"
                              Sort Method: quicksort 
-                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                 ->  Sort (actual rows=4320 loops=1)
+                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                 ->  Sort (actual rows=1080 loops=1)
                        Sort Key: _hyper_2_5_chunk."time"
                        Sort Method: quicksort 
-                       ->  Sort (actual rows=4320 loops=1)
+                       ->  Sort (actual rows=1080 loops=1)
                              Sort Key: _hyper_2_5_chunk."time"
                              Sort Method: quicksort 
-                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                 ->  Sort (actual rows=1440 loops=1)
+                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                 ->  Sort (actual rows=360 loops=1)
                        Sort Key: _hyper_2_6_chunk."time"
                        Sort Method: quicksort 
-                       ->  Sort (actual rows=1440 loops=1)
+                       ->  Sort (actual rows=360 loops=1)
                              Sort Key: _hyper_2_6_chunk."time"
                              Sort Method: quicksort 
-                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-           ->  Merge Append (actual rows=10080 loops=1)
+                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+           ->  Merge Append (actual rows=2520 loops=1)
                  Sort Key: _hyper_2_7_chunk."time"
-                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=2016 loops=1)
-                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=6048 loops=1)
-                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=2016 loops=1)
-           ->  Merge Append (actual rows=10080 loops=1)
+                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
+                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1512 loops=1)
+                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=504 loops=1)
+           ->  Merge Append (actual rows=2520 loops=1)
                  Sort Key: _hyper_2_10_chunk."time"
-                 ->  Sort (actual rows=2016 loops=1)
+                 ->  Sort (actual rows=504 loops=1)
                        Sort Key: _hyper_2_10_chunk."time"
                        Sort Method: quicksort 
-                       ->  Sort (actual rows=2016 loops=1)
+                       ->  Sort (actual rows=504 loops=1)
                              Sort Key: _hyper_2_10_chunk."time"
                              Sort Method: quicksort 
-                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                 ->  Sort (actual rows=6048 loops=1)
+                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                                   ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                 ->  Sort (actual rows=1512 loops=1)
                        Sort Key: _hyper_2_11_chunk."time"
                        Sort Method: quicksort 
-                       ->  Sort (actual rows=6048 loops=1)
+                       ->  Sort (actual rows=1512 loops=1)
                              Sort Key: _hyper_2_11_chunk."time"
                              Sort Method: quicksort 
-                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                                   ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=2016 loops=1)
-   ->  CTE Scan on q (actual rows=27360 loops=1)
+                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                                   ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
+   ->  CTE Scan on q (actual rows=6840 loops=1)
 (57 rows)
 
 -- test CTE join
-:PREFIX WITH
-q1 AS (SELECT time, v1 FROM :TEST_TABLE WHERE device_id=1 ORDER BY time),
-q2 AS (SELECT time, v2 FROM :TEST_TABLE WHERE device_id=2 ORDER BY time)
-SELECT * FROM q1 INNER JOIN q2 ON q1.time=q2.time ORDER BY q1.time;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join (actual rows=5472 loops=1)
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+)
+SELECT *
+FROM q1
+    INNER JOIN q2 ON q1.time = q2.time
+ORDER BY q1.time;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=1368 loops=1)
    Merge Cond: (q1."time" = q2."time")
    CTE q1
-     ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=5472 loops=1)
+     ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1368 loops=1)
            Order: metrics_space."time"
-           ->  Sort (actual rows=1440 loops=1)
+           ->  Sort (actual rows=360 loops=1)
                  Sort Key: _hyper_2_4_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                              Filter: (device_id = 1)
-           ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=2016 loops=1)
+           ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
                  Filter: (device_id = 1)
-           ->  Sort (actual rows=2016 loops=1)
+           ->  Sort (actual rows=504 loops=1)
                  Sort Key: _hyper_2_10_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                              Filter: (device_id = 1)
    CTE q2
-     ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=5472 loops=1)
+     ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=1368 loops=1)
            Order: metrics_space_1."time"
-           ->  Sort (actual rows=1440 loops=1)
+           ->  Sort (actual rows=360 loops=1)
                  Sort Key: _hyper_2_5_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1440 loops=1)
-                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                              Filter: (device_id = 2)
-                             Rows Removed by Filter: 4
-           ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=2016 loops=1)
+                             Rows Removed by Filter: 2
+           ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=504 loops=1)
                  Index Cond: (device_id = 2)
-           ->  Sort (actual rows=2016 loops=1)
+           ->  Sort (actual rows=504 loops=1)
                  Sort Key: _hyper_2_11_chunk."time"
                  Sort Method: quicksort 
-                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=2016 loops=1)
-                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                              Filter: (device_id = 2)
-                             Rows Removed by Filter: 6
-   ->  Sort (actual rows=5472 loops=1)
+                             Rows Removed by Filter: 2
+   ->  Sort (actual rows=1368 loops=1)
          Sort Key: q1."time"
          Sort Method: quicksort 
-         ->  CTE Scan on q1 (actual rows=5472 loops=1)
-   ->  Sort (actual rows=5472 loops=1)
+         ->  CTE Scan on q1 (actual rows=1368 loops=1)
+   ->  Sort (actual rows=1368 loops=1)
          Sort Key: q2."time"
          Sort Method: quicksort 
-         ->  CTE Scan on q2 (actual rows=5472 loops=1)
+         ->  CTE Scan on q2 (actual rows=1368 loops=1)
 (46 rows)
 
 -- test prepared statement
-PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+PREPARE prep AS
+SELECT count(time)
+FROM :TEST_TABLE
+WHERE device_id = 1;
 :PREFIX EXECUTE prep;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
 (10 rows)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 DEALLOCATE prep;
 --
 -- test indexes
 --
-SET enable_seqscan TO false;
+SET enable_seqscan TO FALSE;
 -- IndexScans should work
-:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                        QUERY PLAN                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk."time"
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Filter: (_hyper_2_7_chunk.device_id = 1)
 (23 rows)
 
 -- globs should not plan IndexOnlyScans
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk."time"
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Filter: (_hyper_2_7_chunk.device_id = 1)
 (23 rows)
 
 -- whole row reference should work
-:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE as test_table WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT test_table
+FROM :TEST_TABLE AS test_table
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: test_table."time"
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Output: ((test_table.*)::metrics_space), test_table.device_id, test_table."time"
          Sort Key: test_table."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk test_table (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk test_table (actual rows=504 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: ((test_table_1.*)::metrics_space), test_table_1.device_id, test_table_1."time"
          Sort Key: test_table_1."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk test_table_1 (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk test_table_1 (actual rows=360 loops=1)
                Output: test_table_1.*, test_table_1.device_id, test_table_1."time"
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk test_table_2 (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk test_table_2 (actual rows=504 loops=1)
          Output: test_table_2.*, test_table_2.device_id, test_table_2."time"
          Filter: (test_table_2.device_id = 1)
 (23 rows)
 
 -- even when we select only a segmentby column, we still need count
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
                Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-               Heap Fetches: 3
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+               Heap Fetches: 1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-               Heap Fetches: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+               Heap Fetches: 1
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 2016
+         Heap Fetches: 504
 (17 rows)
 
-:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX_VERBOSE
+SELECT count(*)
+FROM :TEST_TABLE
+WHERE device_id = 1;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    Output: count(*)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-                     Heap Fetches: 3
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Heap Fetches: 1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-                     Heap Fetches: 2
-         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+                     Heap Fetches: 1
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
-               Heap Fetches: 2016
+               Heap Fetches: 504
 (16 rows)
 
 -- should be able to order using an index
-CREATE INDEX tmp_idx ON :TEST_TABLE(device_id);
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE ORDER BY device_id;
+CREATE INDEX tmp_idx ON :TEST_TABLE (device_id);
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+ORDER BY device_id;
                                                                        QUERY PLAN                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=27360 loops=1)
+ Merge Append (actual rows=6840 loops=1)
    Sort Key: _hyper_2_4_chunk.device_id
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
-               Heap Fetches: 2
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=4320 loops=1)
+               Heap Fetches: 1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
          Output: _hyper_2_5_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=6 loops=1)
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id
-               Heap Fetches: 6
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=1440 loops=1)
-         Output: _hyper_2_6_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id
-               Heap Fetches: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
-         Output: _hyper_2_7_chunk.device_id
-         Heap Fetches: 2016
-   ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=6048 loops=1)
-         Output: _hyper_2_8_chunk.device_id
-         Heap Fetches: 6048
-   ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=2016 loops=1)
-         Output: _hyper_2_9_chunk.device_id
-         Heap Fetches: 2016
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
-         Output: _hyper_2_10_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
                Heap Fetches: 3
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
+         Output: _hyper_2_6_chunk.device_id
+         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id
+               Heap Fetches: 1
+   ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
+         Output: _hyper_2_7_chunk.device_id
+         Heap Fetches: 504
+   ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
+         Output: _hyper_2_8_chunk.device_id
+         Heap Fetches: 1512
+   ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
+         Output: _hyper_2_9_chunk.device_id
+         Heap Fetches: 504
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+         Output: _hyper_2_10_chunk.device_id
+         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
+               Heap Fetches: 1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+         ->  Index Only Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id
-               Heap Fetches: 9
-   ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+               Heap Fetches: 3
+   ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id
-         Heap Fetches: 2016
+         Heap Fetches: 504
 (39 rows)
 
 DROP INDEX tmp_idx CASCADE;
 --use the peer index
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -4672,7 +5573,11 @@ DROP INDEX tmp_idx CASCADE;
                Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
 (42 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
@@ -4720,209 +5625,190 @@ DROP INDEX tmp_idx CASCADE;
 (42 rows)
 
 --ensure that we can get a nested loop
-SET enable_seqscan TO true;
-SET enable_hashjoin TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
-                                                                                  QUERY PLAN                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1));
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
+   Join Filter: (_hyper_2_4_chunk.device_id_peer = (1))
+   Rows Removed by Join Filter: 6840
    ->  HashAggregate (actual rows=1 loops=1)
          Output: (1)
          Group Key: 1
          ->  Result (actual rows=1 loops=1)
                Output: 1
-   ->  Append (actual rows=0 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_17_chunk.device_id_peer = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_18_chunk.device_id_peer = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_19_chunk.device_id_peer = (1))
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer
-               Filter: ((1) = _hyper_2_7_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer
-               Filter: ((1) = _hyper_2_8_chunk.device_id_peer)
-               Rows Removed by Filter: 6048
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer
-               Filter: ((1) = _hyper_2_9_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_21_chunk.device_id_peer = (1))
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer
-               Filter: ((1) = _hyper_2_12_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-(49 rows)
+(38 rows)
 
 --with multiple values can get a nested loop.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                                  QUERY PLAN                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=0 loops=1)
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1),
+            (2));
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Nested Loop Semi Join (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Append (actual rows=0 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=2)
+   Join Filter: (_hyper_2_4_chunk.device_id_peer = "*VALUES*".column1)
+   Rows Removed by Join Filter: 13680
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_17_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_18_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_19_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_7_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_8_chunk.device_id_peer)
-               Rows Removed by Filter: 6048
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_9_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
-               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_21_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_12_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-(52 rows)
+   ->  Materialize (actual rows=2 loops=6840)
+         Output: "*VALUES*".column1
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+(37 rows)
 
 RESET enable_hashjoin;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
-                                                                             QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=5472 loops=1)
-   Output: _hyper_2_4_chunk.device_id_peer
-   ->  HashAggregate (actual rows=1 loops=1)
-         Output: (1)
-         Group Key: 1
-         ->  Result (actual rows=1 loops=1)
-               Output: 1
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
-               Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_17_chunk.device_id = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_18_chunk.device_id = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_19_chunk.device_id = (1))
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
-               Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-               Filter: ((1) = _hyper_2_7_chunk.device_id)
-         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-               Index Cond: (_hyper_2_8_chunk.device_id = (1))
-               Heap Fetches: 0
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
-               Filter: ((1) = _hyper_2_9_chunk.device_id)
-               Rows Removed by Filter: 2016
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
-               Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_20_chunk.device_id = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_21_chunk.device_id = (1))
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
-               Filter: ((1) = _hyper_2_12_chunk.device_id)
-               Rows Removed by Filter: 2016
-(48 rows)
-
---with multiple values can get a semi-join or nested loop depending on seq_page_cost.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join (actual rows=10944 loops=1)
+ Hash Semi Join (actual rows=1368 loops=1)
+   Output: _hyper_2_4_chunk.device_id_peer
+   Hash Cond: (_hyper_2_4_chunk.device_id = (1))
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
+               Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
+               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
+               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
+               Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
+               Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
+   ->  Hash (actual rows=1 loops=1)
+         Output: (1)
+         Buckets: 1024  Batches: 1 
+         ->  Result (actual rows=1 loops=1)
+               Output: 1
+(37 rows)
+
+--with multiple values can get a semi-join or nested loop depending on seq_page_cost.
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Semi Join (actual rows=2736 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    Hash Cond: (_hyper_2_4_chunk.device_id = "*VALUES*".column1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=4320 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
          Output: "*VALUES*".column1
@@ -4931,232 +5817,193 @@ RESET enable_hashjoin;
                Output: "*VALUES*".column1
 (37 rows)
 
-SET seq_page_cost=100;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+SET seq_page_cost = 100;
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
+   ->  Unique
          Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
+         ->  Sort
                Output: "*VALUES*".column1
                Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               ->  Values Scan on "*VALUES*"
                      Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720 loops=2)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=720 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 0
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1008 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 0
-(52 rows)
+(47 rows)
 
 RESET seq_page_cost;
 -- force a BitmapHeapScan
-SET enable_indexscan TO false;
-set enable_seqscan TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=5472 loops=1)
+SET enable_indexscan TO FALSE;
+SET enable_seqscan TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Semi Join (actual rows=1368 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  HashAggregate (actual rows=1 loops=1)
+   Hash Cond: (_hyper_2_4_chunk.device_id = (1))
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
+               Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
+               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
+               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=504 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
+               Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
+               Heap Blocks: exact=13
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1512 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
+               Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=504 loops=1)
+   ->  Hash (actual rows=1 loops=1)
          Output: (1)
-         Group Key: 1
+         Buckets: 1024  Batches: 1 
          ->  Result (actual rows=1 loops=1)
                Output: 1
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
-               Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               Filter: ((1) = _hyper_2_4_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_17_chunk.device_id = (1))
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_17_chunk_c_space_index_2 (actual rows=2 loops=1)
-                           Index Cond: (compress_hyper_6_17_chunk.device_id = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
-               Filter: ((1) = _hyper_2_5_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_18_chunk.device_id = (1))
-                     ->  Bitmap Index Scan on compress_hyper_6_18_chunk_c_space_index_2 (actual rows=0 loops=1)
-                           Index Cond: (compress_hyper_6_18_chunk.device_id = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
-               Filter: ((1) = _hyper_2_6_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_19_chunk.device_id = (1))
-                     ->  Bitmap Index Scan on compress_hyper_6_19_chunk_c_space_index_2 (actual rows=0 loops=1)
-                           Index Cond: (compress_hyper_6_19_chunk.device_id = (1))
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
-               Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-               Filter: ((1) = _hyper_2_7_chunk.device_id)
-               Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-               Recheck Cond: (_hyper_2_8_chunk.device_id = (1))
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=1)
-                     Index Cond: (_hyper_2_8_chunk.device_id = (1))
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
-               Filter: ((1) = _hyper_2_9_chunk.device_id)
-               Rows Removed by Filter: 2016
-               Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
-               Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               Filter: ((1) = _hyper_2_10_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_20_chunk.device_id = (1))
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_20_chunk_c_space_index_2 (actual rows=3 loops=1)
-                           Index Cond: (compress_hyper_6_20_chunk.device_id = (1))
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               Filter: ((1) = _hyper_2_11_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                     Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_21_chunk.device_id = (1))
-                     ->  Bitmap Index Scan on compress_hyper_6_21_chunk_c_space_index_2 (actual rows=0 loops=1)
-                           Index Cond: (compress_hyper_6_21_chunk.device_id = (1))
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
-               Filter: ((1) = _hyper_2_12_chunk.device_id)
-               Rows Removed by Filter: 2016
-               Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=2016 loops=1)
-(72 rows)
+(45 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Semi Join (actual rows=2736 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720 loops=2)
+   Hash Cond: (_hyper_2_4_chunk.device_id = "*VALUES*".column1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_4_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_17_chunk_c_space_index_2 (actual rows=1 loops=2)
-                           Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=720 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_5_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_18_chunk_c_space_index_2 (actual rows=1 loops=2)
-                           Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_6_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-                     ->  Bitmap Index Scan on compress_hyper_6_19_chunk_c_space_index_2 (actual rows=0 loops=2)
-                           Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-               Recheck Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
-               Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
-                     Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=504 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-               Recheck Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
-               Heap Blocks: exact=51
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
-                     Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+               Heap Blocks: exact=13
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1512 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
-               Recheck Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=2)
-                     Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1008 loops=2)
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_10_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_20_chunk_c_space_index_2 (actual rows=2 loops=2)
-                           Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_11_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_21_chunk_c_space_index_2 (actual rows=2 loops=2)
-                           Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
-               Recheck Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=0 loops=2)
-                     Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-(77 rows)
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=504 loops=1)
+   ->  Hash (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         Buckets: 1024  Batches: 1 
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+(45 rows)
 
-SET enable_indexscan TO true;
-SET enable_seqscan TO true;
+SET enable_indexscan TO TRUE;
+SET enable_seqscan TO TRUE;
 -- test view
-CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
-:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+CREATE OR REPLACE VIEW compressed_view AS
+SELECT time,
+    device_id,
+    v1,
+    v2
+FROM :TEST_TABLE;
+:PREFIX
+SELECT *
+FROM compressed_view
+WHERE device_id = 1
+ORDER BY time DESC
+LIMIT 10;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -5165,8 +6012,8 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk."time" DESC
                Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
@@ -5179,105 +6026,131 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=27360 loops=1)
+         ->  Hash Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time AND m1.device_id=m2.device_id AND m3.device_id = 3 ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=27360 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Hash Join (actual rows=27360 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Append (actual rows=27360 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                                 ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                                 ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-                           ->  Hash (actual rows=5472 loops=1)
-                                 Buckets: 8192  Batches: 1 
-                                 ->  Append (actual rows=5472 loops=1)
-                                       ->  Seq Scan on _hyper_2_12_chunk m3 (actual rows=2016 loops=1)
+         ->  Hash Join (actual rows=6840 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Hash Join (actual rows=6840 loops=1)
+                     Hash Cond: (m1."time" = m3."time")
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+                     ->  Hash (actual rows=1368 loops=1)
+                           Buckets: 2048  Batches: 1 
+                           ->  Append (actual rows=1368 loops=1)
+                                 ->  Seq Scan on _hyper_2_12_chunk m3 (actual rows=504 loops=1)
+                                       Filter: (device_id = 3)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=1440 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=2 loops=1)
-                                                   Filter: (device_id = 3)
-                                       ->  Seq Scan on _hyper_2_9_chunk m3_2 (actual rows=2016 loops=1)
-                                             Filter: (device_id = 3)
+                                 ->  Seq Scan on _hyper_2_9_chunk m3_2 (actual rows=504 loops=1)
+                                       Filter: (device_id = 3)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (50 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -5288,8 +6161,8 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
@@ -5304,10 +6177,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
                            Index Cond: (device_id = 2)
                      ->  Sort (never executed)
@@ -5317,7 +6190,17 @@ DROP VIEW compressed_view;
                                        Filter: (device_id = 2)
 (35 rows)
 
-:PREFIX SELECT * FROM metrics m1 INNER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -5328,10 +6211,10 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
-                                 Rows Removed by Filter: 8
+                                 Rows Removed by Filter: 4
                ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
@@ -5345,10 +6228,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
                            Index Cond: (device_id = 2)
                      ->  Sort (never executed)
@@ -5359,254 +6242,308 @@ DROP VIEW compressed_view;
 (36 rows)
 
 -- test OUTER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
                      Buckets: 8192  Batches: 1 
-                     ->  Append (actual rows=5472 loops=1)
+                     ->  Append (actual rows=1368 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=2 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                            ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=504 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 6
+                                       Rows Removed by Filter: 2
                            ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (54 rows)
 
-:PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM metrics m1
+    LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
                      Buckets: 8192  Batches: 1 
-                     ->  Append (actual rows=5472 loops=1)
+                     ->  Append (actual rows=1368 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                            ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=504 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 6
+                                       Rows Removed by Filter: 2
                            ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
 -- test implicit self-join
-:PREFIX SELECT * FROM :TEST_TABLE m1, :TEST_TABLE m2 WHERE m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 20;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=20 loops=1)
    ->  Sort (actual rows=20 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
 -- test self-join with sub-query
-:PREFIX SELECT * FROM (SELECT * FROM :TEST_TABLE m1) m1 INNER JOIN (SELECT * FROM :TEST_TABLE m2) m2 ON m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
-:PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time LIMIT 1) m1 ON true;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -5616,10 +6553,9 @@ DROP VIEW compressed_view;
                Chunks excluded during runtime: 7
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (never executed)
                      Filter: ("time" = g."time")
                      ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
@@ -5639,10 +6575,9 @@ DROP VIEW compressed_view;
                      Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
                      Filter: ("time" = g."time")
                      ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
@@ -5650,11 +6585,19 @@ DROP VIEW compressed_view;
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
                      Heap Fetches: 0
-(41 rows)
+(39 rows)
 
 -- test prepared statement with params pushdown
-PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time AND device_id = $1 LIMIT 1) m1 ON true;
-:PREFIX EXECUTE param_prep(1);
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+:PREFIX EXECUTE param_prep (1);
                                                                  QUERY PLAN                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -5664,22 +6607,20 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_1 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_2 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_3 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
                      Heap Fetches: 7
-(20 rows)
+(18 rows)
 
-:PREFIX EXECUTE param_prep(2);
+:PREFIX EXECUTE param_prep (2);
                                                                  QUERY PLAN                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -5692,19 +6633,17 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                      Heap Fetches: 7
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_2 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_3 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 0
-(20 rows)
+(18 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5728,7 +6667,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5752,7 +6691,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5776,7 +6715,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5800,7 +6739,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5827,10 +6766,20 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket ('1d', time) AS time,
+    device_id,
+    avg(v1)
+FROM :TEST_TABLE
+WHERE device_id = 1
+GROUP BY 1,
+    2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-SELECT time FROM cagg_test ORDER BY time LIMIT 1;
+SELECT time
+FROM cagg_test
+ORDER BY time
+LIMIT 1;
              time             
 ------------------------------
  Fri Dec 31 16:00:00 1999 PST
@@ -5840,51 +6789,57 @@ DROP VIEW cagg_test CASCADE;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
-:PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SET enable_bitmapscan = FALSE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = FALSE;
+SET enable_mergejoin = FALSE;
+:PREFIX
+SELECT *
+FROM metrics,
+    metrics_space
+WHERE metrics.time > metrics_space.time
+    AND metrics.device_id = metrics_space.device_id
+    AND metrics.time < metrics_space.time;
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
-   ->  Append (actual rows=0 loops=27360)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+   ->  Append (actual rows=0 loops=6840)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 1440
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=2 loops=27360)
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=27360)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
                Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Filter: (_hyper_2_4_chunk.device_id = device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=27360)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
-               Rows Removed by Filter: 2016
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=3 loops=27360)
+               Rows Removed by Filter: 504
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = true;
-set enable_mergejoin = true;
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = TRUE;
+SET enable_mergejoin = TRUE;
 ---end github issue 1558
 \ir include/transparent_decompression_ordered.sql
 -- This file and its contents are licensed under the Timescale License.
@@ -5922,19 +6877,19 @@ ORDER BY c.id;
 
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
 :PREFIX SELECT * FROM metrics_ordered ORDER BY time DESC LIMIT 10;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_11_28_chunk."time" DESC
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=15 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=15 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=5 loops=1)
 (11 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -5950,60 +6905,60 @@ ORDER BY c.id;
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
 (24 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
-         ->  Merge Append (actual rows=27360 loops=1)
+         ->  Merge Append (actual rows=6840 loops=1)
                Sort Key: d.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk d (actual rows=7200 loops=1)
-                     ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=10 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk d_1 (actual rows=10080 loops=1)
-                     ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=15 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_2 (actual rows=10080 loops=1)
-                     ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=15 loops=1)
-         ->  Limit (actual rows=0 loops=27360)
-               ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=27360)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk d (actual rows=1800 loops=1)
+                     ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk d_1 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_2 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=5 loops=1)
+         ->  Limit (actual rows=0 loops=6840)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=27360)
-                           ->  Sort (actual rows=0 loops=27360)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
+                           ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=27360)
+                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 15
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=27360)
-                           ->  Sort (actual rows=0 loops=27360)
+                                       Rows Removed by Filter: 5
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
+                           ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=27360)
+                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 15
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=27360)
-                           ->  Sort (actual rows=0 loops=27360)
+                                       Rows Removed by Filter: 5
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
+                           ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=27360)
+                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 10
+                                       Rows Removed by Filter: 5
 (34 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
@@ -6072,10 +7027,10 @@ PREPARE tableoid_prep AS SELECT tableoid::regclass FROM :TEST_TABLE WHERE device
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -7674,673 +8629,3 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
 SET enable_seqscan TO true;
 -- diff compressed and uncompressed results
 :DIFF_CMD
--- Testing Index Scan backwards ----
---want more than 1 segment in atleast 1 of the chunks
-CREATE TABLE metrics_ordered_idx(time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int);
-SELECT create_hypertable('metrics_ordered_idx','time', chunk_time_interval=>'2days'::interval);
-         create_hypertable         
------------------------------------
- (15,public,metrics_ordered_idx,t)
-(1 row)
-
-ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby='time ASC',timescaledb.compress_segmentby='device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_16_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_16_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT time, device_id, 0, device_id FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-15 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) ;
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz,'2018-01-20 11:55:00+0','10s') , 4, 5, generate_series(1,5,1) ;
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT now(), generate_series(4,7,1), 5, generate_series(1,5,1) ;
--- misisng values device_id = 7
-CREATE TABLE device_tbl(device_id int, descr text);
-INSERT into device_tbl select generate_series(1, 6,1), 'devicex';
-INSERT into device_tbl select  8, 'device8';
-analyze device_tbl;
--- table for joins ---
-create table nodetime( node int,
-     start_time timestamp ,
-     stop_time timestamp  );
-insert into nodetime values( 4, '2018-01-06 00:00'::timestamp, '2018-12-02 12:00'::timestamp);
--- run queries on uncompressed hypertable and store result
-\set PREFIX ''
-\set PREFIX_VERBOSE ''
-\set ECHO none
---compress all chunks for metrics_ordered_idx table --
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
-               compress_chunk               
---------------------------------------------
- _timescaledb_internal._hyper_15_1438_chunk
- _timescaledb_internal._hyper_15_1439_chunk
- _timescaledb_internal._hyper_15_1440_chunk
- _timescaledb_internal._hyper_15_1441_chunk
- _timescaledb_internal._hyper_15_1442_chunk
-(5 rows)
-
--- run queries on compressed hypertable and store result
-\set PREFIX ''
-\set PREFIX_VERBOSE ''
-\set ECHO none 
--- diff compressed and uncompressed results
-:DIFF_CMD_IDX
-\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
-\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
--- we disable parallelism here otherwise EXPLAIN ANALYZE output
--- will be not stable and differ depending on worker assignment
-SET max_parallel_workers_per_gather TO 0;
-set enable_seqscan = false;
--- get explain for queries on hypertable with compression
-\ir include/transparent_decompression_ordered_indexplan.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
--- tests for explain plan only --
----check index backward scans instead of seq scans ------------
-CREATE TABLE metrics_ordered_idx2(time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 int);
-SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2days'::interval);
-         create_hypertable          
-------------------------------------
- (17,public,metrics_ordered_idx2,t)
-(1 row)
-
-ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_18_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_18 USING BTREE(device_id, _ts_meta_sequence_num)
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_18_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_18 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx2'
-ORDER BY c.id;
-               compress_chunk               
---------------------------------------------
- _timescaledb_internal._hyper_17_1448_chunk
-(1 row)
-
---all queries have only prefix of compress_orderby in ORDER BY clause
--- should have ordered DecompressChunk path because segmentby columns have equality constraints
-:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                                                             QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
-               ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
-                     Index Cond: (device_id = 3)
-                     Filter: (device_id_peer = 3)
-(7 rows)
-
-:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
-                                                                             QUERY PLAN                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
-         Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
-               ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
-                     Index Cond: (device_id = 3)
-                     Filter: (device_id_peer = 3)
-(7 rows)
-
-:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_17_1448_chunk."time" DESC, _hyper_17_1448_chunk.v0 DESC
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=4291 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
-                           Index Cond: (device_id_peer = 3)
-                           Filter: (device_id = 3)
-(9 rows)
-
-:PREFIX SELECT d.device_id, m.time,  m.time
- FROM metrics_ordered_idx2 d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx2 m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=4291 loops=1)
-   ->  Append (actual rows=4291 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk d (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
-   ->  Subquery Scan on m (actual rows=1 loops=4291)
-         Filter: (d.device_id_peer = m.device_id_peer)
-         ->  Limit (actual rows=1 loops=4291)
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
-                     Order: m_1."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk m_2 (actual rows=1 loops=4291)
-                           ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk compress_hyper_18_1449_chunk_1 (actual rows=1 loops=4291)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-(13 rows)
-
-set enable_seqscan = false;
-\ir include/transparent_decompression_ordered_index.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-SET work_mem TO '50MB';
----Lets test for index backward scans instead of seq scans ------------
--- for ordered append tests on compressed chunks we need a hypertable with time as compress_orderby column
--- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
-:PREFIX select * from ( SELECT * FROM metrics_ordered_idx ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: _hyper_15_1442_chunk."time", _hyper_15_1442_chunk.device_id, _hyper_15_1442_chunk.device_id_peer, _hyper_15_1442_chunk.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: _hyper_15_1442_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Append (actual rows=12907 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (actual rows=2880 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-(18 rows)
-
--- should have ordered DecompressChunk path because segmentby columns have equality constraints
-:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10) as q order by 1, 2, 3, 4;
-                                                                                QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
-               Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=0 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=0 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=0 loops=1)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (never executed)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (never executed)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-(26 rows)
-
-:PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                        QUERY PLAN                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Unique (actual rows=1 loops=1)
-   ->  Nested Loop (actual rows=4291 loops=1)
-         ->  Merge Append (actual rows=12907 loops=1)
-               Sort Key: d.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-                     ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-         ->  Subquery Scan on m (actual rows=0 loops=12907)
-               Filter: (d.device_id_peer = m.device_id_peer)
-               Rows Removed by Filter: 0
-               ->  Limit (actual rows=0 loops=12907)
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
-                           Order: m_1."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
-                                 ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
-                                 ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
-                                 ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
-                                 ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
-                                 ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-(41 rows)
-
-:PREFIX SELECT d.device_id, m.time,  m.time
-FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=4291 loops=1)
-   ->  Append (actual rows=12907 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-               ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
-               ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-   ->  Subquery Scan on m (actual rows=0 loops=12907)
-         Filter: (d.device_id_peer = m.device_id_peer)
-         Rows Removed by Filter: 0
-         ->  Limit (actual rows=0 loops=12907)
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
-                     Order: m_1."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
-                           ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
-                           ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
-                           ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                                 Rows Removed by Filter: 3
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
-                           ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
-                           ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-(39 rows)
-
---github issue 1558
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
-:PREFIX select device_id, count(*) from
-(select * from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time) as subq group by device_id;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate (actual rows=1 loops=1)
-   Group Key: mt.device_id
-   ->  Nested Loop (actual rows=4291 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
-         Rows Removed by Join Filter: 8616
-         ->  Merge Append (actual rows=12907 loops=1)
-               Sort Key: mt.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=1440 loops=1)
-                     ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=2880 loops=1)
-                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=12907)
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
-
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4291 loops=1)
-   Sort Key: mt."time"
-   Sort Method: quicksort 
-   ->  Nested Loop (actual rows=4291 loops=1)
-         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Append (actual rows=4291 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
-                     Rows Removed by Filter: 288
-                     ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
-                     Rows Removed by Filter: 576
-                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
-                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=0 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
-                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
-                     Rows Removed by Filter: 1
-                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = nd.node)
-(29 rows)
-
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
-set enable_mergejoin = true;
-set enable_hashjoin = false;
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4291 loops=1)
-   Sort Key: mt."time"
-   Sort Method: quicksort 
-   ->  Merge Join (actual rows=4291 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 865
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=12040 loops=1)
-               Sort Key: mt.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=12907 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=2880 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-(25 rows)
-
-set enable_mergejoin = false;
-set enable_hashjoin = true;
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Sort (actual rows=4291 loops=1)
-   Sort Key: mt."time"
-   Sort Method: quicksort 
-   ->  Hash Join (actual rows=4291 loops=1)
-         Hash Cond: (mt.device_id = nd.node)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 865
-         ->  Append (actual rows=12907 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=2880 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=4291 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
-
---enable all joins after the tests
-set enable_mergejoin = true;
-set enable_hashjoin = true;
- --end github issue 1558
-set enable_seqscan = true;
-\ir include/transparent_decompression_constraintaware.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
---- TEST for constraint aware append  ------------
---should select only newly added chunk --
-set timescaledb.enable_chunk_append to false;
-:PREFIX select * from ( SELECT * FROM metrics_ordered_idx where time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: metrics_ordered_idx."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
-                     Hypertable: metrics_ordered_idx
-                     Chunks left after exclusion: 2
-                     ->  Append (actual rows=4296 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
-(19 rows)
-
--- DecompressChunk path because segmentby columns have equality constraints
-:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 4 AND device_id_peer = 5 and time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10) as q  order by 1, 2, 3, 4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Custom Scan (ConstraintAwareAppend) (actual rows=10 loops=1)
-               Hypertable: metrics_ordered_idx
-               Chunks left after exclusion: 2
-               ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_15_1441_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=9 loops=1)
-                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_16_1446_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=1 loops=1)
-                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_16_1447_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
-
-:PREFIX SELECT m.device_id, d.v0, count(*)
-FROM metrics_ordered_idx d , metrics_ordered_idx m
-WHERE m.device_id = d.device_id AND m.device_id_peer = 5
-and m.time = d.time and m.time > '2002-01-01' and m.time < now()
-AND m.device_id_peer = d.device_id_peer
-group by m.device_id, d.v0 order by 1,2 ,3;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=9 loops=1)
-   Sort Key: m.device_id, d.v0, (count(*))
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=9 loops=1)
-         Group Key: m.device_id, d.v0
-         ->  Hash Join (actual rows=4295 loops=1)
-               Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
-               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
-                     Hypertable: metrics_ordered_idx
-                     Chunks left after exclusion: 2
-                     ->  Append (actual rows=4296 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_1 (actual rows=4291 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_2 (actual rows=5 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
-               ->  Hash (actual rows=4295 loops=1)
-                     Buckets: 8192 (originally 2048)  Batches: 1 (originally 1) 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks left after exclusion: 2
-                           ->  Append (actual rows=4296 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_1 (actual rows=4291 loops=1)
-                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                       ->  Seq Scan on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=5 loops=1)
-                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=5 loops=1)
-                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=5 loops=1)
-                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
-(33 rows)
-
---query with no results --
-:PREFIX SELECT m.device_id, d.v0, count(*) 
-FROM metrics_ordered_idx d , metrics_ordered_idx m 
-WHERE m.time = d.time and  m.time > now()
-group by m.device_id, d.v0 order by 1,2 ,3;
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=0 loops=1)
-   Sort Key: m.device_id, d.v0, (count(*))
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=0 loops=1)
-         Group Key: m.device_id, d.v0
-         ->  Merge Join (actual rows=0 loops=1)
-               Merge Cond: (d."time" = m."time")
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: d."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks left after exclusion: 1
-                           ->  Append (actual rows=0 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_1 (actual rows=0 loops=1)
-                                       Filter: ("time" > now())
-                                       Rows Removed by Filter: 5
-                                       ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-               ->  Sort (never executed)
-                     Sort Key: m."time"
-                     ->  Custom Scan (ConstraintAwareAppend) (never executed)
-                           Hypertable: metrics_ordered_idx
-                           Chunks left after exclusion: 1
-                           ->  Append (never executed)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (never executed)
-                                       Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (never executed)
-(27 rows)
-
---query with all chunks but 1 excluded at plan time --
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d, metrics_ordered_idx m 
-WHERE m.device_id = d.device_id 
-and m.time > '2019-01-01' and m.time < now()
-order by m.v0;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=3 loops=1)
-   Sort Key: m.v0
-   Sort Method: quicksort 
-   ->  Hash Join (actual rows=3 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Append (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m (actual rows=5 loops=1)
-                     Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
-                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                           Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (actual rows=7 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(13 rows)
-
--- no matches in metrics_ordered_idx but one row in device_tbl
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d LEFT OUTER JOIN  metrics_ordered_idx m 
-ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
-WHERE d.device_id = 8 
-order by m.v0;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=1 loops=1)
-   Sort Key: m.v0
-   Sort Method: quicksort 
-   ->  Nested Loop Left Join (actual rows=1 loops=1)
-         Join Filter: (m.device_id = d.device_id)
-         ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
-               Filter: (device_id = 8)
-               Rows Removed by Filter: 6
-         ->  Append (actual rows=0 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m (actual rows=0 loops=1)
-                     Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
-                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
-                           Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
-                           Rows Removed by Filter: 5
-(14 rows)
-
--- no matches in device_tbl but 1 row in metrics_ordered_idx
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d FULL OUTER JOIN  metrics_ordered_idx m 
-ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
-WHERE m.device_id = 7 
-order by m.v0;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=1 loops=1)
-   Sort Key: m.v0
-   Sort Method: quicksort 
-   ->  Hash Left Join (actual rows=1 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < now()))
-         ->  Append (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_4 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
-         ->  Hash (actual rows=0 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
-                     Filter: (device_id = 7)
-                     Rows Removed by Filter: 7
-(32 rows)
-
-set timescaledb.enable_chunk_append to true;

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -2,62 +2,139 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set TEST_BASE_NAME transparent_decompression
-SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
-       format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
-       format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED",
-       format('%s/results/%s_results_uncompressed_idx.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED_IDX",
-       format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESSED",
-       format('%s/results/%s_results_compressed_idx.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESSED_IDX"
-\gset
-SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') as "DIFF_CMD"
-\gset
-SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED_IDX', :'TEST_RESULTS_COMPRESSED_IDX') as "DIFF_CMD_IDX"
-\gset
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNCOMPRESSED",
+    format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_COMPRESSED" \gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 SET work_mem TO '50MB';
-CREATE TABLE metrics(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 int, v2 float, v3 float);
-SELECT create_hypertable('metrics','time');
+CREATE TABLE metrics (
+    filler_1 int,
+    filler_2 int,
+    filler_3 int,
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 int,
+    v2 float,
+    v3 float
+);
+SELECT create_hypertable ('metrics', 'time');
   create_hypertable   
 ----------------------
  (1,public,metrics,t)
 (1 row)
 
-ALTER TABLE metrics DROP COLUMN filler_1;
-INSERT INTO metrics(time,device_id, device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1,  device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics DROP COLUMN filler_2;
-INSERT INTO metrics(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id-1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics DROP COLUMN filler_3;
-INSERT INTO metrics(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ALTER TABLE metrics
+    DROP COLUMN filler_1;
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics
+    DROP COLUMN filler_2;
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id - 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-06 0:00:00+0'::timestamptz, '2000-01-12 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics
+    DROP COLUMN filler_3;
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-19 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
 ANALYZE metrics;
 -- create identical hypertable with space partitioning
-CREATE TABLE metrics_space(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 float, v2 float, v3 float);
-SELECT create_hypertable('metrics_space','time','device_id',3);
+CREATE TABLE metrics_space (
+    filler_1 int,
+    filler_2 int,
+    filler_3 int,
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 float,
+    v2 float,
+    v3 float
+);
+SELECT create_hypertable ('metrics_space', 'time', 'device_id', 3);
      create_hypertable      
 ----------------------------
  (2,public,metrics_space,t)
 (1 row)
 
-ALTER TABLE metrics_space DROP COLUMN filler_1;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics_space DROP COLUMN filler_2;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics_space DROP COLUMN filler_3;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+ALTER TABLE metrics_space
+    DROP COLUMN filler_1;
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics_space
+    DROP COLUMN filler_2;
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-06 0:00:00+0'::timestamptz, '2000-01-12 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+ALTER TABLE metrics_space
+    DROP COLUMN filler_3;
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-19 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
 ANALYZE metrics_space;
 -- run queries on uncompressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
+\set PREFIX_NO_ANALYZE ''
 \set ECHO none
 -- compress first and last chunk on the hypertable
-ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
+ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
 NOTICE:  adding index _compressed_hypertable_5_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_1_1_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_1_3_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_1_3_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_1_3_chunk
@@ -65,70 +142,70 @@ SELECT compress_chunk('_timescaledb_internal._hyper_1_3_chunk');
 
 -- compress some chunks on space partitioned hypertable
 -- we compress all chunks of first time slice, none of second, and 2 of the last time slice
-ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
+ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
 NOTICE:  adding index _compressed_hypertable_6_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id, _ts_meta_sequence_num)
 NOTICE:  adding index _compressed_hypertable_6_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-SELECT compress_chunk('_timescaledb_internal._hyper_2_4_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_4_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_2_4_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_5_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_5_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_2_5_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_6_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_6_chunk');
              compress_chunk             
 ----------------------------------------
  _timescaledb_internal._hyper_2_6_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_10_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_10_chunk');
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_2_10_chunk
 (1 row)
 
-SELECT compress_chunk('_timescaledb_internal._hyper_2_11_chunk');
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_11_chunk');
              compress_chunk              
 -----------------------------------------
  _timescaledb_internal._hyper_2_11_chunk
 (1 row)
 
-SELECT
-	ht.schema_name || '.' || ht.table_name AS "METRICS_COMPRESSED"
+SELECT ht.schema_name || '.' || ht.table_name AS "METRICS_COMPRESSED"
 FROM _timescaledb_catalog.hypertable ht
-	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics'
-\gset
-SELECT
-	ht.schema_name || '.' || ht.table_name AS "METRICS_SPACE_COMPRESSED"
+    INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id = ht2.compressed_hypertable_id
+        AND ht2.table_name = 'metrics' \gset
+SELECT ht.schema_name || '.' || ht.table_name AS "METRICS_SPACE_COMPRESSED"
 FROM _timescaledb_catalog.hypertable ht
-	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics_space'
-\gset
+    INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id = ht2.compressed_hypertable_id
+        AND ht2.table_name = 'metrics_space' \gset
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- Index created using query saved in variable used because there was 
+-- Index created using query saved in variable used because there was
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
-CREATE INDEX c_index ON :METRICS_COMPRESSED(device_id);
-CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED(device_id);
-CREATE INDEX c_index_2 ON :METRICS_COMPRESSED(device_id, _ts_meta_count);
-CREATE INDEX c_space_index_2 ON :METRICS_SPACE_COMPRESSED(device_id, _ts_meta_count);
-CREATE INDEX ON :METRICS_COMPRESSED(device_id_peer);
-CREATE INDEX ON :METRICS_SPACE_COMPRESSED(device_id_peer);
+CREATE INDEX c_index ON :METRICS_COMPRESSED (device_id);
+CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED (device_id);
+CREATE INDEX c_index_2 ON :METRICS_COMPRESSED (device_id, _ts_meta_count);
+CREATE INDEX c_space_index_2 ON :METRICS_SPACE_COMPRESSED (device_id, _ts_meta_count);
+CREATE INDEX ON :METRICS_COMPRESSED (device_id_peer);
+CREATE INDEX ON :METRICS_SPACE_COMPRESSED (device_id_peer);
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-CREATE INDEX ON metrics_space(device_id,device_id_peer, v0, v1 desc, time);
-CREATE INDEX ON metrics_space(device_id,device_id_peer DESC, v0, v1 desc, time);
-CREATE INDEX ON metrics_space(device_id DESC, device_id_peer DESC, v0, v1 desc, time);
+CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
+CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
+CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);
 ANALYZE metrics_space;
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
+\set PREFIX_NO_ANALYZE ''
 \set ECHO none
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
 SET max_parallel_workers_per_gather TO 0;
@@ -139,7 +216,12 @@ SET max_parallel_workers_per_gather TO 0;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- this should use DecompressChunk node
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time
+LIMIT 5;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
@@ -153,12 +235,12 @@ SET max_parallel_workers_per_gather TO 0;
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                      Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Filter: (compress_hyper_5_15_chunk.device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (never executed)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.device_id = 1)
@@ -173,167 +255,197 @@ SET max_parallel_workers_per_gather TO 0;
 (28 rows)
 
 -- test RECORD by itself
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics (actual rows=5472 loops=1)
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics (actual rows=1368 loops=1)
    Order: metrics."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Sort Key: _hyper_1_1_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (19 rows)
 
 -- test expressions
-:PREFIX SELECT
-  time_bucket('1d',time),
-  v1 + v2 AS "sum",
-  COALESCE(NULL,v1,v2) AS "coalesce",
-  NULL AS "NULL",
-  'text' AS "text",
-  :TEST_TABLE AS "RECORD"
-FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    :TEST_TABLE AS "RECORD"
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Sort (actual rows=10944 loops=1)
+ Sort (actual rows=2736 loops=1)
    Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
    Sort Method: quicksort 
-   ->  Result (actual rows=10944 loops=1)
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2880 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=4 loops=1)
+   ->  Result (actual rows=2736 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=4032 loops=1)
+                           Rows Removed by Filter: 3
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1008 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 6048
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=4032 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1512
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
 (16 rows)
 
 -- test empty targetlist
-:PREFIX SELECT FROM :TEST_TABLE;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Append (actual rows=27360 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-   ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+:PREFIX
+SELECT
+FROM :TEST_TABLE;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Append (actual rows=6840 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+   ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (6 rows)
 
 -- test empty resultset
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < 0;
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 10
+               Rows Removed by Filter: 5
    ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
          Filter: (device_id < 0)
-         Rows Removed by Filter: 10080
+         Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 15
+               Rows Removed by Filter: 5
 (12 rows)
 
 -- test targetlist not referencing columns
-:PREFIX SELECT 1 FROM :TEST_TABLE;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Result (actual rows=27360 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+:PREFIX
+SELECT 1
+FROM :TEST_TABLE;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Result (actual rows=6840 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test constraints not present in targetlist
-:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v1
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (15 rows)
 
 -- test order not present in targetlist
-:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v2
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (15 rows)
 
 -- test column with all NULL
-:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+:PREFIX
+SELECT v3
+FROM :TEST_TABLE
+WHERE device_id = 1;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8
-   ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 4
+   ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 12
+               Rows Removed by Filter: 4
 (12 rows)
 
 --
 -- test qual pushdown
 --
 -- v3 is not segment by or order by column so should not be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE v3 > 10.0
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -344,23 +456,29 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Filter: (_hyper_1_1_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 7200
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=10 loops=1)
+               Rows Removed by Filter: 1800
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 10080
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 10080
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               Rows Removed by Filter: 2520
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
 (21 rows)
 
 -- device_id constraint should be pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -369,10 +487,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -383,25 +501,37 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (17 rows)
 
 -- test IS NULL / IS NOT NULL
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NOT NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (device_id IS NOT NULL)
 (13 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -412,40 +542,52 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id IS NULL)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (16 rows)
 
 -- test IN (Const,Const)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2880 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=4 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=720 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=4032 loops=1)
+                           Rows Removed by Filter: 3
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=1008 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 6048
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=4032 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1512
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=1008 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=2 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
 (16 rows)
 
 -- test cast pushdown
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = '1'::text::int
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -454,10 +596,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -468,7 +610,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (17 rows)
 
 --test var op var with two segment by
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = device_id_peer ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = device_id_peer
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -479,36 +627,48 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (16 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id_peer < device_id ORDER BY time, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (device_id_peer < device_id)
 (13 rows)
 
 -- test expressions
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id =  1 + 4/2 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1 + 4 / 2
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -517,10 +677,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 3)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 3)
          ->  Sort (never executed)
@@ -532,7 +692,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test function calls
 -- not yet pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(),1,3)) ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = length(substring(version(), 1, 3))
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -542,10 +708,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
                      Filter: (device_id = length("substring"(version(), 1, 3)))
-                     Rows Removed by Filter: 5760
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 1440
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = length("substring"(version(), 1, 3)))
          ->  Sort (never executed)
@@ -559,183 +725,240 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test segment meta pushdown
 --
 -- order by column and const
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time = '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-         Rows Removed by Filter: 4995
+         Rows Removed by Filter: 1795
          ->  Sort (actual rows=5 loops=1)
                Sort Key: compress_hyper_5_15_chunk.device_id
                Sort Method: quicksort 
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 5
-(10 rows)
+(9 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=60 loops=1)
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=15 loops=1)
                Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 4940
+               Rows Removed by Filter: 1785
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 5
-(10 rows)
+(9 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time <= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=65 loops=1)
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=20 loops=1)
                Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 4935
+               Rows Removed by Filter: 1780
                ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                      Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 5
-(10 rows)
+(9 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time >= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27300 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7140 loops=1)
+         ->  Append (actual rows=6825 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1785 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 60
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 15
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (16 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7135 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 65
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 20
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (16 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE '2000-01-01 1:00:00+0' < time
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7135 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1780 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 65
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 20
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (16 rows)
 
 --pushdowns between order by and segment by columns
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=2016 loops=1)
+         ->  Append (actual rows=504 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 10
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                           Rows Removed by Filter: 5
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                      Filter: (v0 < 1)
-                     Rows Removed by Filter: 8064
+                     Rows Removed by Filter: 2016
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (18 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=10080 loops=1)
+         ->  Append (actual rows=2520 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 10
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+                           Rows Removed by Filter: 5
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (v0 < device_id)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (17 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < v0
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=7200 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
+         ->  Append (actual rows=1800 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (device_id < v0)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (device_id < v0)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (17 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v1 = device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -747,19 +970,25 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v1 = device_id)
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=0 loops=1)
                            Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (v1 = device_id)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v1 = device_id)
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=0 loops=1)
                            Filter: ((_ts_meta_min_2 <= device_id) AND (_ts_meta_max_2 >= device_id))
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
 (18 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 = v1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -769,19 +998,26 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=1)
                      Filter: (v0 = v1)
-                     Rows Removed by Filter: 7200
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+                     Rows Removed by Filter: 1800
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
                ->  Seq Scan on _hyper_1_2_chunk (actual rows=0 loops=1)
                      Filter: (v0 = v1)
-                     Rows Removed by Filter: 10080
+                     Rows Removed by Filter: 2520
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=1)
                      Filter: (v0 = v1)
-                     Rows Removed by Filter: 10080
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     Rows Removed by Filter: 2520
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (16 rows)
 
 --pushdown of quals on order by and segment by cols anded together
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' and device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    AND device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -795,14 +1031,14 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=356 loops=1)
                      Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                      Filter: (_hyper_1_1_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                            Filter: ((compress_hyper_5_15_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_5_15_chunk.device_id = 1))
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (never executed)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Index Cond: (_hyper_1_2_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
@@ -819,47 +1055,64 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (32 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' or device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    OR device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27308 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7148 loops=1)
+         ->  Append (actual rows=6824 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1784 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     Rows Removed by Filter: 52
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+                     Rows Removed by Filter: 16
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (14 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < now()
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: metrics."time", metrics.device_id
          Sort Method: top-N heapsort 
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=27360 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics (actual rows=6840 loops=1)
                Chunks excluded during startup: 0
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
                      Filter: ("time" < now())
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
                      Filter: ("time" < now())
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                      Filter: ("time" < now())
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (14 rows)
 
 -- test sort optimization interaction
-:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+:PREFIX
+SELECT time
+FROM :TEST_TABLE
+ORDER BY time DESC
+LIMIT 10;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -868,8 +1121,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
          ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Heap Fetches: 0
          ->  Sort (never executed)
@@ -878,88 +1131,123 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      ->  Seq Scan on compress_hyper_5_15_chunk (never executed)
 (14 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY time DESC,
+    device_id
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_3_chunk."time" DESC, _hyper_1_3_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
 (10 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY device_id,
+    time DESC
+LIMIT 10;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_1_1_chunk.device_id, _hyper_1_1_chunk."time" DESC
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (10 rows)
 
 --
 -- test ordered path
 --
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
    Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
 -- should produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
          Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- test order by columns not in targetlist
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time
+LIMIT 100;
                                                                                                                                                 QUERY PLAN                                                                                                                                                
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -970,10 +1258,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk."time"
                Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                      Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk."time"
                      Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 3365
+                     Rows Removed by Filter: 845
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1 loops=1)
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk."time"
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -981,14 +1269,21 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                      Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                            Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (22 rows)
 
 -- test ordering only by segmentby columns
 -- should produce ordered path and not have sequence number in targetlist of compressed scan
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer
+LIMIT 100;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -999,10 +1294,10 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer
                Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer
                Sort Method: top-N heapsort 
-               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+               ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                      Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer
                      Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 3365
+                     Rows Removed by Filter: 845
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=1 loops=1)
                Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
@@ -1010,130 +1305,173 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                            Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                            Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (22 rows)
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0;
                                                                                                                               QUERY PLAN                                                                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
          Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0
                Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0, v1 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0, v1 desc;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0,
+    v1
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC;
                                                                                                                                              QUERY PLAN                                                                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1
          Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                Sort Key: compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time,v3;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time,
+    v3;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
    Sort Key: _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time", _hyper_1_2_chunk.v3
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
 
 -- should produce ordered path
 -- ASC/DESC for segmentby columns can be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk.device_id DESC, _hyper_1_2_chunk.device_id_peer DESC, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
-   ->  Sort (actual rows=6715 loops=1)
+   ->  Sort (actual rows=1675 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
          Sort Key: _hyper_1_2_chunk.device_id DESC, _hyper_1_2_chunk.device_id_peer DESC, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1 DESC, _hyper_1_2_chunk."time"
          Sort Method: quicksort 
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=15 loops=1)
+         ->  Sort (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                Sort Key: compress_hyper_5_16_chunk.device_id DESC, compress_hyper_5_16_chunk.device_id_peer DESC, compress_hyper_5_16_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (20 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
    Sort Key: _hyper_1_2_chunk.device_id DESC, _hyper_1_2_chunk.device_id_peer DESC, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk."time"
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=1675 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                Filter: (_hyper_1_3_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Filter: (compress_hyper_5_16_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (15 rows)
@@ -1143,382 +1481,455 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 --
 -- test plan time exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Sort Key: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=6715 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=1675 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 3365
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+               Rows Removed by Filter: 845
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (11 rows)
 
 -- test runtime exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08'::text::timestamptz ORDER BY time, device_id;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'::text::timestamptz
+ORDER BY time,
+    device_id;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Sort Key: metrics."time", metrics.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=16795 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=4195 loops=1)
          Chunks excluded during startup: 1
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=6715 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=1675 loops=1)
                Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
                Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (10 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (7 rows)
 
 -- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
    Sort Key: _hyper_1_1_chunk.device_id
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=5 loops=1)
          Group Key: _hyper_1_1_chunk.device_id
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (11 rows)
 
 -- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT sum(count(*)) OVER ()
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
    Sort Key: _hyper_1_1_chunk.device_id
    Sort Method: quicksort 
    ->  WindowAgg (actual rows=5 loops=1)
          ->  HashAggregate (actual rows=5 loops=1)
                Group Key: _hyper_1_1_chunk.device_id
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=10080 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (12 rows)
 
 -- test CTE
-:PREFIX WITH
-q AS (SELECT v1 FROM :TEST_TABLE ORDER BY time)
-SELECT * FROM q ORDER BY v1;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=27360 loops=1)
+:PREFIX WITH q AS (
+    SELECT v1
+    FROM :TEST_TABLE
+    ORDER BY time
+)
+SELECT *
+FROM q
+ORDER BY v1;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=6840 loops=1)
    Sort Key: q.v1
    Sort Method: quicksort 
-   ->  Subquery Scan on q (actual rows=27360 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics (actual rows=27360 loops=1)
+   ->  Subquery Scan on q (actual rows=6840 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics (actual rows=6840 loops=1)
                Order: metrics."time"
-               ->  Sort (actual rows=7200 loops=1)
+               ->  Sort (actual rows=1800 loops=1)
                      Sort Key: _hyper_1_1_chunk."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=7200 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=10080 loops=1)
-               ->  Sort (actual rows=10080 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=2520 loops=1)
+               ->  Sort (actual rows=2520 loops=1)
                      Sort Key: _hyper_1_3_chunk."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10080 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
+                           ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (17 rows)
 
 -- test CTE join
-:PREFIX WITH
-q1 AS (SELECT time, v1 FROM :TEST_TABLE WHERE device_id=1 ORDER BY time),
-q2 AS (SELECT time, v2 FROM :TEST_TABLE WHERE device_id=2 ORDER BY time)
-SELECT * FROM q1 INNER JOIN q2 ON q1.time=q2.time ORDER BY q1.time;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join (actual rows=5472 loops=1)
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+)
+SELECT *
+FROM q1
+    INNER JOIN q2 ON q1.time = q2.time
+ORDER BY q1.time;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=1368 loops=1)
    Merge Cond: (metrics."time" = metrics_1."time")
-   ->  Custom Scan (ChunkAppend) on metrics (actual rows=5472 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics (actual rows=1368 loops=1)
          Order: metrics."time"
-         ->  Sort (actual rows=1440 loops=1)
+         ->  Sort (actual rows=360 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 8
-         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                           Rows Removed by Filter: 4
+         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Sort (actual rows=2016 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Sort (actual rows=504 loops=1)
                Sort Key: _hyper_1_3_chunk."time"
                Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 12
-   ->  Materialize (actual rows=5472 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=5472 loops=1)
+                           Rows Removed by Filter: 4
+   ->  Materialize (actual rows=1368 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics metrics_1 (actual rows=1368 loops=1)
                Order: metrics_1."time"
-               ->  Sort (actual rows=1440 loops=1)
+               ->  Sort (actual rows=360 loops=1)
                      Sort Key: _hyper_1_1_chunk_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
-                                 Rows Removed by Filter: 8
-               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=2016 loops=1)
+                                 Rows Removed by Filter: 4
+               ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=504 loops=1)
                      Filter: (device_id = 2)
-                     Rows Removed by Filter: 8064
-               ->  Sort (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 2016
+               ->  Sort (actual rows=504 loops=1)
                      Sort Key: _hyper_1_3_chunk_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
-                                 Rows Removed by Filter: 12
+                                 Rows Removed by Filter: 4
 (41 rows)
 
 -- test prepared statement
-PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+PREPARE prep AS
+SELECT count(time)
+FROM :TEST_TABLE
+WHERE device_id = 1;
 :PREFIX EXECUTE prep;
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 8
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+         ->  Seq Scan on _hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-                     Rows Removed by Filter: 12
+                     Rows Removed by Filter: 4
 (13 rows)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 DEALLOCATE prep;
 --
 -- test indexes
 --
-SET enable_seqscan TO false;
+SET enable_seqscan TO FALSE;
 -- IndexScans should work
-:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
          Sort Key: _hyper_1_1_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
 (24 rows)
 
 -- globs should not plan IndexOnlyScans
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
          Sort Key: _hyper_1_1_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
          Sort Key: _hyper_1_3_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
 (24 rows)
 
 -- whole row reference should work
-:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE as test_table WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT test_table
+FROM :TEST_TABLE AS test_table
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: test_table."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: ((test_table.*)::metrics), test_table.device_id, test_table."time"
          Sort Key: test_table."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk test_table (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk test_table (actual rows=360 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk test_table_1 (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk test_table_1 (actual rows=504 loops=1)
          Output: test_table_1.*, test_table_1.device_id, test_table_1."time"
          Filter: (test_table_1.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Sort (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Sort (actual rows=504 loops=1)
          Output: ((test_table_2.*)::metrics), test_table_2.device_id, test_table_2."time"
          Sort Key: test_table_2."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk test_table_2 (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk test_table_2 (actual rows=504 loops=1)
                Output: test_table_2.*, test_table_2.device_id, test_table_2."time"
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
 (24 rows)
 
 -- even when we select only a segmentby column, we still need count
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id
                Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-               Heap Fetches: 2
-   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+               Heap Fetches: 1
+   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk.device_id
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id
                Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
-               Heap Fetches: 3
+               Heap Fetches: 1
 (17 rows)
 
-:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
+:PREFIX_VERBOSE
+SELECT count(*)
+FROM :TEST_TABLE
+WHERE device_id = 1;
                                                                        QUERY PLAN                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    Output: count(*)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
-               ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
+               ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-                     Heap Fetches: 2
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+                     Heap Fetches: 1
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
                Filter: (_hyper_1_2_chunk.device_id = 1)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
-               ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
+               ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
-                     Heap Fetches: 3
+                     Heap Fetches: 1
 (16 rows)
 
 -- should be able to order using an index
-CREATE INDEX tmp_idx ON :TEST_TABLE(device_id);
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE ORDER BY device_id;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=27360 loops=1)
+CREATE INDEX tmp_idx ON :TEST_TABLE (device_id);
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+ORDER BY device_id;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Append (actual rows=6840 loops=1)
    Sort Key: _hyper_1_1_chunk.device_id
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=7200 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
          Output: _hyper_1_1_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=10 loops=1)
+         ->  Index Only Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id
-               Heap Fetches: 10
-   ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=10080 loops=1)
+               Heap Fetches: 5
+   ->  Index Only Scan using _hyper_1_2_chunk_tmp_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_2_chunk.device_id
-         Heap Fetches: 10080
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+         Heap Fetches: 2520
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
          Output: _hyper_1_3_chunk.device_id
-         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+         ->  Index Only Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id
-               Heap Fetches: 15
+               Heap Fetches: 5
 (15 rows)
 
 DROP INDEX tmp_idx CASCADE;
 --use the peer index
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -1534,7 +1945,7 @@ DROP INDEX tmp_idx CASCADE;
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
                Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
                Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 10080
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
@@ -1542,7 +1953,11 @@ DROP INDEX tmp_idx CASCADE;
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
 (19 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
@@ -1554,7 +1969,7 @@ DROP INDEX tmp_idx CASCADE;
    ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
          Output: _hyper_1_2_chunk.device_id_peer
          Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 10080
+         Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
@@ -1563,9 +1978,13 @@ DROP INDEX tmp_idx CASCADE;
 (15 rows)
 
 --ensure that we can get a nested loop
-SET enable_seqscan TO true;
-SET enable_hashjoin TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1));
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
@@ -1574,21 +1993,26 @@ SET enable_hashjoin TO false;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
                Filter: (compress_hyper_5_15_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 10
+               Rows Removed by Filter: 5
    ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
          Output: _hyper_1_2_chunk.device_id_peer
          Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 10080
+         Rows Removed by Filter: 2520
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
          ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
                Filter: (compress_hyper_5_16_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 15
+               Rows Removed by Filter: 5
 (17 rows)
 
 --with multiple values can get a nested loop.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1),
+            (2));
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
@@ -1611,7 +2035,7 @@ SET enable_hashjoin TO false;
          ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=2)
                Output: _hyper_1_2_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id_peer)
-               Rows Removed by Filter: 10080
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer
                Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id_peer)
@@ -1621,33 +2045,42 @@ SET enable_hashjoin TO false;
 (27 rows)
 
 RESET enable_hashjoin;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                Filter: (compress_hyper_5_15_chunk.device_id = 1)
-               Rows Removed by Filter: 8
-   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 4
+   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk.device_id_peer
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                Filter: (compress_hyper_5_16_chunk.device_id = 1)
-               Rows Removed by Filter: 12
+               Rows Removed by Filter: 4
 (17 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+ Nested Loop (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
          Output: "*VALUES*".column1
@@ -1657,84 +2090,98 @@ RESET enable_hashjoin;
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                      Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=2)
+   ->  Append (actual rows=1368 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_1_chunk.device_id)
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=2)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id)
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=2)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
 (27 rows)
 
-SET seq_page_cost=100;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+SET seq_page_cost = 100;
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join (actual rows=10944 loops=1)
+ Hash Semi Join
    Output: _hyper_1_1_chunk.device_id_peer
    Hash Cond: (_hyper_1_1_chunk.device_id = "*VALUES*".column1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=7200 loops=1)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=10 loops=1)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=10080 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=10080 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=15 loops=1)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
-   ->  Hash (actual rows=2 loops=1)
+   ->  Hash
          Output: "*VALUES*".column1
-         Buckets: 1024  Batches: 1 
-         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+         ->  Values Scan on "*VALUES*"
                Output: "*VALUES*".column1
-(19 rows)
+(18 rows)
 
 RESET seq_page_cost;
 -- force a BitmapHeapScan
-SET enable_indexscan TO false;
-set enable_seqscan TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+SET enable_indexscan TO FALSE;
+SET enable_seqscan TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=1)
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=1)
          Output: _hyper_1_1_chunk.device_id_peer
-         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                Recheck Cond: (compress_hyper_5_15_chunk.device_id = 1)
                Heap Blocks: exact=1
-               ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=2 loops=1)
+               ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=1 loops=1)
                      Index Cond: (compress_hyper_5_15_chunk.device_id = 1)
-   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=1)
+   ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=1)
          Output: _hyper_1_2_chunk.device_id_peer
          Filter: (_hyper_1_2_chunk.device_id = 1)
-         Rows Removed by Filter: 8064
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=1)
+         Rows Removed by Filter: 2016
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=1)
          Output: _hyper_1_3_chunk.device_id_peer
-         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=1)
                Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                Recheck Cond: (compress_hyper_5_16_chunk.device_id = 1)
                Heap Blocks: exact=1
-               ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=3 loops=1)
+               ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=1 loops=1)
                      Index Cond: (compress_hyper_5_16_chunk.device_id = 1)
 (21 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+ Nested Loop (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
    ->  Unique (actual rows=2 loops=1)
          Output: "*VALUES*".column1
@@ -1744,36 +2191,46 @@ set enable_seqscan TO false;
                Sort Method: quicksort 
                ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
                      Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1440 loops=2)
+   ->  Append (actual rows=1368 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
                Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_1_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=2 loops=2)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
                      Recheck Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
                      Heap Blocks: exact=2
-                     ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=2 loops=2)
+                     ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=1 loops=2)
                            Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2016 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
                Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
-               Rows Removed by Filter: 8064
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2016 loops=2)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
                Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=3 loops=2)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
                      Recheck Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
                      Heap Blocks: exact=2
-                     ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=3 loops=2)
+                     ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=1 loops=2)
                            Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
 (33 rows)
 
-SET enable_indexscan TO true;
-SET enable_seqscan TO true;
+SET enable_indexscan TO TRUE;
+SET enable_seqscan TO TRUE;
 -- test view
-CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
-:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+CREATE OR REPLACE VIEW compressed_view AS
+SELECT time,
+    device_id,
+    v1,
+    v2
+FROM :TEST_TABLE;
+:PREFIX
+SELECT *
+FROM compressed_view
+WHERE device_id = 1
+ORDER BY time DESC
+LIMIT 10;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -1782,10 +2239,10 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_1_3_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 12
+                           Rows Removed by Filter: 4
          ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -1797,48 +2254,64 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=27360 loops=1)
+         ->  Hash Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time AND m1.device_id=m2.device_id AND m3.device_id = 3 ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Merge Join (actual rows=10 loops=1)
          Merge Cond: (m1."time" = m3."time")
@@ -1847,58 +2320,68 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: m1."time", m1.device_id
                      Sort Method: quicksort 
-                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                            Order: m1."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m1_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m1_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: m2."time", m2.device_id
                      Sort Method: quicksort 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
          ->  Materialize (actual rows=10 loops=1)
                ->  Merge Append (actual rows=3 loops=1)
                      Sort Key: m3."time"
                      ->  Sort (actual rows=3 loops=1)
                            Sort Key: m3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
                                        Filter: (device_id = 3)
-                                       Rows Removed by Filter: 8
+                                       Rows Removed by Filter: 4
                      ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_1 (actual rows=1 loops=1)
                            Filter: (device_id = 3)
                            Rows Removed by Filter: 2
                      ->  Sort (actual rows=1 loops=1)
                            Sort Key: m3_2."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_2 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_2 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
                                        Filter: (device_id = 3)
-                                       Rows Removed by Filter: 12
+                                       Rows Removed by Filter: 4
 (57 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -1909,10 +2392,10 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
-                                 Rows Removed by Filter: 8
+                                 Rows Removed by Filter: 4
                ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
@@ -1926,10 +2409,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 8
+                                       Rows Removed by Filter: 4
                      ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
                            Filter: (device_id = 2)
                      ->  Sort (never executed)
@@ -1939,7 +2422,17 @@ DROP VIEW compressed_view;
                                        Filter: (device_id = 2)
 (36 rows)
 
-:PREFIX SELECT * FROM metrics m1 INNER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -1950,10 +2443,10 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
-                                 Rows Removed by Filter: 8
+                                 Rows Removed by Filter: 4
                ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
@@ -1967,10 +2460,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
                            Index Cond: (device_id = 2)
                      ->  Sort (never executed)
@@ -1981,223 +2474,277 @@ DROP VIEW compressed_view;
 (36 rows)
 
 -- test OUTER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
-                     Buckets: 8192 (originally 4096)  Batches: 1 (originally 1) 
-                     ->  Append (actual rows=5472 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
+                     Buckets: 4096  Batches: 1 
+                     ->  Append (actual rows=1368 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 8
-                           ->  Seq Scan on _hyper_1_2_chunk m2_1 (actual rows=2016 loops=1)
+                                       Rows Removed by Filter: 4
+                           ->  Seq Scan on _hyper_1_2_chunk m2_1 (actual rows=504 loops=1)
                                  Filter: (device_id = 2)
-                                 Rows Removed by Filter: 8064
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_2 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=3 loops=1)
+                                 Rows Removed by Filter: 2016
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_2 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 12
+                                       Rows Removed by Filter: 4
 (35 rows)
 
-:PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM metrics m1
+    LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
                      Buckets: 8192  Batches: 1 
-                     ->  Append (actual rows=5472 loops=1)
+                     ->  Append (actual rows=1368 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                            ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=504 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 6
+                                       Rows Removed by Filter: 2
                            ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
 -- test implicit self-join
-:PREFIX SELECT * FROM :TEST_TABLE m1, :TEST_TABLE m2 WHERE m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 20;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=20 loops=1)
    ->  Sort (actual rows=20 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
 -- test self-join with sub-query
-:PREFIX SELECT * FROM (SELECT * FROM :TEST_TABLE m1) m1 INNER JOIN (SELECT * FROM :TEST_TABLE m2) m2 ON m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.device_id LIMIT 10;
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=27360 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
                            Order: m2."time"
-                           ->  Sort (actual rows=7200 loops=1)
+                           ->  Sort (actual rows=1800 loops=1)
                                  Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=7200 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=10 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=10080 loops=1)
-                           ->  Sort (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
                                  Sort Key: m2_3."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=10080 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=15 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
 (34 rows)
 
-:PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time LIMIT 1) m1 ON true;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
                                                          QUERY PLAN                                                         
 ----------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -2207,24 +2754,30 @@ DROP VIEW compressed_view;
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
                ->  Index Only Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
                      Heap Fetches: 7
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
-(20 rows)
+(18 rows)
 
 -- test prepared statement with params pushdown
-PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time AND device_id = $1 LIMIT 1) m1 ON true;
-:PREFIX EXECUTE param_prep(1);
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+:PREFIX EXECUTE param_prep (1);
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -2234,22 +2787,20 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
                ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
                      Filter: (device_id = 1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
-(20 rows)
+(18 rows)
 
-:PREFIX EXECUTE param_prep(2);
+:PREFIX EXECUTE param_prep (2);
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -2259,23 +2810,23 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=1 loops=7)
                      Index Cond: ("time" = g."time")
                      Filter: (device_id = 2)
                      Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
 (21 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2299,7 +2850,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2323,7 +2874,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2347,7 +2898,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2371,7 +2922,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -2398,10 +2949,20 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket ('1d', time) AS time,
+    device_id,
+    avg(v1)
+FROM :TEST_TABLE
+WHERE device_id = 1
+GROUP BY 1,
+    2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-SELECT time FROM cagg_test ORDER BY time LIMIT 1;
+SELECT time
+FROM cagg_test
+ORDER BY time
+LIMIT 1;
              time             
 ------------------------------
  Fri Dec 31 16:00:00 1999 PST
@@ -2411,51 +2972,57 @@ DROP VIEW cagg_test CASCADE;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
-:PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SET enable_bitmapscan = FALSE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = FALSE;
+SET enable_mergejoin = FALSE;
+:PREFIX
+SELECT *
+FROM metrics,
+    metrics_space
+WHERE metrics.time > metrics_space.time
+    AND metrics.device_id = metrics_space.device_id
+    AND metrics.time < metrics_space.time;
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
-   ->  Append (actual rows=0 loops=27360)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+   ->  Append (actual rows=0 loops=6840)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
-               Rows Removed by Filter: 1440
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=2 loops=27360)
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=27360)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
                Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Filter: (_hyper_2_4_chunk.device_id = device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=27360)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
-               Rows Removed by Filter: 2016
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=3 loops=27360)
+               Rows Removed by Filter: 504
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = true;
-set enable_mergejoin = true;
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = TRUE;
+SET enable_mergejoin = TRUE;
 ---end github issue 1558
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
@@ -2463,7 +3030,12 @@ set enable_mergejoin = true;
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- this should use DecompressChunk node
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time
+LIMIT 5;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
@@ -2477,9 +3049,9 @@ set enable_mergejoin = true;
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                      Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Filter: (compress_hyper_6_17_chunk.device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
@@ -2496,101 +3068,113 @@ set enable_mergejoin = true;
 (27 rows)
 
 -- test RECORD by itself
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time;
-                                                       QUERY PLAN                                                       
-------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ChunkAppend) on metrics_space (actual rows=5472 loops=1)
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_space (actual rows=1368 loops=1)
    Order: metrics_space."time"
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
 (16 rows)
 
 -- test expressions
-:PREFIX SELECT
-  time_bucket('1d',time),
-  v1 + v2 AS "sum",
-  COALESCE(NULL,v1,v2) AS "coalesce",
-  NULL AS "NULL",
-  'text' AS "text",
-  :TEST_TABLE AS "RECORD"
-FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10944 loops=1)
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    :TEST_TABLE AS "RECORD"
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2736 loops=1)
    Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
    Sort Method: quicksort 
-   ->  Result (actual rows=10944 loops=1)
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+   ->  Result (actual rows=2736 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 4
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=504 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 2
 (23 rows)
 
 -- test empty targetlist
-:PREFIX SELECT FROM :TEST_TABLE;
+:PREFIX
+SELECT
+FROM :TEST_TABLE;
                                      QUERY PLAN                                      
 -------------------------------------------------------------------------------------
- Append (actual rows=27360 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-   ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-   ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-   ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-   ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+ Append (actual rows=6840 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+         ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+   ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+   ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+         ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+   ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (15 rows)
 
 -- test empty resultset
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < 0;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 2
+               Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 6
+               Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 2
+               Rows Removed by Filter: 1
    ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
    ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
@@ -2600,85 +3184,98 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 3
+               Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
          ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Filter: (device_id < 0)
-               Rows Removed by Filter: 9
+               Rows Removed by Filter: 3
    ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
          Index Cond: (device_id < 0)
 (29 rows)
 
 -- test targetlist not referencing columns
-:PREFIX SELECT 1 FROM :TEST_TABLE;
+:PREFIX
+SELECT 1
+FROM :TEST_TABLE;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
- Result (actual rows=27360 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+ Result (actual rows=6840 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
 -- test constraints not present in targetlist
-:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v1
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
 (12 rows)
 
 -- test order not present in targetlist
-:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Sort (actual rows=5472 loops=1)
+:PREFIX
+SELECT v2
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Sort (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk.v1
    Sort Method: quicksort 
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
 (12 rows)
 
 -- test column with all NULL
-:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+:PREFIX
+SELECT v3
+FROM :TEST_TABLE
+WHERE device_id = 1;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+         ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Filter: (device_id = 1)
-   ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
          Filter: (device_id = 1)
 (9 rows)
 
@@ -2686,7 +3283,12 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test qual pushdown
 --
 -- v3 is not segment by or order by column so should not be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE v3 > 10.0
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -2697,53 +3299,59 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Filter: (_hyper_2_4_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 1440
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               Rows Removed by Filter: 360
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                Filter: (_hyper_2_5_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 4320
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               Rows Removed by Filter: 1080
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                Filter: (_hyper_2_6_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 1440
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               Rows Removed by Filter: 360
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
          ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
+               Rows Removed by Filter: 504
          ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Filter: (_hyper_2_8_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 6048
+               Rows Removed by Filter: 1512
          ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
+               Rows Removed by Filter: 504
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               Rows Removed by Filter: 504
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 6048
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               Rows Removed by Filter: 1512
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
          ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk.v3 > '10'::double precision)
-               Rows Removed by Filter: 2016
+               Rows Removed by Filter: 504
 (51 rows)
 
 -- device_id constraint should be pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -2752,8 +3360,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
@@ -2765,40 +3373,52 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (16 rows)
 
 -- test IS NULL / IS NOT NULL
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NOT NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (device_id IS NOT NULL)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (device_id IS NOT NULL)
 (28 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -2809,15 +3429,15 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
                ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
@@ -2827,46 +3447,58 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (device_id IS NULL)
 (33 rows)
 
 -- test IN (Const,Const)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=10944 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 4
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=2016 loops=1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=504 loops=1)
                      Index Cond: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                            Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 2
 (23 rows)
 
 -- test cast pushdown
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = '1'::text::int
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -2875,8 +3507,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
@@ -2888,7 +3520,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (16 rows)
 
 --test var op var with two segment by
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = device_id_peer ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = device_id_peer
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -2899,72 +3537,84 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (device_id = device_id_peer)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: (device_id = device_id_peer)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (37 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id_peer < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (device_id_peer < device_id)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (device_id_peer < device_id)
 (28 rows)
 
 -- test expressions
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id =  1 + 4/2 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1 + 4 / 2
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -2973,8 +3623,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_6_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 3)
          ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
                Filter: (device_id = 3)
@@ -2984,7 +3634,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test function calls
 -- not yet pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(),1,3)) ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = length(substring(version(), 1, 3))
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                               QUERY PLAN                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3000,8 +3656,8 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 Rows Removed by Filter: 1440
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                                 Rows Removed by Filter: 360
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
@@ -3010,17 +3666,17 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 Rows Removed by Filter: 4320
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                                 Rows Removed by Filter: 1080
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=10 loops=1)
                      Sort Key: _hyper_2_6_chunk."time"
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=1440 loops=1)
+                     ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                                  Filter: (device_id = length("substring"(version(), 1, 3)))
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_7_chunk."time"
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (never executed)
@@ -3053,7 +3709,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test segment meta pushdown
 --
 -- order by column and const
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time = '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                             QUERY PLAN                                                                                             
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5 loops=1)
@@ -3061,214 +3723,241 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          Sort Key: _hyper_2_4_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 999
+               Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_6_17_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                           Rows Removed by Filter: 1
          ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=3 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2997
+               Rows Removed by Filter: 1077
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: compress_hyper_6_18_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                           Rows Removed by Filter: 3
          ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1 loops=1)
                Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 999
+               Rows Removed by Filter: 359
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_6_19_chunk.device_id
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: ((_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                           Rows Removed by Filter: 1
-(30 rows)
+(27 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=60 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=12 loops=1)
+         Sort Method: quicksort 
+         ->  Append (actual rows=15 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 988
+                     Rows Removed by Filter: 357
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=36 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=9 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 2964
+                     Rows Removed by Filter: 1071
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 3
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=12 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=3 loops=1)
                      Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 988
+                     Rows Removed by Filter: 357
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_min_3 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-(23 rows)
+(20 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time <= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+         Sort Method: quicksort 
+         ->  Append (actual rows=20 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=4 loops=1)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 356
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=12 loops=1)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1068
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=4 loops=1)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 356
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(20 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time >= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=65 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=13 loops=1)
-                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 987
+         ->  Append (actual rows=6825 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=357 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 3
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=39 loops=1)
-                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 2961
+                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1071 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 9
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 3
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=13 loops=1)
-                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 987
+                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=357 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 3
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                           Filter: (_ts_meta_min_3 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                           Rows Removed by Filter: 1
-(23 rows)
-
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Append (actual rows=27300 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1428 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 12
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4284 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 36
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1428 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 12
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                           Filter: (_ts_meta_max_3 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (36 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1427 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4281 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 39
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 12
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (36 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE '2000-01-01 1:00:00+0' < time
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27295 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1427 loops=1)
+         ->  Append (actual rows=6820 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=356 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4281 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 39
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 12
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
 (36 rows)
 
 --pushdowns between order by and segment by columns
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3280,17 +3969,17 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
                ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
@@ -3301,17 +3990,23 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: (v0 < 1)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < 1)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Index Cond: (v0 < 1)
 (38 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3323,80 +4018,92 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 6
+                           Rows Removed by Filter: 3
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 2
+                           Rows Removed by Filter: 1
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 3
+                           Rows Removed by Filter: 1
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
                            Filter: (_ts_meta_min_1 < device_id)
-                           Rows Removed by Filter: 9
+                           Rows Removed by Filter: 3
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: (v0 < device_id)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (42 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < v0
+ORDER BY time,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (device_id < v0)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: (device_id < v0)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Filter: (_ts_meta_max_1 > device_id)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (device_id < v0)
 (33 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v1 = device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3406,40 +4113,46 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 4320
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1080
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     Rows Removed by Filter: 504
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 6048
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     Rows Removed by Filter: 1512
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: (v1 = (device_id)::double precision)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (37 rows)
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 = v1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                           QUERY PLAN                                          
 ----------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
@@ -3449,40 +4162,47 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 4320
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1080
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
                ->  Seq Scan on _hyper_2_7_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Seq Scan on _hyper_2_8_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 6048
+                     Rows Removed by Filter: 1512
                ->  Seq Scan on _hyper_2_9_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     Rows Removed by Filter: 504
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 6048
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     Rows Removed by Filter: 1512
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                ->  Seq Scan on _hyper_2_12_chunk (actual rows=0 loops=1)
                      Filter: ((v0)::double precision = v1)
-                     Rows Removed by Filter: 2016
+                     Rows Removed by Filter: 504
 (37 rows)
 
 --pushdown of quals on order by and segment by cols anded together
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' and device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    AND device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                                                                                                                      QUERY PLAN                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3496,11 +4216,11 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1427 loops=1)
+               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=356 loops=1)
                      Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                      Filter: (_hyper_2_4_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                            Filter: ((compress_hyper_6_17_chunk._ts_meta_max_3 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (compress_hyper_6_17_chunk.device_id = 1))
          ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (never executed)
@@ -3519,80 +4239,97 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 (31 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' or device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    OR device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27308 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Append (actual rows=6824 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4281 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1068 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     Rows Removed by Filter: 39
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1427 loops=1)
+                     Rows Removed by Filter: 12
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=356 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     Rows Removed by Filter: 13
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 4
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                      Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
 (30 rows)
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < now()
+ORDER BY time,
+    device_id
+LIMIT 10;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: metrics_space."time", metrics_space.device_id
          Sort Method: top-N heapsort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=27360 loops=1)
-               ->  Merge Append (actual rows=7200 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=6840 loops=1)
+               ->  Merge Append (actual rows=1800 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Merge Append (actual rows=10080 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=2520 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
-                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
                            Filter: ("time" < now())
-                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
-               ->  Merge Append (actual rows=10080 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               ->  Merge Append (actual rows=2520 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                            Filter: ("time" < now())
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                            Filter: ("time" < now())
 (31 rows)
 
 -- test sort optimization interaction
-:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+:PREFIX
+SELECT time
+FROM :TEST_TABLE
+ORDER BY time DESC
+LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3605,19 +4342,19 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                ->  Sort (actual rows=6 loops=1)
                      Sort Key: _hyper_2_11_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=6048 loops=1)
+                     ->  Sort (actual rows=1512 loops=1)
                            Sort Key: _hyper_2_11_chunk."time" DESC
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: _hyper_2_10_chunk."time" DESC
                      Sort Method: top-N heapsort 
-                     ->  Sort (actual rows=2016 loops=1)
+                     ->  Sort (actual rows=504 loops=1)
                            Sort Key: _hyper_2_10_chunk."time" DESC
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Merge Append (never executed)
                Sort Key: _hyper_2_9_chunk."time" DESC
                ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (never executed)
@@ -3648,31 +4385,43 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                                  ->  Seq Scan on compress_hyper_6_17_chunk (never executed)
 (51 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY time DESC,
+    device_id
+LIMIT 10;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_2_12_chunk."time" DESC, _hyper_2_12_chunk.device_id
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
 (19 rows)
 
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY device_id,
+    time DESC
+LIMIT 10;
                                                             QUERY PLAN                                                             
 -----------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -3681,18 +4430,18 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_4_chunk.device_id, _hyper_2_4_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_5_chunk.device_id, _hyper_2_5_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_6_chunk.device_id, _hyper_2_6_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
          ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
          ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=1 loops=1)
@@ -3702,13 +4451,13 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
          ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_time_idx on _hyper_2_12_chunk (actual rows=1 loops=1)
                Heap Fetches: 1
 (36 rows)
@@ -3717,85 +4466,108 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 -- test ordered path
 --
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
    Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2019
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (32 rows)
 
 -- should produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
 
 -- test order by columns not in targetlist
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time
+LIMIT 100;
                                                                                                                                                 QUERY PLAN                                                                                                                                                
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -3817,7 +4589,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                      Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                            Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
@@ -3827,7 +4599,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                      Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
@@ -3842,7 +4614,14 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- test ordering only by segmentby columns
 -- should produce ordered path and not have sequence number in targetlist of compressed scan
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer
+LIMIT 100;
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -3864,7 +4643,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                      Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                            Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1 loops=1)
@@ -3874,7 +4653,7 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Sort Method: quicksort 
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                            Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1 loops=1)
@@ -3889,209 +4668,252 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0;
                                                                                                                               QUERY PLAN                                                                                                                              
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
-   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 1005
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 504
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0
                Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0
                Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+         Heap Fetches: 335
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
+         Heap Fetches: 335
 (38 rows)
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0, v1 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0, v1 desc;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0,
+    v1
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC;
                                                                                                                                              QUERY PLAN                                                                                                                                             
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC
-   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 4029
-   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 1005
+   ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 2016
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         Heap Fetches: 504
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                Sort Key: compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                Sort Key: compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
-   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+         Heap Fetches: 335
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         Heap Fetches: 1343
+         Heap Fetches: 335
 (38 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time,v3;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time,
+    v3;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
    Sort Key: _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time", _hyper_2_8_chunk.v3
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2019
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
+               Rows Removed by Filter: 169
 (32 rows)
 
 -- should produce ordered path
 -- ASC/DESC for segmentby columns can be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1 DESC,
+    time;
                                                                                                                                                                            QUERY PLAN                                                                                                                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=16795 loops=1)
+ Merge Append (actual rows=4195 loops=1)
    Sort Key: _hyper_2_8_chunk.device_id DESC, _hyper_2_8_chunk.device_id_peer DESC, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1 DESC, _hyper_2_8_chunk."time"
-   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
          Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
          Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
          Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=3 loops=1)
+         ->  Sort (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                Sort Key: compress_hyper_6_20_chunk.device_id DESC, compress_hyper_6_20_chunk.device_id_peer DESC, compress_hyper_6_20_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
          Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=9 loops=1)
+         ->  Sort (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                Sort Key: compress_hyper_6_21_chunk.device_id DESC, compress_hyper_6_21_chunk.device_id_peer DESC, compress_hyper_6_21_chunk._ts_meta_sequence_num
                Sort Method: quicksort 
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
          Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
          Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (34 rows)
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
    Sort Key: _hyper_2_8_chunk.device_id DESC, _hyper_2_8_chunk.device_id_peer DESC, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk."time"
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=4029 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
                Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2019
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
                Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=1343 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
                Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1343 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
                Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
+               Rows Removed by Filter: 169
 (32 rows)
 
 --
@@ -4099,98 +4921,116 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
 --
 -- test plan time exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
    Sort Method: quicksort 
-   ->  Append (actual rows=16795 loops=1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=1343 loops=1)
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=4029 loops=1)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1005 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2019
-         ->  Seq Scan on _hyper_2_9_chunk (actual rows=1343 loops=1)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               Rows Removed by Filter: 673
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
                Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
 (23 rows)
 
 -- test runtime exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08'::text::timestamptz ORDER BY time, device_id;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'::text::timestamptz
+ORDER BY time,
+    device_id;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=16795 loops=1)
+ Sort (actual rows=4195 loops=1)
    Sort Key: metrics_space."time", metrics_space.device_id
    Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=16795 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=4195 loops=1)
          ->  Merge Append (actual rows=0 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 4320
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
+                     Rows Removed by Filter: 1080
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     Rows Removed by Filter: 1440
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Merge Append (actual rows=6715 loops=1)
-               ->  Index Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=1343 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=4029 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=1343 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-         ->  Merge Append (actual rows=10080 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 360
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Merge Append (actual rows=1675 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
+                     Rows Removed by Filter: 169
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1005 loops=1)
+                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+                     Rows Removed by Filter: 169
+         ->  Merge Append (actual rows=2520 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
                      Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(33 rows)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+(35 rows)
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE;
                                         QUERY PLAN                                         
 -------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (16 rows)
 
 -- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
                                            QUERY PLAN                                            
 -------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
@@ -4198,25 +5038,29 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    Sort Method: quicksort 
    ->  HashAggregate (actual rows=5 loops=1)
          Group Key: _hyper_2_4_chunk.device_id
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-               ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-               ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (20 rows)
 
 -- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX
+SELECT sum(count(*)) OVER ()
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Sort (actual rows=5 loops=1)
@@ -4225,371 +5069,424 @@ FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
    ->  WindowAgg (actual rows=5 loops=1)
          ->  HashAggregate (actual rows=5 loops=1)
                Group Key: _hyper_2_4_chunk.device_id
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
 (21 rows)
 
 -- test CTE
-:PREFIX WITH
-q AS (SELECT v1 FROM :TEST_TABLE ORDER BY time)
-SELECT * FROM q ORDER BY v1;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=27360 loops=1)
+:PREFIX WITH q AS (
+    SELECT v1
+    FROM :TEST_TABLE
+    ORDER BY time
+)
+SELECT *
+FROM q
+ORDER BY v1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=6840 loops=1)
    Sort Key: q.v1
    Sort Method: quicksort 
-   ->  Subquery Scan on q (actual rows=27360 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=27360 loops=1)
+   ->  Subquery Scan on q (actual rows=6840 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=6840 loops=1)
                Order: metrics_space."time"
-               ->  Merge Append (actual rows=7200 loops=1)
+               ->  Merge Append (actual rows=1800 loops=1)
                      Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=1440 loops=1)
+                     ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_4_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=1440 loops=1)
+                           ->  Sort (actual rows=360 loops=1)
                                  Sort Key: _hyper_2_4_chunk."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Sort (actual rows=4320 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Sort (actual rows=1080 loops=1)
                            Sort Key: _hyper_2_5_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=4320 loops=1)
+                           ->  Sort (actual rows=1080 loops=1)
                                  Sort Key: _hyper_2_5_chunk."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Sort (actual rows=1440 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Sort (actual rows=360 loops=1)
                            Sort Key: _hyper_2_6_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=1440 loops=1)
+                           ->  Sort (actual rows=360 loops=1)
                                  Sort Key: _hyper_2_6_chunk."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               ->  Merge Append (actual rows=10080 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               ->  Merge Append (actual rows=2520 loops=1)
                      Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=2016 loops=1)
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=6048 loops=1)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=2016 loops=1)
-               ->  Merge Append (actual rows=10080 loops=1)
+                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
+                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1512 loops=1)
+                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=504 loops=1)
+               ->  Merge Append (actual rows=2520 loops=1)
                      Sort Key: _hyper_2_10_chunk."time"
-                     ->  Sort (actual rows=2016 loops=1)
+                     ->  Sort (actual rows=504 loops=1)
                            Sort Key: _hyper_2_10_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=2016 loops=1)
+                           ->  Sort (actual rows=504 loops=1)
                                  Sort Key: _hyper_2_10_chunk."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Sort (actual rows=6048 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Sort (actual rows=1512 loops=1)
                            Sort Key: _hyper_2_11_chunk."time"
                            Sort Method: quicksort 
-                           ->  Sort (actual rows=6048 loops=1)
+                           ->  Sort (actual rows=1512 loops=1)
                                  Sort Key: _hyper_2_11_chunk."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=2016 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
 (56 rows)
 
 -- test CTE join
-:PREFIX WITH
-q1 AS (SELECT time, v1 FROM :TEST_TABLE WHERE device_id=1 ORDER BY time),
-q2 AS (SELECT time, v2 FROM :TEST_TABLE WHERE device_id=2 ORDER BY time)
-SELECT * FROM q1 INNER JOIN q2 ON q1.time=q2.time ORDER BY q1.time;
-                                                                  QUERY PLAN                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------
- Merge Join (actual rows=5472 loops=1)
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+)
+SELECT *
+FROM q1
+    INNER JOIN q2 ON q1.time = q2.time
+ORDER BY q1.time;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=1368 loops=1)
    Merge Cond: (metrics_space."time" = metrics_space_1."time")
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=5472 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=1368 loops=1)
          Order: metrics_space."time"
-         ->  Sort (actual rows=1440 loops=1)
+         ->  Sort (actual rows=360 loops=1)
                Sort Key: _hyper_2_4_chunk."time"
                Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
-         ->  Sort (actual rows=2016 loops=1)
+         ->  Sort (actual rows=504 loops=1)
                Sort Key: _hyper_2_10_chunk."time"
                Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-   ->  Materialize (actual rows=5472 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=5472 loops=1)
+   ->  Materialize (actual rows=1368 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_space metrics_space_1 (actual rows=1368 loops=1)
                Order: metrics_space_1."time"
-               ->  Sort (actual rows=1440 loops=1)
+               ->  Sort (actual rows=360 loops=1)
                      Sort Key: _hyper_2_5_chunk."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
-                                 Rows Removed by Filter: 4
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=2016 loops=1)
+                                 Rows Removed by Filter: 2
+               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk (actual rows=504 loops=1)
                      Index Cond: (device_id = 2)
-               ->  Sort (actual rows=2016 loops=1)
+               ->  Sort (actual rows=504 loops=1)
                      Sort Key: _hyper_2_11_chunk."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 2)
-                                 Rows Removed by Filter: 6
+                                 Rows Removed by Filter: 2
 (37 rows)
 
 -- test prepared statement
-PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+PREPARE prep AS
+SELECT count(time)
+FROM :TEST_TABLE
+WHERE device_id = 1;
 :PREFIX EXECUTE prep;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Filter: (device_id = 1)
-         ->  Seq Scan on _hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                Filter: (device_id = 1)
 (10 rows)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 EXECUTE prep;
  count 
 -------
-  5472
+  1368
 (1 row)
 
 DEALLOCATE prep;
 --
 -- test indexes
 --
-SET enable_seqscan TO false;
+SET enable_seqscan TO FALSE;
 -- IndexScans should work
-:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                        QUERY PLAN                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk."time"
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
          Filter: (_hyper_2_7_chunk.device_id = 1)
 (23 rows)
 
 -- globs should not plan IndexOnlyScans
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: _hyper_2_10_chunk."time"
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
          Sort Key: _hyper_2_10_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
          Sort Key: _hyper_2_4_chunk."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
          Filter: (_hyper_2_7_chunk.device_id = 1)
 (23 rows)
 
 -- whole row reference should work
-:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE as test_table WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT test_table
+FROM :TEST_TABLE AS test_table
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=5472 loops=1)
+ Merge Append (actual rows=1368 loops=1)
    Sort Key: test_table."time"
-   ->  Sort (actual rows=2016 loops=1)
+   ->  Sort (actual rows=504 loops=1)
          Output: ((test_table.*)::metrics_space), test_table.device_id, test_table."time"
          Sort Key: test_table."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk test_table (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk test_table (actual rows=504 loops=1)
                Output: test_table.*, test_table.device_id, test_table."time"
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Sort (actual rows=1440 loops=1)
+   ->  Sort (actual rows=360 loops=1)
          Output: ((test_table_1.*)::metrics_space), test_table_1.device_id, test_table_1."time"
          Sort Key: test_table_1."time"
          Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk test_table_1 (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk test_table_1 (actual rows=360 loops=1)
                Output: test_table_1.*, test_table_1.device_id, test_table_1."time"
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk test_table_2 (actual rows=2016 loops=1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk test_table_2 (actual rows=504 loops=1)
          Output: test_table_2.*, test_table_2.device_id, test_table_2."time"
          Filter: (test_table_2.device_id = 1)
 (23 rows)
 
 -- even when we select only a segmentby column, we still need count
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id;
+                                                                           QUERY PLAN                                                                            
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
                Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-               Heap Fetches: 3
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+               Heap Fetches: 1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-               Heap Fetches: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+               Heap Fetches: 1
+   ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id
          Index Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Fetches: 2016
+         Heap Fetches: 504
 (17 rows)
 
-:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX_VERBOSE
+SELECT count(*)
+FROM :TEST_TABLE
+WHERE device_id = 1;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate (actual rows=1 loops=1)
    Output: count(*)
-   ->  Append (actual rows=5472 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+   ->  Append (actual rows=1368 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-                     Heap Fetches: 3
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     Heap Fetches: 1
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-                     Heap Fetches: 2
-         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+                     Heap Fetches: 1
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
-               Heap Fetches: 2016
+               Heap Fetches: 504
 (16 rows)
 
 -- should be able to order using an index
-CREATE INDEX tmp_idx ON :TEST_TABLE(device_id);
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE ORDER BY device_id;
+CREATE INDEX tmp_idx ON :TEST_TABLE (device_id);
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+ORDER BY device_id;
                                                                        QUERY PLAN                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=27360 loops=1)
+ Merge Append (actual rows=6840 loops=1)
    Sort Key: _hyper_2_4_chunk.device_id
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Index Only Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id
-               Heap Fetches: 2
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=4320 loops=1)
+               Heap Fetches: 1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
          Output: _hyper_2_5_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=6 loops=1)
+         ->  Index Only Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id
-               Heap Fetches: 6
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=1440 loops=1)
-         Output: _hyper_2_6_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=2 loops=1)
-               Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id
-               Heap Fetches: 2
-   ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
-         Output: _hyper_2_7_chunk.device_id
-         Heap Fetches: 2016
-   ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=6048 loops=1)
-         Output: _hyper_2_8_chunk.device_id
-         Heap Fetches: 6048
-   ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=2016 loops=1)
-         Output: _hyper_2_9_chunk.device_id
-         Heap Fetches: 2016
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
-         Output: _hyper_2_10_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
-               Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
                Heap Fetches: 3
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
+         Output: _hyper_2_6_chunk.device_id
+         ->  Index Only Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id
+               Heap Fetches: 1
+   ->  Index Only Scan using _hyper_2_7_chunk_tmp_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
+         Output: _hyper_2_7_chunk.device_id
+         Heap Fetches: 504
+   ->  Index Only Scan using _hyper_2_8_chunk_tmp_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
+         Output: _hyper_2_8_chunk.device_id
+         Heap Fetches: 1512
+   ->  Index Only Scan using _hyper_2_9_chunk_tmp_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
+         Output: _hyper_2_9_chunk.device_id
+         Heap Fetches: 504
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+         Output: _hyper_2_10_chunk.device_id
+         ->  Index Only Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id
+               Heap Fetches: 1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
          Output: _hyper_2_11_chunk.device_id
-         ->  Index Only Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+         ->  Index Only Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id
-               Heap Fetches: 9
-   ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+               Heap Fetches: 3
+   ->  Index Only Scan using _hyper_2_12_chunk_tmp_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
          Output: _hyper_2_12_chunk.device_id
-         Heap Fetches: 2016
+         Heap Fetches: 504
 (39 rows)
 
 DROP INDEX tmp_idx CASCADE;
 --use the peer index
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer,
+    time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
@@ -4636,7 +5533,11 @@ DROP INDEX tmp_idx CASCADE;
                Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
 (42 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
@@ -4684,9 +5585,13 @@ DROP INDEX tmp_idx CASCADE;
 (42 rows)
 
 --ensure that we can get a nested loop
-SET enable_seqscan TO true;
-SET enable_hashjoin TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1));
                                                                            QUERY PLAN                                                                           
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=0 loops=1)
@@ -4695,19 +5600,19 @@ SET enable_hashjoin TO false;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
                Filter: (compress_hyper_6_17_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 2
+               Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
          Output: _hyper_2_5_chunk.device_id_peer
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
                Filter: (compress_hyper_6_18_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 6
+               Rows Removed by Filter: 3
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
          Output: _hyper_2_6_chunk.device_id_peer
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
                Filter: (compress_hyper_6_19_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 2
+               Rows Removed by Filter: 1
    ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
@@ -4725,13 +5630,13 @@ SET enable_hashjoin TO false;
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
                Filter: (compress_hyper_6_20_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 3
+               Rows Removed by Filter: 1
    ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
          Output: _hyper_2_11_chunk.device_id_peer
          ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
                Filter: (compress_hyper_6_21_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 9
+               Rows Removed by Filter: 3
    ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
          Output: _hyper_2_12_chunk.device_id_peer
          Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
@@ -4739,123 +5644,117 @@ SET enable_hashjoin TO false;
 (47 rows)
 
 --with multiple values can get a nested loop.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
-                                                                                  QUERY PLAN                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=0 loops=1)
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1),
+            (2));
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Nested Loop Semi Join (actual rows=0 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Append (actual rows=0 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=2)
+   Join Filter: (_hyper_2_4_chunk.device_id_peer = "*VALUES*".column1)
+   Rows Removed by Join Filter: 13680
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_4_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_17_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_5_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_18_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_6_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_19_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_7_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_8_chunk.device_id_peer)
-               Rows Removed by Filter: 6048
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_9_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_10_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_20_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_11_chunk.device_id_peer)
-               ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=2)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id_peer
-                     Index Cond: (compress_hyper_6_21_chunk.device_id_peer = "*VALUES*".column1)
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer
-               Filter: ("*VALUES*".column1 = _hyper_2_12_chunk.device_id_peer)
-               Rows Removed by Filter: 2016
-(57 rows)
+   ->  Materialize (actual rows=2 loops=6840)
+         Output: "*VALUES*".column1
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+(37 rows)
 
 RESET enable_hashjoin;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                Filter: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
                Filter: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Filter: (_hyper_2_7_chunk.device_id = 1)
 (14 rows)
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join (actual rows=10944 loops=1)
+ Hash Semi Join (actual rows=2736 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
    Hash Cond: (_hyper_2_4_chunk.device_id = "*VALUES*".column1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=4320 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=6 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=1440 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=2 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=6048 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=6048 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=9 loops=1)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=2016 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
    ->  Hash (actual rows=2 loops=1)
          Output: "*VALUES*".column1
@@ -4864,188 +5763,176 @@ RESET enable_hashjoin;
                Output: "*VALUES*".column1
 (37 rows)
 
-SET seq_page_cost=100;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+SET seq_page_cost = 100;
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
+   ->  Unique
          Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
+         ->  Sort
                Output: "*VALUES*".column1
                Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               ->  Values Scan on "*VALUES*"
                      Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720 loops=2)
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_2_4_chunk.device_id)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=720 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_2_5_chunk.device_id)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_2_6_chunk.device_id)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
                Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
                Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 2016
-         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
                Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 0
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1008 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_2_10_chunk.device_id)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
                Filter: ("*VALUES*".column1 = _hyper_2_11_chunk.device_id)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
                      Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
                Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-               Heap Fetches: 0
-(57 rows)
+(52 rows)
 
 RESET seq_page_cost;
 -- force a BitmapHeapScan
-SET enable_indexscan TO false;
-set enable_seqscan TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+SET enable_indexscan TO FALSE;
+SET enable_seqscan TO FALSE;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=5472 loops=1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=2016 loops=1)
+ Append (actual rows=1368 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
          Output: _hyper_2_10_chunk.device_id_peer
-         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=3 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
                Recheck Cond: (compress_hyper_6_20_chunk.device_id = 1)
                Heap Blocks: exact=1
-               ->  Bitmap Index Scan on compress_hyper_6_20_chunk_c_space_index_2 (actual rows=3 loops=1)
+               ->  Bitmap Index Scan on compress_hyper_6_20_chunk_c_space_index_2 (actual rows=1 loops=1)
                      Index Cond: (compress_hyper_6_20_chunk.device_id = 1)
-   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=1440 loops=1)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
          Output: _hyper_2_4_chunk.device_id_peer
-         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=2 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
                Recheck Cond: (compress_hyper_6_17_chunk.device_id = 1)
                Heap Blocks: exact=1
-               ->  Bitmap Index Scan on compress_hyper_6_17_chunk_c_space_index_2 (actual rows=2 loops=1)
+               ->  Bitmap Index Scan on compress_hyper_6_17_chunk_c_space_index_2 (actual rows=1 loops=1)
                      Index Cond: (compress_hyper_6_17_chunk.device_id = 1)
-   ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=2016 loops=1)
+   ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
          Output: _hyper_2_7_chunk.device_id_peer
          Recheck Cond: (_hyper_2_7_chunk.device_id = 1)
-         Heap Blocks: exact=17
-         ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=2016 loops=1)
+         Heap Blocks: exact=5
+         ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=504 loops=1)
                Index Cond: (_hyper_2_7_chunk.device_id = 1)
 (23 rows)
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=10944 loops=1)
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Hash Semi Join (actual rows=2736 loops=1)
    Output: _hyper_2_4_chunk.device_id_peer
-   ->  Unique (actual rows=2 loops=1)
-         Output: "*VALUES*".column1
-         ->  Sort (actual rows=2 loops=1)
-               Output: "*VALUES*".column1
-               Sort Key: "*VALUES*".column1
-               Sort Method: quicksort 
-               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-                     Output: "*VALUES*".column1
-   ->  Append (actual rows=5472 loops=2)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=720 loops=2)
+   Hash Cond: (_hyper_2_4_chunk.device_id = "*VALUES*".column1)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=360 loops=1)
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_4_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_17_chunk_c_space_index_2 (actual rows=1 loops=2)
-                           Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=720 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=1080 loops=1)
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_5_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=1 loops=2)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_18_chunk_c_space_index_2 (actual rows=1 loops=2)
-                           Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=360 loops=1)
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_6_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=2)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-                     ->  Bitmap Index Scan on compress_hyper_6_19_chunk_c_space_index_2 (actual rows=0 loops=2)
-                           Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=1008 loops=2)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=504 loops=1)
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-               Recheck Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
-               Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
-                     Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1008 loops=2)
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=504 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-               Recheck Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
-               Heap Blocks: exact=17
-               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1008 loops=2)
-                     Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=2)
+               Heap Blocks: exact=13
+               ->  Bitmap Index Scan on _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=1512 loops=1)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=504 loops=1)
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
-               Recheck Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=0 loops=2)
-                     Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=1008 loops=2)
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_10_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_20_chunk_c_space_index_2 (actual rows=2 loops=2)
-                           Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1008 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
-               Filter: ("*VALUES*".column1 = _hyper_2_11_chunk.device_id)
-               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=2 loops=2)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
-                     Recheck Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-                     Heap Blocks: exact=1
-                     ->  Bitmap Index Scan on compress_hyper_6_21_chunk_c_space_index_2 (actual rows=2 loops=2)
-                           Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
-         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=2)
+         ->  Bitmap Heap Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
-               Recheck Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=0 loops=2)
-                     Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
-(77 rows)
+               Heap Blocks: exact=5
+               ->  Bitmap Index Scan on _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 (actual rows=504 loops=1)
+   ->  Hash (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         Buckets: 1024  Batches: 1 
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+(45 rows)
 
-SET enable_indexscan TO true;
-SET enable_seqscan TO true;
+SET enable_indexscan TO TRUE;
+SET enable_seqscan TO TRUE;
 -- test view
-CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
-:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+CREATE OR REPLACE VIEW compressed_view AS
+SELECT time,
+    device_id,
+    v1,
+    v2
+FROM :TEST_TABLE;
+:PREFIX
+SELECT *
+FROM compressed_view
+WHERE device_id = 1
+ORDER BY time DESC
+LIMIT 10;
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
@@ -5054,8 +5941,8 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
          ->  Sort (actual rows=10 loops=1)
                Sort Key: _hyper_2_10_chunk."time" DESC
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
          ->  Index Scan using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (never executed)
                Filter: (device_id = 1)
@@ -5068,105 +5955,131 @@ CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=27360 loops=1)
+         ->  Hash Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time AND m1.device_id=m2.device_id AND m3.device_id = 3 ORDER BY m1.time, m1.device_id LIMIT 10;
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=27360 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Hash Join (actual rows=27360 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Append (actual rows=27360 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                                 ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                                 ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-                           ->  Hash (actual rows=5472 loops=1)
-                                 Buckets: 8192  Batches: 1 
-                                 ->  Append (actual rows=5472 loops=1)
-                                       ->  Seq Scan on _hyper_2_12_chunk m3 (actual rows=2016 loops=1)
+         ->  Hash Join (actual rows=6840 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Hash Join (actual rows=6840 loops=1)
+                     Hash Cond: (m1."time" = m3."time")
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+                     ->  Hash (actual rows=1368 loops=1)
+                           Buckets: 2048  Batches: 1 
+                           ->  Append (actual rows=1368 loops=1)
+                                 ->  Seq Scan on _hyper_2_12_chunk m3 (actual rows=504 loops=1)
+                                       Filter: (device_id = 3)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
                                              Filter: (device_id = 3)
-                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=1440 loops=1)
-                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=2 loops=1)
-                                                   Filter: (device_id = 3)
-                                       ->  Seq Scan on _hyper_2_9_chunk m3_2 (actual rows=2016 loops=1)
-                                             Filter: (device_id = 3)
+                                 ->  Seq Scan on _hyper_2_9_chunk m3_2 (actual rows=504 loops=1)
+                                       Filter: (device_id = 3)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (50 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -5177,8 +6090,8 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
                ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
@@ -5193,10 +6106,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
                            Index Cond: (device_id = 2)
                      ->  Sort (never executed)
@@ -5206,7 +6119,17 @@ DROP VIEW compressed_view;
                                        Filter: (device_id = 2)
 (35 rows)
 
-:PREFIX SELECT * FROM metrics m1 INNER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
@@ -5217,10 +6140,10 @@ DROP VIEW compressed_view;
                ->  Sort (actual rows=100 loops=1)
                      Sort Key: m1_1."time"
                      Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                                  Filter: (device_id = 1)
-                                 Rows Removed by Filter: 8
+                                 Rows Removed by Filter: 4
                ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
                      Filter: (device_id = 1)
                ->  Sort (never executed)
@@ -5234,10 +6157,10 @@ DROP VIEW compressed_view;
                      ->  Sort (actual rows=100 loops=1)
                            Sort Key: m2_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                      ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_time_idx on _hyper_2_8_chunk m2_2 (never executed)
                            Index Cond: (device_id = 2)
                      ->  Sort (never executed)
@@ -5248,254 +6171,308 @@ DROP VIEW compressed_view;
 (36 rows)
 
 -- test OUTER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
                      Buckets: 8192  Batches: 1 
-                     ->  Append (actual rows=5472 loops=1)
+                     ->  Append (actual rows=1368 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=2 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                            ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=504 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 6
+                                       Rows Removed by Filter: 2
                            ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (54 rows)
 
-:PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-                                                                             QUERY PLAN                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+:PREFIX
+SELECT *
+FROM metrics m1
+    LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
    ->  Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=27360 loops=1)
+         ->  Hash Left Join (actual rows=6840 loops=1)
                Hash Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 21888
-               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=27360 loops=1)
+               Rows Removed by Join Filter: 5472
+               ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
-                     ->  Sort (actual rows=7200 loops=1)
+                     ->  Sort (actual rows=1800 loops=1)
                            Sort Key: m1_1."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=7200 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=10080 loops=1)
-                     ->  Sort (actual rows=10080 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
                            Sort Key: m1_3."time"
                            Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=10080 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=15 loops=1)
-               ->  Hash (actual rows=5472 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
+               ->  Hash (actual rows=1368 loops=1)
                      Buckets: 8192  Batches: 1 
-                     ->  Append (actual rows=5472 loops=1)
+                     ->  Append (actual rows=1368 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=2 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 4
+                                       Rows Removed by Filter: 2
                            ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 2
+                                       Rows Removed by Filter: 1
                            ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk m2_3 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
-                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=2016 loops=1)
+                           ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk m2_4 (actual rows=504 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk m2_5 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=0 loops=1)
                                  ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
                                        Filter: (device_id = 2)
-                                       Rows Removed by Filter: 6
+                                       Rows Removed by Filter: 2
                            ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk m2_8 (actual rows=0 loops=1)
                                  Index Cond: (device_id = 2)
 (52 rows)
 
 -- test implicit self-join
-:PREFIX SELECT * FROM :TEST_TABLE m1, :TEST_TABLE m2 WHERE m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 20;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=20 loops=1)
    ->  Sort (actual rows=20 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
 -- test self-join with sub-query
-:PREFIX SELECT * FROM (SELECT * FROM :TEST_TABLE m1) m1 INNER JOIN (SELECT * FROM :TEST_TABLE m2) m2 ON m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id, m2.device_id
          Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=136800 loops=1)
+         ->  Hash Join (actual rows=34200 loops=1)
                Hash Cond: (m1."time" = m2."time")
-               ->  Append (actual rows=27360 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=4320 loops=1)
-                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=2016 loops=1)
-                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=6048 loops=1)
-                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=2016 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=2016 loops=1)
-                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=6048 loops=1)
-                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=2016 loops=1)
-               ->  Hash (actual rows=27360 loops=1)
-                     Buckets: 65536  Batches: 1 
-                     ->  Append (actual rows=27360 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=2 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=4320 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=1440 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=2 loops=1)
-                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=2016 loops=1)
-                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=6048 loops=1)
-                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=2016 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=2016 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=3 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=6048 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=9 loops=1)
-                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=2016 loops=1)
+               ->  Append (actual rows=6840 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_1 (actual rows=1080 loops=1)
+                           ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_2 (actual rows=360 loops=1)
+                           ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                     ->  Seq Scan on _hyper_2_7_chunk m1_3 (actual rows=504 loops=1)
+                     ->  Seq Scan on _hyper_2_8_chunk m1_4 (actual rows=1512 loops=1)
+                     ->  Seq Scan on _hyper_2_9_chunk m1_5 (actual rows=504 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_6 (actual rows=504 loops=1)
+                           ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
+                           ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Append (actual rows=6840 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_1 (actual rows=1080 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_2 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                           ->  Seq Scan on _hyper_2_7_chunk m2_3 (actual rows=504 loops=1)
+                           ->  Seq Scan on _hyper_2_8_chunk m2_4 (actual rows=1512 loops=1)
+                           ->  Seq Scan on _hyper_2_9_chunk m2_5 (actual rows=504 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_6 (actual rows=504 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (actual rows=1 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
+                           ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
 (38 rows)
 
-:PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time LIMIT 1) m1 ON true;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
                                                             QUERY PLAN                                                            
 ----------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -5505,10 +6482,9 @@ DROP VIEW compressed_view;
                Chunks excluded during runtime: 7
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (never executed)
                      Filter: ("time" = g."time")
                      ->  Seq Scan on compress_hyper_6_18_chunk (never executed)
@@ -5528,10 +6504,9 @@ DROP VIEW compressed_view;
                      Heap Fetches: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time"))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
                      Filter: ("time" = g."time")
                      ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
@@ -5539,11 +6514,19 @@ DROP VIEW compressed_view;
                ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
                      Index Cond: ("time" = g."time")
                      Heap Fetches: 0
-(41 rows)
+(39 rows)
 
 -- test prepared statement with params pushdown
-PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time AND device_id = $1 LIMIT 1) m1 ON true;
-:PREFIX EXECUTE param_prep(1);
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+:PREFIX EXECUTE param_prep (1);
                                                                  QUERY PLAN                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -5553,22 +6536,20 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                Chunks excluded during runtime: 2
                ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_1 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_2 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 1))
-                           Rows Removed by Filter: 0
                ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_time_idx on _hyper_2_7_chunk m1_3 (actual rows=1 loops=7)
                      Index Cond: ((device_id = 1) AND ("time" = g."time"))
                      Heap Fetches: 7
-(20 rows)
+(18 rows)
 
-:PREFIX EXECUTE param_prep(2);
+:PREFIX EXECUTE param_prep (2);
                                                                  QUERY PLAN                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=19 loops=1)
@@ -5581,19 +6562,17 @@ PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamp
                      Heap Fetches: 7
                ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_2 (actual rows=1 loops=7)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 531
+                     Rows Removed by Filter: 240
                      ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=7)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 0
                ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_3 (actual rows=1 loops=5)
                      Filter: ("time" = g."time")
-                     Rows Removed by Filter: 472
+                     Rows Removed by Filter: 168
                      ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=5)
                            Filter: ((_ts_meta_min_3 <= g."time") AND (_ts_meta_max_3 >= g."time") AND (device_id = 2))
-                           Rows Removed by Filter: 0
-(20 rows)
+(18 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5617,7 +6596,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5641,7 +6620,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5665,7 +6644,7 @@ EXECUTE param_prep(1);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(2);
+EXECUTE param_prep (2);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5689,7 +6668,7 @@ EXECUTE param_prep(2);
  Wed Jan 19 00:00:00 2000 PST | Wed Jan 19 00:00:00 2000 PST
 (19 rows)
 
-EXECUTE param_prep(1);
+EXECUTE param_prep (1);
              time             |             time             
 ------------------------------+------------------------------
  Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
@@ -5716,10 +6695,20 @@ EXECUTE param_prep(1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket ('1d', time) AS time,
+    device_id,
+    avg(v1)
+FROM :TEST_TABLE
+WHERE device_id = 1
+GROUP BY 1,
+    2;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
-SELECT time FROM cagg_test ORDER BY time LIMIT 1;
+SELECT time
+FROM cagg_test
+ORDER BY time
+LIMIT 1;
              time             
 ------------------------------
  Fri Dec 31 16:00:00 1999 PST
@@ -5729,51 +6718,57 @@ DROP VIEW cagg_test CASCADE;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
-:PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
+SET enable_seqscan = FALSE;
+SET enable_bitmapscan = FALSE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = FALSE;
+SET enable_mergejoin = FALSE;
+:PREFIX
+SELECT *
+FROM metrics,
+    metrics_space
+WHERE metrics.time > metrics_space.time
+    AND metrics.device_id = metrics_space.device_id
+    AND metrics.time < metrics_space.time;
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
-   ->  Append (actual rows=27360 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=2 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=4320 loops=1)
-               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=6 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=2 loops=1)
-         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=2016 loops=1)
-         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=6048 loops=1)
-         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=2016 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=2016 loops=1)
-               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=3 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=6048 loops=1)
-               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=9 loops=1)
-         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=2016 loops=1)
-   ->  Append (actual rows=0 loops=27360)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=27360)
+   ->  Append (actual rows=6840 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+   ->  Append (actual rows=0 loops=6840)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
-               Rows Removed by Filter: 1440
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=2 loops=27360)
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
-         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=27360)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
                Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
                Filter: (_hyper_2_4_chunk.device_id = device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=27360)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
                Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
-               Rows Removed by Filter: 2016
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=3 loops=27360)
+               Rows Removed by Filter: 504
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
                      Index Cond: (device_id = _hyper_2_4_chunk.device_id)
 (30 rows)
 
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = true;
-set enable_mergejoin = true;
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = TRUE;
+SET enable_mergejoin = TRUE;
 ---end github issue 1558
 \ir include/transparent_decompression_ordered.sql
 -- This file and its contents are licensed under the Timescale License.
@@ -5811,19 +6806,19 @@ ORDER BY c.id;
 
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
 :PREFIX SELECT * FROM metrics_ordered ORDER BY time DESC LIMIT 10;
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Sort (actual rows=10 loops=1)
          Sort Key: _hyper_11_28_chunk."time" DESC
          Sort Method: top-N heapsort 
-         ->  Append (actual rows=27360 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=15 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=10080 loops=1)
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=15 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=7200 loops=1)
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=10 loops=1)
+         ->  Append (actual rows=6840 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=2520 loops=1)
+                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=1800 loops=1)
+                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=5 loops=1)
 (11 rows)
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
@@ -5839,60 +6834,60 @@ ORDER BY c.id;
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 15
+                           Rows Removed by Filter: 5
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
                ->  Sort (actual rows=0 loops=1)
                      Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
                      Sort Method: quicksort 
                      ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
                            Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 10
+                           Rows Removed by Filter: 5
 (24 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
-         ->  Merge Append (actual rows=27360 loops=1)
+         ->  Merge Append (actual rows=6840 loops=1)
                Sort Key: d.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk d (actual rows=7200 loops=1)
-                     ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=10 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk d_1 (actual rows=10080 loops=1)
-                     ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=15 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_2 (actual rows=10080 loops=1)
-                     ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=15 loops=1)
-         ->  Limit (actual rows=0 loops=27360)
-               ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=27360)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk d (actual rows=1800 loops=1)
+                     ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk d_1 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk d_2 (actual rows=2520 loops=1)
+                     ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=5 loops=1)
+         ->  Limit (actual rows=0 loops=6840)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=27360)
-                           ->  Sort (actual rows=0 loops=27360)
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
+                           ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=27360)
+                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 15
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=27360)
-                           ->  Sort (actual rows=0 loops=27360)
+                                       Rows Removed by Filter: 5
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
+                           ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=27360)
+                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 15
-                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=27360)
-                           ->  Sort (actual rows=0 loops=27360)
+                                       Rows Removed by Filter: 5
+                     ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
+                           ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
                                  Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=27360)
+                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 10
+                                       Rows Removed by Filter: 5
 (34 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
@@ -5961,10 +6956,10 @@ PREPARE tableoid_prep AS SELECT tableoid::regclass FROM :TEST_TABLE WHERE device
          ->  Sort (actual rows=1 loops=1)
                Sort Key: _hyper_1_1_chunk."time"
                Sort Method: top-N heapsort 
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=2 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=1 loops=1)
                            Filter: (device_id = 1)
-                           Rows Removed by Filter: 8
+                           Rows Removed by Filter: 4
          ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (never executed)
                Filter: (device_id = 1)
          ->  Sort (never executed)
@@ -7563,667 +8558,3 @@ EXPLAIN (costs off) SELECT * FROM metrics_space WHERE time > '2000-01-08' ORDER 
 SET enable_seqscan TO true;
 -- diff compressed and uncompressed results
 :DIFF_CMD
--- Testing Index Scan backwards ----
---want more than 1 segment in atleast 1 of the chunks
-CREATE TABLE metrics_ordered_idx(time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int);
-SELECT create_hypertable('metrics_ordered_idx','time', chunk_time_interval=>'2days'::interval);
-         create_hypertable         
------------------------------------
- (15,public,metrics_ordered_idx,t)
-(1 row)
-
-ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby='time ASC',timescaledb.compress_segmentby='device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_16_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_16_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT time, device_id, 0, device_id FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-15 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) ;
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz,'2018-01-20 11:55:00+0','10s') , 4, 5, generate_series(1,5,1) ;
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT now(), generate_series(4,7,1), 5, generate_series(1,5,1) ;
--- misisng values device_id = 7
-CREATE TABLE device_tbl(device_id int, descr text);
-INSERT into device_tbl select generate_series(1, 6,1), 'devicex';
-INSERT into device_tbl select  8, 'device8';
-analyze device_tbl;
--- table for joins ---
-create table nodetime( node int,
-     start_time timestamp ,
-     stop_time timestamp  );
-insert into nodetime values( 4, '2018-01-06 00:00'::timestamp, '2018-12-02 12:00'::timestamp);
--- run queries on uncompressed hypertable and store result
-\set PREFIX ''
-\set PREFIX_VERBOSE ''
-\set ECHO none
---compress all chunks for metrics_ordered_idx table --
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
-               compress_chunk               
---------------------------------------------
- _timescaledb_internal._hyper_15_1438_chunk
- _timescaledb_internal._hyper_15_1439_chunk
- _timescaledb_internal._hyper_15_1440_chunk
- _timescaledb_internal._hyper_15_1441_chunk
- _timescaledb_internal._hyper_15_1442_chunk
-(5 rows)
-
--- run queries on compressed hypertable and store result
-\set PREFIX ''
-\set PREFIX_VERBOSE ''
-\set ECHO none 
--- diff compressed and uncompressed results
-:DIFF_CMD_IDX
-\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
-\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
--- we disable parallelism here otherwise EXPLAIN ANALYZE output
--- will be not stable and differ depending on worker assignment
-SET max_parallel_workers_per_gather TO 0;
-set enable_seqscan = false;
--- get explain for queries on hypertable with compression
-\ir include/transparent_decompression_ordered_indexplan.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
--- tests for explain plan only --
----check index backward scans instead of seq scans ------------
-CREATE TABLE metrics_ordered_idx2(time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 int);
-SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2days'::interval);
-         create_hypertable          
-------------------------------------
- (17,public,metrics_ordered_idx2,t)
-(1 row)
-
-ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_18_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_18 USING BTREE(device_id, _ts_meta_sequence_num)
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_18_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_18 USING BTREE(device_id_peer, _ts_meta_sequence_num)
-INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx2'
-ORDER BY c.id;
-               compress_chunk               
---------------------------------------------
- _timescaledb_internal._hyper_17_1448_chunk
-(1 row)
-
---all queries have only prefix of compress_orderby in ORDER BY clause
--- should have ordered DecompressChunk path because segmentby columns have equality constraints
-:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
-         ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
-               Index Cond: (device_id = 3)
-               Filter: (device_id_peer = 3)
-(5 rows)
-
-:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=10 loops=1)
-         ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_i on compress_hyper_18_1449_chunk (actual rows=1 loops=1)
-               Index Cond: (device_id = 3)
-               Filter: (device_id_peer = 3)
-(5 rows)
-
-:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_17_1448_chunk."time" DESC, _hyper_17_1448_chunk.v0 DESC
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
-                     Index Cond: (device_id_peer = 3)
-                     Filter: (device_id = 3)
-(8 rows)
-
-:PREFIX SELECT d.device_id, m.time,  m.time
- FROM metrics_ordered_idx2 d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx2 m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                       QUERY PLAN                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=4291 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk d (actual rows=4291 loops=1)
-         ->  Index Scan using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk (actual rows=5 loops=1)
-   ->  Subquery Scan on m (actual rows=1 loops=4291)
-         Filter: (d.device_id_peer = m.device_id_peer)
-         ->  Limit (actual rows=1 loops=4291)
-               ->  Sort (actual rows=1 loops=4291)
-                     Sort Key: m_1."time" DESC
-                     Sort Method: top-N heapsort 
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=4291 loops=4291)
-                           ->  Custom Scan (DecompressChunk) on _hyper_17_1448_chunk m_2 (actual rows=4291 loops=4291)
-                                 ->  Index Scan Backward using compress_hyper_18_1449_chunk__compressed_hypertable_18_device_1 on compress_hyper_18_1449_chunk compress_hyper_18_1449_chunk_1 (actual rows=5 loops=4291)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-(14 rows)
-
-set enable_seqscan = false;
-\ir include/transparent_decompression_ordered_index.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
-SET work_mem TO '50MB';
----Lets test for index backward scans instead of seq scans ------------
--- for ordered append tests on compressed chunks we need a hypertable with time as compress_orderby column
--- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
-:PREFIX select * from ( SELECT * FROM metrics_ordered_idx ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: _hyper_15_1442_chunk."time", _hyper_15_1442_chunk.device_id, _hyper_15_1442_chunk.device_id_peer, _hyper_15_1442_chunk.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: _hyper_15_1442_chunk."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Append (actual rows=12907 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (actual rows=2880 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-(18 rows)
-
--- should have ordered DecompressChunk path because segmentby columns have equality constraints
-:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10) as q order by 1, 2, 3, 4;
-                                                                                QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
-               Order: metrics_ordered_idx."time" DESC
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=0 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=0 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=0 loops=1)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk (actual rows=10 loops=1)
-                     ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (never executed)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk (never executed)
-                     ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (never executed)
-                           Index Cond: (device_id = 3)
-                           Filter: (device_id_peer = 3)
-(26 rows)
-
-:PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                        QUERY PLAN                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Unique (actual rows=1 loops=1)
-   ->  Nested Loop (actual rows=4291 loops=1)
-         ->  Merge Append (actual rows=12907 loops=1)
-               Sort Key: d.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-                     ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-         ->  Subquery Scan on m (actual rows=0 loops=12907)
-               Filter: (d.device_id_peer = m.device_id_peer)
-               Rows Removed by Filter: 0
-               ->  Limit (actual rows=0 loops=12907)
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
-                           Order: m_1."time" DESC
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
-                                 ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
-                                 ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
-                                 ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                                       Rows Removed by Filter: 3
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
-                                 ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
-                                 ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-(41 rows)
-
-:PREFIX SELECT d.device_id, m.time,  m.time
-FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                     QUERY PLAN                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop (actual rows=4291 loops=1)
-   ->  Append (actual rows=12907 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk d (actual rows=1440 loops=1)
-               ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk d_1 (actual rows=2880 loops=1)
-               ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk d_2 (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_3 (actual rows=4291 loops=1)
-               ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_4 (actual rows=5 loops=1)
-               ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-   ->  Subquery Scan on m (actual rows=0 loops=12907)
-         Filter: (d.device_id_peer = m.device_id_peer)
-         Rows Removed by Filter: 0
-         ->  Limit (actual rows=0 loops=12907)
-               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=12907)
-                     Order: m_1."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=0 loops=12907)
-                           ->  Index Scan Backward using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=0 loops=12907)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=12907)
-                           ->  Index Scan Backward using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=0 loops=12907)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_4 (actual rows=0 loops=12907)
-                           ->  Index Scan Backward using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk compress_hyper_16_1445_chunk_1 (actual rows=0 loops=12907)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                                 Rows Removed by Filter: 3
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_5 (actual rows=0 loops=7752)
-                           ->  Index Scan Backward using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1444_chunk compress_hyper_16_1444_chunk_1 (actual rows=0 loops=7752)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m_6 (actual rows=0 loops=7752)
-                           ->  Index Scan Backward using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1443_chunk compress_hyper_16_1443_chunk_1 (actual rows=0 loops=7752)
-                                 Index Cond: (device_id_peer = 3)
-                                 Filter: (device_id = d.device_id)
-(39 rows)
-
---github issue 1558
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
-:PREFIX select device_id, count(*) from
-(select * from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time) as subq group by device_id;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate (actual rows=1 loops=1)
-   Group Key: mt.device_id
-   ->  Nested Loop (actual rows=4291 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
-         Rows Removed by Join Filter: 8616
-         ->  Merge Append (actual rows=12907 loops=1)
-               Sort Key: mt.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=1440 loops=1)
-                     ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=2880 loops=1)
-                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=12907)
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
-
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4291 loops=1)
-   Sort Key: mt."time"
-   Sort Method: quicksort 
-   ->  Nested Loop (actual rows=4291 loops=1)
-         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Append (actual rows=4291 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
-                     Rows Removed by Filter: 288
-                     ->  Index Scan using compress_hyper_16_1443_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1443_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
-                     Rows Removed by Filter: 576
-                     ->  Index Scan using compress_hyper_16_1444_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1444_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
-                     ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=0 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
-                     ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                           Index Cond: (device_id = nd.node)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=0 loops=1)
-                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
-                     Rows Removed by Filter: 1
-                     ->  Index Scan using compress_hyper_16_1447_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
-                           Index Cond: (device_id = nd.node)
-(29 rows)
-
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
-set enable_mergejoin = true;
-set enable_hashjoin = false;
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Sort (actual rows=4291 loops=1)
-   Sort Key: mt."time"
-   Sort Method: quicksort 
-   ->  Merge Join (actual rows=4291 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 865
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=12040 loops=1)
-               Sort Key: mt.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=12907 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=1440 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=2880 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-(25 rows)
-
-set enable_mergejoin = false;
-set enable_hashjoin = true;
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Sort (actual rows=4291 loops=1)
-   Sort Key: mt."time"
-   Sort Method: quicksort 
-   ->  Hash Join (actual rows=4291 loops=1)
-         Hash Cond: (mt.device_id = nd.node)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 865
-         ->  Append (actual rows=12907 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk mt (actual rows=1440 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk mt_1 (actual rows=2880 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk mt_2 (actual rows=4291 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk mt_3 (actual rows=4291 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
-
---enable all joins after the tests
-set enable_mergejoin = true;
-set enable_hashjoin = true;
- --end github issue 1558
-set enable_seqscan = true;
-\ir include/transparent_decompression_constraintaware.sql
--- This file and its contents are licensed under the Timescale License.
--- Please see the included NOTICE for copyright information and
--- LICENSE-TIMESCALE for a copy of the license.
---- TEST for constraint aware append  ------------
---should select only newly added chunk --
-set timescaledb.enable_chunk_append to false;
-:PREFIX select * from ( SELECT * FROM metrics_ordered_idx where time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: metrics_ordered_idx."time" DESC
-               Sort Method: top-N heapsort 
-               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
-                     Hypertable: metrics_ordered_idx
-                     Chunks left after exclusion: 2
-                     ->  Append (actual rows=4296 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=4291 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=5 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
-(19 rows)
-
--- DecompressChunk path because segmentby columns have equality constraints
-:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 4 AND device_id_peer = 5 and time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10) as q  order by 1, 2, 3, 4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=10 loops=1)
-   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
-   Sort Method: quicksort 
-   ->  Limit (actual rows=10 loops=1)
-         ->  Custom Scan (ConstraintAwareAppend) (actual rows=10 loops=1)
-               Hypertable: metrics_ordered_idx
-               Chunks left after exclusion: 2
-               ->  Merge Append (actual rows=10 loops=1)
-                     Sort Key: _hyper_15_1441_chunk."time" DESC
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk (actual rows=9 loops=1)
-                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_16_1446_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                     ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk (actual rows=1 loops=1)
-                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_16_1447_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
-
-:PREFIX SELECT m.device_id, d.v0, count(*)
-FROM metrics_ordered_idx d , metrics_ordered_idx m
-WHERE m.device_id = d.device_id AND m.device_id_peer = 5
-and m.time = d.time and m.time > '2002-01-01' and m.time < now()
-AND m.device_id_peer = d.device_id_peer
-group by m.device_id, d.v0 order by 1,2 ,3;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=9 loops=1)
-   Sort Key: m.device_id, d.v0, (count(*))
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=9 loops=1)
-         Group Key: m.device_id, d.v0
-         ->  Hash Join (actual rows=4295 loops=1)
-               Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
-               ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
-                     Hypertable: metrics_ordered_idx
-                     Chunks left after exclusion: 2
-                     ->  Append (actual rows=4296 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk d_1 (actual rows=4291 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=5 loops=1)
-                                       Filter: ((device_id_peer = 5) AND (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone))
-                           ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_2 (actual rows=5 loops=1)
-                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                 ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                                       Filter: ((device_id_peer = 5) AND (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone))
-               ->  Hash (actual rows=4295 loops=1)
-                     Buckets: 8192 (originally 2048)  Batches: 1 (originally 1) 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=4296 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks left after exclusion: 2
-                           ->  Append (actual rows=4296 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_1 (actual rows=4291 loops=1)
-                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                       ->  Seq Scan on compress_hyper_16_1446_chunk compress_hyper_16_1446_chunk_1 (actual rows=5 loops=1)
-                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_2 (actual rows=5 loops=1)
-                                       Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (actual rows=5 loops=1)
-                                             Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id_peer = 5))
-(33 rows)
-
---query with no results --
-:PREFIX SELECT m.device_id, d.v0, count(*) 
-FROM metrics_ordered_idx d , metrics_ordered_idx m 
-WHERE m.time = d.time and  m.time > now()
-group by m.device_id, d.v0 order by 1,2 ,3;
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=0 loops=1)
-   Sort Key: m.device_id, d.v0, (count(*))
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=0 loops=1)
-         Group Key: m.device_id, d.v0
-         ->  Merge Join (actual rows=0 loops=1)
-               Merge Cond: (d."time" = m."time")
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: d."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks left after exclusion: 1
-                           ->  Append (actual rows=0 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk d_1 (actual rows=0 loops=1)
-                                       Filter: ("time" > now())
-                                       Rows Removed by Filter: 5
-                                       ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-               ->  Sort (never executed)
-                     Sort Key: m."time"
-                     ->  Custom Scan (ConstraintAwareAppend) (never executed)
-                           Hypertable: metrics_ordered_idx
-                           Chunks left after exclusion: 1
-                           ->  Append (never executed)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_1 (never executed)
-                                       Filter: ("time" > now())
-                                       ->  Seq Scan on compress_hyper_16_1447_chunk compress_hyper_16_1447_chunk_1 (never executed)
-(27 rows)
-
---query with all chunks but 1 excluded at plan time --
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d, metrics_ordered_idx m 
-WHERE m.device_id = d.device_id 
-and m.time > '2019-01-01' and m.time < now()
-order by m.v0;
-                                                    QUERY PLAN                                                    
-------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=3 loops=1)
-   Sort Key: m.v0
-   Sort Method: quicksort 
-   ->  Hash Join (actual rows=3 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m (actual rows=5 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
-               ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (actual rows=7 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(12 rows)
-
--- no matches in metrics_ordered_idx but one row in device_tbl
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d LEFT OUTER JOIN  metrics_ordered_idx m 
-ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
-WHERE d.device_id = 8 
-order by m.v0;
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=1 loops=1)
-   Sort Key: m.v0
-   Sort Method: quicksort 
-   ->  Nested Loop Left Join (actual rows=1 loops=1)
-         Join Filter: (m.device_id = d.device_id)
-         ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
-               Filter: (device_id = 8)
-               Rows Removed by Filter: 6
-         ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < now()))
-               ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
-                     Rows Removed by Filter: 5
-(13 rows)
-
--- no matches in device_tbl but 1 row in metrics_ordered_idx
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d FULL OUTER JOIN  metrics_ordered_idx m 
-ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
-WHERE m.device_id = 7 
-order by m.v0;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=1 loops=1)
-   Sort Key: m.v0
-   Sort Method: quicksort 
-   ->  Hash Left Join (actual rows=1 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < now()))
-         ->  Append (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1438_chunk m (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1443_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1439_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1444_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1446_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
-               ->  Custom Scan (DecompressChunk) on _hyper_15_1442_chunk m_4 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_16_1447_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
-         ->  Hash (actual rows=0 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
-                     Filter: (device_id = 7)
-                     Rows Removed by Filter: 7
-(32 rows)
-
-set timescaledb.enable_chunk_append to true;

--- a/tsl/test/expected/transparent_decompression_ordered_index-11.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-11.out
@@ -1,0 +1,867 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set TEST_BASE_NAME transparent_decompression_ordered_index
+SELECT format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNCOMPRESSED",
+    format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_COMPRESSED" \gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
+-- Testing Index Scan backwards ----
+-- We want more than 1 segment in atleast 1 of the chunks
+CREATE TABLE metrics_ordered_idx (
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int
+);
+SELECT create_hypertable ('metrics_ordered_idx', 'time', chunk_time_interval => '2days'::interval);
+        create_hypertable         
+----------------------------------
+ (1,public,metrics_ordered_idx,t)
+(1 row)
+
+ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby = 'time ASC', timescaledb.compress_segmentby = 'device_id,device_id_peer');
+NOTICE:  adding index _compressed_hypertable_2_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id, _ts_meta_sequence_num)
+NOTICE:  adding index _compressed_hypertable_2_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id_peer, _ts_meta_sequence_num)
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT time,
+    device_id,
+    0,
+    device_id
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-15 23:55:00+0', '15m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz, '2000-01-20 11:55:00+0', '15m'),
+    3,
+    3,
+    generate_series(1, 5, 1);
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz, '2018-01-20 11:55:00+0', '15m'),
+    4,
+    5,
+    generate_series(1, 5, 1);
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT '2020-01-01 0:00:00+0',
+    generate_series(4, 7, 1),
+    5,
+    generate_series(1, 5, 1);
+-- misisng values device_id = 7
+CREATE TABLE device_tbl (
+    device_id int,
+    descr text
+);
+INSERT INTO device_tbl
+SELECT generate_series(1, 6, 1),
+    'devicex';
+INSERT INTO device_tbl
+SELECT 8,
+    'device8';
+ANALYZE device_tbl;
+-- table for joins ---
+CREATE TABLE nodetime (
+    node int,
+    start_time timestamp,
+    stop_time timestamp
+);
+INSERT INTO nodetime
+    VALUES (4, '2018-01-06 00:00'::timestamp, '2018-12-02 12:00'::timestamp);
+-- run queries on uncompressed hypertable and store result
+\set PREFIX ''
+\set PREFIX_VERBOSE ''
+\set ECHO none
+--compress all chunks for metrics_ordered_idx table --
+SELECT compress_chunk (c.schema_name || '.' || c.table_name)
+FROM _timescaledb_catalog.chunk c
+    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_ordered_idx'
+ORDER BY c.id;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+(5 rows)
+
+-- run queries on compressed hypertable and store result
+\set PREFIX ''
+\set PREFIX_VERBOSE ''
+\set ECHO none
+-- diff compressed and uncompressed results
+:DIFF_CMD
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+-- we disable parallelism here otherwise EXPLAIN ANALYZE output
+-- will be not stable and differ depending on worker assignment
+SET max_parallel_workers_per_gather TO 0;
+SET enable_seqscan = FALSE;
+-- get explain for queries on hypertable with compression
+\ir include/transparent_decompression_ordered_indexplan.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- tests for explain plan only --
+---check index backward scans instead of seq scans ------------
+CREATE TABLE metrics_ordered_idx2(time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 int);
+SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2days'::interval);
+         create_hypertable         
+-----------------------------------
+ (3,public,metrics_ordered_idx2,t)
+(1 row)
+
+ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
+psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id, _ts_meta_sequence_num)
+psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id_peer, _ts_meta_sequence_num)
+INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
+SELECT
+  compress_chunk(c.schema_name || '.' || c.table_name)
+FROM _timescaledb_catalog.chunk c
+  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
+WHERE ht.table_name = 'metrics_ordered_idx2'
+ORDER BY c.id;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_11_chunk
+(1 row)
+
+--all queries have only prefix of compress_orderby in ORDER BY clause
+-- should have ordered DecompressChunk path because segmentby columns have equality constraints
+:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
+         Order: metrics_ordered_idx2."time" DESC
+         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_12_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 3)
+                     Filter: (device_id_peer = 3)
+(7 rows)
+
+:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 (actual rows=10 loops=1)
+         Order: metrics_ordered_idx2."time" DESC, metrics_ordered_idx2.v0
+         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+               ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_12_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 3)
+                     Filter: (device_id_peer = 3)
+(7 rows)
+
+:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_3_11_chunk."time" DESC, _hyper_3_11_chunk.v0 DESC
+         Sort Method: top-N heapsort 
+         ->  Append (actual rows=4291 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=4291 loops=1)
+                     ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                           Index Cond: (device_id_peer = 3)
+                           Filter: (device_id = 3)
+(9 rows)
+
+:PREFIX SELECT d.device_id, m.time,  m.time
+ FROM metrics_ordered_idx2 d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx2 m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=4291 loops=1)
+   ->  Append (actual rows=4291 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk d (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+   ->  Subquery Scan on m (actual rows=1 loops=4291)
+         Filter: (d.device_id_peer = m.device_id_peer)
+         ->  Limit (actual rows=1 loops=4291)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
+                     Order: m_1."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=1 loops=4291)
+                           ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=1 loops=4291)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+(13 rows)
+
+SET enable_seqscan = FALSE;
+\ir include/transparent_decompression_ordered_index.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET work_mem TO '50MB';
+---Lets test for index backward scans instead of seq scans ------------
+-- for ordered append tests on compressed chunks we need a hypertable with time as compress_orderby column
+-- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device_id, _hyper_1_5_chunk.device_id_peer, _hyper_1_5_chunk.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Append (actual rows=1541 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=960 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=480 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+(18 rows)
+
+-- should have ordered DecompressChunk path because segmentby columns have equality constraints
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE device_id = 3
+        AND device_id_peer = 3
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
+               Order: metrics_ordered_idx."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (never executed)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (never executed)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (d.device_id)
+    *
+FROM metrics_ordered_idx d
+    INNER JOIN LATERAL (
+        SELECT *
+        FROM metrics_ordered_idx m
+        WHERE m.device_id = d.device_id
+            AND m.device_id_peer = 3
+        ORDER BY time DESC
+        LIMIT 1) m ON m.device_id_peer = d.device_id_peer
+WHERE extract(minute FROM d.time) = 0;
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=12 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=389 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 5
+               ->  Merge Append (actual rows=389 loops=1)
+                     Sort Key: d_1.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 360
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 720
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 36
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 36
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Subquery Scan on m (actual rows=0 loops=389)
+               Filter: (d.device_id_peer = m.device_id_peer)
+               Rows Removed by Filter: 0
+               ->  Limit (actual rows=0 loops=389)
+                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
+                           Order: m_1."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
+                                 ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_pe on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=389)
+                                 ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=389)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=389)
+                                 ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=389)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=305)
+                                 ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=305)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
+                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+(53 rows)
+
+:PREFIX
+SELECT d.device_id,
+    m.time,
+    m.time
+FROM metrics_ordered_idx d
+    INNER JOIN LATERAL (
+        SELECT *
+        FROM metrics_ordered_idx m
+        WHERE m.device_id = d.device_id
+            AND m.device_id_peer = 3
+        ORDER BY time DESC
+        LIMIT 1) m ON m.device_id_peer = d.device_id_peer
+WHERE extract(minute FROM d.time) = 0;
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=12 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx d (actual rows=389 loops=1)
+         Chunks excluded during startup: 0
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 720
+               ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 36
+               ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 36
+               ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_pe on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+   ->  Subquery Scan on m (actual rows=0 loops=389)
+         Filter: (d.device_id_peer = m.device_id_peer)
+         Rows Removed by Filter: 0
+         ->  Limit (actual rows=0 loops=389)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
+                     Order: m_1."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_pe on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=389)
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=389)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=389)
+                           ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=389)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                                 Rows Removed by Filter: 1
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=305)
+                           ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=305)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
+                           ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+(49 rows)
+
+--github issue 1558
+SET enable_seqscan = FALSE;
+SET enable_bitmapscan = FALSE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = FALSE;
+SET enable_mergejoin = FALSE;
+:PREFIX
+SELECT device_id,
+    count(*)
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx mt,
+        nodetime nd
+    WHERE mt.time > nd.start_time
+        AND mt.device_id = nd.node
+        AND mt.time < nd.stop_time) AS subq
+GROUP BY device_id;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: mt.device_id
+   ->  Nested Loop (actual rows=48 loops=1)
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Rows Removed by Join Filter: 1493
+         ->  Merge Append (actual rows=1541 loops=1)
+               Sort Key: mt.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Materialize (actual rows=1 loops=1541)
+               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+(19 rows)
+
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=48 loops=1)
+   Sort Key: mt."time"
+   Sort Method: quicksort 
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
+
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_mergejoin = TRUE;
+SET enable_hashjoin = FALSE;
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Sort (actual rows=48 loops=1)
+   Sort Key: mt."time"
+   Sort Method: quicksort 
+   ->  Merge Join (actual rows=48 loops=1)
+         Merge Cond: (nd.node = mt.device_id)
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Rows Removed by Join Filter: 289
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: nd.node
+               Sort Method: quicksort 
+               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Sort (actual rows=1250 loops=1)
+               Sort Key: mt.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=1541 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+(25 rows)
+
+SET enable_mergejoin = FALSE;
+SET enable_hashjoin = TRUE;
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Sort (actual rows=48 loops=1)
+   Sort Key: mt."time"
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=48 loops=1)
+         Hash Cond: (mt.device_id = nd.node)
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Rows Removed by Join Filter: 289
+         ->  Append (actual rows=1541 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
+                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 2048  Batches: 1 
+               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+(21 rows)
+
+--enable all joins after the tests
+SET enable_mergejoin = TRUE;
+SET enable_hashjoin = TRUE;
+--end github issue 1558
+SET enable_seqscan = TRUE;
+\ir include/transparent_decompression_constraintaware.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--- TEST for constraint aware append  ------------
+--should select only newly added chunk --
+SET timescaledb.enable_chunk_append TO FALSE;
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE time > '2002-01-01'
+        AND time < now()
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: metrics_ordered_idx."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=53 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 2
+                     ->  Append (actual rows=53 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=48 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
+
+-- DecompressChunk path because segmentby columns have equality constraints
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE device_id = 4
+        AND device_id_peer = 5
+        AND time > '2002-01-01'
+        AND time < now()
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=10 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 2
+               ->  Merge Append (actual rows=10 loops=1)
+                     Sort Key: _hyper_1_4_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                                       Rows Removed by Filter: 4
+(24 rows)
+
+:PREFIX
+SELECT m.device_id,
+    d.v0,
+    count(*)
+FROM metrics_ordered_idx d,
+    metrics_ordered_idx m
+WHERE m.device_id = d.device_id
+    AND m.device_id_peer = 5
+    AND m.time = d.time
+    AND m.time > '2002-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+    AND m.device_id_peer = d.device_id_peer
+GROUP BY m.device_id,
+    d.v0
+ORDER BY 1,
+    2,
+    3;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Hash Join (actual rows=0 loops=1)
+               Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 0
+               ->  Hash (never executed)
+                     ->  Custom Scan (ConstraintAwareAppend) (never executed)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 0
+(14 rows)
+
+--query with no results --
+:PREFIX
+SELECT m.device_id,
+    d.v0,
+    count(*)
+FROM metrics_ordered_idx d,
+    metrics_ordered_idx m
+WHERE m.time = d.time
+    AND m.time > '2000-01-01 0:00:00+0'::text::timestamptz
+GROUP BY m.device_id,
+    d.v0
+ORDER BY 1,
+    2,
+    3;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=42 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=42 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Merge Join (actual rows=7321 loops=1)
+               Merge Cond: (d."time" = m."time")
+               ->  Sort (actual rows=1541 loops=1)
+                     Sort Key: d."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 5
+                           ->  Append (actual rows=1541 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+               ->  Sort (actual rows=7317 loops=1)
+                     Sort Key: m."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 5
+                           ->  Append (actual rows=1541 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
+(51 rows)
+
+--query with all chunks but 1 excluded at plan time --
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d,
+    metrics_ordered_idx m
+WHERE m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+ORDER BY m.v0;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=0 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         ->  Append (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+                     Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+                     Rows Removed by Filter: 5
+                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                           Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+         ->  Hash (never executed)
+               ->  Seq Scan on device_tbl d (never executed)
+(13 rows)
+
+-- no matches in metrics_ordered_idx but one row in device_tbl
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d
+    LEFT OUTER JOIN metrics_ordered_idx m ON m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+WHERE d.device_id = 8
+ORDER BY m.v0;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Nested Loop Left Join (actual rows=1 loops=1)
+         Join Filter: (m.device_id = d.device_id)
+         ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
+               Filter: (device_id = 8)
+               Rows Removed by Filter: 6
+         ->  Append (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+                     Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                           Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                           Rows Removed by Filter: 5
+(14 rows)
+
+-- no matches in device_tbl but 1 row in metrics_ordered_idx
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d
+    FULL OUTER JOIN metrics_ordered_idx m ON m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+WHERE m.device_id = 7
+ORDER BY m.v0;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Left Join (actual rows=1 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+         ->  Append (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_1 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 4
+         ->  Hash (actual rows=0 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
+                     Filter: (device_id = 7)
+                     Rows Removed by Filter: 7
+(32 rows)
+
+SET timescaledb.enable_chunk_append TO TRUE;

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -1,0 +1,861 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set TEST_BASE_NAME transparent_decompression_ordered_index
+SELECT format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNCOMPRESSED",
+    format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_COMPRESSED" \gset
+SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
+-- Testing Index Scan backwards ----
+-- We want more than 1 segment in atleast 1 of the chunks
+CREATE TABLE metrics_ordered_idx (
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int
+);
+SELECT create_hypertable ('metrics_ordered_idx', 'time', chunk_time_interval => '2days'::interval);
+        create_hypertable         
+----------------------------------
+ (1,public,metrics_ordered_idx,t)
+(1 row)
+
+ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby = 'time ASC', timescaledb.compress_segmentby = 'device_id,device_id_peer');
+NOTICE:  adding index _compressed_hypertable_2_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id, _ts_meta_sequence_num)
+NOTICE:  adding index _compressed_hypertable_2_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id_peer, _ts_meta_sequence_num)
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT time,
+    device_id,
+    0,
+    device_id
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-15 23:55:00+0', '15m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz, '2000-01-20 11:55:00+0', '15m'),
+    3,
+    3,
+    generate_series(1, 5, 1);
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz, '2018-01-20 11:55:00+0', '15m'),
+    4,
+    5,
+    generate_series(1, 5, 1);
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT '2020-01-01 0:00:00+0',
+    generate_series(4, 7, 1),
+    5,
+    generate_series(1, 5, 1);
+-- misisng values device_id = 7
+CREATE TABLE device_tbl (
+    device_id int,
+    descr text
+);
+INSERT INTO device_tbl
+SELECT generate_series(1, 6, 1),
+    'devicex';
+INSERT INTO device_tbl
+SELECT 8,
+    'device8';
+ANALYZE device_tbl;
+-- table for joins ---
+CREATE TABLE nodetime (
+    node int,
+    start_time timestamp,
+    stop_time timestamp
+);
+INSERT INTO nodetime
+    VALUES (4, '2018-01-06 00:00'::timestamp, '2018-12-02 12:00'::timestamp);
+-- run queries on uncompressed hypertable and store result
+\set PREFIX ''
+\set PREFIX_VERBOSE ''
+\set ECHO none
+--compress all chunks for metrics_ordered_idx table --
+SELECT compress_chunk (c.schema_name || '.' || c.table_name)
+FROM _timescaledb_catalog.chunk c
+    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_ordered_idx'
+ORDER BY c.id;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+(5 rows)
+
+-- run queries on compressed hypertable and store result
+\set PREFIX ''
+\set PREFIX_VERBOSE ''
+\set ECHO none
+-- diff compressed and uncompressed results
+:DIFF_CMD
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+-- we disable parallelism here otherwise EXPLAIN ANALYZE output
+-- will be not stable and differ depending on worker assignment
+SET max_parallel_workers_per_gather TO 0;
+SET enable_seqscan = FALSE;
+-- get explain for queries on hypertable with compression
+\ir include/transparent_decompression_ordered_indexplan.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- tests for explain plan only --
+---check index backward scans instead of seq scans ------------
+CREATE TABLE metrics_ordered_idx2(time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 int);
+SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2days'::interval);
+         create_hypertable         
+-----------------------------------
+ (3,public,metrics_ordered_idx2,t)
+(1 row)
+
+ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
+psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id, _ts_meta_sequence_num)
+psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id_peer, _ts_meta_sequence_num)
+INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
+SELECT
+  compress_chunk(c.schema_name || '.' || c.table_name)
+FROM _timescaledb_catalog.chunk c
+  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
+WHERE ht.table_name = 'metrics_ordered_idx2'
+ORDER BY c.id;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_11_chunk
+(1 row)
+
+--all queries have only prefix of compress_orderby in ORDER BY clause
+-- should have ordered DecompressChunk path because segmentby columns have equality constraints
+:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_12_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 3)
+               Filter: (device_id_peer = 3)
+(5 rows)
+
+:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 asc LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_12_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 3)
+               Filter: (device_id_peer = 3)
+(5 rows)
+
+:PREFIX SELECT * FROM metrics_ordered_idx2 WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC , v0 desc LIMIT 10;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_3_11_chunk."time" DESC, _hyper_3_11_chunk.v0 DESC
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk (actual rows=4291 loops=1)
+               ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+                     Index Cond: (device_id_peer = 3)
+                     Filter: (device_id = 3)
+(8 rows)
+
+:PREFIX SELECT d.device_id, m.time,  m.time
+ FROM metrics_ordered_idx2 d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx2 m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=4291 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk d (actual rows=4291 loops=1)
+         ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk (actual rows=5 loops=1)
+   ->  Subquery Scan on m (actual rows=1 loops=4291)
+         Filter: (d.device_id_peer = m.device_id_peer)
+         ->  Limit (actual rows=1 loops=4291)
+               ->  Sort (actual rows=1 loops=4291)
+                     Sort Key: m_1."time" DESC
+                     Sort Method: top-N heapsort 
+                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=4291 loops=4291)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=4291 loops=4291)
+                                 ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=5 loops=4291)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+(14 rows)
+
+SET enable_seqscan = FALSE;
+\ir include/transparent_decompression_ordered_index.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET work_mem TO '50MB';
+---Lets test for index backward scans instead of seq scans ------------
+-- for ordered append tests on compressed chunks we need a hypertable with time as compress_orderby column
+-- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: _hyper_1_5_chunk."time", _hyper_1_5_chunk.device_id, _hyper_1_5_chunk.device_id_peer, _hyper_1_5_chunk.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: _hyper_1_5_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Append (actual rows=1541 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (actual rows=960 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=480 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+(18 rows)
+
+-- should have ordered DecompressChunk path because segmentby columns have equality constraints
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE device_id = 3
+        AND device_id_peer = 3
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Custom Scan (ChunkAppend) on metrics_ordered_idx (actual rows=10 loops=1)
+               Order: metrics_ordered_idx."time" DESC
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=10 loops=1)
+                     ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (never executed)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (never executed)
+                     ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (never executed)
+                           Index Cond: (device_id = 3)
+                           Filter: (device_id_peer = 3)
+(26 rows)
+
+:PREFIX SELECT DISTINCT ON (d.device_id)
+    *
+FROM metrics_ordered_idx d
+    INNER JOIN LATERAL (
+        SELECT *
+        FROM metrics_ordered_idx m
+        WHERE m.device_id = d.device_id
+            AND m.device_id_peer = 3
+        ORDER BY time DESC
+        LIMIT 1) m ON m.device_id_peer = d.device_id_peer
+WHERE extract(minute FROM d.time) = 0;
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=12 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=389 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 5
+               ->  Merge Append (actual rows=389 loops=1)
+                     Sort Key: d_1.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 360
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 720
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 36
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           Rows Removed by Filter: 36
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                           Filter: (date_part('minute'::text, "time") = '0'::double precision)
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Subquery Scan on m (actual rows=0 loops=389)
+               Filter: (d.device_id_peer = m.device_id_peer)
+               Rows Removed by Filter: 0
+               ->  Limit (actual rows=0 loops=389)
+                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
+                           Order: m_1."time" DESC
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
+                                 ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_pe on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=389)
+                                 ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=389)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=389)
+                                 ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=389)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                                       Rows Removed by Filter: 1
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=305)
+                                 ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=305)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
+                                 ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
+                                       Index Cond: (device_id_peer = 3)
+                                       Filter: (device_id = d.device_id)
+(53 rows)
+
+:PREFIX
+SELECT d.device_id,
+    m.time,
+    m.time
+FROM metrics_ordered_idx d
+    INNER JOIN LATERAL (
+        SELECT *
+        FROM metrics_ordered_idx m
+        WHERE m.device_id = d.device_id
+            AND m.device_id_peer = 3
+        ORDER BY time DESC
+        LIMIT 1) m ON m.device_id_peer = d.device_id_peer
+WHERE extract(minute FROM d.time) = 0;
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=12 loops=1)
+   ->  Custom Scan (ChunkAppend) on metrics_ordered_idx d (actual rows=389 loops=1)
+         Chunks excluded during startup: 0
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=120 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=240 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 720
+               ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=12 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 36
+               ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=12 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               Rows Removed by Filter: 36
+               ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+               Filter: (date_part('minute'::text, "time") = '0'::double precision)
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_pe on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+   ->  Subquery Scan on m (actual rows=0 loops=389)
+         Filter: (d.device_id_peer = m.device_id_peer)
+         Rows Removed by Filter: 0
+         ->  Limit (actual rows=0 loops=389)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
+                     Order: m_1."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_pe on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=389)
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=0 loops=389)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_4 (actual rows=0 loops=389)
+                           ->  Index Scan Backward using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=0 loops=389)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                                 Rows Removed by Filter: 1
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_5 (actual rows=0 loops=305)
+                           ->  Index Scan Backward using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=0 loops=305)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
+                           ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+(49 rows)
+
+--github issue 1558
+SET enable_seqscan = FALSE;
+SET enable_bitmapscan = FALSE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_hashjoin = FALSE;
+SET enable_mergejoin = FALSE;
+:PREFIX
+SELECT device_id,
+    count(*)
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx mt,
+        nodetime nd
+    WHERE mt.time > nd.start_time
+        AND mt.device_id = nd.node
+        AND mt.time < nd.stop_time) AS subq
+GROUP BY device_id;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate (actual rows=1 loops=1)
+   Group Key: mt.device_id
+   ->  Nested Loop (actual rows=48 loops=1)
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
+         Rows Removed by Join Filter: 1493
+         ->  Merge Append (actual rows=1541 loops=1)
+               Sort Key: mt.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Materialize (actual rows=1 loops=1541)
+               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+(19 rows)
+
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=48 loops=1)
+   Sort Key: mt."time"
+   Sort Method: quicksort 
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
+
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET enable_seqscan = TRUE;
+SET enable_bitmapscan = TRUE;
+SET max_parallel_workers_per_gather = 0;
+SET enable_mergejoin = TRUE;
+SET enable_hashjoin = FALSE;
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Sort (actual rows=48 loops=1)
+   Sort Key: mt."time"
+   Sort Method: quicksort 
+   ->  Merge Join (actual rows=48 loops=1)
+         Merge Cond: (nd.node = mt.device_id)
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Rows Removed by Join Filter: 289
+         ->  Sort (actual rows=1 loops=1)
+               Sort Key: nd.node
+               Sort Method: quicksort 
+               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Sort (actual rows=1250 loops=1)
+               Sort Key: mt.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=1541 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
+                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
+                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
+                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+(25 rows)
+
+SET enable_mergejoin = FALSE;
+SET enable_hashjoin = TRUE;
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Sort (actual rows=48 loops=1)
+   Sort Key: mt."time"
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=48 loops=1)
+         Hash Cond: (mt.device_id = nd.node)
+         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
+         Rows Removed by Join Filter: 289
+         ->  Append (actual rows=1541 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
+                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
+                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 2048  Batches: 1 
+               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+(21 rows)
+
+--enable all joins after the tests
+SET enable_mergejoin = TRUE;
+SET enable_hashjoin = TRUE;
+--end github issue 1558
+SET enable_seqscan = TRUE;
+\ir include/transparent_decompression_constraintaware.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--- TEST for constraint aware append  ------------
+--should select only newly added chunk --
+SET timescaledb.enable_chunk_append TO FALSE;
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE time > '2002-01-01'
+        AND time < now()
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: metrics_ordered_idx."time" DESC
+               Sort Method: top-N heapsort 
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=53 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 2
+                     ->  Append (actual rows=53 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=48 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=5 loops=1)
+                                 Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                                       Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
+
+-- DecompressChunk path because segmentby columns have equality constraints
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE device_id = 4
+        AND device_id_peer = 5
+        AND time > '2002-01-01'
+        AND time < now()
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
+                                                                                QUERY PLAN                                                                                
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10 loops=1)
+   Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
+   Sort Method: quicksort 
+   ->  Limit (actual rows=10 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=10 loops=1)
+               Hypertable: metrics_ordered_idx
+               Chunks left after exclusion: 2
+               ->  Merge Append (actual rows=10 loops=1)
+                     Sort Key: _hyper_1_4_chunk."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
+                           Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
+                                 Sort Method: quicksort 
+                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                                       Rows Removed by Filter: 4
+(24 rows)
+
+:PREFIX
+SELECT m.device_id,
+    d.v0,
+    count(*)
+FROM metrics_ordered_idx d,
+    metrics_ordered_idx m
+WHERE m.device_id = d.device_id
+    AND m.device_id_peer = 5
+    AND m.time = d.time
+    AND m.time > '2002-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+    AND m.device_id_peer = d.device_id_peer
+GROUP BY m.device_id,
+    d.v0
+ORDER BY 1,
+    2,
+    3;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=0 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Hash Join (actual rows=0 loops=1)
+               Hash Cond: ((d.device_id = m.device_id) AND (d."time" = m."time"))
+               ->  Custom Scan (ConstraintAwareAppend) (actual rows=0 loops=1)
+                     Hypertable: metrics_ordered_idx
+                     Chunks left after exclusion: 0
+               ->  Hash (never executed)
+                     ->  Custom Scan (ConstraintAwareAppend) (never executed)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 0
+(14 rows)
+
+--query with no results --
+:PREFIX
+SELECT m.device_id,
+    d.v0,
+    count(*)
+FROM metrics_ordered_idx d,
+    metrics_ordered_idx m
+WHERE m.time = d.time
+    AND m.time > '2000-01-01 0:00:00+0'::text::timestamptz
+GROUP BY m.device_id,
+    d.v0
+ORDER BY 1,
+    2,
+    3;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=42 loops=1)
+   Sort Key: m.device_id, d.v0, (count(*))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=42 loops=1)
+         Group Key: m.device_id, d.v0
+         ->  Merge Join (actual rows=7321 loops=1)
+               Merge Cond: (d."time" = m."time")
+               ->  Sort (actual rows=1541 loops=1)
+                     Sort Key: d."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 5
+                           ->  Append (actual rows=1541 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk d_1 (actual rows=480 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk d_2 (actual rows=960 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk d_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk d_4 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+               ->  Sort (actual rows=7317 loops=1)
+                     Sort Key: m."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                           Hypertable: metrics_ordered_idx
+                           Chunks left after exclusion: 5
+                           ->  Append (actual rows=1541 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                       ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
+(51 rows)
+
+--query with all chunks but 1 excluded at plan time --
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d,
+    metrics_ordered_idx m
+WHERE m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+ORDER BY m.v0;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Join (actual rows=0 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               Rows Removed by Filter: 5
+               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
+         ->  Hash (never executed)
+               ->  Seq Scan on device_tbl d (never executed)
+(12 rows)
+
+-- no matches in metrics_ordered_idx but one row in device_tbl
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d
+    LEFT OUTER JOIN metrics_ordered_idx m ON m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+WHERE d.device_id = 8
+ORDER BY m.v0;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Nested Loop Left Join (actual rows=1 loops=1)
+         Join Filter: (m.device_id = d.device_id)
+         ->  Seq Scan on device_tbl d (actual rows=1 loops=1)
+               Filter: (device_id = 8)
+               Rows Removed by Filter: 6
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
+                     Rows Removed by Filter: 5
+(13 rows)
+
+-- no matches in device_tbl but 1 row in metrics_ordered_idx
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d
+    FULL OUTER JOIN metrics_ordered_idx m ON m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+WHERE m.device_id = 7
+ORDER BY m.v0;
+                                                                                QUERY PLAN                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: m.v0
+   Sort Method: quicksort 
+   ->  Hash Left Join (actual rows=1 loops=1)
+         Hash Cond: (m.device_id = d.device_id)
+         Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+         ->  Append (actual rows=1 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_1 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 5
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=1 loops=1)
+                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = 7)
+                           Rows Removed by Filter: 4
+         ->  Hash (actual rows=0 loops=1)
+               Buckets: 1024  Batches: 1 
+               ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
+                     Filter: (device_id = 7)
+                     Rows Removed by Filter: 7
+(32 rows)
+
+SET timescaledb.enable_chunk_append TO TRUE;

--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -4,6 +4,7 @@
 /continuous_aggs_union_view-*.sql
 /plan_gapfill-*.sql
 /transparent_decompression-*.sql
+/transparent_decompression_ordered_index-*.sql
 /compression_permissions-*.sql
 /compression_qualpushdown-*.sql
 /hypertable_distributed-*.sql

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TEST_TEMPLATES
   move.sql.in
   reorder.sql.in
   transparent_decompression.sql.in
+  transparent_decompression_ordered_index.sql.in
 )
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/tsl/test/sql/include/transparent_decompression_constraintaware.sql
+++ b/tsl/test/sql/include/transparent_decompression_constraintaware.sql
@@ -4,45 +4,105 @@
 
 --- TEST for constraint aware append  ------------
 --should select only newly added chunk --
-set timescaledb.enable_chunk_append to false;
-:PREFIX select * from ( SELECT * FROM metrics_ordered_idx where time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
+
+SET timescaledb.enable_chunk_append TO FALSE;
+
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE time > '2002-01-01'
+        AND time < now()
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
 
 -- DecompressChunk path because segmentby columns have equality constraints
-:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 4 AND device_id_peer = 5 and time > '2002-01-01' and time < now() ORDER BY time DESC LIMIT 10) as q  order by 1, 2, 3, 4;
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE device_id = 4
+        AND device_id_peer = 5
+        AND time > '2002-01-01'
+        AND time < now()
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
 
-:PREFIX SELECT m.device_id, d.v0, count(*)
-FROM metrics_ordered_idx d , metrics_ordered_idx m
-WHERE m.device_id = d.device_id AND m.device_id_peer = 5
-and m.time = d.time and m.time > '2002-01-01' and m.time < now()
-AND m.device_id_peer = d.device_id_peer
-group by m.device_id, d.v0 order by 1,2 ,3;
+:PREFIX
+SELECT m.device_id,
+    d.v0,
+    count(*)
+FROM metrics_ordered_idx d,
+    metrics_ordered_idx m
+WHERE m.device_id = d.device_id
+    AND m.device_id_peer = 5
+    AND m.time = d.time
+    AND m.time > '2002-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+    AND m.device_id_peer = d.device_id_peer
+GROUP BY m.device_id,
+    d.v0
+ORDER BY 1,
+    2,
+    3;
 
 --query with no results --
-:PREFIX SELECT m.device_id, d.v0, count(*) 
-FROM metrics_ordered_idx d , metrics_ordered_idx m 
-WHERE m.time = d.time and  m.time > now()
-group by m.device_id, d.v0 order by 1,2 ,3;
+:PREFIX
+SELECT m.device_id,
+    d.v0,
+    count(*)
+FROM metrics_ordered_idx d,
+    metrics_ordered_idx m
+WHERE m.time = d.time
+    AND m.time > '2000-01-01 0:00:00+0'::text::timestamptz
+GROUP BY m.device_id,
+    d.v0
+ORDER BY 1,
+    2,
+    3;
 
 --query with all chunks but 1 excluded at plan time --
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d, metrics_ordered_idx m 
-WHERE m.device_id = d.device_id 
-and m.time > '2019-01-01' and m.time < now()
-order by m.v0;
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d,
+    metrics_ordered_idx m
+WHERE m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+ORDER BY m.v0;
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d LEFT OUTER JOIN  metrics_ordered_idx m 
-ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
-WHERE d.device_id = 8 
-order by m.v0;
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d
+    LEFT OUTER JOIN metrics_ordered_idx m ON m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+WHERE d.device_id = 8
+ORDER BY m.v0;
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
-:PREFIX SELECT d.*, m.* 
-FROM device_tbl d FULL OUTER JOIN  metrics_ordered_idx m 
-ON m.device_id = d.device_id and m.time > '2019-01-01' and m.time < now()
-WHERE m.device_id = 7 
-order by m.v0;
+:PREFIX
+SELECT d.*,
+    m.*
+FROM device_tbl d
+    FULL OUTER JOIN metrics_ordered_idx m ON m.device_id = d.device_id
+    AND m.time > '2019-01-01'
+    AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
+WHERE m.device_id = 7
+ORDER BY m.v0;
 
+SET timescaledb.enable_chunk_append TO TRUE;
 
-set timescaledb.enable_chunk_append to true;

--- a/tsl/test/sql/include/transparent_decompression_ordered_index.sql
+++ b/tsl/test/sql/include/transparent_decompression_ordered_index.sql
@@ -6,48 +6,135 @@ SET work_mem TO '50MB';
 
 ---Lets test for index backward scans instead of seq scans ------------
 -- for ordered append tests on compressed chunks we need a hypertable with time as compress_orderby column
-
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
-:PREFIX select * from ( SELECT * FROM metrics_ordered_idx ORDER BY time DESC LIMIT 10 ) as q  order by 1,2,3,4;
+
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
-:PREFIX select * from (SELECT * FROM metrics_ordered_idx WHERE device_id = 3 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10) as q order by 1, 2, 3, 4;
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx
+    WHERE device_id = 3
+        AND device_id_peer = 3
+    ORDER BY time DESC
+    LIMIT 10) AS q
+ORDER BY 1,
+    2,
+    3,
+    4;
 
-:PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-:PREFIX SELECT d.device_id, m.time,  m.time
-FROM metrics_ordered_idx d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
+:PREFIX SELECT DISTINCT ON (d.device_id)
+    *
+FROM metrics_ordered_idx d
+    INNER JOIN LATERAL (
+        SELECT *
+        FROM metrics_ordered_idx m
+        WHERE m.device_id = d.device_id
+            AND m.device_id_peer = 3
+        ORDER BY time DESC
+        LIMIT 1) m ON m.device_id_peer = d.device_id_peer
+WHERE extract(minute FROM d.time) = 0;
+
+:PREFIX
+SELECT d.device_id,
+    m.time,
+    m.time
+FROM metrics_ordered_idx d
+    INNER JOIN LATERAL (
+        SELECT *
+        FROM metrics_ordered_idx m
+        WHERE m.device_id = d.device_id
+            AND m.device_id_peer = 3
+        ORDER BY time DESC
+        LIMIT 1) m ON m.device_id_peer = d.device_id_peer
+WHERE extract(minute FROM d.time) = 0;
 
 --github issue 1558
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
+SET enable_seqscan = FALSE;
 
-:PREFIX select device_id, count(*) from
-(select * from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time) as subq group by device_id;
+SET enable_bitmapscan = FALSE;
 
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
+SET max_parallel_workers_per_gather = 0;
 
-set enable_mergejoin = true;
-set enable_hashjoin = false;
+SET enable_hashjoin = FALSE;
 
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
+SET enable_mergejoin = FALSE;
 
-set enable_mergejoin = false;
-set enable_hashjoin = true;
-:PREFIX select nd.node, mt.* from metrics_ordered_idx mt, nodetime nd 
-where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
+:PREFIX
+SELECT device_id,
+    count(*)
+FROM (
+    SELECT *
+    FROM metrics_ordered_idx mt,
+        nodetime nd
+    WHERE mt.time > nd.start_time
+        AND mt.device_id = nd.node
+        AND mt.time < nd.stop_time) AS subq
+GROUP BY device_id;
+
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+
+SET enable_seqscan = TRUE;
+
+SET enable_bitmapscan = TRUE;
+
+SET enable_seqscan = TRUE;
+
+SET enable_bitmapscan = TRUE;
+
+SET max_parallel_workers_per_gather = 0;
+
+SET enable_mergejoin = TRUE;
+
+SET enable_hashjoin = FALSE;
+
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
+
+SET enable_mergejoin = FALSE;
+
+SET enable_hashjoin = TRUE;
+
+:PREFIX
+SELECT nd.node,
+    mt.*
+FROM metrics_ordered_idx mt,
+    nodetime nd
+WHERE mt.time > nd.start_time
+    AND mt.device_id = nd.node
+    AND mt.time < nd.stop_time
+ORDER BY time;
 
 --enable all joins after the tests
-set enable_mergejoin = true;
-set enable_hashjoin = true;
- --end github issue 1558
+SET enable_mergejoin = TRUE;
+
+SET enable_hashjoin = TRUE;
+
+--end github issue 1558

--- a/tsl/test/sql/include/transparent_decompression_query.sql
+++ b/tsl/test/sql/include/transparent_decompression_query.sql
@@ -2,305 +2,864 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
-
 -- this should use DecompressChunk node
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time
+LIMIT 5;
 
 -- test RECORD by itself
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time;
 
 -- test expressions
-:PREFIX SELECT
-  time_bucket('1d',time),
-  v1 + v2 AS "sum",
-  COALESCE(NULL,v1,v2) AS "coalesce",
-  NULL AS "NULL",
-  'text' AS "text",
-  :TEST_TABLE AS "RECORD"
-FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id;
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    :TEST_TABLE AS "RECORD"
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id;
 
 -- test empty targetlist
-:PREFIX SELECT FROM :TEST_TABLE;
+:PREFIX
+SELECT
+FROM :TEST_TABLE;
 
 -- test empty resultset
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < 0;
 
 -- test targetlist not referencing columns
-:PREFIX SELECT 1 FROM :TEST_TABLE;
+:PREFIX
+SELECT 1
+FROM :TEST_TABLE;
 
 -- test constraints not present in targetlist
-:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+:PREFIX
+SELECT v1
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
 
 -- test order not present in targetlist
-:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+:PREFIX
+SELECT v2
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY v1;
 
 -- test column with all NULL
-:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
+:PREFIX
+SELECT v3
+FROM :TEST_TABLE
+WHERE device_id = 1;
 
 --
 -- test qual pushdown
 --
-
 -- v3 is not segment by or order by column so should not be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE v3 > 10.0
+ORDER BY time,
+    device_id;
 
 -- device_id constraint should be pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 -- test IS NULL / IS NOT NULL
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NOT NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IS NULL
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 -- test IN (Const,Const)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1,2) ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id IN (1, 2)
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 -- test cast pushdown
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = '1'::text::int
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 --test var op var with two segment by
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = device_id_peer ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id_peer < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = device_id_peer
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 -- test expressions
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id =  1 + 4/2 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1 + 4 / 2
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 -- test function calls
 -- not yet pushed down
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(),1,3)) ORDER BY time, device_id LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = length(substring(version(), 1, 3))
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 --
 -- test segment meta pushdown
 --
-
 -- order by column and const
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time = '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time <= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time >= '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE '2000-01-01 1:00:00+0' < time
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 --pushdowns between order by and segment by columns
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < 1
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 < device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id < v0
+ORDER BY time,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v1 = device_id
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 --pushdown between two order by column (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE v0 = v1
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 --pushdown of quals on order by and segment by cols anded together
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' and device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    AND device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' or device_id = 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-01 1:00:00+0'
+    OR device_id = 1
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 --functions not yet optimized
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time < now()
+ORDER BY time,
+    device_id
+LIMIT 10;
 
 -- test sort optimization interaction
+:PREFIX
+SELECT time
+FROM :TEST_TABLE
+ORDER BY time DESC
+LIMIT 10;
 
-:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
-:PREFIX SELECT time,device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY time DESC,
+    device_id
+LIMIT 10;
+
+:PREFIX
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+ORDER BY device_id,
+    time DESC
+LIMIT 10;
 
 --
 -- test ordered path
 --
-
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
 
 -- should produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time;
 
 -- test order by columns not in targetlist
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time LIMIT 100;
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time
+LIMIT 100;
 
 -- test ordering only by segmentby columns
 -- should produce ordered path and not have sequence number in targetlist of compressed scan
-:PREFIX_VERBOSE SELECT device_id, device_id_peer FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer LIMIT 100;
+
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer
+LIMIT 100;
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0;
+
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0;
 
 -- should produce ordered path
 -- only referencing PREFIX_VERBOSE should work
-:PREFIX_VERBOSE SELECT device_id,device_id_peer,v0, v1 FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0, v1 desc;
+
+:PREFIX_VERBOSE
+SELECT device_id,
+    device_id_peer,
+    v0,
+    v1
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC;
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id,device_id_peer,v0,v1 desc,time,v3;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id,
+    device_id_peer,
+    v0,
+    v1 DESC,
+    time,
+    v3;
 
 -- should produce ordered path
 -- ASC/DESC for segmentby columns can be pushed down
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1 desc,time;
+
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1 DESC,
+    time;
 
 -- should not produce ordered path
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY device_id DESC,device_id_peer DESC,v0,v1,time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY device_id DESC,
+    device_id_peer DESC,
+    v0,
+    v1,
+    time;
 
 --
 -- test constraint exclusion
 --
-
 -- test plan time exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08' ORDER BY time, device_id;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'
+ORDER BY time,
+    device_id;
 
 -- test runtime exclusion
 -- first chunk should be excluded
-:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-08'::text::timestamptz ORDER BY time, device_id;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE
+WHERE time > '2000-01-08'::text::timestamptz
+ORDER BY time,
+    device_id;
 
 -- test aggregate
-:PREFIX SELECT count(*) FROM :TEST_TABLE;
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE;
 
 -- test aggregate with GROUP BY
-:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX
+SELECT count(*)
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
 
 -- test window functions with GROUP BY
-:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+:PREFIX
+SELECT sum(count(*)) OVER ()
+FROM :TEST_TABLE
+GROUP BY device_id
+ORDER BY device_id;
 
 -- test CTE
-:PREFIX WITH
-q AS (SELECT v1 FROM :TEST_TABLE ORDER BY time)
-SELECT * FROM q ORDER BY v1;
+:PREFIX WITH q AS (
+    SELECT v1
+    FROM :TEST_TABLE
+    ORDER BY time
+)
+SELECT *
+FROM q
+ORDER BY v1;
 
 -- test CTE join
-:PREFIX WITH
-q1 AS (SELECT time, v1 FROM :TEST_TABLE WHERE device_id=1 ORDER BY time),
-q2 AS (SELECT time, v2 FROM :TEST_TABLE WHERE device_id=2 ORDER BY time)
-SELECT * FROM q1 INNER JOIN q2 ON q1.time=q2.time ORDER BY q1.time;
+:PREFIX WITH q1 AS (
+    SELECT time,
+        v1
+    FROM :TEST_TABLE
+    WHERE device_id = 1
+    ORDER BY time
+),
+q2 AS (
+    SELECT time,
+        v2
+    FROM :TEST_TABLE
+    WHERE device_id = 2
+    ORDER BY time
+)
+SELECT *
+FROM q1
+    INNER JOIN q2 ON q1.time = q2.time
+ORDER BY q1.time;
 
 -- test prepared statement
-PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+PREPARE prep AS
+SELECT count(time)
+FROM :TEST_TABLE
+WHERE device_id = 1;
+
 :PREFIX EXECUTE prep;
+
 EXECUTE prep;
+
 EXECUTE prep;
+
 EXECUTE prep;
+
 EXECUTE prep;
+
 EXECUTE prep;
+
 EXECUTE prep;
+
 DEALLOCATE prep;
 
 --
 -- test indexes
 --
 
-SET enable_seqscan TO false;
+SET enable_seqscan TO FALSE;
 
 -- IndexScans should work
-:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT time,
+    device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
 
 -- globs should not plan IndexOnlyScans
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
 
 -- whole row reference should work
-:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE as test_table WHERE device_id = 1 ORDER BY device_id, time;
+:PREFIX_VERBOSE
+SELECT test_table
+FROM :TEST_TABLE AS test_table
+WHERE device_id = 1
+ORDER BY device_id,
+    time;
 
 -- even when we select only a segmentby column, we still need count
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+WHERE device_id = 1
+ORDER BY device_id;
 
-:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
+:PREFIX_VERBOSE
+SELECT count(*)
+FROM :TEST_TABLE
+WHERE device_id = 1;
 
 -- should be able to order using an index
-CREATE INDEX tmp_idx ON :TEST_TABLE(device_id);
+CREATE INDEX tmp_idx ON :TEST_TABLE (device_id);
 
-:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE ORDER BY device_id;
+:PREFIX_VERBOSE
+SELECT device_id
+FROM :TEST_TABLE
+ORDER BY device_id;
 
 DROP INDEX tmp_idx CASCADE;
 
 --use the peer index
-:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer, time;
+:PREFIX_VERBOSE
+SELECT *
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer,
+    time;
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer = 1 ORDER BY device_id_peer;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer = 1
+ORDER BY device_id_peer;
 
 --ensure that we can get a nested loop
-SET enable_seqscan TO true;
-SET enable_hashjoin TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1));
+SET enable_seqscan TO TRUE;
+
+SET enable_hashjoin TO FALSE;
+
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1));
 
 --with multiple values can get a nested loop.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id_peer IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id_peer IN (
+        VALUES (1),
+            (2));
 
 RESET enable_hashjoin;
 
-
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
 
 --with multiple values can get a semi-join or nested loop depending on seq_page_cost.
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
-SET seq_page_cost=100;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+
+SET seq_page_cost = 100;
+
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+
 RESET seq_page_cost;
 
 -- force a BitmapHeapScan
-SET enable_indexscan TO false;
-set enable_seqscan TO false;
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+SET enable_indexscan TO FALSE;
 
-:PREFIX_VERBOSE SELECT device_id_peer FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+SET enable_seqscan TO FALSE;
 
-SET enable_indexscan TO true;
-SET enable_seqscan TO true;
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1));
+
+:PREFIX_VERBOSE
+SELECT device_id_peer
+FROM :TEST_TABLE
+WHERE device_id IN (
+        VALUES (1),
+            (2));
+
+SET enable_indexscan TO TRUE;
+
+SET enable_seqscan TO TRUE;
 
 -- test view
-CREATE OR REPLACE ViEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
-:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+CREATE OR REPLACE VIEW compressed_view AS
+SELECT time,
+    device_id,
+    v1,
+    v2
+FROM :TEST_TABLE;
+
+:PREFIX
+SELECT *
+FROM compressed_view
+WHERE device_id = 1
+ORDER BY time DESC
+LIMIT 10;
+
 DROP VIEW compressed_view;
 
 -- test INNER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time AND m1.device_id=m2.device_id AND m3.device_id = 3 ORDER BY m1.time, m1.device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE m1 INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-:PREFIX SELECT * FROM metrics m1 INNER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
 
 -- test OUTER JOIN
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=m2.device_id ORDER BY m1.time, m1.device_id LIMIT 10;
-:PREFIX SELECT * FROM :TEST_TABLE m1 LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
-:PREFIX SELECT * FROM metrics m1 LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time AND m1.device_id=1 AND m2.device_id=2 ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 100;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+
+:PREFIX
+SELECT *
+FROM metrics m1
+    LEFT OUTER JOIN metrics_space m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
 
 -- test implicit self-join
-:PREFIX SELECT * FROM :TEST_TABLE m1, :TEST_TABLE m2 WHERE m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.time, m2.device_id LIMIT 20;
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
 
 -- test self-join with sub-query
-:PREFIX SELECT * FROM (SELECT * FROM :TEST_TABLE m1) m1 INNER JOIN (SELECT * FROM :TEST_TABLE m2) m2 ON m1.time = m2.time ORDER BY m1.time, m1.device_id, m2.device_id LIMIT 10;
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
 
-:PREFIX SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time LIMIT 1) m1 ON true;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
 
 -- test prepared statement with params pushdown
-PREPARE param_prep(int) AS SELECT * FROM generate_series('2000-01-01'::timestamptz,'2000-02-01'::timestamptz,'1d'::interval) g(time) INNER JOIN LATERAL(SELECT time FROM :TEST_TABLE m1 WHERE m1.time = g.time AND device_id = $1 LIMIT 1) m1 ON true;
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
 
-:PREFIX EXECUTE param_prep(1);
-:PREFIX EXECUTE param_prep(2);
-EXECUTE param_prep(1);
-EXECUTE param_prep(2);
-EXECUTE param_prep(1);
-EXECUTE param_prep(2);
-EXECUTE param_prep(1);
+:PREFIX EXECUTE param_prep (1);
+
+:PREFIX EXECUTE param_prep (2);
+
+EXECUTE param_prep (1);
+
+EXECUTE param_prep (2);
+
+EXECUTE param_prep (1);
+
+EXECUTE param_prep (2);
+
+EXECUTE param_prep (1);
+
 DEALLOCATE param_prep;
 
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS SELECT time_bucket('1d',time) AS time, device_id, avg(v1) FROM :TEST_TABLE WHERE device_id=1 GROUP BY 1,2;
+
+CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket ('1d', time) AS time,
+    device_id,
+    avg(v1)
+FROM :TEST_TABLE
+WHERE device_id = 1
+GROUP BY 1,
+    2;
+
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
+
 REFRESH MATERIALIZED VIEW cagg_test;
-SELECT time FROM cagg_test ORDER BY time LIMIT 1;
+
+SELECT time
+FROM cagg_test
+ORDER BY time
+LIMIT 1;
+
 DROP VIEW cagg_test CASCADE;
+
 RESET client_min_messages;
 
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
-set enable_seqscan = false;
-set enable_bitmapscan = false;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = false;
-set enable_mergejoin = false;
 
-:PREFIX select * from metrics, metrics_space where metrics.time > metrics_space.time and metrics.device_id = metrics_space.device_id and metrics.time < metrics_space.time;
-set enable_seqscan = true;
-set enable_bitmapscan = true;
-set max_parallel_workers_per_gather = 0;
-set enable_hashjoin = true;
-set enable_mergejoin = true;
+SET enable_seqscan = FALSE;
+
+SET enable_bitmapscan = FALSE;
+
+SET max_parallel_workers_per_gather = 0;
+
+SET enable_hashjoin = FALSE;
+
+SET enable_mergejoin = FALSE;
+
+:PREFIX
+SELECT *
+FROM metrics,
+    metrics_space
+WHERE metrics.time > metrics_space.time
+    AND metrics.device_id = metrics_space.device_id
+    AND metrics.time < metrics_space.time;
+
+SET enable_seqscan = TRUE;
+
+SET enable_bitmapscan = TRUE;
+
+SET max_parallel_workers_per_gather = 0;
+
+SET enable_hashjoin = TRUE;
+
+SET enable_mergejoin = TRUE;
 
 ---end github issue 1558

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -3,48 +3,141 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 \set TEST_BASE_NAME transparent_decompression
-SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
-       format('include/%s_query.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
-       format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED",
-       format('%s/results/%s_results_uncompressed_idx.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED_IDX",
-       format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESSED",
-       format('%s/results/%s_results_compressed_idx.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_COMPRESSED_IDX"
-\gset
-SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') as "DIFF_CMD"
-\gset
-SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED_IDX', :'TEST_RESULTS_COMPRESSED_IDX') as "DIFF_CMD_IDX"
-\gset
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNCOMPRESSED",
+    format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_COMPRESSED" \gset
+
+SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
 
 SET work_mem TO '50MB';
 
-CREATE TABLE metrics(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 int, v2 float, v3 float);
-SELECT create_hypertable('metrics','time');
+CREATE TABLE metrics (
+    filler_1 int,
+    filler_2 int,
+    filler_3 int,
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 int,
+    v2 float,
+    v3 float
+);
 
-ALTER TABLE metrics DROP COLUMN filler_1;
-INSERT INTO metrics(time,device_id, device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1,  device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics DROP COLUMN filler_2;
-INSERT INTO metrics(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id-1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics DROP COLUMN filler_3;
-INSERT INTO metrics(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT create_hypertable ('metrics', 'time');
+
+ALTER TABLE metrics
+    DROP COLUMN filler_1;
+
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+ALTER TABLE metrics
+    DROP COLUMN filler_2;
+
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id - 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-06 0:00:00+0'::timestamptz, '2000-01-12 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+ALTER TABLE metrics
+    DROP COLUMN filler_3;
+
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-19 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
 ANALYZE metrics;
 
 -- create identical hypertable with space partitioning
-CREATE TABLE metrics_space(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int, v1 float, v2 float, v3 float);
-SELECT create_hypertable('metrics_space','time','device_id',3);
+CREATE TABLE metrics_space (
+    filler_1 int,
+    filler_2 int,
+    filler_3 int,
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 float,
+    v2 float,
+    v3 float
+);
 
-ALTER TABLE metrics_space DROP COLUMN filler_1;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-01 0:00:00+0'::timestamptz,'2000-01-05 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics_space DROP COLUMN filler_2;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-06 0:00:00+0'::timestamptz,'2000-01-12 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-ALTER TABLE metrics_space DROP COLUMN filler_3;
-INSERT INTO metrics_space(time,device_id,device_id_peer,v0,v1,v2,v3) SELECT time, device_id, 0, device_id+1, device_id + 2, device_id + 0.5, NULL FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-19 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
+SELECT create_hypertable ('metrics_space', 'time', 'device_id', 3);
+
+ALTER TABLE metrics_space
+    DROP COLUMN filler_1;
+
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+ALTER TABLE metrics_space
+    DROP COLUMN filler_2;
+
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-06 0:00:00+0'::timestamptz, '2000-01-12 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+ALTER TABLE metrics_space
+    DROP COLUMN filler_3;
+
+INSERT INTO metrics_space (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-19 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
 ANALYZE metrics_space;
 
 -- run queries on uncompressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
+\set PREFIX_NO_ANALYZE ''
 \set ECHO none
 SET client_min_messages TO error;
+
 \o :TEST_RESULTS_UNCOMPRESSED
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
@@ -52,58 +145,73 @@ SET client_min_messages TO error;
 \ir :TEST_QUERY_NAME
 \o
 RESET client_min_messages;
-\set ECHO all
 
+\set ECHO all
 -- compress first and last chunk on the hypertable
-ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
-SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
-SELECT compress_chunk('_timescaledb_internal._hyper_1_3_chunk');
+ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
+
+SELECT compress_chunk ('_timescaledb_internal._hyper_1_1_chunk');
+
+SELECT compress_chunk ('_timescaledb_internal._hyper_1_3_chunk');
 
 -- compress some chunks on space partitioned hypertable
 -- we compress all chunks of first time slice, none of second, and 2 of the last time slice
-ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby='v0, v1 desc, time', timescaledb.compress_segmentby='device_id,device_id_peer');
-SELECT compress_chunk('_timescaledb_internal._hyper_2_4_chunk');
-SELECT compress_chunk('_timescaledb_internal._hyper_2_5_chunk');
-SELECT compress_chunk('_timescaledb_internal._hyper_2_6_chunk');
-SELECT compress_chunk('_timescaledb_internal._hyper_2_10_chunk');
-SELECT compress_chunk('_timescaledb_internal._hyper_2_11_chunk');
 
-SELECT
-	ht.schema_name || '.' || ht.table_name AS "METRICS_COMPRESSED"
+ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
+
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_4_chunk');
+
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_5_chunk');
+
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_6_chunk');
+
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_10_chunk');
+
+SELECT compress_chunk ('_timescaledb_internal._hyper_2_11_chunk');
+
+SELECT ht.schema_name || '.' || ht.table_name AS "METRICS_COMPRESSED"
 FROM _timescaledb_catalog.hypertable ht
-	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics'
-\gset
-SELECT
-	ht.schema_name || '.' || ht.table_name AS "METRICS_SPACE_COMPRESSED"
+    INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id = ht2.compressed_hypertable_id
+        AND ht2.table_name = 'metrics' \gset
+
+SELECT ht.schema_name || '.' || ht.table_name AS "METRICS_SPACE_COMPRESSED"
 FROM _timescaledb_catalog.hypertable ht
-	INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id=ht2.compressed_hypertable_id AND ht2.table_name = 'metrics_space'
-\gset
+    INNER JOIN _timescaledb_catalog.hypertable ht2 ON ht.id = ht2.compressed_hypertable_id
+        AND ht2.table_name = 'metrics_space' \gset
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
--- Index created using query saved in variable used because there was 
+-- Index created using query saved in variable used because there was
 -- no standard way to create an index on a compressed table.
 -- Once a standard way exists, modify this test to use that method.
-CREATE INDEX c_index ON :METRICS_COMPRESSED(device_id);
-CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED(device_id);
 
-CREATE INDEX c_index_2 ON :METRICS_COMPRESSED(device_id, _ts_meta_count);
-CREATE INDEX c_space_index_2 ON :METRICS_SPACE_COMPRESSED(device_id, _ts_meta_count);
+CREATE INDEX c_index ON :METRICS_COMPRESSED (device_id);
 
-CREATE INDEX ON :METRICS_COMPRESSED(device_id_peer);
-CREATE INDEX ON :METRICS_SPACE_COMPRESSED(device_id_peer);
+CREATE INDEX c_space_index ON :METRICS_SPACE_COMPRESSED (device_id);
+
+CREATE INDEX c_index_2 ON :METRICS_COMPRESSED (device_id, _ts_meta_count);
+
+CREATE INDEX c_space_index_2 ON :METRICS_SPACE_COMPRESSED (device_id, _ts_meta_count);
+
+CREATE INDEX ON :METRICS_COMPRESSED (device_id_peer);
+
+CREATE INDEX ON :METRICS_SPACE_COMPRESSED (device_id_peer);
+
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE INDEX ON metrics_space (device_id, device_id_peer, v0, v1 DESC, time);
 
-CREATE INDEX ON metrics_space(device_id,device_id_peer, v0, v1 desc, time);
-CREATE INDEX ON metrics_space(device_id,device_id_peer DESC, v0, v1 desc, time);
-CREATE INDEX ON metrics_space(device_id DESC, device_id_peer DESC, v0, v1 desc, time);
+CREATE INDEX ON metrics_space (device_id, device_id_peer DESC, v0, v1 DESC, time);
+
+CREATE INDEX ON metrics_space (device_id DESC, device_id_peer DESC, v0, v1 DESC, time);
+
 ANALYZE metrics_space;
-
 
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''
+\set PREFIX_NO_ANALYZE ''
 \set ECHO none
 SET client_min_messages TO error;
+
 \o :TEST_RESULTS_COMPRESSED
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
@@ -111,13 +219,14 @@ SET client_min_messages TO error;
 \ir :TEST_QUERY_NAME
 \o
 RESET client_min_messages;
-\set ECHO all
 
+\set ECHO all
 \set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
 \set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
 -- we disable parallelism here otherwise EXPLAIN ANALYZE output
 -- will be not stable and differ depending on worker assignment
+
 SET max_parallel_workers_per_gather TO 0;
 
 -- get explain for queries on hypertable with compression
@@ -128,80 +237,5 @@ SET max_parallel_workers_per_gather TO 0;
 \ir include/transparent_decompression_ordered.sql
 \ir include/transparent_decompression_systemcolumns.sql
 \ir include/transparent_decompression_undiffed.sql
-
 -- diff compressed and uncompressed results
 :DIFF_CMD
-
--- Testing Index Scan backwards ----
---want more than 1 segment in atleast 1 of the chunks
-CREATE TABLE metrics_ordered_idx(time timestamptz NOT NULL, device_id int, device_id_peer int, v0 int);
-SELECT create_hypertable('metrics_ordered_idx','time', chunk_time_interval=>'2days'::interval);
-ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby='time ASC',timescaledb.compress_segmentby='device_id,device_id_peer');
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT time, device_id, 0, device_id FROM generate_series('2000-01-13 0:00:00+0'::timestamptz,'2000-01-15 23:55:00+0','5m') gtime(time), generate_series(1,5,1) gdevice(device_id);
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) ;
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz,'2018-01-20 11:55:00+0','10s') , 4, 5, generate_series(1,5,1) ;
-INSERT INTO metrics_ordered_idx(time,device_id,device_id_peer,v0) SELECT now(), generate_series(4,7,1), 5, generate_series(1,5,1) ;
-
--- misisng values device_id = 7
-CREATE TABLE device_tbl(device_id int, descr text);
-INSERT into device_tbl select generate_series(1, 6,1), 'devicex';
-INSERT into device_tbl select  8, 'device8';
-analyze device_tbl;
-
--- table for joins ---
-create table nodetime( node int,
-     start_time timestamp ,
-     stop_time timestamp  );
-insert into nodetime values( 4, '2018-01-06 00:00'::timestamp, '2018-12-02 12:00'::timestamp);
-
--- run queries on uncompressed hypertable and store result
-\set PREFIX ''
-\set PREFIX_VERBOSE ''
-\set ECHO none
-SET client_min_messages TO error;
-\o :TEST_RESULTS_UNCOMPRESSED_IDX
-\ir include/transparent_decompression_ordered_index.sql
-\ir include/transparent_decompression_constraintaware.sql
-\o
-RESET client_min_messages;
-\set ECHO all
-
---compress all chunks for metrics_ordered_idx table --
-SELECT
-  compress_chunk(c.schema_name || '.' || c.table_name)
-FROM _timescaledb_catalog.chunk c
-  INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
-WHERE ht.table_name = 'metrics_ordered_idx'
-ORDER BY c.id;
-
--- run queries on compressed hypertable and store result
-\set PREFIX ''
-\set PREFIX_VERBOSE ''
-\set ECHO none 
-SET client_min_messages TO error;
-set enable_seqscan = false;
-\o :TEST_RESULTS_COMPRESSED_IDX
-\ir include/transparent_decompression_ordered_index.sql
-\ir include/transparent_decompression_constraintaware.sql
-set enable_seqscan = true;
-\o
-RESET client_min_messages;
-\set ECHO all
-
--- diff compressed and uncompressed results
-:DIFF_CMD_IDX
-
-
-\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
-\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
-
--- we disable parallelism here otherwise EXPLAIN ANALYZE output
--- will be not stable and differ depending on worker assignment
-SET max_parallel_workers_per_gather TO 0;
-set enable_seqscan = false;
--- get explain for queries on hypertable with compression
-\ir include/transparent_decompression_ordered_indexplan.sql
-set enable_seqscan = false;
-\ir include/transparent_decompression_ordered_index.sql
-set enable_seqscan = true;
-\ir include/transparent_decompression_constraintaware.sql

--- a/tsl/test/sql/transparent_decompression_ordered_index.sql.in
+++ b/tsl/test/sql/transparent_decompression_ordered_index.sql.in
@@ -1,0 +1,134 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set TEST_BASE_NAME transparent_decompression_ordered_index
+SELECT format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNCOMPRESSED",
+    format('%s/results/%s_results_compressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_COMPRESSED" \gset
+
+SELECT format('\! diff %s %s', :'TEST_RESULTS_UNCOMPRESSED', :'TEST_RESULTS_COMPRESSED') AS "DIFF_CMD" \gset
+
+-- Testing Index Scan backwards ----
+-- We want more than 1 segment in atleast 1 of the chunks
+
+CREATE TABLE metrics_ordered_idx (
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int
+);
+
+SELECT create_hypertable ('metrics_ordered_idx', 'time', chunk_time_interval => '2days'::interval);
+
+ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby = 'time ASC', timescaledb.compress_segmentby = 'device_id,device_id_peer');
+
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT time,
+    device_id,
+    0,
+    device_id
+FROM generate_series('2000-01-13 0:00:00+0'::timestamptz, '2000-01-15 23:55:00+0', '15m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz, '2000-01-20 11:55:00+0', '15m'),
+    3,
+    3,
+    generate_series(1, 5, 1);
+
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT generate_series('2018-01-20 0:00:00+0'::timestamptz, '2018-01-20 11:55:00+0', '15m'),
+    4,
+    5,
+    generate_series(1, 5, 1);
+
+INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
+SELECT '2020-01-01 0:00:00+0',
+    generate_series(4, 7, 1),
+    5,
+    generate_series(1, 5, 1);
+
+-- misisng values device_id = 7
+CREATE TABLE device_tbl (
+    device_id int,
+    descr text
+);
+
+INSERT INTO device_tbl
+SELECT generate_series(1, 6, 1),
+    'devicex';
+
+INSERT INTO device_tbl
+SELECT 8,
+    'device8';
+
+ANALYZE device_tbl;
+
+-- table for joins ---
+CREATE TABLE nodetime (
+    node int,
+    start_time timestamp,
+    stop_time timestamp
+);
+
+INSERT INTO nodetime
+    VALUES (4, '2018-01-06 00:00'::timestamp, '2018-12-02 12:00'::timestamp);
+
+-- run queries on uncompressed hypertable and store result
+\set PREFIX ''
+\set PREFIX_VERBOSE ''
+\set ECHO none
+SET client_min_messages TO error;
+
+\o :TEST_RESULTS_UNCOMPRESSED
+\ir include/transparent_decompression_ordered_index.sql
+\ir include/transparent_decompression_constraintaware.sql
+\o
+RESET client_min_messages;
+
+\set ECHO all
+--compress all chunks for metrics_ordered_idx table --
+SELECT compress_chunk (c.schema_name || '.' || c.table_name)
+FROM _timescaledb_catalog.chunk c
+    INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
+WHERE ht.table_name = 'metrics_ordered_idx'
+ORDER BY c.id;
+
+-- run queries on compressed hypertable and store result
+\set PREFIX ''
+\set PREFIX_VERBOSE ''
+\set ECHO none
+SET client_min_messages TO error;
+
+SET enable_seqscan = FALSE;
+
+\o :TEST_RESULTS_COMPRESSED
+\ir include/transparent_decompression_ordered_index.sql
+\ir include/transparent_decompression_constraintaware.sql
+SET enable_seqscan = TRUE;
+
+\o
+RESET client_min_messages;
+
+\set ECHO all
+-- diff compressed and uncompressed results
+:DIFF_CMD
+
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+-- we disable parallelism here otherwise EXPLAIN ANALYZE output
+-- will be not stable and differ depending on worker assignment
+
+SET max_parallel_workers_per_gather TO 0;
+
+SET enable_seqscan = FALSE;
+
+-- get explain for queries on hypertable with compression
+\ir include/transparent_decompression_ordered_indexplan.sql
+SET enable_seqscan = FALSE;
+
+\ir include/transparent_decompression_ordered_index.sql
+SET enable_seqscan = TRUE;
+
+\ir include/transparent_decompression_constraintaware.sql


### PR DESCRIPTION
This PR reduces the dataset size in the transparent_decompression
test to make it finish in a more reasonable time. It also splits
the test.