### PR TITLE
Disable fsync in test config files

### DIFF
--- a/test/postgresql.conf.in
+++ b/test/postgresql.conf.in
@@ -17,3 +17,4 @@ log_line_prefix='%u [%p] %d '
 extra_float_digits=0
 timescaledb.passfile='@TEST_PASSFILE@'
 hba_file='@TEST_PG_HBA_FILE@'
+fsync=off

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -25,3 +25,4 @@ ssl_cert_file='@TEST_OUTPUT_DIR@/ts_data_node.crt'
 ssl_key_file='@TEST_OUTPUT_DIR@/ts_data_node.key'
 timescaledb.ssl_dir='@TEST_OUTPUT_DIR@'
 timescaledb.passfile='@TEST_PASSFILE@'
+fsync=off


### PR DESCRIPTION
fsync is enabled by default in PostgreSQL, there is no good reason to keep it enabled for our tests since it usually increases execution time