### PR TITLE
Do not forward relcache invalidation as syscache invalidation

### DIFF
--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -58,19 +58,6 @@ cache_invalidate_relcache_all(void)
 	ts_bgw_job_cache_invalidate_callback();
 }
 
-static inline void
-cache_invalidate_syscache_all(void)
-{
-	ts_cm_functions->cache_syscache_invalidate(PointerGetDatum(NULL), 0, 0);
-}
-
-static inline void
-cache_invalidate_all()
-{
-	cache_invalidate_relcache_all();
-	cache_invalidate_syscache_all();
-}
-
 /*
  * This function is called when any relcache is invalidated.
  * Should route the invalidation to the correct cache.
@@ -98,7 +85,7 @@ cache_invalidate_callback(Datum arg, Oid relid)
 		ts_bgw_job_cache_invalidate_callback();
 
 	if (relid == InvalidOid)
-		cache_invalidate_all();
+		cache_invalidate_relcache_all();
 }
 
 /* Registration for given cache ids happens at  */
@@ -142,7 +129,7 @@ cache_invalidate_xact_end(XactEvent event, void *arg)
 			 * change since the transaction hasn't been committed and other
 			 * backends cannot have the invalid state.
 			 */
-			cache_invalidate_all();
+			cache_invalidate_relcache_all();
 		default:
 			break;
 	}
@@ -160,7 +147,7 @@ cache_invalidate_subxact_end(SubXactEvent event, SubTransactionId mySubid,
 			 * Invalidate caches on aborted sub transactions. See notes above
 			 * in cache_invalidate_xact_end.
 			 */
-			cache_invalidate_all();
+			cache_invalidate_relcache_all();
 		default:
 			break;
 	}

--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -228,10 +228,7 @@ remote_connection_cache_invalidate_callback(Datum arg, int cacheid, uint32 hashv
 	HASH_SEQ_STATUS scan;
 	ConnectionCacheEntry *entry;
 
-	/* Only care about foreign server invalidations. Ignore general
-	 * invalidation (cacheid == 0), as not relevant here. */
-	if (cacheid != FOREIGNSERVEROID)
-		return;
+	Assert(cacheid == FOREIGNSERVEROID);
 
 	hash_seq_init(&scan, connection_cache->htab);
 


### PR DESCRIPTION
It is incorrect to forward relcache invalidations as syscache invalidations, like `cacheid = InvalidOid` which is not possible condition at the moment. Allow syscache invalidations only for `FOREIGNSERVEROID`s.

Related to: http://github.com/timescale/timescaledb/issues/2001