### PR TITLE
Execute regresscheck-t tests in parallel

### DIFF
--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -99,6 +99,32 @@ if (${PG_VERSION_MAJOR} GREATER_EQUAL "12")
   )
 endif()
 
+# the following tests will run by itself before the parallel
+# tests because they fail or are flaky when run in parallel
+set(SOLO_TESTS
+  chunk_api
+  continuous_aggs_bgw
+  continuous_aggs_dump
+  data_fetcher
+  data_node
+  debug_notice
+  dist_commands
+  dist_compression
+  dist_ddl
+  dist_hypertable-11
+  dist_hypertable-12
+  dist_hypertable_am
+  dist_hypertable_with_oids
+  dist_partial_agg
+  issues
+  read_only
+  remote_copy
+  remote_txn_resolve
+  reorder-11
+  reorder-12
+  telemetry_distributed
+)
+
 # Regression tests that vary with PostgreSQL version. Generated test
 # files are put in the original source directory since all tests must
 # be in the same directory. These files are updated when the template
@@ -120,7 +146,30 @@ endif(CMAKE_BUILD_TYPE MATCHES Debug)
 list(SORT TEST_FILES)
 file(REMOVE ${TEST_SCHEDULE})
 
+if(NOT TEST_GROUP_SIZE)
+  set(PARALLEL_GROUP_SIZE 20)
+else()
+  set(PARALLEL_GROUP_SIZE ${TEST_GROUP_SIZE})
+endif()
+
+# append solo tests to schedule first
+foreach(SOLO_TEST_NAME ${SOLO_TESTS})
+  string(REGEX REPLACE "(.+)" "\\1.sql" TEST_FILE ${SOLO_TEST_NAME})
+  if(TEST_FILE IN_LIST TEST_FILES)
+    file(APPEND ${TEST_SCHEDULE} "test: ${SOLO_TEST_NAME}\n")
+  endif ()
+endforeach(SOLO_TEST_NAME)
+
+set(GROUP_MEMBERS 0)
 foreach(TEST_FILE ${TEST_FILES})
   string(REGEX REPLACE "(.+)\.sql" "\\1" TESTS_TO_RUN ${TEST_FILE})
-  file(APPEND ${TEST_SCHEDULE} "test: ${TESTS_TO_RUN}\n")
+  if(NOT (TESTS_TO_RUN IN_LIST SOLO_TESTS))
+    if(GROUP_MEMBERS EQUAL 0)
+      file(APPEND ${TEST_SCHEDULE} "\ntest: ")
+    endif()
+    file(APPEND ${TEST_SCHEDULE} "${TESTS_TO_RUN} ")
+    MATH(EXPR GROUP_MEMBERS "(${GROUP_MEMBERS}+1)%${PARALLEL_GROUP_SIZE}")
+  endif()
 endforeach(TEST_FILE)
+file(APPEND ${TEST_SCHEDULE} "\n")
+


### PR DESCRIPTION
This patch adds parallel execution capabilities to regresscheck-t.