### PR TITLE
Add locks for dimension slice tuples

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -118,3 +118,77 @@ ALTER TABLE IF EXISTS _timescaledb_catalog.compression_chunk_size ADD COLUMN IF 
 CLUSTER  _timescaledb_catalog.compression_chunk_size USING compression_chunk_size_pkey;
 ALTER TABLE _timescaledb_catalog.compression_chunk_size SET WITHOUT CLUSTER;
 
+-- Recreate missing dimension slices that might be missing due to a bug
+-- that is fixed in this release. If the dimension slice table is broken and there are dimension
+-- slices missing from the table, we will repair it by:
+--    1. Finding all chunk constraints that have missing dimension
+--       slices and extract the constraint expression from the associated
+--       constraint.
+--    2. Parse the constraint expression and extract the column name,
+--       and upper and lower range values as text.
+--    3. Use the column type to construct the range values (UNIX
+--       microseconds) from these values.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.time_to_internal(time_val ANYELEMENT)
+RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_time_to_internal' LANGUAGE C VOLATILE STRICT;
+
+INSERT INTO _timescaledb_catalog.dimension_slice
+WITH
+   -- All dimension slices that are mentioned in the chunk_constraint
+   -- table but are missing from the dimension_slice table.
+   missing_slices AS (
+      SELECT dimension_slice_id,
+      	     constraint_name,
+	     attname AS column_name,
+	     pg_get_expr(conbin, conrelid) AS constraint_expr
+      FROM _timescaledb_catalog.chunk_constraint cc
+      JOIN _timescaledb_catalog.chunk ch ON cc.chunk_id = ch.id
+      JOIN pg_constraint ON conname = constraint_name
+      JOIN pg_namespace ns ON connamespace = ns.oid AND ns.nspname = ch.schema_name
+      JOIN pg_attribute ON attnum = conkey[1] AND attrelid = conrelid
+      WHERE
+	 dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice)
+   ),
+
+  -- Unparsed range start and end for each dimension slice id that
+  -- is missing.
+   unparsed_missing_slices AS (
+      SELECT dimension_slice_id,
+             constraint_name,
+	     column_name,
+	     (SELECT SUBSTRING(constraint_expr, $$>=\s*'?([\d\s:+-]+)'?$$)) AS range_start,
+	     (SELECT SUBSTRING(constraint_expr, $$<\s*'?([\d\s:+-]+)'?$$)) AS range_end
+	FROM missing_slices
+   )
+SELECT dimension_slice_id,
+       di.id AS dimension_id,
+       CASE
+       WHEN di.column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
+       	    CASE
+	    WHEN range_start IS NULL
+	    THEN -9223372036854775808
+	    ELSE _timescaledb_internal.time_to_internal(range_start::bigint)
+	    END
+       WHEN di.column_type = 'timestamptz'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::timestamptz)
+       WHEN di.column_type = 'timestamp'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::timestamp)
+       WHEN di.column_type = 'date'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::date)
+       ELSE
+	    NULL
+       END AS range_start,
+       CASE 
+       WHEN di.column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
+       	    CASE WHEN range_end IS NULL
+	    THEN 9223372036854775807
+	    ELSE _timescaledb_internal.time_to_internal(range_end::bigint)
+	    END
+       WHEN di.column_type = 'timestamptz'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::timestamptz)
+       WHEN di.column_type = 'timestamp'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::timestamp)
+       WHEN di.column_type = 'date'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::date)
+       ELSE NULL
+       END AS range_end
+  FROM unparsed_missing_slices JOIN _timescaledb_catalog.dimension di USING (column_name);

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -864,6 +864,10 @@ static bool
 bgw_job_update_scan(ScanKeyData *scankey, void *data)
 {
 	Catalog *catalog = ts_catalog_get();
+	ScanTupLock scantuplock = {
+		.waitpolicy = LockWaitBlock,
+		.lockmode = LockTupleExclusive,
+	};
 	ScannerCtx scanctx = { .table = catalog_get_table_id(catalog, BGW_JOB),
 						   .index = catalog_get_index(catalog, BGW_JOB, BGW_JOB_PKEY_IDX),
 						   .nkeys = 1,
@@ -874,11 +878,7 @@ bgw_job_update_scan(ScanKeyData *scankey, void *data)
 						   .lockmode = RowExclusiveLock,
 						   .scandirection = ForwardScanDirection,
 						   .result_mctx = CurrentMemoryContext,
-						   .tuplock = {
-							   .waitpolicy = LockWaitBlock,
-							   .lockmode = LockTupleExclusive,
-							   .enabled = false,
-						   } };
+						   .tuplock = &scantuplock };
 
 	return ts_scanner_scan(&scanctx);
 }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -161,7 +161,8 @@ ts_chunk_do_drop_chunks(Hypertable *ht, Datum older_than_datum, Datum newer_than
 extern TSDLLEXPORT Chunk *
 ts_chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum newer_than_datum,
 								  Oid older_than_type, Oid newer_than_type, char *caller_name,
-								  MemoryContext mctx, uint64 *num_chunks_returned);
+								  MemoryContext mctx, uint64 *num_chunks_returned,
+								  ScanTupLock *tuplock);
 extern TSDLLEXPORT Chunk *ts_chunk_find_or_create_without_cuts(Hypertable *ht, Hypercube *hc,
 															   const char *schema_name,
 															   const char *table_name,

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -91,12 +91,52 @@ ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord)
 	return 0;
 }
 
+static void
+lock_result_ok_or_abort(TupleInfo *ti, DimensionSlice *slice)
+{
+	switch (ti->lockresult)
+	{
+		/* Updating a tuple in the same transaction before taking a lock is OK
+		 * even though it is not expected in this case */
+		case TM_SelfModified:
+		case TM_Ok:
+			break;
+
+		case TM_Updated:
+			ereport(ERROR,
+					(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
+					 errmsg("dimension slice %d locked by other transaction", slice->fd.id),
+					 errhint("Retry the operation again.")));
+			pg_unreachable();
+			break;
+
+		case TM_BeingModified:
+			ereport(ERROR,
+					(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
+					 errmsg("dimension slice %d updated by other transaction", slice->fd.id),
+					 errhint("Retry the operation again.")));
+			pg_unreachable();
+
+		case TM_Invisible:
+			elog(ERROR, "attempt to lock invisible tuple");
+			pg_unreachable();
+			break;
+
+		case TM_WouldBlock:
+		default:
+			elog(ERROR, "unexpected tuple lock status");
+			pg_unreachable();
+			break;
+	}
+}
+
 static ScanTupleResult
 dimension_vec_tuple_found(TupleInfo *ti, void *data)
 {
 	DimensionVec **slices = data;
 	DimensionSlice *slice = dimension_slice_from_tuple(ti->tuple);
 
+	lock_result_ok_or_abort(ti, slice);
 	*slices = ts_dimension_vec_add_slice(slices, slice);
 
 	return SCAN_CONTINUE;
@@ -106,7 +146,7 @@ static int
 dimension_slice_scan_limit_direction_internal(int indexid, ScanKeyData *scankey, int nkeys,
 											  tuple_found_func on_tuple_found, void *scandata,
 											  int limit, ScanDirection scandir, LOCKMODE lockmode,
-											  MemoryContext mctx)
+											  ScanTupLock *tuplock, MemoryContext mctx)
 {
 	Catalog *catalog = ts_catalog_get();
 	ScannerCtx scanctx = {
@@ -116,6 +156,7 @@ dimension_slice_scan_limit_direction_internal(int indexid, ScanKeyData *scankey,
 		.scankey = scankey,
 		.data = scandata,
 		.limit = limit,
+		.tuplock = tuplock,
 		.tuple_found = on_tuple_found,
 		.lockmode = lockmode,
 		.scandirection = scandir,
@@ -128,7 +169,7 @@ dimension_slice_scan_limit_direction_internal(int indexid, ScanKeyData *scankey,
 static int
 dimension_slice_scan_limit_internal(int indexid, ScanKeyData *scankey, int nkeys,
 									tuple_found_func on_tuple_found, void *scandata, int limit,
-									LOCKMODE lockmode, MemoryContext mctx)
+									LOCKMODE lockmode, ScanTupLock *tuplock, MemoryContext mctx)
 {
 	return dimension_slice_scan_limit_direction_internal(indexid,
 														 scankey,
@@ -138,6 +179,7 @@ dimension_slice_scan_limit_internal(int indexid, ScanKeyData *scankey, int nkeys
 														 limit,
 														 ForwardScanDirection,
 														 lockmode,
+														 tuplock,
 														 mctx);
 }
 
@@ -147,7 +189,7 @@ dimension_slice_scan_limit_internal(int indexid, ScanKeyData *scankey, int nkeys
  * Returns a dimension vector of slices that enclose the coordinate.
  */
 DimensionVec *
-ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit)
+ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit, ScanTupLock *tuplock)
 {
 	ScanKeyData scankey[3];
 	DimensionVec *slices = ts_dimension_vec_create(limit > 0 ? limit : DIMENSION_VEC_DEFAULT_SIZE);
@@ -181,6 +223,7 @@ ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit)
 										&slices,
 										limit,
 										AccessShareLock,
+										tuplock,
 										CurrentMemoryContext);
 
 	return ts_dimension_vec_sort(&slices);
@@ -190,7 +233,7 @@ static void
 dimension_slice_scan_with_strategies(int32 dimension_id, StrategyNumber start_strategy,
 									 int64 start_value, StrategyNumber end_strategy,
 									 int64 end_value, void *data, tuple_found_func tuple_found,
-									 int limit)
+									 int limit, ScanTupLock *tuplock)
 {
 	ScanKeyData scankey[3];
 	int nkeys = 1;
@@ -261,6 +304,7 @@ dimension_slice_scan_with_strategies(int32 dimension_id, StrategyNumber start_st
 										data,
 										limit,
 										AccessShareLock,
+										tuplock,
 										CurrentMemoryContext);
 }
 
@@ -272,7 +316,7 @@ dimension_slice_scan_with_strategies(int32 dimension_id, StrategyNumber start_st
 DimensionVec *
 ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy,
 									int64 start_value, StrategyNumber end_strategy, int64 end_value,
-									int limit)
+									int limit, ScanTupLock *tuplock)
 {
 	DimensionVec *slices = ts_dimension_vec_create(limit > 0 ? limit : DIMENSION_VEC_DEFAULT_SIZE);
 
@@ -283,7 +327,8 @@ ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_str
 										 end_value,
 										 &slices,
 										 dimension_vec_tuple_found,
-										 limit);
+										 limit,
+										 tuplock);
 
 	return ts_dimension_vec_sort(&slices);
 }
@@ -323,6 +368,7 @@ ts_dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, i
 										&slices,
 										limit,
 										AccessShareLock,
+										NULL,
 										CurrentMemoryContext);
 
 	return ts_dimension_vec_sort(&slices);
@@ -347,6 +393,7 @@ ts_dimension_slice_scan_by_dimension(int32 dimension_id, int limit)
 										&slices,
 										limit,
 										AccessShareLock,
+										NULL,
 										CurrentMemoryContext);
 
 	return ts_dimension_vec_sort(&slices);
@@ -390,6 +437,7 @@ ts_dimension_slice_scan_by_dimension_before_point(int32 dimension_id, int64 poin
 		limit,
 		scandir,
 		AccessShareLock,
+		NULL,
 		mctx);
 
 	return ts_dimension_vec_sort(&slices);
@@ -435,6 +483,7 @@ ts_dimension_slice_delete_by_dimension_id(int32 dimension_id, bool delete_constr
 		&delete_constraints,
 		0,
 		RowExclusiveLock,
+		NULL,
 		CurrentMemoryContext);
 }
 
@@ -456,6 +505,7 @@ ts_dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraint
 											   &delete_constraints,
 											   1,
 											   RowExclusiveLock,
+											   NULL,
 											   CurrentMemoryContext);
 }
 
@@ -470,9 +520,13 @@ dimension_slice_fill(TupleInfo *ti, void *data)
 
 /*
  * Scan for an existing slice that exactly matches the given slice's dimension
- * and range. If a match is found, the given slice is updated with slice ID.
+ * and range. If a match is found, the given slice is updated with slice ID
+ * and the tuple is locked.
+ *
+ * Returns true if the dimension slice was found (and locked), false
+ * otherwise.
  */
-DimensionSlice *
+bool
 ts_dimension_slice_scan_for_existing(DimensionSlice *slice)
 {
 	ScanKeyData scankey[3];
@@ -493,31 +547,35 @@ ts_dimension_slice_scan_for_existing(DimensionSlice *slice)
 				F_INT8EQ,
 				Int64GetDatum(slice->fd.range_end));
 
-	dimension_slice_scan_limit_internal(DIMENSION_SLICE_DIMENSION_ID_RANGE_START_RANGE_END_IDX,
-										scankey,
-										3,
-										dimension_slice_fill,
-										&slice,
-										1,
-										AccessShareLock,
-										CurrentMemoryContext);
-
-	return slice;
+	return dimension_slice_scan_limit_internal(
+		DIMENSION_SLICE_DIMENSION_ID_RANGE_START_RANGE_END_IDX,
+		scankey,
+		3,
+		dimension_slice_fill,
+		&slice,
+		1,
+		AccessShareLock,
+		NULL,
+		CurrentMemoryContext);
 }
 
 static ScanTupleResult
 dimension_slice_tuple_found(TupleInfo *ti, void *data)
 {
 	DimensionSlice **slice = data;
-	MemoryContext old = MemoryContextSwitchTo(ti->mctx);
+	MemoryContext old;
 
+	lock_result_ok_or_abort(ti, *slice);
+
+	old = MemoryContextSwitchTo(ti->mctx);
 	*slice = dimension_slice_from_tuple(ti->tuple);
 	MemoryContextSwitchTo(old);
 	return SCAN_DONE;
 }
 
 DimensionSlice *
-ts_dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx)
+ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id, ScanTupLock *tuplock,
+									   MemoryContext mctx)
 {
 	DimensionSlice *slice = NULL;
 	ScanKeyData scankey[1];
@@ -535,6 +593,7 @@ ts_dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx)
 										&slice,
 										1,
 										AccessShareLock,
+										tuplock,
 										mctx);
 
 	return slice;
@@ -685,7 +744,7 @@ ts_dimension_slice_insert_multi(DimensionSlice **slices, Size num_slices, bool o
 		if (only_non_existing)
 		{
 			slices[i]->fd.id = 0;
-			slices[i] = ts_dimension_slice_scan_for_existing(slices[i]);
+			ts_dimension_slice_scan_for_existing(slices[i]);
 		}
 
 		if (!only_non_existing || slices[i]->fd.id == 0)
@@ -733,6 +792,7 @@ ts_dimension_slice_nth_latest_slice(int32 dimension_id, int n)
 		n,
 		BackwardScanDirection,
 		AccessShareLock,
+		NULL,
 		CurrentMemoryContext);
 	if (num_tuples < n)
 		return NULL;
@@ -794,7 +854,8 @@ ts_dimension_slice_oldest_valid_chunk_for_reorder(int32 job_id, int32 dimension_
 										 end_value,
 										 &info,
 										 dimension_slice_check_chunk_stats_tuple_found,
-										 -1);
+										 -1,
+										 NULL);
 
 	return info.chunk_id;
 }
@@ -835,7 +896,8 @@ ts_dimension_slice_get_chunkid_to_compress(int32 dimension_id, StrategyNumber st
 										 end_value,
 										 &chunk_id_ret,
 										 dimension_slice_check_is_chunk_uncompressed_tuple_found,
-										 -1);
+										 -1,
+										 NULL);
 
 	return chunk_id_ret;
 }

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -42,16 +42,18 @@ typedef struct DimensionSlice
 typedef struct DimensionVec DimensionVec;
 typedef struct Hypercube Hypercube;
 
-extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit);
-extern DimensionVec *ts_dimension_slice_scan_range_limit(int32 dimension_id,
-														 StrategyNumber start_strategy,
-														 int64 start_value,
-														 StrategyNumber end_strategy,
-														 int64 end_value, int limit);
+extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit,
+												   ScanTupLock *tuplock);
+extern DimensionVec *
+ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy,
+									int64 start_value, StrategyNumber end_strategy, int64 end_value,
+									int limit, ScanTupLock *tuplock);
 extern DimensionVec *ts_dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start,
 															 int64 range_end, int limit);
-extern DimensionSlice *ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
-extern DimensionSlice *ts_dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
+extern bool ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
+extern DimensionSlice *ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id,
+															  ScanTupLock *tuplock,
+															  MemoryContext mctx);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension_before_point(int32 dimension_id,
 																	   int64 point, int limit,
@@ -83,8 +85,8 @@ extern TSDLLEXPORT int32 ts_dimension_slice_get_chunkid_to_compress(int32 dimens
 																	int64 end_value);
 #define dimension_slice_insert(slice) ts_dimension_slice_insert_multi(&(slice), 1)
 
-#define dimension_slice_scan(dimension_id, coordinate)                                             \
-	ts_dimension_slice_scan_limit(dimension_id, coordinate, 0)
+#define dimension_slice_scan(dimension_id, coordinate, tuplock)                                    \
+	ts_dimension_slice_scan_limit(dimension_id, coordinate, 0, tuplock)
 
 #define dimension_slice_collision_scan(dimension_id, range_start, range_end)                       \
 	ts_dimension_slice_collision_scan_limit(dimension_id, range_start, range_end, 0)

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -30,7 +30,7 @@ extern TSDLLEXPORT Hypercube *ts_hypercube_alloc(int16 num_dimensions);
 extern void ts_hypercube_free(Hypercube *hc);
 extern TSDLLEXPORT void ts_hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
 extern Hypercube *ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
-extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p);
+extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p, ScanTupLock *tuplock);
 extern bool ts_hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
 extern TSDLLEXPORT DimensionSlice *ts_hypercube_get_slice_by_dimension_id(Hypercube *hc,
 																		  int32 dimension_id);

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -245,7 +245,8 @@ dimension_restrict_info_open_slices(DimensionRestrictInfoOpen *dri)
 											   dri->upper_bound,
 											   dri->lower_strategy,
 											   dri->lower_bound,
-											   0);
+											   0,
+											   NULL);
 }
 
 static DimensionVec *
@@ -266,7 +267,8 @@ dimension_restrict_info_closed_slices(DimensionRestrictInfoClosed *dri)
 																	partition,
 																	BTGreaterEqualStrategyNumber,
 																	partition,
-																	0);
+																	0,
+																	NULL);
 
 			for (i = 0; i < tmp->num_slices; i++)
 				dim_vec = ts_dimension_vec_add_unique_slice(&dim_vec, tmp->slices[i]);
@@ -280,7 +282,8 @@ dimension_restrict_info_closed_slices(DimensionRestrictInfoClosed *dri)
 											   -1,
 											   InvalidStrategy,
 											   -1,
-											   0);
+											   0,
+											   NULL);
 }
 
 static DimensionVec *

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -226,7 +226,7 @@ ts_scanner_next(ScannerCtx *ctx, InternalScannerCtx *ictx)
 		{
 			ictx->tinfo.count++;
 
-			if (ctx->tuplock.enabled)
+			if (ctx->tuplock)
 			{
 				Buffer buffer;
 				TM_FailureData hufd;
@@ -234,8 +234,8 @@ ts_scanner_next(ScannerCtx *ctx, InternalScannerCtx *ictx)
 				ictx->tinfo.lockresult = heap_lock_tuple(ictx->tablerel,
 														 ictx->tinfo.tuple,
 														 GetCurrentCommandId(false),
-														 ctx->tuplock.lockmode,
-														 ctx->tuplock.waitpolicy,
+														 ctx->tuplock->lockmode,
+														 ctx->tuplock->waitpolicy,
 														 false,
 														 &buffer,
 														 &hufd);

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -7,12 +7,20 @@
 #define TIMESCALEDB_SCANNER_H
 
 #include <postgres.h>
+
 #include <access/genam.h>
-#include <utils/fmgroids.h>
 #include <access/heapam.h>
+#include <nodes/lockoptions.h>
 #include <utils.h>
+#include <utils/fmgroids.h>
 
 #include "compat.h"
+
+typedef struct ScanTupLock
+{
+	LockTupleMode lockmode;
+	LockWaitPolicy waitpolicy;
+} ScanTupLock;
 
 /* Tuple information passed on to handlers when scanning for tuples. */
 typedef struct TupleInfo
@@ -70,12 +78,7 @@ typedef struct ScannerCtx
 	LOCKMODE lockmode;
 	MemoryContext result_mctx; /* The memory context to allocate the result
 								* on */
-	struct
-	{
-		LockTupleMode lockmode;
-		LockWaitPolicy waitpolicy;
-		bool enabled;
-	} tuplock;
+	ScanTupLock *tuplock;
 	ScanDirection scandirection;
 	void *data; /* User-provided data passed on to filter()
 				 * and tuple_found() */

--- a/test/isolation/expected/insert_dropchunks_race.out
+++ b/test/isolation/expected/insert_dropchunks_race.out
@@ -1,0 +1,15 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1a s2a s1b s2b s1c
+step s1a: INSERT INTO insert_dropchunks_race_t1 VALUES ('2020-01-03 10:30', 3, 33.4);
+step s2a: SELECT COUNT(*) FROM drop_chunks('insert_dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
+step s1b: COMMIT;
+step s2a: <... completed>
+count          
+
+2              
+step s2b: COMMIT;
+step s1c: SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint LEFT JOIN _timescaledb_catalog.dimension_slice sl ON dimension_slice_id = sl.id WHERE sl.id IS NULL;
+count          
+
+0              

--- a/test/isolation/specs/CMakeLists.txt
+++ b/test/isolation/specs/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 set(TEST_FILES
     deadlock_dropchunks_select.spec
+    insert_dropchunks_race.spec
     isolation_nop.spec
     read_committed_insert.spec
     read_uncommitted_insert.spec

--- a/test/isolation/specs/insert_dropchunks_race.spec
+++ b/test/isolation/specs/insert_dropchunks_race.spec
@@ -1,0 +1,37 @@
+# Race condition between insert and drop_chunks
+#
+# If an insert need to create a new chunk, it will look for existing
+# dimension slices to see if any need to be added: if slices already
+# exist, they do not need to be re-constructed and constraints can be
+# added that reference these slices. If chunks are dropped, there is a
+# cleanup of unreferenced dimension slices which can possibly remove
+# unreferenced dimension slices if transactions creating new chunks do
+# not lock the dimension slices for read.
+#
+# This isolation test check that a concurrent insert and drop_chunks
+# do not accidentally create a broken state by adding chunk
+# constraints that reference non-existing dimension slices.
+
+setup {
+  DROP TABLE IF EXISTS insert_dropchunks_race_t1;
+  CREATE TABLE insert_dropchunks_race_t1 (time timestamptz, device int, temp float);
+  SELECT create_hypertable('insert_dropchunks_race_t1', 'time', 'device', 2);
+  INSERT INTO insert_dropchunks_race_t1 VALUES ('2020-01-03 10:30', 1, 32.2);
+}
+
+teardown {
+  DROP TABLE insert_dropchunks_race_t1;
+}
+
+session "s1"
+setup		{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; }
+step "s1a"	{ INSERT INTO insert_dropchunks_race_t1 VALUES ('2020-01-03 10:30', 3, 33.4); }
+step "s1b" 	{ COMMIT; }
+step "s1c" 	{ SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint LEFT JOIN _timescaledb_catalog.dimension_slice sl ON dimension_slice_id = sl.id WHERE sl.id IS NULL; }
+
+session "s2"
+setup	        { BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; }
+step "s2a"	{ SELECT COUNT(*) FROM drop_chunks('insert_dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); }
+step "s2b"	{ COMMIT; }
+
+permutation "s1a" "s2a" "s1b" "s2b" "s1c"


### PR DESCRIPTION
If a dimension slice tuple is found while adding new chunk constraints
as part of a chunk creation it is not locked prior to adding the chunk
constraint. Hence a concurrently executing `drop_chunks` can find a
dimension slice unused (because there is no chunk constraint that
references it) and subsequently remove it. The insert will the continue
to add the chunk constraint with a reference to a now non-existent
dimension slice.

This commit fixes this by locking the dimension slice tuple with a
share lock and locking the dimension slice with an exclusive lock
prior to scanning for existing chunk constraints.

There is an isolation test as a separate commit.

An update script is added that will reconstruct the missing dimension slices and insert them into the `dimension_slice` table. It has been manually tested by deleting dimension slices from the table (after removing all foreign key constraints) and run it to re-construct the `dimension_slice` table.

Possible fix for #1986 