### PR TITLE
Retain parallel schedule when using IGNORES

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/${{ env.PG_SRC_DIR }}
-        key: ${{ runner.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ matrix.build_type }}
+        key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ matrix.build_type }}
 
     - name: Build PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'

--- a/test/pg_isolation_regress.sh
+++ b/test/pg_isolation_regress.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 
-# Wrapper around pg_regress to be able to override the tests to run via the
-# TESTS environment variable
+# Wrapper around pg_isolation_regress to be able to control the schedule with environment variables
+#
+# The following control variables are supported:
+#
+# TESTS     only run tests from this list
+# IGNORES   failure of tests in this list will not lead to test failure
+# SKIPS     tests from this list are not run
 
-# NB this script mirrors the adjacent pg_regress.sh, and they should
-# be kept in sync
+# This script and pg_regress.sh use the same environment variables
+# to decide which tests to run and should be kept in sync.
 
 CURRENT_DIR=$(dirname $0)
 EXE_DIR=${EXE_DIR:-${CURRENT_DIR}}
-SPECS_DIR=${SPECS_DIR:-${EXE_DIR}/isolation/specs}
 PG_ISOLATION_REGRESS=${PG_ISOLATION_REGRESS:-pg_isolation_regress}
-ISOLATION_TEST_SCHEDULE=${ISOLATION_TEST_SCHEDULE:-}
+TEST_SCHEDULE=${ISOLATION_TEST_SCHEDULE:-}
+PG_REGRESS_DIFF_OPTS=-u
 TEMP_SCHEDULE=${CURRENT_DIR}/temp_schedule
+SCHEDULE=
 TESTS=${TESTS:-}
 IGNORES=${IGNORES:-}
 SKIPS=${SKIPS:-}
@@ -22,84 +28,74 @@ contains() {
     return $?
 }
 
+if [[ -z ${TEST_SCHEDULE} ]];  then
+  echo "No test schedule supplied please set ISOLATION_TEST_SCHEDULE"
+  exit 1;
+fi
+
 echo "TESTS ${TESTS}"
 echo "IGNORES ${IGNORES}"
 echo "SKIPS ${SKIPS}"
 
-if [[ -z ${TESTS} ]]; then
-    if [[ -z ${ISOLATION_TEST_SCHEDULE} ]]; then
-        for t in ${SPECS_DIR}/*.spec; do
-            t=${t##${SPECS_DIR}/}
-            t=${t%.spec}
+if [[ -z ${TESTS} ]] && [[ -z ${SKIPS} ]] && [[ -z ${IGNORES} ]]; then
+  # no filter variables set
+  # nothing to do here and we can use the cmake generated schedule
 
-            if ! contains "${SKIPS}" "${t}"; then
-                TESTS="${TESTS} ${t}"
-            fi
-        done
-    elif [[ -n ${IGNORES} ]] || [[ -n ${SKIPS} ]]; then
-        # get the tests from the test schedule, but ignore our IGNORES
-        while read t; do
-            if [[ t =~ ignore:* ]]; then
-                t=${t##ignore:* }
-                IGNORES="${t} ${IGNORES}"
-                # run the test but ignore the result
-                TESTS="${TESTS} ${t}"
-                continue
-            fi
-            t=${t##test: }
-            ## check each individual test in test group to see if it should be ignored
-            ## note that now isolation tests are not grouped together and so the for loop
-            ## will always run once.
-            for el in ${t[@]}; do
-                if ! contains "${SKIPS}" "${el}"; then
-                    TESTS="${TESTS} ${el}"
-                fi
-            done
-        done < ${ISOLATION_TEST_SCHEDULE}
-        # no longer needed as the contents has been parsed above
-        # and unsetting it helps take a shortcut later
-        ISOLATION_TEST_SCHEDULE=
-    else
-        PG_ISOLATION_REGRESS_OPTS="${PG_ISOLATION_REGRESS_OPTS} --schedule=${ISOLATION_TEST_SCHEDULE}"
-    fi
+  SCHEDULE=${TEST_SCHEDULE}
+
+elif [[ -z ${TESTS} ]] && [[ -z ${SKIPS} ]] && [[ -n ${IGNORES} ]]; then
+  # if we only have IGNORES we can use the cmake created schedule
+  # and just prepend ignore lines for the tests whose result should be
+  # ignored. This will allow us to retain the parallel groupings from
+  # the supplied schedule
+
+  echo > ${TEMP_SCHEDULE}
+
+  for t in ${IGNORES}; do
+      echo "ignore: ${t}" >> ${TEMP_SCHEDULE}
+  done
+  cat ${TEST_SCHEDULE} >> ${TEMP_SCHEDULE}
+
+  SCHEDULE=${TEMP_SCHEDULE}
+
 else
-    # Both this and pg_regress.sh use the same TESTS env var to decide which tests to run.
-    # Since we only want to pass the test runner the kind of tests it can understand,
-    # and only those which actually exist, we use TESTS as a filter for the test folder,
-    # passing in only those tests from the directory which are found in TESTS
-    FILTER=${TESTS}
-    TESTS=
-    for t in ${SPECS_DIR}/*.spec*; do
-        t=${t##${SPECS_DIR}/}
-        t=${t%.spec}
-        t=${t%.spec.in}
+  # either TESTS or SKIPS was specified so we need to create a new schedule
+  # based on those
 
-        if contains "${FILTER}" "${t}" && ! contains "${SKIPS}" "${t}"; then
-            TESTS="${TESTS} $t"
+  if [[ -z ${TESTS} ]]; then
+
+    # get the tests from the test schedule, but ignore our IGNORES
+    while read t; do
+      if [[ t =~ ignore:* ]]; then
+        t=${t##ignore:* }
+        IGNORES="${t} ${IGNORES}"
+        continue
+      fi
+      t=${t##test: }
+      ## check each individual test in test group to see if it should be ignored
+      for el in ${t[@]}; do
+        if ! contains "${SKIPS}" "${el}"; then
+          TESTS="${TESTS} ${el}"
         fi
-    done
-    # When TESTS is specified the passed tests scheduler is not used and emptying it helps take a shortcut later
-    ISOLATION_TEST_SCHEDULE=
+      done
+    done < ${TEST_SCHEDULE}
+  fi
+
+  echo > ${TEMP_SCHEDULE}
+
+  for t in ${IGNORES}; do
+      echo "ignore: ${t}" >> ${TEMP_SCHEDULE}
+  done
+
+  for t in ${TESTS}; do
+      echo "test: ${t}" >> ${TEMP_SCHEDULE}
+  done
+
+  SCHEDULE=${TEMP_SCHEDULE}
+
 fi
 
-if [[ -z ${TESTS} ]] && [[ -z ${ISOLATION_TEST_SCHEDULE} ]]; then
-    exit 0;
-fi
+export PG_REGRESS_DIFF_OPTS
 
-touch ${TEMP_SCHEDULE}
-rm ${TEMP_SCHEDULE}
-touch ${TEMP_SCHEDULE}
-
-for t in ${IGNORES}; do
-    echo "ignore: ${t}" >> ${TEMP_SCHEDULE}
-done
-
-for t in ${TESTS}; do
-    echo "test: ${t}" >> ${TEMP_SCHEDULE}
-done
-
-PG_ISOLATION_REGRESS_OPTS="${PG_ISOLATION_REGRESS_OPTS}  --schedule=${TEMP_SCHEDULE}"
-
-export PGISOLATIONTIMEOUT=100
-
+PG_ISOLATION_REGRESS_OPTS="${PG_ISOLATION_REGRESS_OPTS}  --schedule=${SCHEDULE}"
 ${PG_ISOLATION_REGRESS} $@ ${PG_ISOLATION_REGRESS_OPTS}

--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
-# Wrapper around pg_regress to be able to override the tests to run via the
-# TESTS environment variable
+# Wrapper around pg_regress to be able to control the schedule with environment variables
+#
+# The following control variables are supported:
+#
+# TESTS     only run tests from this list
+# IGNORES   failure of tests in this list will not lead to test failure
+# SKIPS     tests from this list are not run
 
-# NB this script mirrors the adjacent pg_isolation_regress.sh, and they should
-# be kept in sync
+# This script and pg_isolation_regress.sh use the same environment variables
+# to decide which tests to run and should be kept in sync.
 
 CURRENT_DIR=$(dirname $0)
 EXE_DIR=${EXE_DIR:-${CURRENT_DIR}}
@@ -12,6 +17,7 @@ PG_REGRESS=${PG_REGRESS:-pg_regress}
 PG_REGRESS_DIFF_OPTS=-u
 TEST_SCHEDULE=${TEST_SCHEDULE:-}
 TEMP_SCHEDULE=${CURRENT_DIR}/temp_schedule
+SCHEDULE=
 TESTS=${TESTS:-}
 IGNORES=${IGNORES:-}
 SKIPS=${SKIPS:-}
@@ -22,63 +28,71 @@ contains() {
     return $?
 }
 
+if [[ -z ${TEST_SCHEDULE} ]];  then
+  echo "No test schedule supplied please set TEST_SCHEDULE"
+  exit 1;
+fi
+
 echo "TESTS ${TESTS}"
 echo "IGNORES ${IGNORES}"
 echo "SKIPS ${SKIPS}"
 
-if [[ -z ${TESTS} ]]; then
-    if [[ -z ${TEST_SCHEDULE} ]]; then
-        for t in ${EXE_DIR}/sql/*.sql; do
-            t=${t##${EXE_DIR}/sql/}
-            t=${t%.sql}
+if [[ -z ${TESTS} ]] && [[ -z ${SKIPS} ]] && [[ -z ${IGNORES} ]]; then
+  # no filter variables set
+  # nothing to do here and we can use the cmake generated schedule
 
-            if ! contains "${SKIPS}" "${t}"; then
-                TESTS="${TESTS} ${t}"
-            fi
-        done
-    elif [[ -n ${IGNORES} ]] || [[ -n ${SKIPS} ]]; then
-        # get the tests from the test schedule, but ignore our IGNORES
-        while read t; do
-            if [[ t =~ ignore:* ]]; then
-                t=${t##ignore:* }
-                IGNORES="${t} ${IGNORES}"
-                continue
-            fi
-            t=${t##test: }
-            ## check each individual test in test group to see if it should be ignored
-            for el in ${t[@]}; do
-                if ! contains "${SKIPS}" "${el}"; then
-                    TESTS="${TESTS} ${el}"
-                fi
-            done
-        done < ${TEST_SCHEDULE}
-        # no longer needed as the contents has been parsed above
-        # and unsetting it helps take a shortcut later
-        TEST_SCHEDULE=
-    else
-        PG_REGRESS_OPTS="${PG_REGRESS_OPTS} --schedule=${TEST_SCHEDULE}"
-    fi
+  SCHEDULE=${TEST_SCHEDULE}
+
+elif [[ -z ${TESTS} ]] && [[ -z ${SKIPS} ]] && [[ -n ${IGNORES} ]]; then
+  # if we only have IGNORES we can use the cmake created schedule
+  # and just prepend ignore lines for the tests whose result should be
+  # ignored. This will allow us to retain the parallel groupings from
+  # the supplied schedule
+
+  echo > ${TEMP_SCHEDULE}
+
+  for t in ${IGNORES}; do
+      echo "ignore: ${t}" >> ${TEMP_SCHEDULE}
+  done
+  cat ${TEST_SCHEDULE} >> ${TEMP_SCHEDULE}
+
+  SCHEDULE=${TEMP_SCHEDULE}
+
 else
-    # Both this and pg_isolation_regress.sh use the same TESTS env var to decide which tests to run.
-    # Since we only want to pass the test runner the kind of tests it can understand,
-    # and only those which actually exist, we use TESTS as a filter for the test folder,
-    # passing in only those tests from the directory which are found in TESTS
-    FILTER=${TESTS}
-    TESTS=
-    for t in ${EXE_DIR}/sql/*.sql; do
-        t=${t##${EXE_DIR}/sql/}
-        t=${t%.sql}
+  # either TESTS or SKIPS was specified so we need to create a new schedule
+  # based on those
 
-        if contains "${FILTER}" "${t}" && ! contains "${SKIPS}" "${t}"; then
-            TESTS="${TESTS} $t"
+  if [[ -z ${TESTS} ]]; then
+
+    # get the tests from the test schedule, but ignore our IGNORES
+    while read t; do
+      if [[ t =~ ignore:* ]]; then
+        t=${t##ignore:* }
+        IGNORES="${t} ${IGNORES}"
+        continue
+      fi
+      t=${t##test: }
+      ## check each individual test in test group to see if it should be ignored
+      for el in ${t[@]}; do
+        if ! contains "${SKIPS}" "${el}"; then
+          TESTS="${TESTS} ${el}"
         fi
-    done
-    # When TESTS is specified the passed tests scheduler is not used and emptying it helps take a shortcut later
-    TEST_SCHEDULE=
-fi
+      done
+    done < ${TEST_SCHEDULE}
+  fi
 
-if [[ -z ${TESTS} ]] && [[ -z ${TEST_SCHEDULE} ]]; then
-    exit 0;
+  echo > ${TEMP_SCHEDULE}
+
+  for t in ${IGNORES}; do
+      echo "ignore: ${t}" >> ${TEMP_SCHEDULE}
+  done
+
+  for t in ${TESTS}; do
+      echo "test: ${t}" >> ${TEMP_SCHEDULE}
+  done
+
+  SCHEDULE=${TEMP_SCHEDULE}
+
 fi
 
 function cleanup() {
@@ -103,17 +117,5 @@ mkdir -p ${EXE_DIR}/sql/dump
 
 export PG_REGRESS_DIFF_OPTS
 
-touch ${TEMP_SCHEDULE}
-rm ${TEMP_SCHEDULE}
-touch ${TEMP_SCHEDULE}
-
-for t in ${IGNORES}; do
-    echo "ignore: ${t}" >> ${TEMP_SCHEDULE}
-done
-
-for t in ${TESTS}; do
-    echo "test: ${t}" >> ${TEMP_SCHEDULE}
-done
-
-PG_REGRESS_OPTS="${PG_REGRESS_OPTS}  --schedule=${TEMP_SCHEDULE}"
+PG_REGRESS_OPTS="${PG_REGRESS_OPTS}  --schedule=${SCHEDULE}"
 ${PG_REGRESS} $@ ${PG_REGRESS_OPTS}

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -102,7 +102,9 @@ endif()
 # the following tests will run by itself before the parallel
 # tests because they fail or are flaky when run in parallel
 set(SOLO_TESTS
+  bgw_reorder_drop_chunks
   chunk_api
+  compress_bgw_reorder_drop_chunks
   continuous_aggs_bgw
   continuous_aggs_dump
   data_fetcher
@@ -118,7 +120,9 @@ set(SOLO_TESTS
   dist_partial_agg
   issues
   read_only
+  remote_connection_cache
   remote_copy
+  remote_txn
   remote_txn_resolve
   reorder-11
   reorder-12


### PR DESCRIPTION
When either TESTS, SKIPS or IGNORES is set for a regression check
run we would generate a new temporary schedule based on those
variables without any parallelity. This patch changes the behaviour
to keep the original test schedule when only parallel is specified
and just prepend the ignore lines to a copy of the original schedule.