### PR TITLE
Improve github action stacktrace handling

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -52,28 +52,30 @@ jobs:
 
     - name: make installcheck
       id: installcheck
-      run: sudo -u postgres make -k -C build installcheck IGNORES="${{ matrix.installcheck_ignores }}"
+      run: sudo -u postgres make -k -C build installcheck IGNORES="${{ matrix.installcheck_ignores }}" | tee installcheck.log
 
-    - name: Regression diffs
-      if: failure()
+    - name: Show regression diffs
+      if: always()
+      id: collectlogs
       run: |
-        find build -name regression.diffs -exec cat {} + > regression.diffs
-        find build -name postmaster.log -exec cat {} + > postmaster.log
-        cat regression.diffs
+        find . -name regression.diffs -exec cat {} + > regression.log
+        find . -name postmaster.log -exec cat {} + > postgres.log
+        grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
+        cat regression.log
 
     - name: Save regression diffs
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v1
       with:
         name: Regression diff ${{ matrix.pg }}
-        path: regression.diffs
+        path: regression.log
 
     - name: Save postmaster.log
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v1
       with:
         name: PostgreSQL log ${{ matrix.pg }}
-        path: postmaster.log
+        path: postgres.log
 
     - name: Slack Notification
       if: failure()

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      fail-fast: ${{ steps.set-matrix.outputs.fail-fast }}
     steps:
     - uses: actions/checkout@v2
 
@@ -25,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix: ${{ fromJson(needs.matrixbuilder.outputs.matrix) }}
-      fail-fast: ${{ fromJson(needs.matrixbuilder.outputs.fail-fast) }}
+      fail-fast: false
     env:
       PG_SRC_DIR: pgbuild
       PG_INSTALL_DIR: postgresql
@@ -88,7 +87,7 @@ jobs:
 
     - name: make installcheck
       id: installcheck
-      run: make -k -C build installcheck ${{ matrix.installcheck_args }}
+      run: make -k -C build installcheck ${{ matrix.installcheck_args }} | tee installcheck.log
 
     - name: coverage
       if: matrix.coverage
@@ -101,31 +100,35 @@ jobs:
         file: ./build/codecov/timescaledb-codecov.info
 
     - name: Show regression diffs
-      if: failure()
+      if: always()
+      id: collectlogs
       run: |
         find . -name regression.diffs -exec cat {} + > regression.log
         find . -name postmaster.log -exec cat {} + > postgres.log
+        if [[ "${{ runner.os }}" == "Linux" ]] && coredumpctl -q list >/dev/null; then echo "::set-output name=coredumps::true"; fi
+        grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
         cat regression.log
 
     - name: Save regression diffs
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: Regression diff ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: regression.log
 
     - name: Save postmaster.log
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: PostgreSQL log ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: postgres.log
 
     - name: Stack trace
-      if: failure() && runner.os == 'Linux'
+      if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
         sleep 10 # wait for in progress coredumps to finish
         echo "bt full" | sudo coredumpctl gdb
+        false
 
     - name: Slack Notification
       if: failure() && github.event_name != 'pull_request'

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -13,8 +13,6 @@
 # harder to browse because the workflow will have lots of entries and
 # only by navigating into the individual jobs would it be visible
 # if a job was actually run.
-# Additionally we set fail-fast to true for pull requests and false
-# for other event types.
 
 import json
 import sys
@@ -127,5 +125,4 @@ if event_type != "pull_request":
 
 # generate command to set github action variable
 print(str.format("::set-output name=matrix::{0}",json.dumps(m)))
-print(str.format("::set-output name=fail-fast::{0}",json.dumps(event_type == "pull_request")))
 


### PR DESCRIPTION
Check for coredumps and only execute the stracktrace if there are
actually coredumps. This also changes the log handling to always
collect logs and upload them cause they might have useful
information even when all steps succeed.