### PR TITLE
Improve dimension slice locking

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -897,7 +897,7 @@ chunk_create_metadata_after_lock(Hypertable *ht, Hypercube *cube, const char *sc
 	ts_chunk_insert_lock(chunk, RowExclusiveLock);
 
 	/* Insert any new dimension slices */
-	ts_dimension_slice_insert_multi(cube->slices, cube->num_slices, true);
+	ts_dimension_slice_insert_multi(cube->slices, cube->num_slices);
 
 	/* Add metadata for dimensional and inheritable constraints */
 	ts_chunk_add_constraints(chunk);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -66,8 +66,7 @@ extern TSDLLEXPORT bool ts_dimension_slices_collide(DimensionSlice *slice1, Dime
 extern bool ts_dimension_slices_equal(DimensionSlice *slice1, DimensionSlice *slice2);
 extern bool ts_dimension_slice_cut(DimensionSlice *to_cut, DimensionSlice *other, int64 coord);
 extern void ts_dimension_slice_free(DimensionSlice *slice);
-extern int ts_dimension_slice_insert_multi(DimensionSlice **slice, Size num_slices,
-										   bool only_non_existing);
+extern int ts_dimension_slice_insert_multi(DimensionSlice **slice, int num_slices);
 extern int ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right);
 extern int ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
 
@@ -81,7 +80,6 @@ extern TSDLLEXPORT int32 ts_dimension_slice_get_chunkid_to_compress(int32 dimens
 																	int64 start_value,
 																	StrategyNumber end_strategy,
 																	int64 end_value);
-#define dimension_slice_insert(slice) ts_dimension_slice_insert_multi(&(slice), 1)
 
 #define dimension_slice_scan(dimension_id, coordinate)                                             \
 	ts_dimension_slice_scan_limit(dimension_id, coordinate, 0)


### PR DESCRIPTION
Several commits. See each commit for details.

    Function `ts_insert_dimension_slices_multi` takes an exclusive lock on
    the table when only reading slices. This can blocks other transactions
    that only read from the table and will reduce read or insert
    performance when executing concurrent insert statement (or
    `drop_chunks`).
    
    This commit changes the locking to take a read lock while reading the
    table and taking a row exclusive lock only when it is necessary to
    insert new dimension slices.

In addition:

    The macro `dimension_slice_insert` is not used and hence removed.
    
    The second parameter to `ts_dimension_slice_insert_multi` is set to
    true in the single invocation, so remove the parameter and changed the
    logic of the function accordingly by removing the check of the
    parameter.

The PR is on top of another one.