### PR TITLE
Upload coredumps as artifact

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -52,7 +52,9 @@ jobs:
 
     - name: make installcheck
       id: installcheck
-      run: sudo -u postgres make -k -C build installcheck IGNORES="${{ matrix.installcheck_ignores }}" | tee installcheck.log
+      run: |
+        set -o pipefail
+        sudo -u postgres make -k -C build installcheck IGNORES="${{ matrix.installcheck_ignores }}" | tee installcheck.log
 
     - name: Show regression diffs
       if: always()

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -87,7 +87,9 @@ jobs:
 
     - name: make installcheck
       id: installcheck
-      run: make -k -C build installcheck ${{ matrix.installcheck_args }} | tee installcheck.log
+      run: |
+        set -o pipefail
+        make -k -C build installcheck ${{ matrix.installcheck_args }} | tee installcheck.log
 
     - name: coverage
       if: matrix.coverage
@@ -128,7 +130,15 @@ jobs:
       run: |
         sleep 10 # wait for in progress coredumps to finish
         echo "bt full" | sudo coredumpctl gdb
+        ./scripts/bundle_coredumps.sh
         false
+
+    - name: Coredumps
+      if: always() && steps.collectlogs.outputs.coredumps == 'true'
+      uses: actions/upload-artifact@v2
+      with:
+        name: Coredumps ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
+        path: coredumps
 
     - name: Slack Notification
       if: failure() && github.event_name != 'pull_request'

--- a/scripts/bundle_coredumps.sh
+++ b/scripts/bundle_coredumps.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+TARGET=coredumps
+COREDUMP_DIR=/var/lib/systemd/coredump
+
+set -e
+
+mkdir -p "$TARGET"
+
+# get information from gdb
+info=$(echo "info sharedlibrary" | coredumpctl gdb)
+
+executable=$(echo "$info" | grep Executable | sed -e 's!^[^/]\+!!')
+
+cp "$executable" "$TARGET"
+cp ${COREDUMP_DIR}/* "$TARGET"
+
+# copy libraries extracted from gdb info
+echo "$info" | grep '^0x' | sed -e 's!^[^/]\+!!' | xargs -ILIB cp "LIB" "$TARGET"
+


### PR DESCRIPTION
This patch adds collecting coredumps to the regression workflow
in addition to the binary all shared libraries used by the coredump
are collected as well.