### PR TITLE
Fix potential mem corruption in distributed copy

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -119,7 +119,7 @@ extern Chunk **ts_chunk_find_all(Hypertable *ht, List *dimension_vecs, LOCKMODE 
 extern List *ts_chunk_find_all_oids(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode);
 extern TSDLLEXPORT int ts_chunk_add_constraints(Chunk *chunk);
 
-extern Chunk *ts_chunk_copy(Chunk *chunk);
+extern TSDLLEXPORT Chunk *ts_chunk_copy(Chunk *chunk);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_name_with_memory_context(const char *schema_name,
 																   const char *table_name,
 																   MemoryContext mctx,

--- a/tsl/src/remote/dist_copy.c
+++ b/tsl/src/remote/dist_copy.c
@@ -282,7 +282,7 @@ create_connection_list_for_chunk(CopyConnectionState *state, Chunk *chunk)
 
 	MemoryContext oldcontext = MemoryContextSwitchTo(state->mctx);
 	chunk_connections = palloc(sizeof(ChunkConnectionList));
-	chunk_connections->chunk = chunk;
+	chunk_connections->chunk = ts_chunk_copy(chunk);
 	chunk_connections->connections = NIL;
 	foreach (lc, chunk->data_nodes)
 	{


### PR DESCRIPTION
This change copies the chunk object into the distributed copy's
memory context before caching it in the ChunkConnectionList. This
resolves an issue where the chunk was being modified after being
stored which was resulting in rows being sent to the incorrect
data node.

Fixes #2037 