### PR TITLE
Cleanup unused code paths

### DIFF
--- a/src/chunk_dispatch_state.c
+++ b/src/chunk_dispatch_state.c
@@ -72,16 +72,12 @@ on_chunk_insert_state_changed(ChunkInsertState *cis, void *data)
 	 */
 	if (cis->arbiter_indexes != NIL)
 	{
-#if PG11
 		/*
 		 * In PG11 several fields were removed from the
 		 * ModifyTableState node and ExecInsert function nodes, as
 		 * they were redundant.
 		 */
 		mtplan->arbiterIndexes = cis->arbiter_indexes;
-#else
-		mtstate->mt_arbiterindexes = cis->arbiter_indexes;
-#endif
 	}
 
 	/* Update slot tuple descriptors to handle ON CONFLICT DO UPDATE for the
@@ -216,7 +212,7 @@ ts_chunk_dispatch_state_create(Oid hypertable_relid, Plan *subplan)
  * these slots are required when changing chunk.
  */
 #define setup_tuple_slots_for_on_conflict_handling(state)
-#elif PG11
+#else
 /*
  * In PG11, tuple table slots for ON CONFLICT handling are tied to the format of
  * the "root" table, unless partition routing is enabled (which isn't the case

--- a/src/chunk_insert_state.c
+++ b/src/chunk_insert_state.c
@@ -321,11 +321,7 @@ get_default_existing_slot(ChunkInsertState *state, ChunkDispatch *dispatch)
 static TupleDesc
 get_default_confl_tupdesc(ChunkInsertState *state, ChunkDispatch *dispatch)
 {
-#if PG11
 	return get_hyper_rri(dispatch)->ri_onConflict->oc_ProjTupdesc;
-#else
-	return dispatch->dispatch_state->conflproj_tupdesc;
-#endif /* PG11 */
 }
 
 static TupleTableSlot *


### PR DESCRIPTION
This change removes some code paths that are no longer used after the
removal of PG10 and PG9.6 support.