### PR TITLE
Better handling of chunk insert state destruction

### DIFF
--- a/test/expected/insert-10.out
+++ b/test/expected/insert-10.out
@@ -636,3 +636,26 @@ WHERE NOT EXISTS (
 		AND toe = '2020-05-09 10:34:35.296288+00'
 );
 DROP TABLE readings;
+CREATE TABLE sample_table (
+       sequence INTEGER NOT NULL,
+       time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+       value NUMERIC NOT NULL,
+       UNIQUE (sequence, time)
+);
+SELECT * FROM create_hypertable('sample_table', 'time',
+       chunk_time_interval => INTERVAL '1 day');
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            12 | public      | sample_table | t
+(1 row)
+
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+\set ON_ERROR_STOP 0
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-07-21', TIMESTAMP '2019-08-01', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+ERROR:  duplicate key value violates unique constraint "27_1_sample_table_sequence_time_key"
+\set ON_ERROR_STOP 1
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
+DROP TABLE sample_table;

--- a/test/expected/insert-11.out
+++ b/test/expected/insert-11.out
@@ -636,3 +636,26 @@ WHERE NOT EXISTS (
 		AND toe = '2020-05-09 10:34:35.296288+00'
 );
 DROP TABLE readings;
+CREATE TABLE sample_table (
+       sequence INTEGER NOT NULL,
+       time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+       value NUMERIC NOT NULL,
+       UNIQUE (sequence, time)
+);
+SELECT * FROM create_hypertable('sample_table', 'time',
+       chunk_time_interval => INTERVAL '1 day');
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            12 | public      | sample_table | t
+(1 row)
+
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+\set ON_ERROR_STOP 0
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-07-21', TIMESTAMP '2019-08-01', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+ERROR:  duplicate key value violates unique constraint "27_1_sample_table_sequence_time_key"
+\set ON_ERROR_STOP 1
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
+DROP TABLE sample_table;

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -636,3 +636,26 @@ WHERE NOT EXISTS (
 		AND toe = '2020-05-09 10:34:35.296288+00'
 );
 DROP TABLE readings;
+CREATE TABLE sample_table (
+       sequence INTEGER NOT NULL,
+       time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+       value NUMERIC NOT NULL,
+       UNIQUE (sequence, time)
+);
+SELECT * FROM create_hypertable('sample_table', 'time',
+       chunk_time_interval => INTERVAL '1 day');
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            12 | public      | sample_table | t
+(1 row)
+
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+\set ON_ERROR_STOP 0
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-07-21', TIMESTAMP '2019-08-01', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+ERROR:  duplicate key value violates unique constraint "27_1_sample_table_sequence_time_key"
+\set ON_ERROR_STOP 1
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
+DROP TABLE sample_table;

--- a/test/expected/insert-9.6.out
+++ b/test/expected/insert-9.6.out
@@ -636,3 +636,26 @@ WHERE NOT EXISTS (
 		AND toe = '2020-05-09 10:34:35.296288+00'
 );
 DROP TABLE readings;
+CREATE TABLE sample_table (
+       sequence INTEGER NOT NULL,
+       time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+       value NUMERIC NOT NULL,
+       UNIQUE (sequence, time)
+);
+SELECT * FROM create_hypertable('sample_table', 'time',
+       chunk_time_interval => INTERVAL '1 day');
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            12 | public      | sample_table | t
+(1 row)
+
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+\set ON_ERROR_STOP 0
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-07-21', TIMESTAMP '2019-08-01', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+ERROR:  duplicate key value violates unique constraint "27_1_sample_table_sequence_time_key"
+\set ON_ERROR_STOP 1
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
+DROP TABLE sample_table;

--- a/test/sql/insert.sql.in
+++ b/test/sql/insert.sql.in
@@ -180,3 +180,21 @@ WHERE NOT EXISTS (
 		AND toe = '2020-05-09 10:34:35.296288+00'
 );
 DROP TABLE readings;
+CREATE TABLE sample_table (
+       sequence INTEGER NOT NULL,
+       time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+       value NUMERIC NOT NULL,
+       UNIQUE (sequence, time)
+);
+SELECT * FROM create_hypertable('sample_table', 'time',
+       chunk_time_interval => INTERVAL '1 day');
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+\set ON_ERROR_STOP 0
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7, generate_series(TIMESTAMP '2019-07-21', TIMESTAMP '2019-08-01', INTERVAL '10 minutes'), ROUND(RANDOM()*10)::int);
+\set ON_ERROR_STOP 1
+INSERT INTO sample_table (sequence,time,value) VALUES
+       (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
+
+DROP TABLE sample_table;


### PR DESCRIPTION
    Previously, the memory context for the chunk insert state was freed
    using a reset callback on the per-tuple context. This created an
    unfortunate cyclic dependency between memory contexts, since both the
    per-tuple context and chunk insert state shared the same memory
    context parent (the query memory context).
    
    Thus, when deletion happens by calling MemoryContextDelete on the
    parent, without having deleted the children first, the parent could
    first delete the chunk insert state child, followed by the per-tuple
    context which then tried to delete the chunk insert state again.
    
    A better way to handle this is to simply switch the parent of the
    chunk insert state's memory context to be the per-tuple context as
    long as it is still valid, thus breaking the cycle.

Fixes #1699
Part of #824