### PR TITLE
Add regresscheck-shared sql files to license check

### DIFF
--- a/scripts/check_license_all.sh
+++ b/scripts/check_license_all.sh
@@ -4,7 +4,7 @@ BASE_DIR=$(dirname ${SCRIPT_DIR})
 
 SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -c ${BASE_DIR}/src -s ${BASE_DIR}/sql -c ${BASE_DIR}/test -t ${BASE_DIR}/test
 exit_apache=$?
-SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -e ${BASE_DIR}/tsl/src -u ${BASE_DIR}/tsl/test/sql -e ${BASE_DIR}/tsl/test/src
+SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -e ${BASE_DIR}/tsl/src -u ${BASE_DIR}/tsl/test/sql -u ${BASE_DIR}/tsl/test/shared/sql -e ${BASE_DIR}/tsl/test/src
 exit_tsl=$?
 
 if [ ${exit_apache} -ne 0 ] || [ ${exit_tsl} -ne 0 ]; then

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -16,6 +16,9 @@ set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test prepared statements
 -- executor startup exclusion with no chunks excluded
 PREPARE prep AS SELECT time FROM :TEST_TABLE WHERE time < now() AND device_id = 1 ORDER BY time;
@@ -496,6 +499,9 @@ DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test prepared statements
 -- executor startup exclusion with no chunks excluded
 PREPARE prep AS SELECT time FROM :TEST_TABLE WHERE time < now() AND device_id = 1 ORDER BY time;
@@ -1256,6 +1262,9 @@ DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
 \set TEST_TABLE 'metrics_compressed'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test prepared statements
 -- executor startup exclusion with no chunks excluded
 PREPARE prep AS SELECT time FROM :TEST_TABLE WHERE time < now() AND device_id = 1 ORDER BY time;
@@ -1856,6 +1865,9 @@ DEALLOCATE prep;
 RESET timescaledb.enable_chunk_append;
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test prepared statements
 -- executor startup exclusion with no chunks excluded
 PREPARE prep AS SELECT time FROM :TEST_TABLE WHERE time < now() AND device_id = 1 ORDER BY time;

--- a/tsl/test/shared/expected/ordered_append-11.out
+++ b/tsl/test/shared/expected/ordered_append-11.out
@@ -15,6 +15,9 @@ set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time
@@ -1298,6 +1301,9 @@ FROM :TEST_TABLE ORDER BY time LIMIT 3;
 
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time
@@ -3824,6 +3830,9 @@ FROM :TEST_TABLE ORDER BY time LIMIT 3;
 
 \set TEST_TABLE 'metrics_compressed'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time
@@ -5267,6 +5276,9 @@ FROM :TEST_TABLE ORDER BY time LIMIT 3;
 
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time

--- a/tsl/test/shared/expected/ordered_append-12.out
+++ b/tsl/test/shared/expected/ordered_append-12.out
@@ -15,6 +15,9 @@ set work_mem to '64MB';
 set max_parallel_workers_per_gather to 0;
 \set TEST_TABLE 'metrics'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time
@@ -1294,6 +1297,9 @@ FROM :TEST_TABLE ORDER BY time LIMIT 3;
 
 \set TEST_TABLE 'metrics_space'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time
@@ -3834,6 +3840,9 @@ FROM :TEST_TABLE ORDER BY time LIMIT 3;
 
 \set TEST_TABLE 'metrics_compressed'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time
@@ -5278,6 +5287,9 @@ FROM :TEST_TABLE ORDER BY time LIMIT 3;
 
 \set TEST_TABLE 'metrics_space_compressed'
 \ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 -- test ASC for ordered chunks
 :PREFIX SELECT
   time

--- a/tsl/test/shared/sql/include/constraint_exclusion_prepared.sql
+++ b/tsl/test/shared/sql/include/constraint_exclusion_prepared.sql
@@ -1,3 +1,6 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 
 -- test prepared statements
 -- executor startup exclusion with no chunks excluded

--- a/tsl/test/shared/sql/include/ordered_append_query.sql
+++ b/tsl/test/shared/sql/include/ordered_append_query.sql
@@ -1,3 +1,6 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 
 -- test ASC for ordered chunks
 :PREFIX SELECT

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -1,3 +1,6 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 
 SET client_min_messages TO ERROR;
 


### PR DESCRIPTION
This adds the directories used by regresscheck-shared to the license
check and adds a license where it is currently missing.