### PR TITLE
Add locks for dimension slice tuples

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,74 @@
+-- Recreate missing dimension slices that might be missing due to a bug
+-- that is fixed in this release. If the dimension slice table is broken and there are dimension
+-- slices missing from the table, we will repair it by:
+--    1. Finding all chunk constraints that have missing dimension
+--       slices and extract the constraint expression from the associated
+--       constraint.
+--    2. Parse the constraint expression and extract the column name,
+--       and upper and lower range values as text.
+--    3. Use the column type to construct the range values (UNIX
+--       microseconds) from these values.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.time_to_internal(time_val ANYELEMENT)
+RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_time_to_internal' LANGUAGE C VOLATILE STRICT;
+
+INSERT INTO _timescaledb_catalog.dimension_slice
+WITH
+   -- All dimension slices that are mentioned in the chunk_constraint
+   -- table but are missing from the dimension_slice table.
+   missing_slices AS (
+      SELECT dimension_slice_id,
+      	     constraint_name,
+	     attname AS column_name,
+	     pg_get_expr(conbin, conrelid) AS constraint_expr
+      FROM _timescaledb_catalog.chunk_constraint cc
+      JOIN _timescaledb_catalog.chunk ch ON cc.chunk_id = ch.id
+      JOIN pg_constraint ON conname = constraint_name
+      JOIN pg_namespace ns ON connamespace = ns.oid AND ns.nspname = ch.schema_name
+      JOIN pg_attribute ON attnum = conkey[1] AND attrelid = conrelid
+      WHERE
+	 dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice)
+   ),
+
+  -- Unparsed range start and end for each dimension slice id that
+  -- is missing.
+   unparsed_missing_slices AS (
+      SELECT dimension_slice_id,
+             constraint_name,
+	     column_name,
+	     (SELECT SUBSTRING(constraint_expr, $$>=\s*'?([\d\s:+-]+)'?$$)) AS range_start,
+	     (SELECT SUBSTRING(constraint_expr, $$<\s*'?([\d\s:+-]+)'?$$)) AS range_end
+	FROM missing_slices
+   )
+SELECT dimension_slice_id,
+       di.id AS dimension_id,
+       CASE
+       WHEN di.column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
+       	    CASE
+	    WHEN range_start IS NULL
+	    THEN -9223372036854775808
+	    ELSE _timescaledb_internal.time_to_internal(range_start::bigint)
+	    END
+       WHEN di.column_type = 'timestamptz'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::timestamptz)
+       WHEN di.column_type = 'timestamp'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::timestamp)
+       WHEN di.column_type = 'date'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_start::date)
+       ELSE
+	    NULL
+       END AS range_start,
+       CASE 
+       WHEN di.column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
+       	    CASE WHEN range_end IS NULL
+	    THEN 9223372036854775807
+	    ELSE _timescaledb_internal.time_to_internal(range_end::bigint)
+	    END
+       WHEN di.column_type = 'timestamptz'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::timestamptz)
+       WHEN di.column_type = 'timestamp'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::timestamp)
+       WHEN di.column_type = 'date'::regtype THEN
+       	    _timescaledb_internal.time_to_internal(range_end::date)
+       ELSE NULL
+       END AS range_end
+  FROM unparsed_missing_slices JOIN _timescaledb_catalog.dimension di USING (column_name);

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -868,6 +868,10 @@ static bool
 bgw_job_update_scan(ScanKeyData *scankey, void *data)
 {
 	Catalog *catalog = ts_catalog_get();
+	ScanTupLock scantuplock = {
+		.waitpolicy = LockWaitBlock,
+		.lockmode = LockTupleExclusive,
+	};
 	ScannerCtx scanctx = { .table = catalog_get_table_id(catalog, BGW_JOB),
 						   .index = catalog_get_index(catalog, BGW_JOB, BGW_JOB_PKEY_IDX),
 						   .nkeys = 1,
@@ -878,11 +882,7 @@ bgw_job_update_scan(ScanKeyData *scankey, void *data)
 						   .lockmode = RowExclusiveLock,
 						   .scandirection = ForwardScanDirection,
 						   .result_mctx = CurrentMemoryContext,
-						   .tuplock = {
-							   .waitpolicy = LockWaitBlock,
-							   .lockmode = LockTupleExclusive,
-							   .enabled = false,
-						   } };
+						   .tuplock = &scantuplock };
 
 	return ts_scanner_scan(&scanctx);
 }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -145,7 +145,8 @@ ts_chunk_do_drop_chunks(Oid table_relid, Datum older_than_datum, Datum newer_tha
 extern TSDLLEXPORT Chunk *
 ts_chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum newer_than_datum,
 								  Oid older_than_type, Oid newer_than_type, char *caller_name,
-								  MemoryContext mctx, uint64 *num_chunks_returned);
+								  MemoryContext mctx, uint64 *num_chunks_returned,
+								  ScanTupLock *tuplock);
 
 extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_can_be_compressed(int32 chunk_id);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -42,16 +42,18 @@ typedef struct DimensionSlice
 typedef struct DimensionVec DimensionVec;
 typedef struct Hypercube Hypercube;
 
-extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit);
-extern DimensionVec *ts_dimension_slice_scan_range_limit(int32 dimension_id,
-														 StrategyNumber start_strategy,
-														 int64 start_value,
-														 StrategyNumber end_strategy,
-														 int64 end_value, int limit);
+extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit,
+												   ScanTupLock *tuplock);
+extern DimensionVec *
+ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy,
+									int64 start_value, StrategyNumber end_strategy, int64 end_value,
+									int limit, ScanTupLock *tuplock);
 extern DimensionVec *ts_dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start,
 															 int64 range_end, int limit);
-extern DimensionSlice *ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
-extern DimensionSlice *ts_dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
+extern bool ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
+extern DimensionSlice *ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id,
+															  ScanTupLock *tuplock,
+															  MemoryContext mctx);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension_before_point(int32 dimension_id,
 																	   int64 point, int limit,
@@ -82,8 +84,8 @@ extern TSDLLEXPORT int32 ts_dimension_slice_get_chunkid_to_compress(int32 dimens
 																	int64 end_value);
 #define dimension_slice_insert(slice) ts_dimension_slice_insert_multi(&(slice), 1)
 
-#define dimension_slice_scan(dimension_id, coordinate)                                             \
-	ts_dimension_slice_scan_limit(dimension_id, coordinate, 0)
+#define dimension_slice_scan(dimension_id, coordinate, tuplock)                                    \
+	ts_dimension_slice_scan_limit(dimension_id, coordinate, 0, tuplock)
 
 #define dimension_slice_collision_scan(dimension_id, range_start, range_end)                       \
 	ts_dimension_slice_collision_scan_limit(dimension_id, range_start, range_end, 0)

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -158,7 +158,7 @@ ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx)
 			DimensionSlice *slice;
 
 			Assert(hc->num_slices < constraints->num_dimension_constraints);
-			slice = ts_dimension_slice_scan_by_id(cc->fd.dimension_slice_id, mctx);
+			slice = ts_dimension_slice_scan_by_id_and_lock(cc->fd.dimension_slice_id, NULL, mctx);
 			Assert(slice != NULL);
 			hc->slices[hc->num_slices++] = slice;
 		}
@@ -192,7 +192,7 @@ ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx)
  * hypercubes. This happens in a later step.
  */
 Hypercube *
-ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p)
+ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p, ScanTupLock *tuplock)
 {
 	Hypercube *cube;
 	int i;
@@ -217,7 +217,7 @@ ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p)
 		{
 			DimensionVec *vec;
 
-			vec = ts_dimension_slice_scan_limit(dim->fd.id, value, 1);
+			vec = ts_dimension_slice_scan_limit(dim->fd.id, value, 1, tuplock);
 
 			if (vec->num_slices > 0)
 			{
@@ -238,6 +238,9 @@ ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p)
 			 * Check if there's already an existing slice with the calculated
 			 * range. If a slice already exists, use that slice's ID instead
 			 * of a new one.
+			 *
+			 * The tuples are already locked in
+			 * `chunk_create_from_point_after_lock`, so nothing to do here.
 			 */
 			ts_dimension_slice_scan_for_existing(cube->slices[i]);
 		}

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -30,7 +30,7 @@ extern Hypercube *ts_hypercube_alloc(int16 num_dimensions);
 extern void ts_hypercube_free(Hypercube *hc);
 extern void ts_hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
 extern Hypercube *ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
-extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p);
+extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p, ScanTupLock *tuplock);
 extern bool ts_hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
 extern DimensionSlice *ts_hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id);
 extern Hypercube *ts_hypercube_copy(Hypercube *hc);

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -245,7 +245,8 @@ dimension_restrict_info_open_slices(DimensionRestrictInfoOpen *dri)
 											   dri->upper_bound,
 											   dri->lower_strategy,
 											   dri->lower_bound,
-											   0);
+											   0,
+											   NULL);
 }
 
 static DimensionVec *
@@ -266,7 +267,8 @@ dimension_restrict_info_closed_slices(DimensionRestrictInfoClosed *dri)
 																	partition,
 																	BTGreaterEqualStrategyNumber,
 																	partition,
-																	0);
+																	0,
+																	NULL);
 
 			for (i = 0; i < tmp->num_slices; i++)
 				dim_vec = ts_dimension_vec_add_unique_slice(&dim_vec, tmp->slices[i]);
@@ -280,7 +282,8 @@ dimension_restrict_info_closed_slices(DimensionRestrictInfoClosed *dri)
 											   -1,
 											   InvalidStrategy,
 											   -1,
-											   0);
+											   0,
+											   NULL);
 }
 
 static DimensionVec *

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -220,7 +220,7 @@ ts_scanner_next(ScannerCtx *ctx, InternalScannerCtx *ictx)
 		{
 			ictx->tinfo.count++;
 
-			if (ctx->tuplock.enabled)
+			if (ctx->tuplock)
 			{
 				Buffer buffer;
 				TM_FailureData hufd;
@@ -228,8 +228,8 @@ ts_scanner_next(ScannerCtx *ctx, InternalScannerCtx *ictx)
 				ictx->tinfo.lockresult = heap_lock_tuple(ictx->tablerel,
 														 ictx->tinfo.tuple,
 														 GetCurrentCommandId(false),
-														 ctx->tuplock.lockmode,
-														 ctx->tuplock.waitpolicy,
+														 ctx->tuplock->lockmode,
+														 ctx->tuplock->waitpolicy,
 														 false,
 														 &buffer,
 														 &hufd);

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -7,12 +7,20 @@
 #define TIMESCALEDB_SCANNER_H
 
 #include <postgres.h>
+
 #include <access/genam.h>
-#include <utils/fmgroids.h>
 #include <access/heapam.h>
+#include <nodes/lockoptions.h>
 #include <utils.h>
+#include <utils/fmgroids.h>
 
 #include "compat.h"
+
+typedef struct ScanTupLock
+{
+	LockTupleMode lockmode;
+	LockWaitPolicy waitpolicy;
+} ScanTupLock;
 
 /* Tuple information passed on to handlers when scanning for tuples. */
 typedef struct TupleInfo
@@ -69,12 +77,7 @@ typedef struct ScannerCtx
 	LOCKMODE lockmode;
 	MemoryContext result_mctx; /* The memory context to allocate the result
 								* on */
-	struct
-	{
-		LockTupleMode lockmode;
-		LockWaitPolicy waitpolicy;
-		bool enabled;
-	} tuplock;
+	ScanTupLock *tuplock;
 	ScanDirection scandirection;
 	void *data; /* User-provided data passed on to filter()
 				 * and tuple_found() */

--- a/test/isolation/expected/insert_dropchunks_race.out
+++ b/test/isolation/expected/insert_dropchunks_race.out
@@ -1,0 +1,15 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1a s2a s1b s2b s1c
+step s1a: INSERT INTO insert_dropchunks_race_t1 VALUES ('2020-01-03 10:30', 3, 33.4);
+step s2a: SELECT COUNT(*) FROM drop_chunks(TIMESTAMPTZ '2020-03-01', 'insert_dropchunks_race_t1'); <waiting ...>
+step s1b: COMMIT;
+step s2a: <... completed>
+count          
+
+2              
+step s2b: COMMIT;
+step s1c: SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint LEFT JOIN _timescaledb_catalog.dimension_slice sl ON dimension_slice_id = sl.id WHERE sl.id IS NULL;
+count          
+
+0              

--- a/test/isolation/specs/CMakeLists.txt
+++ b/test/isolation/specs/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 set(TEST_FILES
     deadlock_dropchunks_select.spec
+    insert_dropchunks_race.spec
     isolation_nop.spec
     read_committed_insert.spec
     read_uncommitted_insert.spec

--- a/test/isolation/specs/insert_dropchunks_race.spec
+++ b/test/isolation/specs/insert_dropchunks_race.spec
@@ -1,0 +1,37 @@
+# Race condition between insert and drop_chunks
+#
+# If an insert need to create a new chunk, it will look for existing
+# dimension slices to see if any need to be added: if slices already
+# exist, they do not need to be re-constructed and constraints can be
+# added that reference these slices. If chunks are dropped, there is a
+# cleanup of unreferenced dimension slices which can possibly remove
+# unreferenced dimension slices if transactions creating new chunks do
+# not lock the dimension slices for read.
+#
+# This isolation test check that a concurrent insert and drop_chunks
+# do not accidentally create a broken state by adding chunk
+# constraints that reference non-existing dimension slices.
+
+setup {
+  DROP TABLE IF EXISTS insert_dropchunks_race_t1;
+  CREATE TABLE insert_dropchunks_race_t1 (time timestamptz, device int, temp float);
+  SELECT create_hypertable('insert_dropchunks_race_t1', 'time', 'device', 2);
+  INSERT INTO insert_dropchunks_race_t1 VALUES ('2020-01-03 10:30', 1, 32.2);
+}
+
+teardown {
+  DROP TABLE insert_dropchunks_race_t1;
+}
+
+session "s1"
+setup		{ BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; }
+step "s1a"	{ INSERT INTO insert_dropchunks_race_t1 VALUES ('2020-01-03 10:30', 3, 33.4); }
+step "s1b" 	{ COMMIT; }
+step "s1c" 	{ SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint LEFT JOIN _timescaledb_catalog.dimension_slice sl ON dimension_slice_id = sl.id WHERE sl.id IS NULL; }
+
+session "s2"
+setup	        { BEGIN; SET TRANSACTION ISOLATION LEVEL READ COMMITTED; }
+step "s2a"	{ SELECT COUNT(*) FROM drop_chunks(TIMESTAMPTZ '2020-03-01', 'insert_dropchunks_race_t1'); }
+step "s2b"	{ COMMIT; }
+
+permutation "s1a" "s2a" "s1b" "s2b" "s1c"


### PR DESCRIPTION
If a dimension slice tuple is found while adding new chunk constraints
as part of a chunk creation it is not locked prior to adding the chunk
constraint. Hence a concurrently executing `drop_chunks` can find a
dimension slice unused (because there is no chunk constraint that
references it) and subsequently remove it. The insert will the continue
to add the chunk constraint with a reference to a now non-existent
dimension slice.

This commit fixes this by locking the dimension slice tuple with a
share lock when creating chunks and locking the dimension slice with an
exclusive lock prior to scanning for existing chunk constraints.

The commit also contains a script that repair the `dimension_slice`
table if it is broken by extracting information about dimension slices
that are mentioned in `chunk_constraint` table but not present in
`dimension_slice` table and re-create the rows from the constraints on
the chunks.