### PR TITLE
Add missing ORDER BY clause to chunk_api test

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -84,6 +84,6 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_COLOR: '#ff0000'
         SLACK_USERNAME: GitHub Action
-        SLACK_TITLE: APT Package ${{ matrix.image }} PG${{ matrix.pg }} {{ job.status }}
+        SLACK_TITLE: APT Package ${{ matrix.image }} PG${{ matrix.pg }} ${{ job.status }}
         SLACK_MESSAGE: ${{ github.event.head_commit.message }}
       uses: rtCamp/action-slack-notify@v2.0.2

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -295,7 +295,8 @@ SELECT * FROM distributed_exec('ANALYZE disttable', '{ "data_node_1" }');
 -- Stats should now be refreshed after running get_chunk_{col,rel}stats
 SELECT relname, reltuples, relpages, relallvisible FROM pg_class WHERE relname IN
 (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name
- FROM show_chunks('disttable'));
+ FROM show_chunks('disttable'))
+ORDER BY relname;
         relname        | reltuples | relpages | relallvisible 
 -----------------------+-----------+----------+---------------
  _dist_hyper_2_3_chunk |         0 |        0 |             0

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -149,7 +149,8 @@ SELECT * FROM distributed_exec('ANALYZE disttable', '{ "data_node_1" }');
 -- Stats should now be refreshed after running get_chunk_{col,rel}stats
 SELECT relname, reltuples, relpages, relallvisible FROM pg_class WHERE relname IN
 (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name
- FROM show_chunks('disttable'));
+ FROM show_chunks('disttable'))
+ORDER BY relname;
 SELECT * FROM pg_stats WHERE tablename IN
 (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name
  FROM show_chunks('disttable'))


### PR DESCRIPTION
The chunk_api test fails sometimes because of inconsistent resultset
ordering in one of the queries. This patch adds the missing ORDER BY
clause to that query.