### PR TITLE
Remove debian 8 from package test

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Debian images:  8 (jessie), 9 (stretch), or 10 (buster)
+        # Debian images:  9 (stretch), or 10 (buster)
         # Ubuntu images:  18.04 LTS (bionic), 19.10 (eoan), 20.04 LTS (focal)
-        image: [ "debian:8-slim", "debian:9-slim", "debian:10-slim", "ubuntu:bionic", "ubuntu:eoan", "ubuntu:focal"]
+        image: [ "debian:9-slim", "debian:10-slim", "ubuntu:bionic", "ubuntu:eoan", "ubuntu:focal"]
         pg: [ 9.6, 10, 11, 12 ]
         exclude:
           - image: "ubuntu:focal"

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -27,7 +27,7 @@ jobs:
         tee /etc/yum.repos.d/timescale_timescaledb.repo <<EOL
         [timescale_timescaledb]
         name=timescale_timescaledb
-        baseurl=https://packagecloud.io/timescale/timescaledb/el/7/\$basearch
+        baseurl=https://packagecloud.io/timescale/timescaledb/el/$(rpm -E %{rhel})/\$basearch
         repo_gpgcheck=1
         gpgcheck=0
         enabled=1

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -39,6 +39,7 @@ def build_debug_config(overrides):
     "build_type": "Debug",
     "pg_build_args": "--enable-debug --enable-cassert",
     "tsdb_build_args": "-DCODECOVERAGE=ON",
+    "installcheck_args": "IGNORES='bgw_db_scheduler'",
     "coverage": True,
     "llvm_config": "llvm-config-9",
     "clang": "clang-9",
@@ -89,7 +90,7 @@ macos_config = {
   "tsdb_build_args": "-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl",
   "llvm_config": "/usr/local/opt/llvm/bin/llvm-config",
   "coverage": False,
-  "installcheck_args": "IGNORES='bgw_db_scheduler'"
+  "installcheck_args": "IGNORES='bgw_db_scheduler bgw_launcher remote_connection'",
 }
 
 m["include"].append(build_debug_config(macos_config))


### PR DESCRIPTION
This patch removes Debian 8 from the package test since its no
longer supported. This patch also fixes the repository URL for
centos 8.