### PR TITLE
Adopt table scan methods for Scanner

### DIFF
--- a/src/bgw_policy/policy.c
+++ b/src/bgw_policy/policy.c
@@ -3,8 +3,6 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-
-#include "bgw_policy/compress_chunks.h"
 #include <postgres.h>
 
 #include "policy.h"
@@ -44,7 +42,7 @@ ts_bgw_policy_delete_row_only_tuple_found(TupleInfo *ti, void *const data)
 	CatalogSecurityContext sec_ctx;
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-	ts_catalog_delete(ti->scanrel, ti->tuple);
+	ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
 	ts_catalog_restore_user(&sec_ctx);
 
 	return SCAN_CONTINUE;

--- a/src/bgw_policy/reorder.c
+++ b/src/bgw_policy/reorder.c
@@ -26,7 +26,7 @@ bgw_policy_reorder_tuple_found(TupleInfo *ti, void *const data)
 {
 	BgwPolicyReorder **policy = data;
 
-	*policy = STRUCT_FROM_TUPLE(ti->tuple, ti->mctx, BgwPolicyReorder, FormData_bgw_policy_reorder);
+	*policy = STRUCT_FROM_SLOT(ti->slot, ti->mctx, BgwPolicyReorder, FormData_bgw_policy_reorder);
 
 	return SCAN_CONTINUE;
 }

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -258,12 +258,12 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 			[CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_PKEY] = "continuous_aggs_invalidation_threshold_pkey",
 		},
 	},
-    [CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG] = {
-        .length = _MAX_CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_INDEX,
-        .names = (char *[]) {
-            [CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_IDX] = "continuous_aggs_materialization_invalidation_log_idx",
-        },
-    },
+	[CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG] = {
+		.length = _MAX_CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_INDEX,
+		.names = (char *[]) {
+			[CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_IDX] = "continuous_aggs_materialization_invalidation_log_idx",
+		},
+	},
 	[HYPERTABLE_COMPRESSION] = {
 		.length =  _MAX_HYPERTABLE_COMPRESSION_INDEX,
 		.names = (char *[]) {
@@ -685,7 +685,7 @@ ts_catalog_delete_tid(Relation rel, ItemPointer tid)
 	CommandCounterIncrement();
 }
 
-TSDLLEXPORT void
+void
 ts_catalog_delete(Relation rel, HeapTuple tuple)
 {
 	ts_catalog_delete_tid(rel, &tuple->t_self);
@@ -695,6 +695,12 @@ void
 ts_catalog_delete_only(Relation rel, HeapTuple tuple)
 {
 	CatalogTupleDelete(rel, &tuple->t_self);
+}
+
+void
+ts_catalog_delete_tid_only(Relation rel, ItemPointer tid)
+{
+	CatalogTupleDelete(rel, tid);
 }
 
 /*

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -1477,7 +1477,8 @@ extern TSDLLEXPORT void ts_catalog_insert_values(Relation rel, TupleDesc tupdesc
 												 bool *nulls);
 extern TSDLLEXPORT void ts_catalog_update_tid(Relation rel, ItemPointer tid, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_update(Relation rel, HeapTuple tuple);
-extern void ts_catalog_delete_tid(Relation rel, ItemPointer tid);
+extern TSDLLEXPORT void ts_catalog_delete_tid(Relation rel, ItemPointer tid);
+extern void ts_catalog_delete_tid_only(Relation rel, ItemPointer tid);
 extern TSDLLEXPORT void ts_catalog_delete(Relation rel, HeapTuple tuple);
 extern void ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -167,8 +167,8 @@ extern TSDLLEXPORT Chunk *ts_chunk_find_or_create_without_cuts(Hypertable *ht, H
 															   const char *schema_name,
 															   const char *table_name,
 															   bool *created);
-extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(Chunk *chunk);
-extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(Chunk *chunk);
+extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(const Chunk *chunk);
+extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_can_be_compressed(int32 chunk_id);
 extern TSDLLEXPORT Datum ts_chunk_id_from_relid(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT List *ts_chunk_get_chunk_ids_by_hypertable_id(int32 hypertable_id);

--- a/src/compat/tableam.h
+++ b/src/compat/tableam.h
@@ -23,6 +23,7 @@
 #define table_beginscan_catalog(rel, nkeys, keys) heap_beginscan_catalog(rel, nkeys, keys)
 #define table_endscan(scan) heap_endscan(scan)
 
+#define table_slot_callbacks(rel) NULL
 #define table_slot_create(rel, reglist) ts_table_slot_create(rel, reglist)
 #define table_tuple_insert(rel, slot, cid, options, bistate)                                       \
 	ts_table_tuple_insert(rel, slot, cid, options, bistate)

--- a/src/compat/tuptable.h
+++ b/src/compat/tuptable.h
@@ -8,12 +8,15 @@
 
 #include <postgres.h>
 #include <executor/tuptable.h>
+#include <utils/relcache.h>
+
+#include "export.h"
 
 #define ExecFetchSlotHeapTuple(slot, materialize, should_free)                                     \
 	ts_exec_fetch_slot_heap_tuple(slot, materialize, should_free)
 
-extern HeapTuple ts_exec_fetch_slot_heap_tuple(TupleTableSlot *slot, bool materialize,
-											   bool *should_free);
+extern TSDLLEXPORT HeapTuple ts_exec_fetch_slot_heap_tuple(TupleTableSlot *slot, bool materialize,
+														   bool *should_free);
 extern void ts_tuptableslot_set_table_oid(TupleTableSlot *slot, Oid table_oid);
 
 #endif /* TIMESCALEDB_COMPAT_TUPTABLE_H */

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -105,7 +105,7 @@ extern TSDLLEXPORT bool ts_hypertable_has_privs_of(Oid hypertable_oid, Oid useri
 extern TSDLLEXPORT Oid ts_hypertable_permissions_check(Oid hypertable_oid, Oid userid);
 
 extern TSDLLEXPORT void ts_hypertable_permissions_check_by_id(int32 hypertable_id);
-extern Hypertable *ts_hypertable_from_tupleinfo(TupleInfo *ti);
+extern Hypertable *ts_hypertable_from_tupleinfo(const TupleInfo *ti);
 extern int ts_hypertable_scan_with_memory_context(const char *schema, const char *table,
 												  tuple_found_func tuple_found, void *data,
 												  LOCKMODE lockmode, bool tuplock,

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -77,7 +77,7 @@ metadata_tuple_get_value(TupleInfo *ti, void *data)
 {
 	DatumValue *dv = data;
 
-	dv->value = heap_getattr(ti->tuple, Anum_metadata_value, ti->desc, &dv->isnull);
+	dv->value = slot_getattr(ti->slot, Anum_metadata_value, &dv->isnull);
 
 	if (!dv->isnull)
 		dv->value = convert_text_to_type(dv->value, dv->typeid);
@@ -178,7 +178,7 @@ ts_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_value, Oid v
 static ScanTupleResult
 metadata_tuple_delete(TupleInfo *ti, void *data)
 {
-	ts_catalog_delete(ti->scanrel, ti->tuple);
+	ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
 
 	return SCAN_CONTINUE;
 }

--- a/src/planner.c
+++ b/src/planner.c
@@ -29,12 +29,11 @@
 #include <tcop/tcopprot.h>
 #include <optimizer/plancat.h>
 #include <nodes/nodeFuncs.h>
-
 #include <parser/analyze.h>
-
 #include <catalog/pg_constraint.h>
-#include "compat.h"
 #include "compat-msvc-exit.h"
+
+#include "compat.h"
 
 #if PG11
 #include <optimizer/var.h>

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3178,10 +3178,13 @@ process_refresh_mat_view_start(ProcessUtilityArgs *args)
 
 	ts_scanner_foreach(&continuous_aggregate_iter)
 	{
-		HeapTuple tuple = ts_scan_iterator_tuple(&continuous_aggregate_iter);
-		Form_continuous_agg form = (Form_continuous_agg) GETSTRUCT(tuple);
+		bool isnull;
+		Datum hyper_id = slot_getattr(ts_scan_iterator_slot(&continuous_aggregate_iter),
+									  Anum_continuous_agg_mat_hypertable_id,
+									  &isnull);
+		Assert(!isnull);
 		Assert(materialization_id == -1);
-		materialization_id = form->mat_hypertable_id;
+		materialization_id = DatumGetInt32(hyper_id);
 	}
 
 	if (materialization_id == -1)

--- a/src/scan_iterator.h
+++ b/src/scan_iterator.h
@@ -5,7 +5,9 @@
  */
 #ifndef TIMESCALEDB_SCAN_ITERATOR_H
 #define TIMESCALEDB_SCAN_ITERATOR_H
+
 #include <postgres.h>
+#include <utils/palloc.h>
 
 #include "scanner.h"
 
@@ -32,21 +34,39 @@ typedef struct ScanIterator
 	}
 
 static inline TupleInfo *
-ts_scan_iterator_tuple_info(ScanIterator *iterator)
+ts_scan_iterator_tuple_info(const ScanIterator *iterator)
 {
 	return iterator->tinfo;
 }
 
-static inline HeapTuple
-ts_scan_iterator_tuple(ScanIterator *iterator)
+static inline TupleTableSlot *
+ts_scan_iterator_slot(const ScanIterator *iterator)
 {
-	return iterator->tinfo->tuple;
+	return iterator->tinfo->slot;
+}
+
+static inline HeapTuple
+ts_scan_iterator_fetch_heap_tuple(const ScanIterator *iterator, bool materialize, bool *should_free)
+{
+	return ts_scanner_fetch_heap_tuple(iterator->tinfo, materialize, should_free);
 }
 
 static inline TupleDesc
-ts_scan_iterator_tupledesc(ScanIterator *iterator)
+ts_scan_iterator_tupledesc(const ScanIterator *iterator)
 {
-	return iterator->tinfo->desc;
+	return ts_scanner_get_tupledesc(iterator->tinfo);
+}
+
+static inline MemoryContext
+ts_scan_iterator_get_result_memory_context(const ScanIterator *iterator)
+{
+	return iterator->tinfo->mctx;
+}
+
+static inline void *
+ts_scan_iterator_alloc_result(const ScanIterator *iterator, Size size)
+{
+	return ts_scanner_alloc_result(iterator->tinfo, size);
 }
 
 void TSDLLEXPORT ts_scan_iterator_close(ScanIterator *iterator);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -6,15 +6,18 @@
 #include <postgres.h>
 #include <access/relscan.h>
 #include <access/xact.h>
+#include <access/htup_details.h>
+#include <executor/tuptable.h>
 #include <storage/lmgr.h>
 #include <storage/bufmgr.h>
 #include <utils/rel.h>
+#include <utils/palloc.h>
 
 #include "scanner.h"
 
 enum ScannerType
 {
-	ScannerTypeHeap,
+	ScannerTypeTable,
 	ScannerTypeIndex,
 };
 
@@ -23,45 +26,60 @@ enum ScannerType
  */
 typedef struct Scanner
 {
-	Relation (*openheap)(InternalScannerCtx *ctx);
+	Relation (*openscan)(InternalScannerCtx *ctx);
 	ScanDesc (*beginscan)(InternalScannerCtx *ctx);
 	bool (*getnext)(InternalScannerCtx *ctx);
 	void (*endscan)(InternalScannerCtx *ctx);
-	void (*closeheap)(InternalScannerCtx *ctx);
+	void (*closescan)(InternalScannerCtx *ctx);
 } Scanner;
 
 /* Functions implementing heap scans */
 static Relation
-heap_scanner_open(InternalScannerCtx *ctx)
+table_scanner_open(InternalScannerCtx *ctx)
 {
 	ctx->tablerel = table_open(ctx->sctx->table, ctx->sctx->lockmode);
 	return ctx->tablerel;
 }
 
 static ScanDesc
-heap_scanner_beginscan(InternalScannerCtx *ctx)
+table_scanner_beginscan(InternalScannerCtx *ctx)
 {
 	ScannerCtx *sctx = ctx->sctx;
 
-	ctx->scan.heap_scan = table_beginscan(ctx->tablerel, SnapshotSelf, sctx->nkeys, sctx->scankey);
+	ctx->scan.table_scan = table_beginscan(ctx->tablerel, SnapshotSelf, sctx->nkeys, sctx->scankey);
 	return ctx->scan;
 }
 
 static bool
-heap_scanner_getnext(InternalScannerCtx *ctx)
+table_scanner_getnext(InternalScannerCtx *ctx)
 {
-	ctx->tinfo.tuple = heap_getnext(ctx->scan.heap_scan, ctx->sctx->scandirection);
-	return HeapTupleIsValid(ctx->tinfo.tuple);
+	bool success;
+#if PG12_LT
+	HeapTuple tuple = heap_getnext(ctx->scan.table_scan, ForwardScanDirection);
+
+	success = HeapTupleIsValid(tuple);
+
+	if (success)
+	{
+		ctx->tinfo.tid = tuple->t_self;
+		/* The tuple is managed by the heap so shouldn't free it */
+		ExecStoreTuple(tuple, ctx->tinfo.slot, InvalidBuffer, false);
+	}
+#else
+	success = table_scan_getnextslot(ctx->scan.table_scan, ForwardScanDirection, ctx->tinfo.slot);
+#endif
+
+	return success;
 }
 
 static void
-heap_scanner_endscan(InternalScannerCtx *ctx)
+table_scanner_endscan(InternalScannerCtx *ctx)
 {
-	heap_endscan(ctx->scan.heap_scan);
+	table_endscan(ctx->scan.table_scan);
 }
 
 static void
-heap_scanner_close(InternalScannerCtx *ctx)
+table_scanner_close(InternalScannerCtx *ctx)
 {
 	table_close(ctx->tablerel, ctx->sctx->lockmode);
 }
@@ -92,16 +110,19 @@ index_scanner_getnext(InternalScannerCtx *ctx)
 {
 	bool success;
 #if PG12_LT
-	ctx->tinfo.tuple = index_getnext(ctx->scan.index_scan, ctx->sctx->scandirection);
-	success = HeapTupleIsValid(ctx->tinfo.tuple);
-#else
-	/* We should use the slot type here instead of the HeapTuple to avoid unneeded materialization.
-	 * This would require changing consumers of this function's output to use a TupleTableSlot
-	 * instead of a HeapTuple and dynamically determining the slot type from the index, instead of
-	 * just assuming HeapTuple */
-	success = index_getnext_slot(ctx->scan.index_scan, ctx->sctx->scandirection, ctx->tinfo.slot);
+	HeapTuple tuple;
+
+	tuple = index_getnext(ctx->scan.index_scan, ctx->sctx->scandirection);
+	success = HeapTupleIsValid(tuple);
+
 	if (success)
-		ctx->tinfo.tuple = ExecFetchSlotHeapTuple(ctx->tinfo.slot, false, NULL);
+	{
+		ctx->tinfo.tid = tuple->t_self;
+		/* index_getnext() returns disk page tuples, so should not be freed */
+		ExecStoreTuple(tuple, ctx->tinfo.slot, InvalidBuffer, false);
+	}
+#else
+	success = index_getnext_slot(ctx->scan.index_scan, ctx->sctx->scandirection, ctx->tinfo.slot);
 #endif
 
 	ctx->tinfo.ituple = ctx->scan.index_scan->xs_itup;
@@ -126,19 +147,19 @@ index_scanner_close(InternalScannerCtx *ctx)
  * Two scanners by type: heap and index scanners.
  */
 static Scanner scanners[] = {
-	[ScannerTypeHeap] = {
-		.openheap = heap_scanner_open,
-		.beginscan = heap_scanner_beginscan,
-		.getnext = heap_scanner_getnext,
-		.endscan = heap_scanner_endscan,
-		.closeheap = heap_scanner_close,
+	[ScannerTypeTable] = {
+		.openscan = table_scanner_open,
+		.beginscan = table_scanner_beginscan,
+		.getnext = table_scanner_getnext,
+		.endscan = table_scanner_endscan,
+		.closescan = table_scanner_close,
 	},
 	[ScannerTypeIndex] = {
-		.openheap = index_scanner_open,
+		.openscan = index_scanner_open,
 		.beginscan = index_scanner_beginscan,
 		.getnext = index_scanner_getnext,
 		.endscan = index_scanner_endscan,
-		.closeheap = index_scanner_close,
+		.closescan = index_scanner_close,
 	}
 };
 
@@ -148,7 +169,7 @@ scanner_ctx_get_scanner(ScannerCtx *ctx)
 	if (OidIsValid(ctx->index))
 		return &scanners[ScannerTypeIndex];
 	else
-		return &scanners[ScannerTypeHeap];
+		return &scanners[ScannerTypeTable];
 }
 
 /*
@@ -169,19 +190,15 @@ ts_scanner_start_scan(ScannerCtx *ctx, InternalScannerCtx *ictx)
 
 	scanner = scanner_ctx_get_scanner(ctx);
 
-	scanner->openheap(ictx);
+	scanner->openscan(ictx);
 	scanner->beginscan(ictx);
 
 	tuple_desc = RelationGetDescr(ictx->tablerel);
 
 	ictx->tinfo.scanrel = ictx->tablerel;
-	ictx->tinfo.desc = tuple_desc;
 	ictx->tinfo.mctx = ctx->result_mctx == NULL ? CurrentMemoryContext : ctx->result_mctx;
-#if PG12_GE /* As an optimization, we should dynamically determine the slot type from the index    \
-			   here and not force a BufferHeapTuple to avoid allocating memory if it's not a       \
-			   BufferHeapTuple and to support custom index slot types */
-	ictx->tinfo.slot = MakeSingleTupleTableSlot(tuple_desc, &TTSOpsBufferHeapTuple);
-#endif
+	ictx->tinfo.slot =
+		MakeSingleTupleTableSlotCompat(tuple_desc, table_slot_callbacks(ictx->tablerel));
 
 	/* Call pre-scan handler, if any. */
 	if (ctx->prescan != NULL)
@@ -207,10 +224,9 @@ ts_scanner_end_scan(ScannerCtx *ctx, InternalScannerCtx *ictx)
 		ictx->sctx->postscan(ictx->tinfo.count, ictx->sctx->data);
 
 	scanner->endscan(ictx);
-	scanner->closeheap(ictx);
-#if PG12_GE
+	scanner->closescan(ictx);
+
 	ExecDropSingleTupleTableSlot(ictx->tinfo.slot);
-#endif
 	ictx->closed = true;
 }
 
@@ -228,23 +244,41 @@ ts_scanner_next(ScannerCtx *ctx, InternalScannerCtx *ictx)
 
 			if (ctx->tuplock)
 			{
+				TM_FailureData tmfd;
+
+#if PG12_GE
+				TupleTableSlot *slot = ictx->tinfo.slot;
+
+				PushActiveSnapshot(GetLatestSnapshot());
+				ictx->tinfo.lockresult = table_tuple_lock(ictx->tablerel,
+														  &(slot->tts_tid),
+														  GetLatestSnapshot(),
+														  slot,
+														  GetCurrentCommandId(false),
+														  ctx->tuplock->lockmode,
+														  ctx->tuplock->waitpolicy,
+														  0 /* don't follow updates */,
+														  &tmfd);
+
+				PopActiveSnapshot();
+#else
+				HeapTuple tuple = ExecFetchSlotTuple(ictx->tinfo.slot);
 				Buffer buffer;
-				TM_FailureData hufd;
 
 				ictx->tinfo.lockresult = heap_lock_tuple(ictx->tablerel,
-														 ictx->tinfo.tuple,
+														 tuple,
 														 GetCurrentCommandId(false),
 														 ctx->tuplock->lockmode,
 														 ctx->tuplock->waitpolicy,
 														 false,
 														 &buffer,
-														 &hufd);
-
+														 &tmfd);
 				/*
 				 * A tuple lock pins the underlying buffer, so we need to
 				 * unpin it.
 				 */
 				ReleaseBuffer(buffer);
+#endif
 			}
 
 			/* stop at a valid tuple */
@@ -263,7 +297,7 @@ ts_scanner_next(ScannerCtx *ctx, InternalScannerCtx *ictx)
  * ScannerCtx. ScannerCtx must be setup by caller with the proper information
  * for the scan, including filters and callbacks for found tuples.
  *
- * Return the number of tuples that where found.
+ * Return the number of tuples that were found.
  */
 TSDLLEXPORT int
 ts_scanner_scan(ScannerCtx *ctx)
@@ -285,7 +319,7 @@ ts_scanner_scan(ScannerCtx *ctx)
 }
 
 TSDLLEXPORT bool
-ts_scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type)
+ts_scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, const char *item_type)
 {
 	int num_found = ts_scanner_scan(ctx);
 
@@ -305,4 +339,32 @@ ts_scanner_scan_one(ScannerCtx *ctx, bool fail_if_not_found, char *item_type)
 			elog(ERROR, "more than one %s found", item_type);
 			return false;
 	}
+}
+
+ItemPointer
+ts_scanner_get_tuple_tid(TupleInfo *ti)
+{
+#if PG12_GE
+	return &ti->slot->tts_tid;
+#else
+	return &ti->tid;
+#endif
+}
+
+HeapTuple
+ts_scanner_fetch_heap_tuple(const TupleInfo *ti, bool materialize, bool *should_free)
+{
+	return ExecFetchSlotHeapTuple(ti->slot, materialize, should_free);
+}
+
+TupleDesc
+ts_scanner_get_tupledesc(const TupleInfo *ti)
+{
+	return ti->slot->tts_tupleDescriptor;
+}
+
+void *
+ts_scanner_alloc_result(const TupleInfo *ti, Size size)
+{
+	return MemoryContextAllocZero(ti->mctx, size);
 }

--- a/src/telemetry/telemetry_metadata.c
+++ b/src/telemetry/telemetry_metadata.c
@@ -35,11 +35,11 @@ ts_telemetry_metadata_add_values(JsonbParseState *state)
 	{
 		TupleInfo *ti = iterator.tinfo;
 
-		key = heap_getattr(ti->tuple, Anum_metadata_key, ti->desc, &key_isnull);
+		key = slot_getattr(ti->slot, Anum_metadata_key, &key_isnull);
+
 		include_entry =
 			!key_isnull &&
-			DatumGetBool(
-				heap_getattr(ti->tuple, Anum_metadata_include_in_telemetry, ti->desc, &key_isnull));
+			DatumGetBool(slot_getattr(ti->slot, Anum_metadata_include_in_telemetry, &key_isnull));
 
 		if (include_entry)
 		{
@@ -50,7 +50,7 @@ ts_telemetry_metadata_add_values(JsonbParseState *state)
 				namestrcmp(key_name, METADATA_EXPORTED_UUID_KEY_NAME) != 0 &&
 				namestrcmp(key_name, METADATA_TIMESTAMP_KEY_NAME) != 0)
 			{
-				value = heap_getattr(ti->tuple, Anum_metadata_value, ti->desc, &value_isnull);
+				value = slot_getattr(ti->slot, Anum_metadata_value, &value_isnull);
 
 				if (!value_isnull)
 					ts_jsonb_add_str(state, DatumGetCString(key), TextDatumGetCString(value));

--- a/src/utils.c
+++ b/src/utils.c
@@ -460,7 +460,7 @@ ts_type_is_int8_binary_compatible(Oid sourcetype)
  * that might have variable lengths.
  * Also note that the function assumes no NULLs in the tuple.
  */
-void *
+static void *
 ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size,
 							size_t copy_size)
 {
@@ -471,6 +471,20 @@ ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_si
 	memcpy(struct_ptr, GETSTRUCT(tuple), copy_size);
 
 	return struct_ptr;
+}
+
+void *
+ts_create_struct_from_slot(TupleTableSlot *slot, MemoryContext mctx, size_t alloc_size,
+						   size_t copy_size)
+{
+	bool should_free;
+	HeapTuple tuple = ExecFetchSlotHeapTuple(slot, false, &should_free);
+	void *result = ts_create_struct_from_tuple(tuple, mctx, alloc_size, copy_size);
+
+	if (should_free)
+		heap_freetuple(tuple);
+
+	return result;
 }
 
 bool

--- a/src/utils.h
+++ b/src/utils.h
@@ -82,8 +82,8 @@ extern TSDLLEXPORT Oid ts_get_function_oid(const char *funcname, const char *sch
 
 extern TSDLLEXPORT Oid ts_get_cast_func(Oid source, Oid target);
 
-extern void *ts_create_struct_from_tuple(HeapTuple tuple, MemoryContext mctx, size_t alloc_size,
-										 size_t copy_size);
+extern void *ts_create_struct_from_slot(TupleTableSlot *slot, MemoryContext mctx, size_t alloc_size,
+										size_t copy_size);
 
 extern TSDLLEXPORT AppendRelInfo *ts_get_appendrelinfo(PlannerInfo *root, Index rti,
 													   bool missing_ok);
@@ -94,8 +94,8 @@ extern TSDLLEXPORT bool ts_has_row_security(Oid relid);
 
 extern TSDLLEXPORT List *ts_get_reloptions(Oid relid);
 
-#define STRUCT_FROM_TUPLE(tuple, mctx, to_type, form_type)                                         \
-	(to_type *) ts_create_struct_from_tuple(tuple, mctx, sizeof(to_type), sizeof(form_type));
+#define STRUCT_FROM_SLOT(slot, mctx, to_type, form_type)                                           \
+	(to_type *) ts_create_struct_from_slot(slot, mctx, sizeof(to_type), sizeof(form_type));
 
 /* note PG10 has_superclass but PG96 does not so use this */
 #define is_inheritance_child(relid) (ts_inheritance_parent_relid(relid) != InvalidOid)

--- a/tsl/src/continuous_aggs/job.c
+++ b/tsl/src/continuous_aggs/job.c
@@ -3,6 +3,7 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#include "catalog.h"
 #include <postgres.h>
 #include <utils/builtins.h>
 
@@ -112,10 +113,14 @@ ts_continuous_agg_job_find_materializtion_by_job_id(int32 job_id)
 								   Int32GetDatum(job_id));
 	ts_scanner_foreach(&continuous_aggregate_iter)
 	{
-		HeapTuple tuple = ts_scan_iterator_tuple(&continuous_aggregate_iter);
-		Form_continuous_agg form = (Form_continuous_agg) GETSTRUCT(tuple);
+		bool isnull;
+		Datum id;
 		Assert(materialization_id == -1);
-		materialization_id = form->mat_hypertable_id;
+		id = slot_getattr(ts_scan_iterator_slot(&continuous_aggregate_iter),
+						  Anum_continuous_agg_mat_hypertable_id,
+						  &isnull);
+		Assert(!isnull);
+		materialization_id = DatumGetInt32(id);
 	}
 
 	return materialization_id;

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -139,16 +139,23 @@ update_refresh_lag(ContinuousAgg *agg, int64 new_lag)
 		bool nulls[Natts_continuous_agg];
 		Datum values[Natts_continuous_agg];
 		bool repl[Natts_continuous_agg] = { false };
-		HeapTuple new;
+		bool should_free;
+		HeapTuple tuple = ts_scan_iterator_fetch_heap_tuple(&iterator, false, &should_free);
+		HeapTuple new_tuple;
+		TupleDesc tupdesc = ts_scan_iterator_tupledesc(&iterator);
 
-		heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
+		heap_deform_tuple(tuple, tupdesc, values, nulls);
 
 		repl[AttrNumberGetAttrOffset(Anum_continuous_agg_refresh_lag)] = true;
 		values[AttrNumberGetAttrOffset(Anum_continuous_agg_refresh_lag)] = Int64GetDatum(new_lag);
 
-		new = heap_modify_tuple(ti->tuple, ti->desc, values, nulls, repl);
+		new_tuple = heap_modify_tuple(tuple, tupdesc, values, nulls, repl);
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
 
-		ts_catalog_update(ti->scanrel, new);
+		if (should_free)
+			heap_freetuple(tuple);
+
 		break;
 	}
 	ts_scan_iterator_close(&iterator);
@@ -173,17 +180,25 @@ update_materialized_only(ContinuousAgg *agg, bool materialized_only)
 		bool nulls[Natts_continuous_agg];
 		Datum values[Natts_continuous_agg];
 		bool repl[Natts_continuous_agg] = { false };
-		HeapTuple new;
+		bool should_free;
+		HeapTuple tuple = ts_scan_iterator_fetch_heap_tuple(&iterator, false, &should_free);
+		HeapTuple new_tuple;
+		TupleDesc tupdesc = ts_scan_iterator_tupledesc(&iterator);
 
-		heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
+		heap_deform_tuple(tuple, tupdesc, values, nulls);
 
 		repl[AttrNumberGetAttrOffset(Anum_continuous_agg_materialize_only)] = true;
 		values[AttrNumberGetAttrOffset(Anum_continuous_agg_materialize_only)] =
 			BoolGetDatum(materialized_only);
 
-		new = heap_modify_tuple(ti->tuple, ti->desc, values, nulls, repl);
+		new_tuple = heap_modify_tuple(tuple, tupdesc, values, nulls, repl);
 
-		ts_catalog_update(ti->scanrel, new);
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
+
+		if (should_free)
+			heap_freetuple(tuple);
+
 		break;
 	}
 	ts_scan_iterator_close(&iterator);
@@ -208,17 +223,25 @@ update_max_interval_per_job(ContinuousAgg *agg, int64 new_max)
 		bool nulls[Natts_continuous_agg];
 		Datum values[Natts_continuous_agg];
 		bool repl[Natts_continuous_agg] = { false };
-		HeapTuple new;
+		bool should_free;
+		HeapTuple tuple = ts_scan_iterator_fetch_heap_tuple(&iterator, false, &should_free);
+		HeapTuple new_tuple;
+		TupleDesc tupdesc = ts_scan_iterator_tupledesc(&iterator);
 
-		heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
+		heap_deform_tuple(tuple, tupdesc, values, nulls);
 
 		repl[AttrNumberGetAttrOffset(Anum_continuous_agg_max_interval_per_job)] = true;
 		values[AttrNumberGetAttrOffset(Anum_continuous_agg_max_interval_per_job)] =
 			Int64GetDatum(new_max);
 
-		new = heap_modify_tuple(ti->tuple, ti->desc, values, nulls, repl);
+		new_tuple = heap_modify_tuple(tuple, tupdesc, values, nulls, repl);
 
-		ts_catalog_update(ti->scanrel, new);
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
+
+		if (should_free)
+			heap_freetuple(tuple);
+
 		break;
 	}
 	ts_scan_iterator_close(&iterator);
@@ -243,17 +266,25 @@ update_ignore_invalidation_older_than(ContinuousAgg *agg, int64 new_ignore_inval
 		bool nulls[Natts_continuous_agg];
 		Datum values[Natts_continuous_agg];
 		bool repl[Natts_continuous_agg] = { false };
-		HeapTuple new;
+		bool should_free;
+		HeapTuple tuple = ts_scan_iterator_fetch_heap_tuple(&iterator, false, &should_free);
+		HeapTuple new_tuple;
+		TupleDesc tupdesc = ts_scan_iterator_tupledesc(&iterator);
 
-		heap_deform_tuple(ti->tuple, ti->desc, values, nulls);
+		heap_deform_tuple(tuple, tupdesc, values, nulls);
 
 		repl[AttrNumberGetAttrOffset(Anum_continuous_agg_ignore_invalidation_older_than)] = true;
 		values[AttrNumberGetAttrOffset(Anum_continuous_agg_ignore_invalidation_older_than)] =
 			Int64GetDatum(new_ignore_invalidation_older_than);
 
-		new = heap_modify_tuple(ti->tuple, ti->desc, values, nulls, repl);
+		new_tuple = heap_modify_tuple(tuple, tupdesc, values, nulls, repl);
 
-		ts_catalog_update(ti->scanrel, new);
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
+
+		if (should_free)
+			heap_freetuple(tuple);
+
 		break;
 	}
 	ts_scan_iterator_close(&iterator);

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -695,7 +695,7 @@ remote_txn_persistent_record_exists(const RemoteTxnId *parsed)
 static ScanTupleResult
 persistent_record_tuple_delete(TupleInfo *ti, void *data)
 {
-	ts_catalog_delete(ti->scanrel, ti->tuple);
+	ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
 	return SCAN_CONTINUE;
 }
 


### PR DESCRIPTION
This change makes the Scanner code agnostic to the underlying storage
implementation of the tables it scans. This also fixes a bug that made
it impossible to use non-heap table access methods on a
hypertable. The bug existed because a check is made for existing data
before a table is made into a hypertable. And, since this check reads
data from the table using the Scanner, it must be able to read the
data irrespective of the underlying storage.

As a result of the more generic scan interface, resource management is
also improved by delivering tuples in reference-counted tuple table
slots. A backwards-compatibility layer is used for PG11, which maps
all table access functions to the heap equivalents.

A potential memory corruption issue is also fixed when scanning chunk constraints (separate commit).

Fixes #2075 