### PR TITLE
Fix update tests

### DIFF
--- a/test/sql/updates/post.post_insert.sql
+++ b/test/sql/updates/post.post_insert.sql
@@ -70,4 +70,4 @@ $BODY$;
 SELECT timescaledb_integrity_test();
 
 -- Verify that the default jobs are the same in bgw_job
-SELECT * FROM _timescaledb_config.bgw_job;
+SELECT * FROM _timescaledb_config.bgw_job ORDER BY id;


### PR DESCRIPTION
The update test checks that default jobs are the same before and after
an upgrade, but does not order the jobs in any specific way. This means
that if the database order is different before and after the update, it
will result in a false negative even if the jobs are identical.

This commit fixes this by ordering the jobs by id.