### PR TITLE
Utility function and hypertables view

### DIFF
--- a/sql/dist_internal.sql
+++ b/sql/dist_internal.sql
@@ -8,22 +8,6 @@ AS '@MODULE_PATHNAME@', 'ts_dist_set_id' LANGUAGE C VOLATILE STRICT;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.set_peer_dist_id(dist_id UUID) RETURNS BOOL
 AS '@MODULE_PATHNAME@', 'ts_dist_set_peer_id' LANGUAGE C VOLATILE STRICT;
 
-CREATE OR REPLACE FUNCTION data_node_hypertable_info(
-    node_name              NAME
-)
-RETURNS TABLE (id   int,
-    table_schema    name,
-    table_name      name,
-    table_owner     name,
-    num_dimensions  smallint,
-    num_chunks      bigint,
-    distributed     bool,
-    table_bytes     bigint,
-    index_bytes     bigint,
-    toast_bytes     bigint,
-    total_bytes     bigint)
-AS '@MODULE_PATHNAME@', 'ts_dist_remote_hypertable_info' LANGUAGE C VOLATILE STRICT;
-
 -- Function to validate that a node has local settings to function as
 -- a data node. Throws error if validation fails.
 CREATE OR REPLACE FUNCTION _timescaledb_internal.validate_as_data_node() RETURNS void

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -5,7 +5,68 @@
 -- This file contains utility functions to get the relation size
 -- of hypertables, chunks, and indexes on hypertables.
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.hypertable_relation_local_size(
+CREATE OR REPLACE VIEW _timescaledb_internal.hypertable_chunk_local_size AS 
+SELECT
+   h.schema_name,
+   h.table_name,
+   h.id as hypertable_id,
+   c.id as chunk_id,
+   c.schema_name as chunk_schema,
+   c.table_name as chunk_name,
+   pg_total_relation_size(format('%I.%I', c.schema_name, c.table_name))::bigint AS total_bytes,
+   pg_indexes_size(format('%I.%I', c.schema_name, c.table_name))::bigint AS index_bytes,
+   pg_total_relation_size(reltoastrelid)::bigint AS toast_bytes,
+   map.compressed_heap_size,
+   map.compressed_index_size,
+   map.compressed_toast_size 
+FROM
+   _timescaledb_catalog.hypertable h 
+   INNER JOIN
+      _timescaledb_catalog.chunk c 
+      ON h.id = c.hypertable_id 
+      and c.dropped = false 
+   INNER JOIN
+      pg_class pgc 
+      ON pgc.relname = h.table_name 
+   INNER JOIN
+      pg_namespace pns 
+      ON pns.oid = pgc.relnamespace 
+      AND pns.nspname = h.schema_name 
+   LEFT OUTER JOIN
+      _timescaledb_catalog.compression_chunk_size map 
+      ON map.chunk_id = c.id 
+WHERE pgc.relkind = 'r';
+
+GRANT SELECT ON  _timescaledb_internal.hypertable_chunk_local_size TO PUBLIC;
+ 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.data_node_hypertable_info(
+    node_name              NAME,
+    schema_name_in name,
+    table_name_in name
+)
+RETURNS TABLE (
+    table_bytes     bigint,
+    index_bytes     bigint,
+    toast_bytes     bigint,
+    total_bytes     bigint)
+AS '@MODULE_PATHNAME@', 'ts_dist_remote_hypertable_info' LANGUAGE C VOLATILE STRICT;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.data_node_chunk_info(
+    node_name              NAME,
+    schema_name_in name,
+    table_name_in name
+)
+RETURNS TABLE (
+    chunk_id        integer,
+    chunk_schema    name,
+    chunk_name      name,
+    table_bytes     bigint,
+    index_bytes     bigint,
+    toast_bytes     bigint,
+    total_bytes     bigint)
+AS '@MODULE_PATHNAME@', 'ts_dist_remote_chunk_info' LANGUAGE C VOLATILE STRICT;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.hypertable_local_size(
     schema_name_in name,
     table_name_in name)
 RETURNS TABLE (
@@ -16,48 +77,47 @@ RETURNS TABLE (
 LANGUAGE PLPGSQL STABLE STRICT AS
 $BODY$
 BEGIN
-    RETURN QUERY
-    SELECT
-        sub2.table_bytes,
-        sub2.index_bytes,
-        sub2.toast_bytes,
-        sub2.total_bytes
-    FROM (
-        SELECT
+   RETURN QUERY 
+   SELECT
+      (sub2.table_bytes + sub2.compressed_heap_bytes)::bigint as heap_bytes,
+      (sub2.index_bytes + sub2.compressed_index_bytes)::bigint as index_bytes,
+      (sub2.toast_bytes + sub2.compressed_toast_bytes)::bigint as toast_bytes,
+      (sub2.total_bytes + sub2.compressed_heap_bytes + sub2.compressed_index_bytes + sub2.compressed_toast_bytes)::bigint as total_bytes 
+   FROM
+      (
+         SELECT
             *,
-            sub1.total_bytes - sub1.index_bytes - COALESCE(sub1.toast_bytes, 0) AS table_bytes
-        FROM (
-            SELECT
-                sum(pg_total_relation_size(format('%I.%I', c.schema_name, c.table_name)))::bigint AS total_bytes,
-                sum(pg_indexes_size(format('%I.%I', c.schema_name, c.table_name)))::bigint AS index_bytes,
-                sum(pg_total_relation_size(reltoastrelid))::bigint AS toast_bytes
-            FROM
-                _timescaledb_catalog.hypertable h,
-                _timescaledb_catalog.chunk c,
-                pg_class pgc,
-                pg_namespace pns
-            WHERE
-                h.schema_name = schema_name_in
-                AND h.table_name = table_name_in
-                AND c.dropped = FALSE
-                AND c.hypertable_id = h.id
-                AND pgc.relname = h.table_name
-                AND pns.oid = pgc.relnamespace
-                AND pns.nspname = h.schema_name
-                AND relkind = 'r'
-             ) sub1
-         ) sub2;
+            sub1.total_bytes - sub1.index_bytes - sub1.toast_bytes AS table_bytes 
+         FROM
+            (
+               SELECT
+                  sum(ch.total_bytes) as total_bytes,
+                  COALESCE( sum(ch.index_bytes) , 0 ) as index_bytes,
+                  COALESCE( sum(ch.toast_bytes), 0 ) as toast_bytes,
+                  COALESCE( sum(ch.compressed_heap_size) , 0 ) as compressed_heap_bytes,
+                  COALESCE( sum(ch.compressed_index_size) , 0) as compressed_index_bytes,
+                  COALESCE( sum(ch.compressed_toast_size) , 0 ) as compressed_toast_bytes 
+               FROM
+                  _timescaledb_internal.hypertable_chunk_local_size ch 
+               WHERE
+                  schema_name = schema_name_in 
+                  AND table_name = table_name_in 
+               GROUP BY
+                  hypertable_id 
+            ) sub1 
+      ) sub2;
 END;
 $BODY$;
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.hypertable_relation_remote_size(
+CREATE OR REPLACE FUNCTION _timescaledb_internal.hypertable_remote_size(
     schema_name_in name,
     table_name_in name)
 RETURNS TABLE (
     table_bytes bigint,
     index_bytes bigint,
     toast_bytes bigint,
-    total_bytes bigint)
+    total_bytes bigint,
+    node_name   NAME)
 LANGUAGE PLPGSQL STABLE STRICT AS
 $BODY$
 BEGIN
@@ -66,11 +126,12 @@ BEGIN
         sum(entry.table_bytes)::bigint AS table_bytes,
         sum(entry.index_bytes)::bigint AS index_bytes,
         sum(entry.toast_bytes)::bigint AS toast_bytes,
-        sum(entry.total_bytes)::bigint AS total_bytes
+        sum(entry.total_bytes)::bigint AS total_bytes,
+        srv.node_name
     FROM (
         SELECT
             s.node_name,
-            _timescaledb_internal.ping_data_node (node_name) AS node_up
+            _timescaledb_internal.ping_data_node (s.node_name) AS node_up
         FROM
             _timescaledb_catalog.hypertable AS ht,
             _timescaledb_catalog.hypertable_data_node AS s
@@ -79,21 +140,18 @@ BEGIN
             AND ht.table_name = table_name_in
             AND s.hypertable_id = ht.id
          ) AS srv
-    LEFT OUTER JOIN LATERAL @extschema@.data_node_hypertable_info(
+    LEFT OUTER JOIN LATERAL _timescaledb_internal.data_node_hypertable_info(
     CASE WHEN srv.node_up THEN
         srv.node_name
     ELSE
         NULL
-    END) entry ON TRUE
-    WHERE
-        entry.table_schema = schema_name_in
-        AND entry.table_name = table_name_in;
+    END, schema_name_in, table_name_in) entry ON TRUE
+    GROUP BY srv.node_name;
 END;
 $BODY$;
 
 -- Get relation size of hypertable
 -- like pg_relation_size(hypertable)
--- (https://www.postgresql.org/docs/9.6/static/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE)
 --
 -- main_table - hypertable to get size of
 --
@@ -103,13 +161,14 @@ $BODY$;
 -- toast_bytes        - Disk space of toast tables
 -- total_bytes        - Total disk space used by the specified table, including all indexes and TOAST data
 
-CREATE OR REPLACE FUNCTION hypertable_relation_size(
+CREATE OR REPLACE FUNCTION hypertable_detailed_size(
     main_table              REGCLASS
 )
 RETURNS TABLE (table_bytes BIGINT,
                index_bytes BIGINT,
                toast_bytes BIGINT,
-               total_bytes BIGINT
+               total_bytes BIGINT,
+               node_name   NAME
                ) LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
@@ -126,151 +185,206 @@ BEGIN
         WHERE c.OID = main_table;
 
         CASE WHEN is_distributed THEN
-            RETURN QUERY SELECT * FROM _timescaledb_internal.hypertable_relation_remote_size(schema_name, table_name);
+            RETURN QUERY SELECT * FROM _timescaledb_internal.hypertable_remote_size(schema_name, table_name);
         ELSE
-            RETURN QUERY SELECT * FROM _timescaledb_internal.hypertable_relation_local_size(schema_name, table_name);
+            RETURN QUERY SELECT *, NULL::name FROM _timescaledb_internal.hypertable_local_size(schema_name, table_name);
         END CASE;
 END;
 $BODY$;
 
-
-CREATE OR REPLACE FUNCTION _timescaledb_internal.range_value_to_pretty(
-    time_value      BIGINT,
-    column_type     REGTYPE
+--- returns total-bytes for a hypertable (includes table + index)
+CREATE OR REPLACE FUNCTION hypertable_size(
+    main_table              REGCLASS
 )
-    RETURNS TEXT LANGUAGE PLPGSQL STABLE AS
+RETURNS BIGINT 
+LANGUAGE PLPGSQL STABLE STRICT AS
 $BODY$
 DECLARE
+  num_bytes BIGINT;
 BEGIN
-    IF NOT _timescaledb_internal.dimension_is_finite(time_value) THEN
-        RETURN '';
-    END IF;
-    IF time_value IS NULL THEN
-        RETURN format('%L', NULL);
-    END IF;
-    CASE column_type
-      WHEN 'BIGINT'::regtype, 'INTEGER'::regtype, 'SMALLINT'::regtype THEN
-        RETURN format('%L', time_value); -- scale determined by user.
-      WHEN 'TIMESTAMP'::regtype, 'TIMESTAMPTZ'::regtype THEN
-        -- assume time_value is in microsec
-        RETURN format('%1$L', _timescaledb_internal.to_timestamp(time_value)); -- microseconds
-      WHEN 'DATE'::regtype THEN
-        RETURN format('%L', timezone('UTC',_timescaledb_internal.to_timestamp(time_value))::date);
-      ELSE
-        RETURN time_value;
-    END CASE;
-END
+   SELECT sum(hd.total_bytes) INTO STRICT num_bytes
+   FROM hypertable_detailed_size(main_table) hd;
+   RETURN num_bytes;
+END;
 $BODY$;
 
-
-CREATE OR REPLACE FUNCTION _timescaledb_internal.partitioning_column_to_pretty(
-    d   _timescaledb_catalog.dimension
-)
-    RETURNS TEXT LANGUAGE PLPGSQL STABLE STRICT AS
+CREATE OR REPLACE FUNCTION _timescaledb_internal.chunks_local_size(
+    schema_name_in name,
+    table_name_in name)
+RETURNS TABLE (
+    chunk_id    integer,
+    chunk_schema NAME,
+    chunk_name  NAME,
+    table_bytes bigint,
+    index_bytes bigint,
+    toast_bytes bigint,
+    total_bytes bigint)
+LANGUAGE PLPGSQL STABLE STRICT AS
 $BODY$
-DECLARE
 BEGIN
-        IF d.partitioning_func IS NULL THEN
-           RETURN d.column_name;
-        ELSE
-           RETURN format('%I.%I(%I)', d.partitioning_func_schema, d.partitioning_func, d.column_name);
-        END IF;
-END
+   RETURN QUERY
+   SELECT
+      ch.chunk_id,
+      ch.chunk_schema,
+      ch.chunk_name,
+      (ch.total_bytes - COALESCE( ch.index_bytes , 0 ) - COALESCE( ch.toast_bytes, 0 ) + COALESCE( ch.compressed_heap_size , 0 ))::bigint  as heap_bytes,
+      (COALESCE( ch.index_bytes, 0 ) + COALESCE( ch.compressed_index_size , 0) )::bigint as index_bytes,
+      (COALESCE( ch.toast_bytes, 0 ) + COALESCE( ch.compressed_toast_size, 0 ))::bigint as toast_bytes,
+      (ch.total_bytes + COALESCE( ch.compressed_heap_size, 0 ) + COALESCE( ch.compressed_index_size, 0) + COALESCE( ch.compressed_toast_size, 0 ))::bigint as total_bytes 
+   FROM
+   _timescaledb_internal.hypertable_chunk_local_size ch 
+   WHERE
+      ch.schema_name = schema_name_in 
+      AND ch.table_name = table_name_in 
+; 
+END;
 $BODY$;
 
+---should return same information as chunks_local_size--
+CREATE OR REPLACE FUNCTION _timescaledb_internal.chunks_remote_size(
+    schema_name_in name,
+    table_name_in name)
+RETURNS TABLE (
+    chunk_id    integer,
+    chunk_schema NAME,
+    chunk_name  NAME,
+    table_bytes bigint,
+    index_bytes bigint,
+    toast_bytes bigint,
+    total_bytes bigint,
+    node_name NAME)
+LANGUAGE PLPGSQL STABLE STRICT AS
+$BODY$
+BEGIN
+    RETURN QUERY
+    SELECT
+        entry.chunk_id,
+        entry.chunk_schema,
+        entry.chunk_name,
+        entry.table_bytes AS table_bytes,
+        entry.index_bytes AS index_bytes,
+        entry.toast_bytes AS toast_bytes,
+        entry.total_bytes AS total_bytes,
+        srv.node_name
+    FROM (
+        SELECT
+            s.node_name,
+            _timescaledb_internal.ping_data_node (s.node_name) AS node_up
+        FROM
+            _timescaledb_catalog.hypertable AS ht,
+            _timescaledb_catalog.hypertable_data_node AS s
+        WHERE
+            ht.schema_name = schema_name_in
+            AND ht.table_name = table_name_in
+            AND s.hypertable_id = ht.id
+         ) AS srv
+    LEFT OUTER JOIN LATERAL _timescaledb_internal.data_node_chunk_info(
+    CASE WHEN srv.node_up THEN
+        srv.node_name
+    ELSE
+        NULL
+    END , schema_name_in, table_name_in) entry ON TRUE;
+END;
+$BODY$;
 
--- Get relation size of hypertable
--- like pg_relation_size(hypertable)
--- (https://www.postgresql.org/docs/9.6/static/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE)
---
+-- Get relation size of the chunks of an hypertable
 -- main_table - hypertable to get size of
 --
 -- Returns:
--- table_size         - Pretty output of table_bytes
--- index_bytes        - Pretty output of index_bytes
--- toast_bytes        - Pretty output of toast_bytes
--- total_size         - Pretty output of total_bytes
-
-CREATE OR REPLACE FUNCTION hypertable_relation_size_pretty(
+-- chunk_schema                  - schema name for chunk
+-- chunk_name                    - chunk table name
+-- table_bytes                   - Disk space used by chunk table 
+-- index_bytes                   - Disk space used by indexes
+-- toast_bytes                   - Disk space of toast tables
+-- total_bytes                   - Disk space used in total
+-- node_name                     - node on which chunk lives if this is
+--                              a distributed hypertable.
+CREATE OR REPLACE FUNCTION chunks_detailed_size(
     main_table              REGCLASS
 )
-RETURNS TABLE (table_size  TEXT,
-               index_size  TEXT,
-               toast_size  TEXT,
-               total_size  TEXT) LANGUAGE PLPGSQL STABLE STRICT
+RETURNS TABLE (
+               chunk_schema NAME,
+               chunk_name NAME,
+               table_bytes BIGINT,
+               index_bytes BIGINT,
+               toast_bytes BIGINT,
+               total_bytes BIGINT,
+               node_name   NAME)
+               LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
 DECLARE
         table_name       NAME;
         schema_name      NAME;
+        is_distributed   BOOL;
 BEGIN
-        RETURN QUERY
-        SELECT pg_size_pretty(table_bytes) as table,
-               pg_size_pretty(index_bytes) as index,
-               pg_size_pretty(toast_bytes) as toast,
-               pg_size_pretty(total_bytes) as total
-               FROM @extschema@.hypertable_relation_size(main_table);
+        SELECT relname, nspname, replication_factor > 0
+        INTO STRICT table_name, schema_name, is_distributed
+        FROM pg_class c
+        INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
+        INNER JOIN _timescaledb_catalog.hypertable ht ON (ht.schema_name = n.nspname AND ht.table_name = c.relname)
+        WHERE c.OID = main_table;
 
+        CASE WHEN is_distributed THEN
+            RETURN QUERY SELECT ch.chunk_schema, ch.chunk_name, ch.table_bytes, ch.index_bytes, 
+                        ch.toast_bytes, ch.total_bytes, ch.node_name   
+            FROM _timescaledb_internal.chunks_remote_size(schema_name, table_name) ch;
+        ELSE
+            RETURN QUERY SELECT chl.chunk_schema, chl.chunk_name, chl.table_bytes, chl.index_bytes, 
+                        chl.toast_bytes, chl.total_bytes, NULL::NAME   
+            FROM _timescaledb_internal.chunks_local_size(schema_name, table_name) chl;
+        END CASE;
 END;
 $BODY$;
 
-
--- Get the per-node relation size of a distributed hypertable across all nodes in a distributed database
--- like pg_relation_size(hypertable)
--- (https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE)
+-- Get sizes of indexes on a hypertable
 --
--- main_table - hypertable to get size of
+-- main_table - hypertable to get index sizes of
 --
 -- Returns:
--- node_name          - Data node hosting part of the table
--- num_chunks         - Number of chunks hosted on the data node
--- table_size         - Pretty output of table_bytes for the data node
--- index_bytes        - Pretty output of index_bytes for the data node
--- toast_bytes        - Pretty output of toast_bytes for the data node
--- total_size         - Pretty output of total_bytes for the data node
+-- index_name           - index on hyper table
+-- total_bytes          - size of index on disk
 
-CREATE OR REPLACE FUNCTION hypertable_data_node_relation_size(
+CREATE OR REPLACE FUNCTION indexes_relation_size(
     main_table              REGCLASS
 )
-RETURNS TABLE (node_name   NAME,
-               num_chunks  BIGINT,
-               table_size  TEXT,
-               index_size  TEXT,
-               toast_size  TEXT,
-               total_size  TEXT) LANGUAGE PLPGSQL STABLE STRICT
+RETURNS TABLE (index_name TEXT,
+               total_bytes BIGINT)
+               LANGUAGE PLPGSQL STABLE STRICT
                AS
 $BODY$
+<<main>>
 DECLARE
-        local_table_name       NAME;
-        local_schema_name      NAME;
+        table_name       NAME;
+        schema_name      NAME;
 BEGIN
         SELECT relname, nspname
-        INTO STRICT local_table_name, local_schema_name
+        INTO STRICT table_name, schema_name
         FROM pg_class c
         INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
         WHERE c.OID = main_table;
 
-        IF NOT (SELECT distributed FROM timescaledb_information.hypertable ht WHERE ht.table_name = local_table_name AND ht.table_schema = local_schema_name)
-            THEN RAISE NOTICE 'calling hypertable_data_node_relation_size on a non-distributed hypertable';
-        END IF;
-
-        RETURN QUERY EXECUTE format(
-        $$
-        SELECT s.node_name as node,
-               size.num_chunks as chunks,
-               pg_size_pretty(table_bytes) as table,
-               pg_size_pretty(index_bytes) as index,
-               pg_size_pretty(toast_bytes) as toast,
-               pg_size_pretty(total_bytes) as total
-            FROM timescaledb_information.data_node s
-                LEFT OUTER JOIN LATERAL @extschema@.data_node_hypertable_info(s.node_name) size ON TRUE
-            WHERE size.table_schema = %L
-            AND size.table_name = %L;
-        $$,
-        local_schema_name, local_table_name);
+        RETURN QUERY
+        SELECT format('%I.%I', h.schema_name, ci.hypertable_index_name),
+               sum(pg_relation_size(c.oid))::bigint
+        FROM
+        pg_class c,
+        pg_namespace n,
+        _timescaledb_catalog.hypertable h,
+        _timescaledb_catalog.chunk ch,
+        _timescaledb_catalog.chunk_index ci
+        WHERE ch.schema_name = n.nspname
+            AND c.relnamespace = n.oid
+            AND c.relname = ci.index_name
+            AND ch.id = ci.chunk_id
+            AND h.id = ci.hypertable_id
+            AND h.schema_name = main.schema_name
+            AND h.table_name = main.table_name
+        GROUP BY h.schema_name, ci.hypertable_index_name;
 END;
 $BODY$;
 
+------- REMOVE chunk_relation_size -----
 -- Get relation size of the chunks of an hypertable
 -- like pg_relation_size
 -- (https://www.postgresql.org/docs/9.6/static/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE)
@@ -469,78 +583,33 @@ BEGIN
 END;
 $BODY$;
 
-
--- Get sizes of indexes on a hypertable
---
--- main_table - hypertable to get index sizes of
---
--- Returns:
--- index_name           - index on hyper table
--- total_bytes          - size of index on disk
-
-CREATE OR REPLACE FUNCTION indexes_relation_size(
-    main_table              REGCLASS
+CREATE OR REPLACE FUNCTION _timescaledb_internal.range_value_to_pretty(
+    time_value      BIGINT,
+    column_type     REGTYPE
 )
-RETURNS TABLE (index_name TEXT,
-               total_bytes BIGINT)
-               LANGUAGE PLPGSQL STABLE STRICT
-               AS
+    RETURNS TEXT LANGUAGE PLPGSQL STABLE AS
 $BODY$
-<<main>>
 DECLARE
-        table_name       NAME;
-        schema_name      NAME;
 BEGIN
-        SELECT relname, nspname
-        INTO STRICT table_name, schema_name
-        FROM pg_class c
-        INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
-        WHERE c.OID = main_table;
-
-        RETURN QUERY
-        SELECT format('%I.%I', h.schema_name, ci.hypertable_index_name),
-               sum(pg_relation_size(c.oid))::bigint
-        FROM
-        pg_class c,
-        pg_namespace n,
-        _timescaledb_catalog.hypertable h,
-        _timescaledb_catalog.chunk ch,
-        _timescaledb_catalog.chunk_index ci
-        WHERE ch.schema_name = n.nspname
-            AND c.relnamespace = n.oid
-            AND c.relname = ci.index_name
-            AND ch.id = ci.chunk_id
-            AND h.id = ci.hypertable_id
-            AND h.schema_name = main.schema_name
-            AND h.table_name = main.table_name
-        GROUP BY h.schema_name, ci.hypertable_index_name;
-END;
+    IF NOT _timescaledb_internal.dimension_is_finite(time_value) THEN
+        RETURN '';
+    END IF;
+    IF time_value IS NULL THEN
+        RETURN format('%L', NULL);
+    END IF;
+    CASE column_type
+      WHEN 'BIGINT'::regtype, 'INTEGER'::regtype, 'SMALLINT'::regtype THEN
+        RETURN format('%L', time_value); -- scale determined by user.
+      WHEN 'TIMESTAMP'::regtype, 'TIMESTAMPTZ'::regtype THEN
+        -- assume time_value is in microsec
+        RETURN format('%1$L', _timescaledb_internal.to_timestamp(time_value)); -- microseconds
+      WHEN 'DATE'::regtype THEN
+        RETURN format('%L', timezone('UTC',_timescaledb_internal.to_timestamp(time_value))::date);
+      ELSE
+        RETURN time_value;
+    END CASE;
+END
 $BODY$;
-
-
--- Get sizes of indexes on a hypertable
---
--- main_table - hypertable to get index sizes of
---
--- Returns:
--- index_name           - index on hyper table
--- total_size           - pretty output of total_bytes
-
-CREATE OR REPLACE FUNCTION indexes_relation_size_pretty(
-    main_table              REGCLASS
-)
-RETURNS TABLE (index_name TEXT,
-               total_size TEXT) LANGUAGE PLPGSQL STABLE STRICT
-               AS
-$BODY$
-BEGIN
-        RETURN QUERY
-        SELECT s.index_name,
-               pg_size_pretty(s.total_bytes)
-        FROM @extschema@.indexes_relation_size(main_table) s;
-END;
-$BODY$;
-
 
 -- Convenience function to return approximate row count
 --

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,13 @@
+--Drop functions in size_utils and dependencies, ordering matters.
+-- Do not reorder
+DROP VIEW timescaledb_information.hypertable;
+DROP FUNCTION hypertable_relation_size_pretty;
+DROP FUNCTION  hypertable_relation_size;
+DROP FUNCTION indexes_relation_size_pretty;
+DROP FUNCTION  indexes_relation_size;
+DROP FUNCTION _timescaledb_internal.partitioning_column_to_pretty;
+-- end of do not reorder
+
 -- Add new function definitions, columns and tables for distributed hypertables
 DROP FUNCTION IF EXISTS create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc);
 DROP FUNCTION IF EXISTS add_drop_chunks_policy;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -4,66 +4,41 @@
 
 CREATE SCHEMA IF NOT EXISTS timescaledb_information;
 
--- Convenience view to list all hypertables and their space usage
-CREATE OR REPLACE VIEW timescaledb_information.hypertable_size_info AS
-  SELECT ht.id, ht.schema_name AS table_schema,
-    ht.table_name,
-    t.tableowner AS table_owner,
+-- Convenience view to list all hypertables 
+CREATE OR REPLACE VIEW timescaledb_information.hypertables AS
+  SELECT 
+    ht.schema_name AS table_schema,
+    ht.table_name as table_name,
+    t.tableowner AS owner,
     ht.num_dimensions,
     (SELECT count(1)
      FROM _timescaledb_catalog.chunk ch
      WHERE ch.hypertable_id=ht.id
     ) AS num_chunks,
-    (CASE WHEN ht.replication_factor > 0 THEN true ELSE false END) AS distributed,
-    bsize.table_bytes,
-    bsize.index_bytes,
-    bsize.toast_bytes,
-    bsize.total_bytes
+    (CASE WHEN ht.compressed_hypertable_id IS NULL THEN false ELSE true END) AS
+  compression_enabled,
+    (CASE WHEN ht.replication_factor > 0 THEN true ELSE false END) AS is_distributed,
+    ht.replication_factor ,
+    dn.node_list as data_nodes,
+    srchtbs.tablespace_list as tablespaces
   FROM _timescaledb_catalog.hypertable ht
-    LEFT OUTER JOIN pg_tables t ON ht.table_name=t.tablename AND ht.schema_name=t.schemaname
-    LEFT OUTER JOIN LATERAL @extschema@.hypertable_relation_size(
-      CASE WHEN has_schema_privilege(ht.schema_name,'USAGE') THEN format('%I.%I',ht.schema_name,ht.table_name) ELSE NULL END
-    ) bsize ON true;
-
--- Convenience view to list all hypertables and their space usage
-CREATE OR REPLACE VIEW timescaledb_information.hypertable AS
-WITH ht_size as (
-  SELECT ht.id, ht.table_schema,
-    ht.table_name,
-    ht.table_owner,
-    ht.num_dimensions,
-    (SELECT count(1)
-     FROM _timescaledb_catalog.chunk ch
-     WHERE ch.hypertable_id=ht.id
-    ) AS num_chunks,
-    ht.table_bytes,
-    ht.index_bytes,
-    ht.toast_bytes,
-    ht.total_bytes,
-    ht.distributed
-  FROM timescaledb_information.hypertable_size_info ht
-),
-compht_size as
-(
-  select srcht.id,
-  sum(map.compressed_heap_size) as heap_bytes,
-  sum(map.compressed_index_size) as index_bytes,
-  sum(map.compressed_toast_size) as toast_bytes,
-  sum(map.compressed_heap_size) + sum(map.compressed_toast_size) + sum(map.compressed_index_size) as total_bytes
- FROM _timescaledb_catalog.chunk srcch, _timescaledb_catalog.compression_chunk_size map,
-      _timescaledb_catalog.hypertable srcht
- where map.chunk_id = srcch.id and srcht.id = srcch.hypertable_id
- group by srcht.id
-)
-select hts.table_schema, hts.table_name, hts.table_owner,
-       hts.num_dimensions, hts.num_chunks,
-       pg_size_pretty( COALESCE(hts.table_bytes + compht_size.heap_bytes, hts.table_bytes)) as table_size,
-       pg_size_pretty( COALESCE(hts.index_bytes + compht_size.index_bytes , hts.index_bytes, compht_size.index_bytes)) as index_size,
-       pg_size_pretty( COALESCE(hts.toast_bytes + compht_size.toast_bytes, hts.toast_bytes, compht_size.toast_bytes)) as toast_size,
-       pg_size_pretty( COALESCE(hts.total_bytes + compht_size.total_bytes, hts.total_bytes)) as total_size,
-       hts.distributed
-FROM ht_size hts LEFT OUTER JOIN compht_size
-ON hts.id = compht_size.id;
+        INNER JOIN pg_tables t
+        ON ht.table_name=t.tablename 
+           AND ht.schema_name=t.schemaname
+        LEFT OUTER JOIN (
+            SELECT hypertable_id, 
+            array_agg(tablespace_name ORDER BY id) as tablespace_list 
+            FROM _timescaledb_catalog.tablespace
+            GROUP BY hypertable_id ) srchtbs
+       ON ht.id = srchtbs.hypertable_id
+       LEFT OUTER JOIN ( 
+            SELECT hypertable_id, 
+            array_agg(node_name ORDER BY node_name) as node_list
+                      FROM _timescaledb_catalog.hypertable_data_node
+                      GROUP BY hypertable_id) dn
+    ON ht.id = dn.hypertable_id
+    WHERE ht.compressed is false --> no internal compression tables
+;
 
 CREATE OR REPLACE VIEW timescaledb_information.license AS
   SELECT _timescaledb_internal.license_edition() as edition,
@@ -254,16 +229,11 @@ AS
  group by srcht.id;
 
 CREATE OR REPLACE VIEW timescaledb_information.data_node AS
-  SELECT s.node_name, s.owner, s.options, s.node_up,
-    COUNT(size.table_name) AS num_dist_tables,
-    SUM(size.num_chunks) AS num_dist_chunks,
-    pg_size_pretty(SUM(size.total_bytes)) AS total_dist_size
-  FROM (SELECT srvname AS node_name, srvowner::regrole::name AS owner, srvoptions AS options, _timescaledb_internal.ping_data_node(srvname) AS node_up
+  SELECT s.node_name, s.owner, s.options
+  FROM (SELECT srvname AS node_name, srvowner::regrole::name AS owner, srvoptions AS options
         FROM pg_catalog.pg_foreign_server AS srv, pg_catalog.pg_foreign_data_wrapper AS fdw
         WHERE srv.srvfdw = fdw.oid
-        AND fdw.fdwname = 'timescaledb_fdw') AS s
-    LEFT OUTER JOIN LATERAL @extschema@.data_node_hypertable_info(CASE WHEN s.node_up THEN s.node_name ELSE NULL END) size ON TRUE
-  GROUP BY s.node_name, s.node_up, s.owner, s.options;
+        AND fdw.fdwname = 'timescaledb_fdw') AS s;
 
 -- chunks metadata view, shows information about the primary dimension column
 -- query plans with CTEs are not always optimized by PG. So use in-line

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -78,6 +78,7 @@ CROSSMODULE_WRAPPER(remote_txn_id_out);
 CROSSMODULE_WRAPPER(remote_txn_heal_data_node);
 CROSSMODULE_WRAPPER(remote_connection_cache_show);
 CROSSMODULE_WRAPPER(dist_remote_hypertable_info);
+CROSSMODULE_WRAPPER(dist_remote_chunk_info);
 CROSSMODULE_WRAPPER(distributed_exec);
 CROSSMODULE_WRAPPER(hypertable_distributed_set_replication_factor);
 
@@ -404,6 +405,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.is_frontend_session = error_no_default_fn_bool_void_community,
 	.remove_from_distributed_db = error_no_default_fn_bool_void_community,
 	.dist_remote_hypertable_info = error_no_default_fn_pg_community,
+	.dist_remote_chunk_info = error_no_default_fn_pg_community,
 	.validate_as_data_node = error_no_default_fn_community,
 	.func_call_on_data_nodes = func_call_on_data_nodes_default,
 	.chunk_get_relstats = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -145,6 +145,7 @@ typedef struct CrossModuleFunctions
 	bool (*is_frontend_session)(void);
 	bool (*remove_from_distributed_db)(void);
 	PGFunction dist_remote_hypertable_info;
+	PGFunction dist_remote_chunk_info;
 	void (*validate_as_data_node)(void);
 	void (*func_call_on_data_nodes)(FunctionCallInfo fcinfo, List *data_node_oids);
 	PGFunction distributed_exec;

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -12,8 +12,8 @@ WHERE OID IN (
     deptype = 'e' and classid = 'pg_catalog.pg_proc'::regclass
 ) AND pronamespace = 'public'::regnamespace
 ORDER BY proname;
-              proname               
-------------------------------------
+             proname              
+----------------------------------
  add_compress_chunks_policy
  add_data_node
  add_dimension
@@ -26,10 +26,10 @@ ORDER BY proname;
  block_new_chunks
  chunk_relation_size
  chunk_relation_size_pretty
+ chunks_detailed_size
  compress_chunk
  create_distributed_hypertable
  create_hypertable
- data_node_hypertable_info
  decompress_chunk
  delete_data_node
  detach_data_node
@@ -41,11 +41,9 @@ ORDER BY proname;
  get_telemetry_report
  histogram
  hypertable_approximate_row_count
- hypertable_data_node_relation_size
- hypertable_relation_size
- hypertable_relation_size_pretty
+ hypertable_detailed_size
+ hypertable_size
  indexes_relation_size
- indexes_relation_size_pretty
  interpolate
  last
  locf
@@ -67,5 +65,5 @@ ORDER BY proname;
  timescaledb_fdw_validator
  timescaledb_post_restore
  timescaledb_pre_restore
-(53 rows)
+(51 rows)
 

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -547,8 +547,8 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
  timescaledb_information.reorder_policies
  timescaledb_information.drop_chunks_policies
  timescaledb_information.license
- timescaledb_information.hypertable
- timescaledb_information.hypertable_size_info
+ timescaledb_information.hypertables
+ _timescaledb_internal.hypertable_chunk_local_size
  _timescaledb_catalog.compression_algorithm
  _timescaledb_internal.bgw_policy_chunk_stats
  _timescaledb_internal.bgw_job_stat

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -156,23 +156,21 @@ SELECT * FROM test_dt ORDER BY time;
 (0 rows)
 
 -- testing drop_chunks END
--- testing hypertable_relation_size_pretty START
-SELECT * FROM "testSchema0".hypertable_relation_size_pretty('test_ts');
- table_size | index_size | toast_size | total_size 
-------------+------------+------------+------------
- 16 kB      | 64 kB      | 16 kB      | 96 kB
+-- testing hypertable_detailed_size START
+SELECT * FROM "testSchema0".hypertable_detailed_size('test_ts');
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+       16384 |       65536 |       16384 |       98304 | 
 (1 row)
 
--- testing hypertable_relation_size_pretty END
--- testing indexes_relation_size_pretty START
-SELECT * FROM "testSchema0".indexes_relation_size_pretty('test_ts') ORDER BY index_name;
-           index_name           | total_size 
---------------------------------+------------
- public.test_ts_device_time_idx | 32 kB
- public.test_ts_time_idx        | 32 kB
+-- testing hypertable_detailed_size END
+SELECT * FROM "testSchema0".indexes_relation_size('test_ts') ORDER BY index_name;
+           index_name           | total_bytes 
+--------------------------------+-------------
+ public.test_ts_device_time_idx |       32768
+ public.test_ts_time_idx        |       32768
 (2 rows)
 
--- testing indexes_relation_size_pretty END
 CREATE SCHEMA "testSchema";
 \set ON_ERROR_STOP 0
 ALTER EXTENSION timescaledb SET SCHEMA "testSchema";

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -42,16 +42,10 @@ INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 (1257894000000000000, 'dev2', 1.5, 2);
 INSERT 0 1
 \set QUIET on
-SELECT * FROM hypertable_relation_size('"public"."two_Partitions"');
- table_bytes | index_bytes | toast_bytes | total_bytes 
--------------+-------------+-------------+-------------
-       32768 |      417792 |       32768 |      483328
-(1 row)
-
-SELECT * FROM hypertable_relation_size_pretty('"public"."two_Partitions"');
- table_size | index_size | toast_size | total_size 
-------------+------------+------------+------------
- 32 kB      | 408 kB     | 32 kB      | 472 kB
+SELECT * FROM hypertable_detailed_size('"public"."two_Partitions"');
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+       32768 |      417792 |       32768 |      483328 | 
 (1 row)
 
 SELECT * FROM chunk_relation_size('"public"."two_Partitions"');
@@ -84,17 +78,14 @@ SELECT * FROM indexes_relation_size('"public"."two_Partitions"');
  public."two_Partitions_timeCustom_series_bool_idx" |       49152
 (7 rows)
 
-SELECT * FROM indexes_relation_size_pretty('"public"."two_Partitions"');
-                     index_name                     | total_size 
-----------------------------------------------------+------------
- public."two_Partitions_device_id_timeCustom_idx"   | 64 kB
- public."two_Partitions_timeCustom_device_id_idx"   | 64 kB
- public."two_Partitions_timeCustom_idx"             | 64 kB
- public."two_Partitions_timeCustom_series_0_idx"    | 64 kB
- public."two_Partitions_timeCustom_series_1_idx"    | 64 kB
- public."two_Partitions_timeCustom_series_2_idx"    | 40 kB
- public."two_Partitions_timeCustom_series_bool_idx" | 48 kB
-(7 rows)
+SELECT * FROM chunks_detailed_size('"public"."two_Partitions"') order by chunk_name;
+     chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk |        8192 |      114688 |        8192 |      131072 | 
+ _timescaledb_internal | _hyper_1_2_chunk |        8192 |      106496 |        8192 |      122880 | 
+ _timescaledb_internal | _hyper_1_3_chunk |        8192 |       98304 |        8192 |      114688 | 
+ _timescaledb_internal | _hyper_1_4_chunk |        8192 |       98304 |        8192 |      114688 | 
+(4 rows)
 
 CREATE TABLE timestamp_partitioned(time TIMESTAMP, value TEXT);
 SELECT * FROM create_hypertable('timestamp_partitioned', 'time', 'value', 2);
@@ -226,23 +217,13 @@ SELECT * FROM chunk_relation_size_pretty(NULL);
 ----------+-------------+----------------------+---------------------------+-----------------------------+--------+------------+------------+------------+------------
 (0 rows)
 
-SELECT * FROM hypertable_relation_size(NULL);
- table_bytes | index_bytes | toast_bytes | total_bytes 
--------------+-------------+-------------+-------------
-(0 rows)
-
-SELECT * FROM hypertable_relation_size_pretty(NULL);
- table_size | index_size | toast_size | total_size 
-------------+------------+------------+------------
+SELECT * FROM hypertable_detailed_size(NULL);
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
 (0 rows)
 
 SELECT * FROM indexes_relation_size(NULL);
  index_name | total_bytes 
 ------------+-------------
-(0 rows)
-
-SELECT * FROM indexes_relation_size_pretty(NULL);
- index_name | total_size 
-------------+------------
 (0 rows)
 

--- a/test/expected/views.out
+++ b/test/expected/views.out
@@ -1,9 +1,9 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
-SELECT * FROM timescaledb_information.hypertable;
- table_schema | table_name | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+------------+-------------+----------------+------------+------------+------------+------------+------------+-------------
+SELECT * FROM timescaledb_information.hypertables;
+ table_schema | table_name | owner | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
+--------------+------------+-------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
 (0 rows)
 
 -- create simple hypertable with 1 chunk
@@ -24,11 +24,11 @@ SELECT create_hypertable('ht2','time');
 (1 row)
 
 INSERT INTO ht2 SELECT '2000-01-01'::TIMESTAMPTZ, repeat('8k',4096);
-SELECT * FROM timescaledb_information.hypertable ORDER BY table_schema, table_name;
- table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+------------+-------------------+----------------+------------+------------+------------+------------+------------+-------------
- public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB      | f
- public       | ht2        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      | 8192 bytes | 32 kB      | f
+SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
+ table_schema | table_name |       owner       | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
+--------------+------------+-------------------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
+ public       | ht1        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
+ public       | ht2        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -55,47 +55,118 @@ SELECT create_hypertable('closed.closed_ht','time');
 (1 row)
 
 INSERT INTO closed.closed_ht SELECT '2000-01-01'::TIMESTAMPTZ;
-SELECT * FROM timescaledb_information.hypertable ORDER BY table_schema, table_name;
- table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+------------+-------------------+----------------+------------+------------+------------+------------+------------+-------------
- closed       | closed_ht  | super_user        |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB      | f
- open         | open_ht    | super_user        |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB      | f
- public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB      | f
- public       | ht2        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      | 8192 bytes | 32 kB      | f
+SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
+ table_schema | table_name |       owner       | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
+--------------+------------+-------------------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
+ closed       | closed_ht  | super_user        |              1 |          1 | f                   | f              |                    |            | 
+ open         | open_ht    | super_user        |              1 |          3 | f                   | f              |                    |            | 
+ public       | ht1        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
+ public       | ht2        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
 (4 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SELECT * FROM timescaledb_information.hypertable ORDER BY table_schema,table_name;
- table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+------------+-------------------+----------------+------------+------------+------------+------------+------------+-------------
- closed       | closed_ht  | super_user        |              1 |          1 |            |            |            |            | f
- open         | open_ht    | super_user        |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB      | f
- public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB      | f
- public       | ht2        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      | 8192 bytes | 32 kB      | f
-(4 rows)
+\set ON_ERROR_STOP 0
+\x
+SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema,table_name;
+-[ RECORD 1 ]-------+------------------
+table_schema        | closed
+table_name          | closed_ht
+owner               | super_user
+num_dimensions      | 1
+num_chunks          | 1
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
+-[ RECORD 2 ]-------+------------------
+table_schema        | open
+table_name          | open_ht
+owner               | super_user
+num_dimensions      | 1
+num_chunks          | 3
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
+-[ RECORD 3 ]-------+------------------
+table_schema        | public
+table_name          | ht1
+owner               | default_perm_user
+num_dimensions      | 1
+num_chunks          | 1
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
+-[ RECORD 4 ]-------+------------------
+table_schema        | public
+table_name          | ht2
+owner               | default_perm_user
+num_dimensions      | 1
+num_chunks          | 1
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
 
 -- filter by schema
-SELECT * FROM timescaledb_information.hypertable WHERE table_schema = 'closed' ORDER BY table_schema, table_name;
- table_schema | table_name | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+------------+-------------+----------------+------------+------------+------------+------------+------------+-------------
- closed       | closed_ht  | super_user  |              1 |          1 |            |            |            |            | f
-(1 row)
+SELECT * FROM timescaledb_information.hypertables WHERE table_schema = 'closed' ORDER BY table_schema, table_name;
+-[ RECORD 1 ]-------+-----------
+table_schema        | closed
+table_name          | closed_ht
+owner               | super_user
+num_dimensions      | 1
+num_chunks          | 1
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
 
 -- filter by table name
-SELECT * FROM timescaledb_information.hypertable WHERE table_name = 'ht1' ORDER BY table_schema, table_name;
- table_schema | table_name |    table_owner    | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+------------+-------------------+----------------+------------+------------+------------+------------+------------+-------------
- public       | ht1        | default_perm_user |              1 |          1 | 8192 bytes | 16 kB      |            | 24 kB      | f
-(1 row)
+SELECT * FROM timescaledb_information.hypertables WHERE table_name = 'ht1' ORDER BY table_schema, table_name;
+-[ RECORD 1 ]-------+------------------
+table_schema        | public
+table_name          | ht1
+owner               | default_perm_user
+num_dimensions      | 1
+num_chunks          | 1
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
 
 -- filter by owner
-SELECT * FROM timescaledb_information.hypertable WHERE table_owner = 'super_user' ORDER BY table_schema,table_name;
- table_schema | table_name | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+------------+-------------+----------------+------------+------------+------------+------------+------------+-------------
- closed       | closed_ht  | super_user  |              1 |          1 |            |            |            |            | f
- open         | open_ht    | super_user  |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB      | f
-(2 rows)
+SELECT * FROM timescaledb_information.hypertables WHERE owner = 'super_user' ORDER BY table_schema,table_name;
+-[ RECORD 1 ]-------+-----------
+table_schema        | closed
+table_name          | closed_ht
+owner               | super_user
+num_dimensions      | 1
+num_chunks          | 1
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
+-[ RECORD 2 ]-------+-----------
+table_schema        | open
+table_name          | open_ht
+owner               | super_user
+num_dimensions      | 1
+num_chunks          | 3
+compression_enabled | f
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
 
+\x
 ---Add integer table --
 CREATE TABLE test_table_int(time bigint, junk int);
 SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 10);

--- a/test/isolation/expected/multi_transaction_indexing.out
+++ b/test/isolation/expected/multi_transaction_indexing.out
@@ -6,8 +6,8 @@ step I1: INSERT INTO ts_index_test VALUES (31, 6.4, 1);
 step Ic: COMMIT;
 step Bc: ROLLBACK;
 step CI: <... completed>
-step P: SELECT index_size FROM timescaledb_information.hypertable;
-index_size     
+step P: SELECT pg_size_pretty(total_bytes) as total_size FROM indexes_relation_size('ts_index_test');
+total_size     
 
 64 kB          
 step Sc: COMMIT;
@@ -18,8 +18,8 @@ step CI: CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.tr
 step Bc: ROLLBACK;
 step Ic: COMMIT;
 step CI: <... completed>
-step P: SELECT index_size FROM timescaledb_information.hypertable;
-index_size     
+step P: SELECT pg_size_pretty(total_bytes) as total_size FROM indexes_relation_size('ts_index_test');
+total_size     
 
 64 kB          
 step Sc: COMMIT;
@@ -35,8 +35,8 @@ step CI: CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.tr
 step Bc: ROLLBACK;
 step CI: <... completed>
 step Sc: COMMIT;
-step P: SELECT index_size FROM timescaledb_information.hypertable;
-index_size     
+step P: SELECT pg_size_pretty(total_bytes) as total_size FROM indexes_relation_size('ts_index_test');
+total_size     
 
 48 kB          
 step Ic: COMMIT;
@@ -48,10 +48,9 @@ step DI: DROP INDEX test_index; <waiting ...>
 step Bc: ROLLBACK;
 step CI: <... completed>
 step DI: <... completed>
-step P: SELECT index_size FROM timescaledb_information.hypertable;
-index_size     
+step P: SELECT pg_size_pretty(total_bytes) as total_size FROM indexes_relation_size('ts_index_test');
+total_size     
 
-0 bytes        
 step Ic: COMMIT;
 step Sc: COMMIT;
 
@@ -61,8 +60,8 @@ step RI: ALTER TABLE test_index RENAME COLUMN location TO height; <waiting ...>
 step Bc: ROLLBACK;
 step CI: <... completed>
 step RI: <... completed>
-step P: SELECT index_size FROM timescaledb_information.hypertable;
-index_size     
+step P: SELECT pg_size_pretty(total_bytes) as total_size FROM indexes_relation_size('ts_index_test');
+total_size     
 
 48 kB          
 step Ic: COMMIT;

--- a/test/isolation/specs/multi_transaction_indexing.spec
+++ b/test/isolation/specs/multi_transaction_indexing.spec
@@ -42,7 +42,7 @@ session "RENAME COLUMN"
 step "RI"	{ ALTER TABLE test_index RENAME COLUMN location TO height; }
 
 session "COUNT INDEXES"
-step "P"    {  SELECT index_size FROM timescaledb_information.hypertable; }
+step "P"    {  SELECT pg_size_pretty(total_bytes) as total_size FROM indexes_relation_size('ts_index_test'); }
 
 # we need to COMMIT every transaction started in setup regardless of whether we use them
 # inserts work between chunks

--- a/test/sql/relocate_extension.sql
+++ b/test/sql/relocate_extension.sql
@@ -72,13 +72,11 @@ SELECT * FROM test_tz ORDER BY time;
 SELECT * FROM test_dt ORDER BY time;
 -- testing drop_chunks END
 
--- testing hypertable_relation_size_pretty START
-SELECT * FROM "testSchema0".hypertable_relation_size_pretty('test_ts');
--- testing hypertable_relation_size_pretty END
+-- testing hypertable_detailed_size START
+SELECT * FROM "testSchema0".hypertable_detailed_size('test_ts');
+-- testing hypertable_detailed_size END
 
--- testing indexes_relation_size_pretty START
-SELECT * FROM "testSchema0".indexes_relation_size_pretty('test_ts') ORDER BY index_name;
--- testing indexes_relation_size_pretty END
+SELECT * FROM "testSchema0".indexes_relation_size('test_ts') ORDER BY index_name;
 
 CREATE SCHEMA "testSchema";
 

--- a/test/sql/size_utils.sql
+++ b/test/sql/size_utils.sql
@@ -4,12 +4,11 @@
 
 \ir include/insert_two_partitions.sql
 
-SELECT * FROM hypertable_relation_size('"public"."two_Partitions"');
-SELECT * FROM hypertable_relation_size_pretty('"public"."two_Partitions"');
+SELECT * FROM hypertable_detailed_size('"public"."two_Partitions"');
 SELECT * FROM chunk_relation_size('"public"."two_Partitions"');
 SELECT * FROM chunk_relation_size_pretty('"public"."two_Partitions"');
 SELECT * FROM indexes_relation_size('"public"."two_Partitions"');
-SELECT * FROM indexes_relation_size_pretty('"public"."two_Partitions"');
+SELECT * FROM chunks_detailed_size('"public"."two_Partitions"') order by chunk_name;
 
 CREATE TABLE timestamp_partitioned(time TIMESTAMP, value TEXT);
 SELECT * FROM create_hypertable('timestamp_partitioned', 'time', 'value', 2);
@@ -62,8 +61,5 @@ SELECT * FROM hypertable_approximate_row_count(NULL);
 
 SELECT * FROM chunk_relation_size(NULL);
 SELECT * FROM chunk_relation_size_pretty(NULL);
-SELECT * FROM hypertable_relation_size(NULL);
-SELECT * FROM hypertable_relation_size_pretty(NULL);
+SELECT * FROM hypertable_detailed_size(NULL);
 SELECT * FROM indexes_relation_size(NULL);
-SELECT * FROM indexes_relation_size_pretty(NULL);
-

--- a/test/sql/views.sql
+++ b/test/sql/views.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-SELECT * FROM timescaledb_information.hypertable;
+SELECT * FROM timescaledb_information.hypertables;
 
 -- create simple hypertable with 1 chunk
 CREATE TABLE ht1(time TIMESTAMPTZ NOT NULL);
@@ -14,7 +14,7 @@ CREATE TABLE ht2(time TIMESTAMPTZ NOT NULL, data TEXT);
 SELECT create_hypertable('ht2','time');
 INSERT INTO ht2 SELECT '2000-01-01'::TIMESTAMPTZ, repeat('8k',4096);
 
-SELECT * FROM timescaledb_information.hypertable ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
@@ -33,19 +33,22 @@ CREATE TABLE closed.closed_ht(time TIMESTAMPTZ NOT NULL);
 SELECT create_hypertable('closed.closed_ht','time');
 INSERT INTO closed.closed_ht SELECT '2000-01-01'::TIMESTAMPTZ;
 
-SELECT * FROM timescaledb_information.hypertable ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
-SELECT * FROM timescaledb_information.hypertable ORDER BY table_schema,table_name;
+\set ON_ERROR_STOP 0
+\x
+SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema,table_name;
 
 -- filter by schema
-SELECT * FROM timescaledb_information.hypertable WHERE table_schema = 'closed' ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables WHERE table_schema = 'closed' ORDER BY table_schema, table_name;
 
 -- filter by table name
-SELECT * FROM timescaledb_information.hypertable WHERE table_name = 'ht1' ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables WHERE table_name = 'ht1' ORDER BY table_schema, table_name;
 
 -- filter by owner
-SELECT * FROM timescaledb_information.hypertable WHERE table_owner = 'super_user' ORDER BY table_schema,table_name;
+SELECT * FROM timescaledb_information.hypertables WHERE owner = 'super_user' ORDER BY table_schema,table_name;
+\x
 
 ---Add integer table --
 CREATE TABLE test_table_int(time bigint, junk int);

--- a/tsl/src/dist_util.h
+++ b/tsl/src/dist_util.h
@@ -31,6 +31,7 @@ void dist_util_set_peer_id(Datum dist_id);
 bool dist_util_is_frontend_session(void);
 
 Datum dist_util_remote_hypertable_info(PG_FUNCTION_ARGS);
+Datum dist_util_remote_chunk_info(PG_FUNCTION_ARGS);
 
 void validate_data_node_settings(void);
 bool dist_util_is_compatible_version(const char *data_node_version, const char *access_node_version,

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -165,6 +165,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.is_frontend_session = dist_util_is_frontend_session,
 	.remove_from_distributed_db = dist_util_remove_from_db,
 	.dist_remote_hypertable_info = dist_util_remote_hypertable_info,
+	.dist_remote_chunk_info = dist_util_remote_chunk_info,
 	.validate_as_data_node = validate_data_node_settings,
 	.distributed_exec = ts_dist_cmd_exec,
 	.func_call_on_data_nodes = ts_dist_cmd_func_call_on_data_nodes,

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -434,31 +434,49 @@ vacuum full conditions;
 -- After vacuum, table_bytes is 0, but any associated index/toast storage is not
 -- completely reclaimed. Sets it at 8K (page size). So a chunk which has
 -- been compressed still incurs an overhead of n * 8KB (for every index + toast table) storage on the original uncompressed chunk.
-select * from timescaledb_information.hypertable
+select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
+pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes) 
+from hypertable_detailed_size('foo');
+-[ RECORD 1 ]--+-----------
+pg_size_pretty | 32 kB
+pg_size_pretty | 144 kB
+pg_size_pretty | 8192 bytes
+pg_size_pretty | 184 kB
+
+select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
+pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes) 
+from hypertable_detailed_size('conditions');
+-[ RECORD 1 ]--+------
+pg_size_pretty | 16 kB
+pg_size_pretty | 48 kB
+pg_size_pretty | 32 kB
+pg_size_pretty | 96 kB
+
+select * from timescaledb_information.hypertables
 where table_name like 'foo' or table_name like 'conditions'
 order by table_name;
--[ RECORD 1 ]--+------------------
-table_schema   | public
-table_name     | conditions
-table_owner    | default_perm_user
-num_dimensions | 1
-num_chunks     | 2
-table_size     | 16 kB
-index_size     | 48 kB
-toast_size     | 32 kB
-total_size     | 96 kB
-distributed    | f
--[ RECORD 2 ]--+------------------
-table_schema   | public
-table_name     | foo
-table_owner    | default_perm_user
-num_dimensions | 1
-num_chunks     | 4
-table_size     | 32 kB
-index_size     | 144 kB
-toast_size     | 8192 bytes
-total_size     | 184 kB
-distributed    | f
+-[ RECORD 1 ]-------+------------------
+table_schema        | public
+table_name          | conditions
+owner               | default_perm_user
+num_dimensions      | 1
+num_chunks          | 2
+compression_enabled | t
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
+-[ RECORD 2 ]-------+------------------
+table_schema        | public
+table_name          | foo
+owner               | default_perm_user
+num_dimensions      | 1
+num_chunks          | 4
+compression_enabled | t
+is_distributed      | f
+replication_factor  | 
+data_nodes          | 
+tablespaces         | 
 
 \x
 SELECT decompress_chunk(ch1.schema_name|| '.' || ch1.table_name) AS chunk

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -322,7 +322,7 @@ select generate_series('2018-01-01 00:00'::timestamp, '2018-01-31 00:00'::timest
 insert into test4
 select generate_series('2018-02-01 00:00'::timestamp, '2018-02-14 00:00'::timestamp, '1 min'), 'POR', 'klick', 55, 75;
 select table_name, num_chunks
-from timescaledb_information.hypertable
+from timescaledb_information.hypertables
 where table_name like 'test4';
  table_name | num_chunks 
 ------------+------------

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -43,12 +43,6 @@ SELECT * FROM add_data_node('data_node_3', host => 'localhost',
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
 SET client_min_messages TO NOTICE;
 SET ROLE :ROLE_1;
-SELECT setseed(1);
- setseed 
----------
- 
-(1 row)
-
 CREATE TABLE compressed(time timestamptz, device int, temp float);
 -- Replicate twice to see that compress_chunk compresses all replica chunks
 SELECT create_distributed_hypertable('compressed', 'time', 'device', replication_factor => 2);
@@ -395,6 +389,20 @@ NOTICE:  chunk "_dist_hyper_1_1_chunk" is not compressed
 (1 row)
 
 \x
+SELECT * FROM timescaledb_information.hypertables
+WHERE table_name = 'compressed';
+-[ RECORD 1 ]-------+--------------------------------------
+table_schema        | public
+table_name          | compressed
+owner               | test_role_1
+num_dimensions      | 2
+num_chunks          | 3
+compression_enabled | f
+is_distributed      | t
+replication_factor  | 2
+data_nodes          | {data_node_1,data_node_2,data_node_3}
+tablespaces         | 
+
 SELECT * from timescaledb_information.chunks 
 ORDER BY hypertable_name, chunk_name;
 -[ RECORD 1 ]----------+-----------------------------
@@ -464,4 +472,25 @@ time_interval     |
 integer_interval  | 
 integer_now_func  | 
 num_partitions    | 3
+
+\x
+SELECT * FROM chunks_detailed_size('compressed'::regclass) 
+ORDER BY chunk_name, node_name;
+     chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | data_node_3
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | data_node_3
+(6 rows)
+
+SELECT * FROM hypertable_detailed_size('compressed'::regclass) 
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+       16384 |       65536 |           0 |       81920 | data_node_1
+       16384 |       65536 |           0 |       81920 | data_node_3
+       16384 |       65536 |           0 |       81920 | data_node_2
+(3 rows)
 

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -387,12 +387,12 @@ SELECT node_name, "options" FROM timescaledb_information.data_node ORDER BY node
  data_node_3 | {host=localhost,port=55432,dbname=data_node_3}
 (3 rows)
 
-SELECT * FROM hypertable_data_node_relation_size('disttable');
-  node_name  | num_chunks | table_size | index_size | toast_size | total_size 
--------------+------------+------------+------------+------------+------------
- data_node_3 |          2 | 80 kB      | 96 kB      |            | 176 kB
- data_node_1 |          2 | 80 kB      | 96 kB      |            | 176 kB
- data_node_2 |          2 | 80 kB      | 96 kB      |            | 176 kB
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+       81920 |       98304 |           0 |      180224 | data_node_1
+       81920 |       98304 |           0 |      180224 | data_node_2
+       81920 |       98304 |           0 |      180224 | data_node_3
 (3 rows)
 
 -- Show what some queries would look like on the frontend
@@ -1415,12 +1415,12 @@ time|device|temp|Color
 (1 row)
 
 -- The hypertable view also shows no chunks and no data
-SELECT * FROM timescaledb_information.hypertable
+SELECT * FROM timescaledb_information.hypertables
 ORDER BY table_schema, table_name;
- table_schema |   table_name    | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+-----------------+-------------+----------------+------------+------------+------------+------------+------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 |            |            |            |            | t
- public       | underreplicated | test_role_1 |              1 |          0 |            |            |            |            | t
+ table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
+--------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
+ public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {data_node_1,data_node_2,data_node_3} | 
+ public       | underreplicated | test_role_1 |              1 |          0 | f                   | t              |                  4 | {data_node_1,data_node_2,data_node_3} | 
 (2 rows)
 
 -- Test underreplicated chunk warning
@@ -1657,12 +1657,12 @@ CREATE TABLE remotetable2(time timestamptz PRIMARY KEY, device int CHECK (device
 SELECT * FROM create_distributed_hypertable('remotetable2', 'time', replication_factor => 0);
 ERROR:  invalid replication factor
 \set ON_ERROR_STOP 1
-SELECT * FROM timescaledb_information.hypertable
+SELECT * FROM timescaledb_information.hypertables
 ORDER BY table_schema, table_name;
- table_schema |   table_name    | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+-----------------+-------------+----------------+------------+------------+------------+------------+------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 |            |            |            |            | t
- public       | underreplicated | test_role_1 |              1 |          1 | 24 kB      | 48 kB      |            | 72 kB      | t
+ table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
+--------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
+ public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {data_node_1,data_node_2,data_node_3} | 
+ public       | underreplicated | test_role_1 |              1 |          1 | f                   | t              |                  4 | {data_node_1,data_node_2,data_node_3} | 
 (2 rows)
 
 -- Test distributed hypertable creation with many parameters

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -387,12 +387,12 @@ SELECT node_name, "options" FROM timescaledb_information.data_node ORDER BY node
  data_node_3 | {host=localhost,port=55432,dbname=data_node_3}
 (3 rows)
 
-SELECT * FROM hypertable_data_node_relation_size('disttable');
-  node_name  | num_chunks | table_size | index_size | toast_size | total_size 
--------------+------------+------------+------------+------------+------------
- data_node_3 |          2 | 80 kB      | 96 kB      |            | 176 kB
- data_node_1 |          2 | 80 kB      | 96 kB      |            | 176 kB
- data_node_2 |          2 | 80 kB      | 96 kB      |            | 176 kB
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+       81920 |       98304 |           0 |      180224 | data_node_1
+       81920 |       98304 |           0 |      180224 | data_node_2
+       81920 |       98304 |           0 |      180224 | data_node_3
 (3 rows)
 
 -- Show what some queries would look like on the frontend
@@ -1415,12 +1415,12 @@ time|device|temp|Color
 (1 row)
 
 -- The hypertable view also shows no chunks and no data
-SELECT * FROM timescaledb_information.hypertable
+SELECT * FROM timescaledb_information.hypertables
 ORDER BY table_schema, table_name;
- table_schema |   table_name    | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+-----------------+-------------+----------------+------------+------------+------------+------------+------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 |            |            |            |            | t
- public       | underreplicated | test_role_1 |              1 |          0 |            |            |            |            | t
+ table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
+--------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
+ public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {data_node_1,data_node_2,data_node_3} | 
+ public       | underreplicated | test_role_1 |              1 |          0 | f                   | t              |                  4 | {data_node_1,data_node_2,data_node_3} | 
 (2 rows)
 
 -- Test underreplicated chunk warning
@@ -1657,12 +1657,12 @@ CREATE TABLE remotetable2(time timestamptz PRIMARY KEY, device int CHECK (device
 SELECT * FROM create_distributed_hypertable('remotetable2', 'time', replication_factor => 0);
 ERROR:  invalid replication factor
 \set ON_ERROR_STOP 1
-SELECT * FROM timescaledb_information.hypertable
+SELECT * FROM timescaledb_information.hypertables
 ORDER BY table_schema, table_name;
- table_schema |   table_name    | table_owner | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+-----------------+-------------+----------------+------------+------------+------------+------------+------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 |            |            |            |            | t
- public       | underreplicated | test_role_1 |              1 |          1 | 24 kB      | 48 kB      |            | 72 kB      | t
+ table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
+--------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
+ public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {data_node_1,data_node_2,data_node_3} | 
+ public       | underreplicated | test_role_1 |              1 |          1 | f                   | t              |                  4 | {data_node_1,data_node_2,data_node_3} | 
 (2 rows)
 
 -- Test distributed hypertable creation with many parameters

--- a/tsl/test/expected/dist_query-11.out
+++ b/tsl/test/expected/dist_query-11.out
@@ -155,7 +155,7 @@ ANALYZE reference;
 ANALYZE hyper;
 ANALYZE hyper1d;
 SELECT table_schema, table_name, num_dimensions, num_chunks
-FROM timescaledb_information.hypertable
+FROM timescaledb_information.hypertables
 ORDER BY 1,2;
  table_schema | table_name | num_dimensions | num_chunks 
 --------------+------------+----------------+------------

--- a/tsl/test/expected/dist_query-12.out
+++ b/tsl/test/expected/dist_query-12.out
@@ -155,7 +155,7 @@ ANALYZE reference;
 ANALYZE hyper;
 ANALYZE hyper1d;
 SELECT table_schema, table_name, num_dimensions, num_chunks
-FROM timescaledb_information.hypertable
+FROM timescaledb_information.hypertables
 ORDER BY 1,2;
  table_schema | table_name | num_dimensions | num_chunks 
 --------------+------------+----------------+------------

--- a/tsl/test/expected/dist_util.out
+++ b/tsl/test/expected/dist_util.out
@@ -242,41 +242,41 @@ INSERT INTO disttable VALUES
        ('2019-01-01 09:11', 3, 2.1),
        ('2017-01-01 06:05', 1, 1.4);
 SELECT * FROM timescaledb_information.data_node ORDER BY node_name;
-  node_name  |       owner        |                    options                     | node_up | num_dist_tables | num_dist_chunks | total_dist_size 
--------------+--------------------+------------------------------------------------+---------+-----------------+-----------------+-----------------
- data_node_1 | cluster_super_user | {host=localhost,port=55432,dbname=backend_2_1} | t       |               1 |               2 | 48 kB
- data_node_2 | cluster_super_user | {host=localhost,port=55432,dbname=backend_x_2} | t       |               1 |               1 | 24 kB
+  node_name  |       owner        |                    options                     
+-------------+--------------------+------------------------------------------------
+ data_node_1 | cluster_super_user | {host=localhost,port=55432,dbname=backend_2_1}
+ data_node_2 | cluster_super_user | {host=localhost,port=55432,dbname=backend_x_2}
 (2 rows)
 
-SELECT * FROM timescaledb_information.hypertable;
- table_schema |  table_name  |    table_owner     | num_dimensions | num_chunks | table_size | index_size | toast_size | total_size | distributed 
---------------+--------------+--------------------+----------------+------------+------------+------------+------------+------------+-------------
- public       | nondisttable | cluster_super_user |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB      | f
- public       | disttable    | cluster_super_user |              1 |          3 | 24 kB      | 48 kB      |            | 72 kB      | t
+SELECT * FROM timescaledb_information.hypertables;
+ table_schema |  table_name  |       owner        | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |        data_nodes         | tablespaces 
+--------------+--------------+--------------------+----------------+------------+---------------------+----------------+--------------------+---------------------------+-------------
+ public       | nondisttable | cluster_super_user |              1 |          3 | f                   | f              |                    |                           | 
+ public       | disttable    | cluster_super_user |              1 |          3 | f                   | t              |                  1 | {data_node_1,data_node_2} | 
 (2 rows)
 
-SELECT * FROM hypertable_relation_size('disttable');
- table_bytes | index_bytes | toast_bytes | total_bytes 
--------------+-------------+-------------+-------------
-       24576 |       49152 |             |       73728
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+       16384 |       32768 |           0 |       49152 | data_node_1
+        8192 |       16384 |           0 |       24576 | data_node_2
+(2 rows)
+
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+       24576 |       49152 |           0 |       73728 | 
 (1 row)
 
-SELECT * FROM hypertable_relation_size('nondisttable');
- table_bytes | index_bytes | toast_bytes | total_bytes 
--------------+-------------+-------------+-------------
-       24576 |       49152 |             |       73728
+SELECT * FROM hypertable_size('disttable') ;
+ hypertable_size 
+-----------------
+           73728
 (1 row)
 
-SELECT * FROM hypertable_data_node_relation_size('disttable') ORDER BY node_name;
-  node_name  | num_chunks | table_size | index_size | toast_size | total_size 
--------------+------------+------------+------------+------------+------------
- data_node_1 |          2 | 16 kB      | 32 kB      |            | 48 kB
- data_node_2 |          1 | 8192 bytes | 16 kB      |            | 24 kB
-(2 rows)
-
-SELECT * FROM hypertable_data_node_relation_size('nondisttable') ORDER BY node_name;
-NOTICE:  calling hypertable_data_node_relation_size on a non-distributed hypertable
- node_name | num_chunks | table_size | index_size | toast_size | total_size 
------------+------------+------------+------------+------------+------------
-(0 rows)
+SELECT * FROM hypertable_size('nondisttable') ;
+ hypertable_size 
+-----------------
+           73728
+(1 row)
 

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -1,0 +1,154 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+---------------------------------------------------
+-- Test views and size_utils functions on distributed hypertable
+---------------------------------------------------
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+SET client_min_messages TO ERROR;
+DROP DATABASE IF EXISTS data_node_1;
+DROP DATABASE IF EXISTS data_node_2;
+DROP DATABASE IF EXISTS data_node_3;
+SELECT * FROM add_data_node('data_node_1', host => 'localhost',
+                            database => 'data_node_1');
+  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
+-------------+-----------+-------+-------------+--------------+------------------+-------------------
+ data_node_1 | localhost | 55432 | data_node_1 | t            | t                | t
+(1 row)
+
+SELECT * FROM add_data_node('data_node_2', host => 'localhost',
+                            database => 'data_node_2');
+  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
+-------------+-----------+-------+-------------+--------------+------------------+-------------------
+ data_node_2 | localhost | 55432 | data_node_2 | t            | t                | t
+(1 row)
+
+SELECT * FROM add_data_node('data_node_3', host => 'localhost',
+                            database => 'data_node_3');
+  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
+-------------+-----------+-------+-------------+--------------+------------------+-------------------
+ data_node_3 | localhost | 55432 | data_node_3 | t            | t                | t
+(1 row)
+
+GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
+SET client_min_messages TO NOTICE;
+SET ROLE :ROLE_1;
+SELECT setseed(1);
+ setseed 
+---------
+ 
+(1 row)
+
+CREATE TABLE dist_table(time timestamptz, device int, temp float);
+SELECT create_distributed_hypertable('dist_table', 'time', 'device', replication_factor => 2);
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (1,public,dist_table,t)
+(1 row)
+
+INSERT INTO dist_table SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, 80
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-04 1:00', '1 hour') t;
+ALTER TABLE dist_table SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
+-- Test that compression is rolled back on aborted transaction
+BEGIN;
+SELECT compress_chunk(chunk)
+FROM show_chunks('dist_table') AS chunk
+ORDER BY chunk
+LIMIT 1;
+               compress_chunk                
+---------------------------------------------
+ _timescaledb_internal._dist_hyper_1_1_chunk
+(1 row)
+
+SELECT * FROM timescaledb_information.hypertables
+WHERE table_name = 'dist_table';
+ table_schema | table_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
+--------------+------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
+ public       | dist_table | test_role_1 |              2 |          3 | f                   | t              |                  2 | {data_node_1,data_node_2,data_node_3} | 
+(1 row)
+
+SELECT * from timescaledb_information.chunks 
+ORDER BY hypertable_name, chunk_name;
+ hypertable_schema | hypertable_name |     chunk_schema      |      chunk_name       | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace |        data_nodes         
+-------------------+-----------------+-----------------------+-----------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+---------------------------
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_1_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | false         |                  | {data_node_1,data_node_2}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_2_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | false         |                  | {data_node_2,data_node_3}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_3_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | false         |                  | {data_node_1,data_node_3}
+(3 rows)
+
+SELECT * from timescaledb_information.dimensions 
+ORDER BY hypertable_name, dimension_number;
+ hypertable_schema | hypertable_name | dimension_number | column_name |       column_type        | dimension_type | time_interval | integer_interval | integer_now_func | num_partitions 
+-------------------+-----------------+------------------+-------------+--------------------------+----------------+---------------+------------------+------------------+----------------
+ public            | dist_table      |                1 | time        | timestamp with time zone | Time           | @ 7 days      |                  |                  |               
+ public            | dist_table      |                2 | device      | integer                  | Space          |               |                  |                  |              3
+(2 rows)
+
+SELECT * FROM chunks_detailed_size('dist_table'::regclass) 
+ORDER BY chunk_name, node_name;
+     chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |        8192 |       49152 | data_node_1
+ _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |        8192 |       49152 | data_node_2
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | data_node_3
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | data_node_3
+(6 rows)
+
+SELECT * FROM hypertable_detailed_size('dist_table'::regclass);
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+       16384 |       65536 |        8192 |       90112 | data_node_1
+       16384 |       65536 |           0 |       81920 | data_node_3
+       16384 |       65536 |        8192 |       90112 | data_node_2
+(3 rows)
+
+---tables with special characters in the name ----
+CREATE TABLE "quote'tab" ( a timestamp,  b integer);
+SELECT create_distributed_hypertable( '"quote''tab"', 'a', 'b', replication_factor=>2, chunk_time_interval=>INTERVAL '1 day');
+NOTICE:  adding not-null constraint to column "a"
+ create_distributed_hypertable 
+-------------------------------
+ (2,public,quote'tab,t)
+(1 row)
+
+INSERT into "quote'tab" select generate_series( '2020-02-02 10:00', '2020-02-05 10:00' , '1 day'::interval), 10;
+SELECT * FROM  chunks_detailed_size( '"quote''tab"') ORDER BY chunk_name, node_name;
+     chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_2_4_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_4_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_7_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_7_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+                       |                       |             |             |             |             | data_node_3
+(9 rows)
+
+CREATE TABLE "special#tab" ( a timestamp,  b integer);
+SELECT create_hypertable( 'special#tab', 'a', 'b', replication_factor=>2, chunk_time_interval=>INTERVAL '1 day');
+NOTICE:  adding not-null constraint to column "a"
+    create_hypertable     
+--------------------------
+ (3,public,special#tab,t)
+(1 row)
+
+INSERT into "special#tab" select generate_series( '2020-02-02 10:00', '2020-02-05 10:00' , '1 day'::interval), 10;
+SELECT * FROM  chunks_detailed_size( '"special#tab"') ORDER BY chunk_name, node_name;
+     chunk_schema      |       chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+------------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_3_10_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_3_10_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_3_11_chunk |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_3_11_chunk |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_3_8_chunk  |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_3_8_chunk  |        8192 |       32768 |           0 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_3_9_chunk  |        8192 |       32768 |           0 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_3_9_chunk  |        8192 |       32768 |           0 |       40960 | data_node_2
+                       |                        |             |             |             |             | data_node_3
+(9 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -101,6 +101,8 @@ endif()
 
 # the following tests will run by itself before the parallel
 # tests because they fail or are flaky when run in parallel
+# dist_views.sql sets some global information, so do not run it 
+# in parallel
 set(SOLO_TESTS
   bgw_reorder_drop_chunks
   chunk_api
@@ -119,6 +121,7 @@ set(SOLO_TESTS
   dist_hypertable_am
   dist_hypertable_with_oids
   dist_partial_agg
+  dist_views.sql
   issues
   read_only
   remote_connection_cache

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -176,7 +176,13 @@ vacuum full conditions;
 -- After vacuum, table_bytes is 0, but any associated index/toast storage is not
 -- completely reclaimed. Sets it at 8K (page size). So a chunk which has
 -- been compressed still incurs an overhead of n * 8KB (for every index + toast table) storage on the original uncompressed chunk.
-select * from timescaledb_information.hypertable
+select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
+pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes) 
+from hypertable_detailed_size('foo');
+select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
+pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes) 
+from hypertable_detailed_size('conditions');
+select * from timescaledb_information.hypertables
 where table_name like 'foo' or table_name like 'conditions'
 order by table_name;
 \x

--- a/tsl/test/sql/compression_hypertable.sql
+++ b/tsl/test/sql/compression_hypertable.sql
@@ -139,7 +139,7 @@ select generate_series('2018-01-01 00:00'::timestamp, '2018-01-31 00:00'::timest
 insert into test4
 select generate_series('2018-02-01 00:00'::timestamp, '2018-02-14 00:00'::timestamp, '1 min'), 'POR', 'klick', 55, 75;
 select table_name, num_chunks
-from timescaledb_information.hypertable
+from timescaledb_information.hypertables
 where table_name like 'test4';
 
 select location, count(*)

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -23,7 +23,6 @@ SELECT * FROM add_data_node('data_node_3', host => 'localhost',
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
 SET client_min_messages TO NOTICE;
 SET ROLE :ROLE_1;
-SELECT setseed(1);
 
 CREATE TABLE compressed(time timestamptz, device int, temp float);
 -- Replicate twice to see that compress_chunk compresses all replica chunks
@@ -108,7 +107,14 @@ ORDER BY chunk
 LIMIT 1;
 
 \x
+SELECT * FROM timescaledb_information.hypertables
+WHERE table_name = 'compressed';
 SELECT * from timescaledb_information.chunks 
 ORDER BY hypertable_name, chunk_name;
 SELECT * from timescaledb_information.dimensions 
 ORDER BY hypertable_name, dimension_number;
+\x
+
+SELECT * FROM chunks_detailed_size('compressed'::regclass) 
+ORDER BY chunk_name, node_name;
+SELECT * FROM hypertable_detailed_size('compressed'::regclass) 

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -195,7 +195,7 @@ SELECT * FROM disttable;
 $$);
 
 SELECT node_name, "options" FROM timescaledb_information.data_node ORDER BY node_name;
-SELECT * FROM hypertable_data_node_relation_size('disttable');
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
 
 -- Show what some queries would look like on the frontend
 EXPLAIN (VERBOSE, COSTS FALSE)
@@ -436,7 +436,7 @@ SELECT * FROM disttable;
 $$);
 
 -- The hypertable view also shows no chunks and no data
-SELECT * FROM timescaledb_information.hypertable
+SELECT * FROM timescaledb_information.hypertables
 ORDER BY table_schema, table_name;
 
 -- Test underreplicated chunk warning
@@ -495,7 +495,7 @@ CREATE TABLE remotetable2(time timestamptz PRIMARY KEY, device int CHECK (device
 SELECT * FROM create_distributed_hypertable('remotetable2', 'time', replication_factor => 0);
 \set ON_ERROR_STOP 1
 
-SELECT * FROM timescaledb_information.hypertable
+SELECT * FROM timescaledb_information.hypertables
 ORDER BY table_schema, table_name;
 
 -- Test distributed hypertable creation with many parameters

--- a/tsl/test/sql/dist_query.sql.in
+++ b/tsl/test/sql/dist_query.sql.in
@@ -26,7 +26,7 @@ SET client_min_messages TO notice;
 -- Load the data
 \ir :TEST_LOAD_NAME
 SELECT table_schema, table_name, num_dimensions, num_chunks
-FROM timescaledb_information.hypertable
+FROM timescaledb_information.hypertables
 ORDER BY 1,2;
 SELECT count(*) FROM hyper;
 

--- a/tsl/test/sql/dist_util.sql
+++ b/tsl/test/sql/dist_util.sql
@@ -137,8 +137,8 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:05', 1, 1.4);
 
 SELECT * FROM timescaledb_information.data_node ORDER BY node_name;
-SELECT * FROM timescaledb_information.hypertable;
-SELECT * FROM hypertable_relation_size('disttable');
-SELECT * FROM hypertable_relation_size('nondisttable');
-SELECT * FROM hypertable_data_node_relation_size('disttable') ORDER BY node_name;
-SELECT * FROM hypertable_data_node_relation_size('nondisttable') ORDER BY node_name;
+SELECT * FROM timescaledb_information.hypertables;
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+SELECT * FROM hypertable_size('disttable') ;
+SELECT * FROM hypertable_size('nondisttable') ;

--- a/tsl/test/sql/dist_views.sql
+++ b/tsl/test/sql/dist_views.sql
@@ -1,0 +1,60 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+---------------------------------------------------
+-- Test views and size_utils functions on distributed hypertable
+---------------------------------------------------
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+
+SET client_min_messages TO ERROR;
+DROP DATABASE IF EXISTS data_node_1;
+DROP DATABASE IF EXISTS data_node_2;
+DROP DATABASE IF EXISTS data_node_3;
+SELECT * FROM add_data_node('data_node_1', host => 'localhost',
+                            database => 'data_node_1');
+SELECT * FROM add_data_node('data_node_2', host => 'localhost',
+                            database => 'data_node_2');
+SELECT * FROM add_data_node('data_node_3', host => 'localhost',
+                            database => 'data_node_3');
+
+GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
+SET client_min_messages TO NOTICE;
+SET ROLE :ROLE_1;
+SELECT setseed(1);
+
+CREATE TABLE dist_table(time timestamptz, device int, temp float);
+SELECT create_distributed_hypertable('dist_table', 'time', 'device', replication_factor => 2);
+INSERT INTO dist_table SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, 80
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-04 1:00', '1 hour') t;
+ALTER TABLE dist_table SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
+
+-- Test that compression is rolled back on aborted transaction
+BEGIN;
+SELECT compress_chunk(chunk)
+FROM show_chunks('dist_table') AS chunk
+ORDER BY chunk
+LIMIT 1;
+
+SELECT * FROM timescaledb_information.hypertables
+WHERE table_name = 'dist_table';
+SELECT * from timescaledb_information.chunks 
+ORDER BY hypertable_name, chunk_name;
+SELECT * from timescaledb_information.dimensions 
+ORDER BY hypertable_name, dimension_number;
+
+SELECT * FROM chunks_detailed_size('dist_table'::regclass) 
+ORDER BY chunk_name, node_name;
+SELECT * FROM hypertable_detailed_size('dist_table'::regclass);
+
+---tables with special characters in the name ----
+CREATE TABLE "quote'tab" ( a timestamp,  b integer);
+SELECT create_distributed_hypertable( '"quote''tab"', 'a', 'b', replication_factor=>2, chunk_time_interval=>INTERVAL '1 day');
+INSERT into "quote'tab" select generate_series( '2020-02-02 10:00', '2020-02-05 10:00' , '1 day'::interval), 10;
+SELECT * FROM  chunks_detailed_size( '"quote''tab"') ORDER BY chunk_name, node_name;
+
+CREATE TABLE "special#tab" ( a timestamp,  b integer);
+SELECT create_hypertable( 'special#tab', 'a', 'b', replication_factor=>2, chunk_time_interval=>INTERVAL '1 day');
+INSERT into "special#tab" select generate_series( '2020-02-02 10:00', '2020-02-05 10:00' , '1 day'::interval), 10;
+SELECT * FROM  chunks_detailed_size( '"special#tab"') ORDER BY chunk_name, node_name;
+


### PR DESCRIPTION
Add hypertable_detailed_size and chunk_detailed_size functions.
Remove size functionality from timescaledb_information.hypertable view and rename the view
as timescaledb_information.hypertables.

To reviewers:
chunk_relation_size and variants will be removed in another PR. 
All internal views and functions have been added to _timescaledb_internal. External facing views are in timescaledb_information. External facing functions are not schema prefixed.