### PR TITLE
Fix index creation with IF NOT EXISTS for existing indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## Unreleased
+
+**Bugfixes**
+* #2090 Fix index creation with IF NOT EXISTS for existing indexes
+
+**Thanks**
+* @PichetGoulu for reporting an issue with index creation and IF NOT EXISTS
+
 ## 1.7.2 (2020-07-07)
 
 This maintenance release contains bugfixes since the 1.7.1 release. We deem it medium

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1986,6 +1986,16 @@ process_index_start(ProcessUtilityArgs *args)
 														   args->query_string,
 														   info.extended_options.multitransaction,
 														   hypertable_is_distributed(ht));
+
+	/* root_table_index will have 0 objectId if the index already exists
+	 * and if_not_exists is true. In that case there is nothing else
+	 * to do here. */
+	if (!OidIsValid(root_table_index.objectId) && stmt->if_not_exists)
+	{
+		ts_cache_release(hcache);
+		return DDL_DONE;
+	}
+	Assert(OidIsValid(root_table_index.objectId));
 	info.obj.objectId = root_table_index.objectId;
 
 	/* CREATE INDEX on the chunks, unless this is a distributed hypertable */

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -526,3 +526,26 @@ INSERT INTO idx_tableref_test SELECT '2000-01-01';
 DROP INDEX tableref_idx;
 -- try creating index on hypertable with existing chunks
 CREATE INDEX tableref_idx ON idx_tableref_test(tableref_func(idx_tableref_test));
+-- test index creation with if not exists
+CREATE TABLE idx_exists(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('idx_exists', 'time');
+ table_name 
+------------
+ idx_exists
+(1 row)
+
+-- should be skipped since this index was already created by create_hypertable
+CREATE INDEX IF NOT EXISTS idx_exists_time_idx ON idx_exists(time DESC);
+NOTICE:  relation "idx_exists_time_idx" already exists, skipping
+-- should create index
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+-- should be skipped since it was created in previous command
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+NOTICE:  relation "idx_exists_time_asc_idx" already exists, skipping
+DROP INDEX idx_exists_time_asc_idx;
+INSERT INTO idx_exists VALUES ('2000-01-01'),('2001-01-01');
+-- should create index
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+-- should be skipped since it was created in previous command
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+NOTICE:  relation "idx_exists_time_asc_idx" already exists, skipping

--- a/test/sql/index.sql
+++ b/test/sql/index.sql
@@ -242,3 +242,22 @@ DROP INDEX tableref_idx;
 -- try creating index on hypertable with existing chunks
 CREATE INDEX tableref_idx ON idx_tableref_test(tableref_func(idx_tableref_test));
 
+-- test index creation with if not exists
+CREATE TABLE idx_exists(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('idx_exists', 'time');
+-- should be skipped since this index was already created by create_hypertable
+CREATE INDEX IF NOT EXISTS idx_exists_time_idx ON idx_exists(time DESC);
+-- should create index
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+-- should be skipped since it was created in previous command
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+DROP INDEX idx_exists_time_asc_idx;
+
+INSERT INTO idx_exists VALUES ('2000-01-01'),('2001-01-01');
+-- should create index
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+-- should be skipped since it was created in previous command
+CREATE INDEX IF NOT EXISTS idx_exists_time_asc_idx ON idx_exists(time ASC);
+
+
+


### PR DESCRIPTION
When creating an index with IF NOT EXISTS we still tried to
create indexes for all the chunks but since no index was created
on the parent table the meta data did not have the object id of
the main table index leading to an error when trying to open
the main table index. This patch adjusts the logic to check
for IF NOT EXISTS and does an early return when no index was
created on the parent table.

Fixes #2081 