### PR TITLE
Add license note to TSL isolation test

### DIFF
--- a/tsl/test/isolation/specs/compression_ddl.spec
+++ b/tsl/test/isolation/specs/compression_ddl.spec
@@ -1,3 +1,7 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
 setup
 {
     CREATE TABLE ts_device_table(time INTEGER, device INTEGER, location INTEGER, value INTEGER);

--- a/tsl/test/isolation/specs/continuous_aggs_insert.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_insert.spec
@@ -1,3 +1,6 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
 
 setup
 {

--- a/tsl/test/isolation/specs/continuous_aggs_multi.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_multi.spec
@@ -1,3 +1,6 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
 
 setup
 {

--- a/tsl/test/isolation/specs/reorder_deadlock.spec.in
+++ b/tsl/test/isolation/specs/reorder_deadlock.spec.in
@@ -1,3 +1,7 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
 # reorder should win the deadlock detector
 setup {
  CREATE TABLE ts_reorder_test(time int, temp float, location int);

--- a/tsl/test/isolation/specs/reorder_vs_insert.spec.in
+++ b/tsl/test/isolation/specs/reorder_vs_insert.spec.in
@@ -1,3 +1,7 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
 # reorder should be fully blocked by an insert into the chunk being reordered
 setup
 {

--- a/tsl/test/isolation/specs/reorder_vs_insert_other_chunk.spec.in
+++ b/tsl/test/isolation/specs/reorder_vs_insert_other_chunk.spec.in
@@ -1,3 +1,7 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
 # reorder should not be blocked by an insert into another chunk
 setup
 {

--- a/tsl/test/isolation/specs/reorder_vs_select.spec.in
+++ b/tsl/test/isolation/specs/reorder_vs_select.spec.in
@@ -1,3 +1,7 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
 # reorder should only be blocked by select for the final table swap
 setup {
  CREATE TABLE ts_reorder_test(time int, temp float, location int);


### PR DESCRIPTION
Adding Timescale License header to specs of isolation TSL tests.