### PR TITLE
Analyze ignore_invalidation_older_than for default value

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3192,7 +3192,8 @@ ts_chunk_drop_process_materialization(Oid hypertable_relid,
 														 ignore_invalidation_older_than);
 
 	/* minimum_invalidation_time is inclusive; older_than_time is exclusive */
-	if (minimum_invalidation_time < older_than_time)
+	if (ignore_invalidation_older_than != PG_INT64_MAX /* if this parameter is set for cagg*/
+		&& minimum_invalidation_time < older_than_time)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("older_than must be greater than the "

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -573,7 +573,7 @@ AS SELECT time_bucket('5', time), max(data)
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 \set ON_ERROR_STOP 0
 SELECT drop_chunks('drop_chunks_table', older_than => 13, cascade_to_materializations => false);
-ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
+ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 ALTER VIEW drop_chunks_view SET (timescaledb.ignore_invalidation_older_than = 9);
 -- 9 is too small (less than timescaledb.ignore_invalidation_older_than)
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-8), cascade_to_materializations => false);

--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -1,4 +1,6 @@
-\c :TEST_DBNAME :ROLE_SUPERUSER
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
 --
 -- Check that drop chunks with a unique constraint works as expected.
 --
@@ -119,7 +121,7 @@ REFRESH MATERIALIZED VIEW records_monthly;
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 REFRESH MATERIALIZED VIEW records_monthly;
 \set VERBOSITY default
-SELECT drop_chunks('2000-03-16'::timestamptz, 'records',
+SELECT drop_chunks('records', '2000-03-16'::timestamptz,
        cascade_to_materializations => FALSE);
 NOTICE:  making sure all invalidations for public.records_monthly have been processed prior to dropping chunks
                drop_chunks               
@@ -140,4 +142,57 @@ NOTICE:  making sure all invalidations for public.records_monthly have been proc
  _timescaledb_internal._hyper_1_14_chunk
  _timescaledb_internal._hyper_1_15_chunk
 (15 rows)
+
+-- Issue #1921 (https://github.com/timescale/timescaledb/issues/1921)
+-- drop_chunks() Fails against hypertable with cagg defined with no ignore_invalidation_older set 
+CREATE TABLE conditions (
+    time       TIMESTAMPTZ       NOT NULL,
+    temperature DOUBLE PRECISION  NULL
+);
+SELECT table_name FROM create_hypertable( 'conditions', 'time');
+ table_name 
+------------
+ conditions
+(1 row)
+
+CREATE VIEW conditions_cagg( timec, maxt)
+    WITH ( timescaledb.continuous, timescaledb.refresh_lag='-1day',
+        timescaledb.max_interval_per_job='260 day')
+AS
+SELECT time_bucket('1day', time), max(temperature)
+FROM conditions
+GROUP BY time_bucket('1day', time);
+INSERT INTO conditions VALUES ('2020-06-10', '1');
+INSERT INTO conditions VALUES ('2020-06-10', '2');
+INSERT INTO conditions VALUES ('2020-05-15', '3');
+INSERT INTO conditions VALUES ('2020-05-15', '6');
+INSERT INTO conditions VALUES ('2020-04-23', '10');
+INSERT INTO conditions VALUES ('2020-04-23', '11');
+SET timescaledb.current_timestamp_mock = '2020-07-01';
+REFRESH MATERIALIZED VIEW conditions_cagg;
+SELECT * FROM conditions_cagg;
+            timec             | maxt 
+------------------------------+------
+ Tue Jun 09 17:00:00 2020 PDT |    2
+ Thu May 14 17:00:00 2020 PDT |    6
+ Wed Apr 22 17:00:00 2020 PDT |   11
+(3 rows)
+
+-- No error on this statement
+SELECT drop_chunks('conditions', '2020-06-01'::timestamptz, cascade_to_materializations => FALSE);
+NOTICE:  making sure all invalidations for public.conditions_cagg have been processed prior to dropping chunks
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_3_63_chunk
+ _timescaledb_internal._hyper_3_64_chunk
+(2 rows)
+
+-- No changes to cagg since cascade_to_materialization is FALSE
+SELECT * FROM conditions_cagg;
+            timec             | maxt 
+------------------------------+------
+ Tue Jun 09 17:00:00 2020 PDT |    2
+ Thu May 14 17:00:00 2020 PDT |    6
+ Wed Apr 22 17:00:00 2020 PDT |   11
+(3 rows)
 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_FILES_DEBUG
   continuous_aggs_bgw_drop_chunks.sql
   continuous_aggs_bgw.sql
   continuous_aggs_ddl.sql
+  continuous_aggs_drop_chunks.sql
   continuous_aggs_dump.sql
   continuous_aggs_materialize.sql
   continuous_aggs_multi.sql


### PR DESCRIPTION
Analyze ignore_invalidation_older_than parameter of a continuous
aggregate for default value (when this parameter is not set
during the continous aggregate creation). This allows to drop
chunks without having an error.

Fixes #1921