### PR TITLE
Support moving compressed chunks

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -167,6 +167,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_find_or_create_without_cuts(Hypertable *ht, H
 															   const char *schema_name,
 															   const char *table_name,
 															   bool *created);
+extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_can_be_compressed(int32 chunk_id);
 extern TSDLLEXPORT Datum ts_chunk_id_from_relid(PG_FUNCTION_ARGS);

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -150,22 +150,32 @@ FROM pg_tables WHERE tablespace = 'tablespace1';
 (0 rows)
 
 \set ON_ERROR_STOP 0
-SELECT move_chunk(chunk=>:'UNCOMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."_hyper_1_1_chunk_test1_Time_idx"');
-WARNING:  Timescale License expired
-ERROR:  "_hyper_1_1_chunk" is a compressed chunk
-\set ON_ERROR_STOP 1
 SELECT move_chunk(chunk=>:'COMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."compress_hyper_2_28_chunk__compressed_hypertable_2_b__ts_meta_s"');
+WARNING:  Timescale License expired
+ERROR:  cannot directly move internal compression data
+\set ON_ERROR_STOP 1
+-- ensure that both compressed and uncompressed chunks moved
+SELECT move_chunk(chunk=>:'UNCOMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."_hyper_1_1_chunk_test1_Time_idx"');
+NOTICE:  Ignoring index parameter
  move_chunk 
 ------------
  
 (1 row)
+
+SELECT tablename
+FROM pg_tables WHERE tablespace = 'tablespace1';
+         tablename         
+---------------------------
+ _hyper_1_1_chunk
+ compress_hyper_2_28_chunk
+(2 rows)
 
 -- the compressed chunk is in here now
 SELECT count(*)
 FROM pg_tables WHERE tablespace = 'tablespace1';
  count 
 -------
-     1
+     2
 (1 row)
 
 SELECT decompress_chunk(:'UNCOMPRESSED_CHUNK_NAME');
@@ -179,7 +189,7 @@ SELECT count(*)
 FROM pg_tables WHERE tablespace = 'tablespace1';
  count 
 -------
-     0
+     1
 (1 row)
 
 SELECT move_chunk(chunk=>:'UNCOMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."_hyper_1_1_chunk_test1_Time_idx"');

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -111,10 +111,13 @@ SELECT tablename
 FROM pg_tables WHERE tablespace = 'tablespace1';
 
 \set ON_ERROR_STOP 0
-SELECT move_chunk(chunk=>:'UNCOMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."_hyper_1_1_chunk_test1_Time_idx"');
+SELECT move_chunk(chunk=>:'COMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."compress_hyper_2_28_chunk__compressed_hypertable_2_b__ts_meta_s"');
 \set ON_ERROR_STOP 1
 
-SELECT move_chunk(chunk=>:'COMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."compress_hyper_2_28_chunk__compressed_hypertable_2_b__ts_meta_s"');
+-- ensure that both compressed and uncompressed chunks moved
+SELECT move_chunk(chunk=>:'UNCOMPRESSED_CHUNK_NAME', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1',  reorder_index=>'_timescaledb_internal."_hyper_1_1_chunk_test1_Time_idx"');
+SELECT tablename
+FROM pg_tables WHERE tablespace = 'tablespace1';
 
 -- the compressed chunk is in here now
 SELECT count(*)


### PR DESCRIPTION
Allow move_chunk() to work with uncompressed chunk and automatically move associated compressed chunk to specified
tablespace. Block move_chunk() execution for compressed chunks.

This change executes alter set tablespace underneath for compressed chunk. I guess it we might also use index used for orderby compression and call chunk_reorder() with it, not really sure if that would work.

Related issue: https://github.com/timescale/timescaledb/issues/2067