### PR TITLE
Remove include of pg_config.h

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -4,7 +4,7 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <pg_config.h>
+
 #include <access/xact.h>
 #include <commands/extension.h>
 #include <miscadmin.h>

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -4,7 +4,7 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <pg_config.h>
+
 #include <access/xact.h>
 #include <access/heapam.h>
 #include "../compat-msvc-enter.h"

--- a/src/net/conn.c
+++ b/src/net/conn.c
@@ -4,7 +4,6 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <pg_config.h>
 
 #include "conn_internal.h"
 

--- a/src/net/conn.h
+++ b/src/net/conn.h
@@ -6,7 +6,7 @@
 #ifndef TIMESCALEDB_NET_CONN_H
 #define TIMESCALEDB_NET_CONN_H
 
-#include <pg_config.h>
+#include <postgres.h>
 
 typedef struct ConnOps ConnOps;
 

--- a/src/net/conn_plain.c
+++ b/src/net/conn_plain.c
@@ -5,7 +5,7 @@
  */
 #include <unistd.h>
 #include <postgres.h>
-#include <pg_config.h>
+
 #include <sys/socket.h>
 #include <sys/time.h>
 

--- a/src/net/conn_ssl.c
+++ b/src/net/conn_ssl.c
@@ -4,7 +4,6 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <pg_config.h>
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -7,7 +7,6 @@
 #define TIMESCALEDB_TELEMETRY_TELEMETRY_H
 #include <postgres.h>
 #include <fmgr.h>
-#include <pg_config.h> // To get USE_OPENSSL from postgres build
 #include <utils/builtins.h>
 
 #include "compat.h"

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -4,7 +4,7 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <pg_config.h>
+
 #include <access/xact.h>
 #include <config.h>
 #ifndef WIN32

--- a/test/src/net/conn_mock.c
+++ b/test/src/net/conn_mock.c
@@ -10,7 +10,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <postgres.h>
-#include <pg_config.h>
 
 #include "conn_internal.h"
 #include "conn_mock.h"


### PR DESCRIPTION
The `pg_config.h` file in the PostgreSQL include directory does not
contain any include guards, so including it will generate errors when
building from PGDG-distributed packages.

Since `pg_config.h` is included from `c.h` (which has include guards)
which in turn is included from `postgres.h` (which also has include
guards), we remove usage of `pg_config.h` from all places where
`postgres.h` is included and replace it with `postgres.h` where it is
not included.