### PR TITLE
Make scheduler ignore jobs where scheduled = false

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -206,6 +206,7 @@ CREATE TABLE IF NOT EXISTS _timescaledb_config.bgw_job (
     CONSTRAINT  valid_job_type CHECK (job_type IN ('telemetry_and_version_check_if_enabled', 'reorder', 'drop_chunks', 'continuous_aggregate', 'compress_chunks', 'custom'))
 );
 ALTER SEQUENCE _timescaledb_config.bgw_job_id_seq OWNED BY _timescaledb_config.bgw_job.id;
+CREATE INDEX IF NOT EXISTS bgw_job_proc_hypertable_id_idx ON _timescaledb_config.bgw_job(proc_name,proc_schema,hypertable_id);
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_job', 'WHERE id >= 1000');
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -132,6 +132,8 @@ ALTER TABLE _timescaledb_config.bgw_job ADD CONSTRAINT valid_job_type CHECK (job
 CLUSTER  _timescaledb_config.bgw_job USING bgw_job_pkey;
 ALTER TABLE _timescaledb_config.bgw_job SET WITHOUT CLUSTER;
 
+CREATE INDEX IF NOT EXISTS bgw_job_proc_hypertable_id_idx ON _timescaledb_config.bgw_job(proc_name,proc_schema,hypertable_id);
+
 ---Clean up constraints on hypertable catalog table ---
 ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_table_name_schema_name_key UNIQUE(table_name, schema_name);
 ALTER TABLE _timescaledb_catalog.hypertable DROP CONSTRAINT hypertable_schema_name_table_name_key;

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -42,6 +42,12 @@ extern BackgroundWorkerHandle *ts_bgw_job_start(BgwJob *job, Oid user_oid);
 
 extern List *ts_bgw_job_get_scheduled(size_t alloc_size, MemoryContext mctx);
 
+extern TSDLLEXPORT List *ts_bgw_job_find_by_proc(const char *proc_name, const char *proc_schema);
+extern TSDLLEXPORT List *ts_bgw_job_find_by_hypertable_id(int32 hypertable_id);
+extern TSDLLEXPORT List *ts_bgw_job_find_by_proc_and_hypertable_id(const char *proc_name,
+																   const char *proc_schema,
+																   int32 hypertable_id);
+
 extern bool ts_bgw_job_get_share_lock(int32 bgw_job_id, MemoryContext mctx);
 
 TSDLLEXPORT BgwJob *ts_bgw_job_find(int job_id, MemoryContext mctx, bool fail_if_not_found);

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -40,7 +40,7 @@ extern BackgroundWorkerHandle *ts_bgw_start_worker(const char *function, const c
 
 extern BackgroundWorkerHandle *ts_bgw_job_start(BgwJob *job, Oid user_oid);
 
-extern List *ts_bgw_job_get_all(size_t alloc_size, MemoryContext mctx);
+extern List *ts_bgw_job_get_scheduled(size_t alloc_size, MemoryContext mctx);
 
 extern bool ts_bgw_job_get_share_lock(int32 bgw_job_id, MemoryContext mctx);
 

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -402,7 +402,7 @@ terminate_and_cleanup_job(ScheduledBgwJob *sjob)
 List *
 ts_update_scheduled_jobs_list(List *cur_jobs_list, MemoryContext mctx)
 {
-	List *new_jobs = ts_bgw_job_get_all(sizeof(ScheduledBgwJob), mctx);
+	List *new_jobs = ts_bgw_job_get_scheduled(sizeof(ScheduledBgwJob), mctx);
 	ListCell *new_ptr = list_head(new_jobs);
 	ListCell *cur_ptr = list_head(cur_jobs_list);
 

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -195,6 +195,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length = _MAX_BGW_JOB_INDEX,
 		.names = (char *[]) {
 			[BGW_JOB_PKEY_IDX] = "bgw_job_pkey",
+			[BGW_JOB_PROC_HYPERTABLE_ID_IDX] = "bgw_job_proc_hypertable_id_idx",
 		},
 	},
 	[BGW_JOB_STAT] = {

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -682,6 +682,7 @@ typedef FormData_bgw_job *Form_bgw_job;
 enum
 {
 	BGW_JOB_PKEY_IDX = 0,
+	BGW_JOB_PROC_HYPERTABLE_ID_IDX,
 	_MAX_BGW_JOB_INDEX,
 };
 
@@ -692,6 +693,16 @@ enum Anum_bgw_job_pkey_idx
 };
 
 #define Natts_bjw_job_pkey_idx (_Anum_bgw_job_pkey_idx_max - 1)
+
+enum Anum_bgw_job_proc_hypertable_id_idx
+{
+	Anum_bgw_job_proc_hypertable_id_idx_proc_name = 1,
+	Anum_bgw_job_proc_hypertable_id_idx_proc_schema,
+	Anum_bgw_job_proc_hypertable_id_idx_hypertable_id,
+	_Anum_bgw_job_proc_hypertable_id_idx_max,
+};
+
+#define Natts_bgw_job_proc_hypertable_id_idx (_Anum_bgw_job_proc_hypertable_id_idx_max - 1)
 
 /************************************
  *

--- a/src/jsonb_utils.h
+++ b/src/jsonb_utils.h
@@ -22,10 +22,9 @@ extern TSDLLEXPORT void ts_jsonb_add_numeric(JsonbParseState *state, const char 
 
 extern void ts_jsonb_add_value(JsonbParseState *state, const char *key, JsonbValue *value);
 
-extern TSDLLEXPORT text *ts_jsonb_get_text_field(Jsonb *json, text *field_name);
-extern TSDLLEXPORT char *ts_jsonb_get_str_field(Jsonb *license, text *field_name);
-extern TSDLLEXPORT TimestampTz ts_jsonb_get_time_field(Jsonb *license, text *field_name,
+extern TSDLLEXPORT char *ts_jsonb_get_str_field(Jsonb *jsonb, const char *key);
+extern TSDLLEXPORT TimestampTz ts_jsonb_get_time_field(Jsonb *jsonb, const char *key,
 													   bool *field_found);
-extern TSDLLEXPORT int32 ts_jsonb_get_int32_field(Jsonb *json, text *field_name, bool *field_found);
+extern TSDLLEXPORT int32 ts_jsonb_get_int32_field(Jsonb *json, const char *key, bool *field_found);
 
 #endif /* TIMESCALEDB_JSONB_UTILS_H */

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -17,10 +17,14 @@ CREATE OR REPLACE FUNCTION ts_bgw_params_destroy() RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
 CREATE OR REPLACE FUNCTION ts_bgw_params_reset_time(set_time BIGINT = 0, wait BOOLEAN = false) RETURNS VOID
 AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
-CREATE OR REPLACE FUNCTION insert_job(application_name NAME, job_type NAME, schedule_interval INTERVAL, max_runtime INTERVAL, max_retries INTEGER, retry_period INTERVAL, proc_name NAME DEFAULT '', proc_schema NAME DEFAULT '', owner NAME DEFAULT '', hypertable_id INTEGER DEFAULT 0, scheduled BOOL DEFAULT true, config JSONB DEFAULT '{}')
+CREATE OR REPLACE FUNCTION insert_job(application_name NAME, job_type NAME, schedule_interval INTERVAL, max_runtime INTERVAL, max_retries INTEGER, retry_period INTERVAL, proc_name NAME DEFAULT '', proc_schema NAME DEFAULT '', owner NAME DEFAULT '', scheduled BOOL DEFAULT true, hypertable_id INTEGER DEFAULT 0, config JSONB DEFAULT '{}')
 RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_bgw_job_insert_relation'
 LANGUAGE C VOLATILE STRICT;
+CREATE OR REPLACE FUNCTION test_toggle_scheduled(job_id INTEGER) RETURNS VOID LANGUAGE SQL SECURITY DEFINER AS
+$$
+  UPDATE _timescaledb_config.bgw_job SET scheduled = NOT scheduled WHERE id = $1;
+$$;
 CREATE OR REPLACE FUNCTION delete_job(job_id INTEGER)
 RETURNS VOID
 AS :MODULE_PATHNAME, 'ts_test_bgw_job_delete_by_id'
@@ -101,10 +105,72 @@ SELECT * FROM sorted_bgw_log;
 (1 row)
 
 --
+-- Test running the scheduler with a job marked as unscheduled
+--
+TRUNCATE bgw_log;
+SELECT ts_bgw_params_reset_time();
+ ts_bgw_params_reset_time 
+--------------------------
+ 
+(1 row)
+
+SELECT insert_job('unscheduled', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '100s', 5, INTERVAL '1s',scheduled:= false);
+ insert_job 
+------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+-- empty
+SELECT * FROM _timescaledb_internal.bgw_job_stat;
+ job_id | last_start | last_finish | next_start | last_successful_finish | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+------------+-------------+------------+------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+(0 rows)
+
+SELECT test_toggle_scheduled(1000);
+ test_toggle_scheduled 
+-----------------------
+ 
+(1 row)
+
+SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50);
+ ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish 
+------------------------------------------------------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_internal.bgw_job_stat;
+ job_id |           last_start            |           last_finish           |           next_start            |     last_successful_finish      | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
+--------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
+   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | t                |          1 | @ 0            |               1 |              0 |             0 |                    0 |                   0
+(1 row)
+
+SELECT * FROM sorted_bgw_log;
+ msg_no | mock_time | application_name |                      msg                      
+--------+-----------+------------------+-----------------------------------------------
+      0 |         0 | DB Scheduler     | [TESTING] Wait until 50000, started at 0
+      0 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
+      1 |     50000 | DB Scheduler     | [TESTING] Wait until 100000, started at 50000
+      0 |     50000 | unscheduled      | Execute job 1
+(4 rows)
+
+SELECT delete_job(1000);
+ delete_job 
+------------
+ 
+(1 row)
+
+--
 -- Test running a normal job
 --
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE bgw_log;
+ALTER SEQUENCE _timescaledb_config.bgw_job_id_seq RESTART;
 SELECT ts_bgw_params_reset_time();
  ts_bgw_params_reset_time 
 --------------------------

--- a/tsl/src/license.c
+++ b/tsl/src/license.c
@@ -264,21 +264,20 @@ license_info_init_from_jsonb(Jsonb *json_license, LicenseInfo *out)
 static char *
 json_get_id(Jsonb *license)
 {
-	return ts_jsonb_get_str_field(license, cstring_to_text(ID_FIELD));
+	return ts_jsonb_get_str_field(license, ID_FIELD);
 }
 
 static char *
 json_get_kind(Jsonb *license)
 {
-	return ts_jsonb_get_str_field(license, cstring_to_text(KIND_FIELD));
+	return ts_jsonb_get_str_field(license, KIND_FIELD);
 }
 
 static TimestampTz
 json_get_start_time(Jsonb *license)
 {
 	bool found = false;
-	TimestampTz start_time =
-		ts_jsonb_get_time_field(license, cstring_to_text(START_TIME_FIELD), &found);
+	TimestampTz start_time = ts_jsonb_get_time_field(license, START_TIME_FIELD, &found);
 
 	if (!found)
 		elog(ERRCODE_FEATURE_NOT_SUPPORTED, FIELD_NOT_FOUND_ERRSTRING, START_TIME_FIELD);
@@ -289,8 +288,7 @@ static TimestampTz
 json_get_end_time(Jsonb *license)
 {
 	bool found = false;
-	TimestampTz end_time =
-		ts_jsonb_get_time_field(license, cstring_to_text(END_TIME_FIELD), &found);
+	TimestampTz end_time = ts_jsonb_get_time_field(license, END_TIME_FIELD, &found);
 
 	if (!found)
 		elog(ERRCODE_FEATURE_NOT_SUPPORTED, FIELD_NOT_FOUND_ERRSTRING, END_TIME_FIELD);


### PR DESCRIPTION
This patch makes the scheduler ignore all jobs where scheduled = false.
The schedule flag can be used to disable jobs without deleting the job
entry.

This patch also changes the job retrieval to use an index scan to
satisfy the assumption of the scheduler to receive a list ordered
by job_id.