### PR TITLE
Improve update test github output

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -31,6 +31,18 @@ jobs:
       run: |
         ./scripts/test_updates_pg${{ matrix.pg_major}}.sh
 
+    - name: Update diff
+      if: failure()
+      run: |
+        find . -name "update_test.diff.*" -maxdepth 1 | xargs -IFILE sh -c "echo '\nFILE\n';cat FILE"
+
+    - name: Upload Artifacts
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: Extension update diff ${{ matrix.pg }}
+        path: update_test.diff.*
+
     - name: Slack Notification
       if: failure() && github.event_name != 'pull_request'
       env:

--- a/scripts/test_update_from_tag.sh
+++ b/scripts/test_update_from_tag.sh
@@ -93,11 +93,15 @@ docker_pgtest() {
 }
 
 docker_pgdiff() {
+    diff_file=update_test.diff.${UPDATE_FROM_TAG}
     >&2 echo -e "\033[1m$1 vs $2\033[0m: $2"
     docker_pgtest $1 $3
     docker_pgtest $2 $3
     echo "RUNNING:  diff ${TEST_TMPDIR}/$1.out ${TEST_TMPDIR}/$2.out "
-    diff -u ${TEST_TMPDIR}/$1.out ${TEST_TMPDIR}/$2.out | tee ${TEST_TMPDIR}/update_test.output
+    diff -u ${TEST_TMPDIR}/$1.out ${TEST_TMPDIR}/$2.out | tee ${diff_file}
+    if [ ! -s ${diff_file} ]; then
+      rm ${diff_file}
+    fi
 }
 
 docker_run() {


### PR DESCRIPTION
This patch adds the diff output of the update in a separate step
in the workflow and also uploads the update test diff as artifact.

Fixes #2139 