### PR TITLE
Add self-reference check to add_data_node

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -535,6 +535,10 @@ data_node_bootstrap_extension(TSConnection *conn)
 	}
 }
 
+/* Add dist_uuid on the remote node.
+ *
+ * If the remote node is set to use the current database, `set_dist_id` will report an error and not
+ * set it. */
 static void
 add_distributed_id_to_data_node(TSConnection *conn)
 {

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -1273,11 +1273,23 @@ BEGIN
 END
 $BODY$;
 CREATE EXTENSION timescaledb VERSION '0.0.0';
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+\c :TEST_DBNAME :ROLE_SUPERUSER;
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('data_node_1', 'localhost', database => 'data_node_1',
                             bootstrap => false);
 ERROR:  remote PostgreSQL instance has an incompatible timescaledb extension version
+-- Testing that it is not possible to use oneself as a data node. This
+-- is not allowed since it would create a cycle.
+--
+-- We need to use the same owner for this connection as the extension
+-- owner here to avoid triggering another error.
+--
+-- We cannot use default verbosity here for debugging since the
+-- version number is printed in some of the notices.
+SELECT * FROM add_data_node('data_node_99', host => 'localhost');
+NOTICE:  database "db_data_node" already exists on data node, skipping
+NOTICE:  extension "timescaledb" already exists on data node, skipping
+ERROR:  [data_node_99]: cannot add the current database as a data node to itself
 \set ON_ERROR_STOP 1
 RESET ROLE;
 DROP DATABASE data_node_1;

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -639,11 +639,21 @@ $BODY$;
 
 CREATE EXTENSION timescaledb VERSION '0.0.0';
 
-\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+\c :TEST_DBNAME :ROLE_SUPERUSER;
 
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('data_node_1', 'localhost', database => 'data_node_1',
                             bootstrap => false);
+
+-- Testing that it is not possible to use oneself as a data node. This
+-- is not allowed since it would create a cycle.
+--
+-- We need to use the same owner for this connection as the extension
+-- owner here to avoid triggering another error.
+--
+-- We cannot use default verbosity here for debugging since the
+-- version number is printed in some of the notices.
+SELECT * FROM add_data_node('data_node_99', host => 'localhost');
 \set ON_ERROR_STOP 1
 
 RESET ROLE;


### PR DESCRIPTION
If `add_data_node` is attempted with the same instance and database as
the one the `add_data_node` is executed on, it will deadlock since a
transaction is opened on the datanode which will block updates.

This commit fixes this by updating `set_dist_id` to check if the UUID
being added as `dist_uuid` is the same as the `uuid` in the metadata.
If that is the case, it raises an error.

In addition, it also checks that `uuid` is non-null and generate an
error if it is not. This should not normally happen, but can do for
broken data nodes if the `uuid` is accidentally dropped.

Fixes #2133 