### PR TITLE
Lock dimension slice tuple when scanning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
   set(TS_DEBUG 1)
   set(DEBUG 1)
   list(APPEND SOURCES
+    debug_wait.c
     debug_guc.c)
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -35,6 +35,7 @@
 #include <access/tupdesc.h>
 
 #include "export.h"
+#include "debug_wait.h"
 #include "chunk.h"
 #include "chunk_index.h"
 #include "chunk_data_node.h"
@@ -1189,18 +1190,18 @@ chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti, const ChunkStub
 	chunk_formdata_fill(&chunk->fd, ti);
 
 	/*
-	 * When searching for the chunk stub matching the dimensional point, we only
-	 * scanned for dimensional constraints. We now need to rescan the
+	 * When searching for the chunk stub matching the dimensional point, we
+	 * only scanned for dimensional constraints. We now need to rescan the
 	 * constraints to also get the inherited constraints.
 	 */
 	chunk->constraints =
 		ts_chunk_constraint_scan_by_chunk_id(chunk->fd.id, num_constraints_hint, ti->mctx);
 
-	/* If a stub is provided then reuse its hypercube. Note that stubs that are
-	 * results of a point or range scan might be incomplete (in terms of number
-	 * of slices and constraints). Only a chunk stub that matches in all
-	 * dimensions will have a complete hypercube. Thus, we need to check the
-	 * validity of the stub before we can reuse it.
+	/* If a stub is provided then reuse its hypercube. Note that stubs that
+	 * are results of a point or range scan might be incomplete (in terms of
+	 * number of slices and constraints). Only a chunk stub that matches in
+	 * all dimensions will have a complete hypercube. Thus, we need to check
+	 * the validity of the stub before we can reuse it.
 	 */
 	if (chunk_stub_is_valid(stub, chunk->constraints->num_dimension_constraints))
 	{
@@ -1244,9 +1245,9 @@ chunk_tuple_found(TupleInfo *ti, void *arg)
 	Assert(!chunk->fd.dropped);
 
 	/* Fill in table relids. Note that we cannot do this in
-	 * chunk_build_from_tuple_and_stub() since chunk_resurrect() also uses that
-	 * function and, in that case, the chunk object is needed to create the data
-	 * table and related objects. */
+	 * chunk_build_from_tuple_and_stub() since chunk_resurrect() also uses
+	 * that function and, in that case, the chunk object is needed to create
+	 * the data table and related objects. */
 	chunk->table_id = get_relname_relid(chunk->fd.table_name.data,
 										get_namespace_oid(chunk->fd.schema_name.data, true));
 	chunk->hypertable_relid = ts_inheritance_parent_relid(chunk->table_id);
@@ -2493,22 +2494,24 @@ chunk_tuple_delete(TupleInfo *ti, DropBehavior behavior, bool preserve_chunk_cat
 														   &tuplock,
 														   CurrentMemoryContext);
 				/* If the slice is not found in the scan above, the table is
-				 * broken so we do not delete the slice. We proceed with
+				 * broken so we do not delete the slice. We proceed
 				 * anyway since users need to be able to drop broken tables or
 				 * remove broken chunks. */
 				if (!slice)
+				{
+					const Hypertable *const ht = ts_hypertable_get_by_id(form.hypertable_id);
 					ereport(WARNING,
-							(errmsg("dimension slice %d was missing, proceeding anyway",
-									cc->fd.dimension_slice_id),
-							 errdetail("Chunk \"%s.%s\" is dependent on dimension slice %d, but it "
-									   "was missing. Proceeding to delete chunk anyway.",
-									   quote_identifier(NameStr(form.schema_name)),
-									   quote_identifier(NameStr(form.table_name)),
-									   cc->fd.dimension_slice_id)));
-				if (slice &&
-					ts_chunk_constraint_scan_by_dimension_slice_id(slice->fd.id,
-																   NULL,
-																   CurrentMemoryContext) == 0)
+							(errmsg("unexpected state for chunk %s.%s, dropping anyway",
+									quote_identifier(NameStr(form.schema_name)),
+									quote_identifier(NameStr(form.table_name))),
+							 errdetail("The integrity of hypertable %s.%s might be compromised "
+									   "since one of its chunks lacked a dimension slice.",
+									   quote_identifier(NameStr(ht->fd.schema_name)),
+									   quote_identifier(NameStr(ht->fd.table_name)))));
+				}
+				else if (ts_chunk_constraint_scan_by_dimension_slice_id(slice->fd.id,
+																		NULL,
+																		CurrentMemoryContext) == 0)
 					ts_dimension_slice_delete_by_id(cc->fd.dimension_slice_id, false);
 			}
 		}
@@ -2821,9 +2824,9 @@ ts_chunk_drop_fks(Chunk *const chunk)
 }
 
 /*
- * Recreates all FK constraints on a chunk by using the constraints on the parent hypertable as a
- * template. Currently it is used only during chunk decompression, since FK constraints are dropped
- * during compression.
+ * Recreates all FK constraints on a chunk by using the constraints on the parent hypertable as
+ * a template. Currently it is used only during chunk decompression, since FK constraints are
+ * dropped during compression.
  */
 void
 ts_chunk_create_fks(Chunk *const chunk)
@@ -3015,10 +3018,9 @@ chunk_cmp(const void *ch1, const void *ch2)
 }
 
 /*
- * This is a helper set returning function (SRF) that takes a set returning function context and as
- * argument and returns oids extracted from funcctx->user_fctx (which is Chunk* array).
- * Note that the caller needs to be registered as a
- * set returning function for this to work.
+ * This is a helper set returning function (SRF) that takes a set returning function context and
+ * as argument and returns oids extracted from funcctx->user_fctx (which is Chunk* array). Note
+ * that the caller needs to be registered as a set returning function for this to work.
  */
 static Datum
 chunks_return_srf(FunctionCallInfo fcinfo)
@@ -3133,11 +3135,12 @@ ts_chunk_drop_process_invalidations(Oid hypertable_relid, int64 older_than, int6
 						cagg.user_view_schema.data,
 						cagg.user_view_name.data)));
 
-	/* Lock all chunks in Exclusive mode, blocking everything but selects on the table. We have to
-	 * block all modifications so that we can't get new invalidation entries. This makes sure that
-	 * all future modifying txns on this data region will have a now() that higher than ours and
-	 * thus will not invalidate. Otherwise, we could have an old txn with a now() in the past that
-	 * all of a sudden decides to to insert data right after we process_invalidations. */
+	/* Lock all chunks in Exclusive mode, blocking everything but selects on the table. We have
+	 * to block all modifications so that we can't get new invalidation entries. This makes sure
+	 * that all future modifying txns on this data region will have a now() that higher than
+	 * ours and thus will not invalidate. Otherwise, we could have an old txn with a now() in
+	 * the past that all of a sudden decides to to insert data right after we
+	 * process_invalidations. */
 	for (i = 0; i < num_chunks; i++)
 	{
 		LockRelationOid(chunks[i].table_id, ExclusiveLock);
@@ -3156,12 +3159,13 @@ ts_chunk_drop_process_invalidations(Oid hypertable_relid, int64 older_than, int6
 		bool finished_all_invalidation = false;
 
 		/* This will loop until all invalidations are done, each iteration of the loop will do
-		 * max_interval_per_job's worth of data. We don't want to ignore max_interval_per_job here
-		 * to avoid large sorts. */
+		 * max_interval_per_job's worth of data. We don't want to ignore max_interval_per_job
+		 * here to avoid large sorts. */
 		while (!finished_all_invalidation)
 		{
 			elog(NOTICE,
-				 "making sure all invalidations for %s.%s have been processed prior to dropping "
+				 "making sure all invalidations for %s.%s have been processed prior to "
+				 "dropping "
 				 "chunks",
 				 NameStr(ca->data.user_view_schema),
 				 NameStr(ca->data.user_view_name));
@@ -3210,6 +3214,7 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 	const int32 hypertable_id = ht->fd.id;
 	bool has_continuous_aggs;
 	List *data_nodes = NIL;
+	const MemoryContext oldcontext = CurrentMemoryContext;
 	ScanTupLock tuplock = {
 		.waitpolicy = LockWaitBlock,
 		.lockmode = LockTupleExclusive,
@@ -3244,13 +3249,33 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 			break;
 	}
 
-	chunks = get_chunks_in_time_range(ht,
-									  older_than,
-									  newer_than,
-									  DROP_CHUNKS_FUNCNAME,
-									  CurrentMemoryContext,
-									  &num_chunks,
-									  &tuplock);
+	PG_TRY();
+	{
+		chunks = get_chunks_in_time_range(ht,
+										  older_than,
+										  newer_than,
+										  DROP_CHUNKS_FUNCNAME,
+										  CurrentMemoryContext,
+										  &num_chunks,
+										  &tuplock);
+	}
+	PG_CATCH();
+	{
+		ErrorData *edata;
+		MemoryContextSwitchTo(oldcontext);
+		edata = CopyErrorData();
+		if (edata->sqlerrcode == ERRCODE_LOCK_NOT_AVAILABLE)
+		{
+			FlushErrorState();
+			edata->detail = edata->message;
+			edata->message =
+				psprintf("some chunks could not be read since they are being concurrently updated");
+		}
+		ReThrowError(edata);
+	}
+	PG_END_TRY();
+
+	DEBUG_WAITPOINT("drop_chunks_chunks_found");
 
 	if (has_continuous_aggs)
 		ts_chunk_drop_process_invalidations(ht->main_table_relid,
@@ -3293,10 +3318,9 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 }
 
 /*
- * This is a helper set returning function (SRF) that takes a set returning function context and as
- * argument and returns cstrings extracted from funcctx->user_fctx (which is a List).
- * Note that the caller needs to be registered as a
- * set returning function for this to work.
+ * This is a helper set returning function (SRF) that takes a set returning function context and
+ * as argument and returns cstrings extracted from funcctx->user_fctx (which is a List). Note
+ * that the caller needs to be registered as a set returning function for this to work.
  */
 static Datum
 list_return_srf(FunctionCallInfo fcinfo)
@@ -3513,9 +3537,10 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 }
 
 /**
- * This function is used to explicitly specify chunks that are being scanned. It's being processed
- * in the planning phase and removed from the query tree. This means that the actual function
- * implementation will only be executed if something went wrong during explicit chunk exclusion.
+ * This function is used to explicitly specify chunks that are being scanned. It's being
+ * processed in the planning phase and removed from the query tree. This means that the actual
+ * function implementation will only be executed if something went wrong during explicit chunk
+ * exclusion.
  */
 Datum
 ts_chunks_in(PG_FUNCTION_ARGS)

--- a/src/compat.h
+++ b/src/compat.h
@@ -254,6 +254,12 @@
 #define TUPLE_DESC_HAS_OIDS(desc) false
 #endif
 
+#if defined(__GNUC__)
+#define TS_ATTRIBUTE_NONNULL(X) __attribute__((nonnull X))
+#else
+#define TS_ATTRIBUTE_NONNULL(X)
+#endif
+
 /* Compatibility functions for table access method API introduced in PG12 */
 #if PG11
 #include "compat/tupconvert.h"

--- a/src/debug_wait.c
+++ b/src/debug_wait.c
@@ -78,7 +78,9 @@ debug_waitpoint_release(DebugWait *waitpoint)
  * enabled.
  */
 TS_FUNCTION_INFO_V1(ts_debug_waitpoint_enable);
-Datum ts_debug_waitpoint_enable(PG_FUNCTION_ARGS)
+
+Datum
+ts_debug_waitpoint_enable(PG_FUNCTION_ARGS)
 {
 	text *tag = PG_GETARG_TEXT_PP(0);
 	DebugWait waitpoint;
@@ -95,7 +97,8 @@ Datum ts_debug_waitpoint_enable(PG_FUNCTION_ARGS)
  * Release a waitpoint allowing execution to proceed.
  */
 TS_FUNCTION_INFO_V1(ts_debug_waitpoint_release);
-Datum ts_debug_waitpoint_release(PG_FUNCTION_ARGS)
+Datum
+ts_debug_waitpoint_release(PG_FUNCTION_ARGS)
 {
 	text *tag = PG_GETARG_TEXT_PP(0);
 	DebugWait waitpoint;

--- a/src/debug_wait.c
+++ b/src/debug_wait.c
@@ -1,0 +1,109 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include "debug_wait.h"
+
+#include <postgres.h>
+
+#include <fmgr.h>
+
+#include <access/hash.h>
+#include <storage/lock.h>
+#include <miscadmin.h>
+#include <utils/builtins.h>
+
+#include "export.h"
+
+void
+ts_debug_waitpoint_init(DebugWait *waitpoint, const char *tagname)
+{
+	/* Use 64-bit hashing to get two independent 32-bit hashes */
+	uint64 hash = DatumGetUInt32(hash_any((const unsigned char *) tagname, strlen(tagname)));
+
+	SET_LOCKTAG_ADVISORY(waitpoint->tag, MyDatabaseId, (uint32)(hash >> 32), (uint32) hash, 1);
+	waitpoint->tagname = pstrdup(tagname);
+	ereport(DEBUG1, (errmsg("initializing waitpoint '%s' to use %lu", waitpoint->tagname, hash)));
+}
+
+/*
+ * Wait for the waitpoint to be released.
+ *
+ * This is handled by first trying to get a shared lock, which will not block
+ * other sessions that try to grab the same lock but will block if an
+ * exclusive lock is already taken, and then release the lock immediately
+ * after.
+ */
+void
+ts_debug_waitpoint_wait(DebugWait *waitpoint)
+{
+	LockAcquireResult lock_acquire_result pg_attribute_unused();
+	bool lock_release_result pg_attribute_unused();
+
+	ereport(DEBUG1, (errmsg("waiting on waitpoint '%s'", waitpoint->tagname)));
+
+	/* Take the lock. This should always succeed, anything else is a bug. */
+	lock_acquire_result = LockAcquire(&waitpoint->tag, ShareLock, true, false);
+	Assert(lock_acquire_result == LOCKACQUIRE_OK);
+
+	lock_release_result = LockRelease(&waitpoint->tag, ShareLock, true);
+	Assert(lock_release_result);
+
+	ereport(DEBUG1, (errmsg("proceeding after waitpoint '%s'", waitpoint->tagname)));
+}
+
+static void
+debug_waitpoint_enable(DebugWait *waitpoint)
+{
+	ereport(DEBUG1, (errmsg("enabling waitpoint \"%s\"", waitpoint->tagname)));
+	if (LockAcquire(&waitpoint->tag, ExclusiveLock, true, true) == LOCKACQUIRE_NOT_AVAIL)
+		ereport(NOTICE, (errmsg("debug waitpoint \"%s\" already enabled", waitpoint->tagname)));
+}
+
+static void
+debug_waitpoint_release(DebugWait *waitpoint)
+{
+	ereport(DEBUG1, (errmsg("releasing waitpoint \"%s\"", waitpoint->tagname)));
+	if (!LockRelease(&waitpoint->tag, ExclusiveLock, true))
+		elog(ERROR, "cannot release waitpoint \"%s\"", waitpoint->tagname);
+}
+
+/*
+ * Enable a waitpoint to block when being reached.
+ *
+ * This function will always succeed since we will not lock the waitpoint if
+ * it is already locked. A notice will be printed if the waitpoint is already
+ * enabled.
+ */
+TS_FUNCTION_INFO_V1(ts_debug_waitpoint_enable);
+Datum ts_debug_waitpoint_enable(PG_FUNCTION_ARGS)
+{
+	text *tag = PG_GETARG_TEXT_PP(0);
+	DebugWait waitpoint;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("no tag provided")));
+
+	ts_debug_waitpoint_init(&waitpoint, text_to_cstring(tag));
+	debug_waitpoint_enable(&waitpoint);
+	PG_RETURN_VOID();
+}
+
+/*
+ * Release a waitpoint allowing execution to proceed.
+ */
+TS_FUNCTION_INFO_V1(ts_debug_waitpoint_release);
+Datum ts_debug_waitpoint_release(PG_FUNCTION_ARGS)
+{
+	text *tag = PG_GETARG_TEXT_PP(0);
+	DebugWait waitpoint;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("no tag provided")));
+
+	ts_debug_waitpoint_init(&waitpoint, text_to_cstring(tag));
+	debug_waitpoint_release(&waitpoint);
+	PG_RETURN_VOID();
+}

--- a/src/debug_wait.h
+++ b/src/debug_wait.h
@@ -1,0 +1,52 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#ifndef TIMESCALEDB_DEBUG_WAIT_H_
+#define TIMESCALEDB_DEBUG_WAIT_H_
+
+#include <postgres.h>
+
+#include <storage/lock.h>
+
+/* Debug waitpoint tag for debug waitpoints.
+ *
+ * Debug waitpoints only exists in debug-built code and is intended to allow
+ * more controlled testing of the code by creating wait-points where execution
+ * will halt until explicitly released.
+ *
+ * Each debug waitpoint is identified by a string that is hashed to a 8-byte
+ * number and used with the normal advisory locks available in PostgreSQL.
+ *
+ * When blocking on a waitpoint, there is an attempt to take a shared lock on
+ * the waitpoint. If the waitpoint is enabled by locking using an exclusive
+ * lock, this will block all waiters. Once the exclusive lock is released, all
+ * waiters will be able to proceed.
+ */
+typedef struct DebugWait
+{
+	const char *tagname;
+	LOCKTAG tag;
+} DebugWait;
+
+void ts_debug_waitpoint_init(DebugWait *waitpoint, const char *tagname);
+void ts_debug_waitpoint_wait(DebugWait *waitpoint);
+
+#ifdef TS_DEBUG
+#define DEBUG_WAITPOINT(TAG)                                                                       \
+	do                                                                                             \
+	{                                                                                              \
+		DebugWait waitpoint;                                                                       \
+		ts_debug_waitpoint_init(&waitpoint, (TAG));                                                \
+		ts_debug_waitpoint_wait(&waitpoint);                                                       \
+	} while (0)
+#else
+#define DEBUG_WAITPOINT(TAG)                                                                       \
+	do                                                                                             \
+	{                                                                                              \
+	} while (0)
+#endif
+
+#endif /* TIMESCALEDB_DEBUG_WAIT_H_ */

--- a/src/debug_wait.h
+++ b/src/debug_wait.h
@@ -11,11 +11,11 @@
 
 #include <storage/lock.h>
 
-/* Debug waitpoint tag for debug waitpoints.
+/* Tag for debug waitpoints.
  *
- * Debug waitpoints only exists in debug-built code and is intended to allow
- * more controlled testing of the code by creating wait-points where execution
- * will halt until explicitly released.
+ * Debug waitpoints only exist in debug code and are intended to allow
+ * more controlled testing of the code by creating waitpoints where execution
+ * will halt until the waitpoints are explicitly released.
  *
  * Each debug waitpoint is identified by a string that is hashed to a 8-byte
  * number and used with the normal advisory locks available in PostgreSQL.

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -53,7 +53,8 @@ extern DimensionVec *ts_dimension_slice_collision_scan_limit(int32 dimension_id,
 extern bool ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
 extern DimensionSlice *ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id,
 															  ScanTupLock *tuplock,
-															  MemoryContext mctx);
+															  MemoryContext mctx)
+	TS_ATTRIBUTE_NONNULL((2));
 extern DimensionVec *ts_dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension_before_point(int32 dimension_id,
 																	   int64 point, int limit,

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -862,6 +862,10 @@ ts_hypertable_lock_tuple_simple(Oid table_relid)
 		case TM_Ok:
 			/* successfully locked */
 			return true;
+
+#if PG12_GE
+		case TM_Deleted:
+#endif
 		case TM_Updated:
 			ereport(ERROR,
 					(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
@@ -870,6 +874,7 @@ ts_hypertable_lock_tuple_simple(Oid table_relid)
 					 errhint("Retry the operation again.")));
 			pg_unreachable();
 			return false;
+
 		case TM_BeingModified:
 			ereport(ERROR,
 					(errcode(ERRCODE_LOCK_NOT_AVAILABLE),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -303,7 +303,7 @@ ts_scanner_next(ScannerCtx *ctx, InternalScannerCtx *ictx)
 														  GetCurrentCommandId(false),
 														  ctx->tuplock->lockmode,
 														  ctx->tuplock->waitpolicy,
-														  0 /* don't follow updates */,
+														  ctx->tuplock->lockflags,
 														  &tmfd);
 
 #else

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -19,6 +19,7 @@ typedef struct ScanTupLock
 {
 	LockTupleMode lockmode;
 	LockWaitPolicy waitpolicy;
+	unsigned int lockflags;
 } ScanTupLock;
 
 /* Tuple information passed on to handlers when scanning for tuples. */

--- a/test/expected/broken_tables.out
+++ b/test/expected/broken_tables.out
@@ -74,10 +74,12 @@ SELECT * FROM missing_slices;
                   1 | constraint_1    | time        | (("time" >= 3) AND ("time" < 6))
 (1 row)
 
+-- Setting level to ERROR since warnings are printed in different
+-- order on PG11 and PG12.
+SET client_min_messages TO error;
 TRUNCATE TABLE chunk_test_int;
-WARNING:  dimension slice 1 was missing, proceeding anyway
-WARNING:  dimension slice 1 was missing, proceeding anyway
 DROP TABLE chunk_test_int;
+RESET client_min_messages;
 CREATE TABLE chunk_test_int(time integer, temp float8, tag integer, color integer);
 SELECT create_hypertable('chunk_test_int', 'time', 'tag', 2, chunk_time_interval => 3);
 NOTICE:  adding not-null constraint to column "time"
@@ -119,6 +121,8 @@ SELECT * FROM missing_slices;
                   5 | constraint_5    | time        | (("time" >= 3) AND ("time" < 6))
 (1 row)
 
+-- Setting level to ERROR since warnings are printed in different
+-- order on PG11 and PG12.
+SET client_min_messages TO error;
 DROP TABLE chunk_test_int;
-WARNING:  dimension slice 5 was missing, proceeding anyway
-WARNING:  dimension slice 5 was missing, proceeding anyway
+RESET client_min_messages;

--- a/test/expected/broken_tables.out
+++ b/test/expected/broken_tables.out
@@ -1,0 +1,124 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Hypertables can break as a result of race conditions, but we should
+-- still not crash when trying to truncate or delete the broken table.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE VIEW missing_slices AS
+SELECT DISTINCT
+    dimension_slice_id,
+    constraint_name,
+    attname AS column_name,
+    pg_get_expr(conbin, conrelid) AS constraint_expr
+FROM
+    _timescaledb_catalog.chunk_constraint cc
+    JOIN _timescaledb_catalog.chunk ch ON cc.chunk_id = ch.id
+    JOIN pg_constraint ON conname = constraint_name
+    JOIN pg_namespace ns ON connamespace = ns.oid
+        AND ns.nspname = ch.schema_name
+    JOIN pg_attribute ON attnum = conkey[1]
+        AND attrelid = conrelid
+WHERE
+    dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
+-- To drop rows from dimension_slice table, we need to remove some
+-- constraints.
+ALTER TABLE _timescaledb_catalog.chunk_constraint
+      DROP CONSTRAINT chunk_constraint_dimension_slice_id_fkey;
+CREATE TABLE chunk_test_int(time integer, temp float8, tag integer, color integer);
+SELECT create_hypertable('chunk_test_int', 'time', 'tag', 2, chunk_time_interval => 3);
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable      
+-----------------------------
+ (1,public,chunk_test_int,t)
+(1 row)
+
+INSERT INTO chunk_test_int VALUES
+       (4, 24.3, 1, 1),
+       (4, 24.3, 2, 1),
+       (10, 24.3, 2, 1);
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |      range_end      
+----+--------------+----------------------+---------------------
+  1 |            1 |                    3 |                   6
+  2 |            2 | -9223372036854775808 |          1073741823
+  3 |            2 |           1073741823 | 9223372036854775807
+  4 |            1 |                    9 |                  12
+(4 rows)
+
+SELECT DISTINCT
+       chunk_id,
+       dimension_slice_id,
+       constraint_name,
+       pg_get_expr(conbin, conrelid) AS constraint_expr
+FROM _timescaledb_catalog.chunk_constraint,
+     LATERAL (
+     	     SELECT *
+	     FROM pg_constraint JOIN pg_namespace ns ON connamespace = ns.oid
+	     WHERE conname = constraint_name
+     ) AS con
+ORDER BY chunk_id, dimension_slice_id;
+ chunk_id | dimension_slice_id | constraint_name |                        constraint_expr                        
+----------+--------------------+-----------------+---------------------------------------------------------------
+        1 |                  1 | constraint_1    | (("time" >= 3) AND ("time" < 6))
+        1 |                  2 | constraint_2    | (_timescaledb_internal.get_partition_hash(tag) < 1073741823)
+        2 |                  1 | constraint_1    | (("time" >= 3) AND ("time" < 6))
+        2 |                  3 | constraint_3    | (_timescaledb_internal.get_partition_hash(tag) >= 1073741823)
+        3 |                  3 | constraint_3    | (_timescaledb_internal.get_partition_hash(tag) >= 1073741823)
+        3 |                  4 | constraint_4    | (("time" >= 9) AND ("time" < 12))
+(6 rows)
+
+DELETE FROM _timescaledb_catalog.dimension_slice WHERE id = 1;
+SELECT * FROM missing_slices;
+ dimension_slice_id | constraint_name | column_name |         constraint_expr          
+--------------------+-----------------+-------------+----------------------------------
+                  1 | constraint_1    | time        | (("time" >= 3) AND ("time" < 6))
+(1 row)
+
+TRUNCATE TABLE chunk_test_int;
+WARNING:  dimension slice 1 was missing, proceeding anyway
+WARNING:  dimension slice 1 was missing, proceeding anyway
+DROP TABLE chunk_test_int;
+CREATE TABLE chunk_test_int(time integer, temp float8, tag integer, color integer);
+SELECT create_hypertable('chunk_test_int', 'time', 'tag', 2, chunk_time_interval => 3);
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable      
+-----------------------------
+ (2,public,chunk_test_int,t)
+(1 row)
+
+INSERT INTO chunk_test_int VALUES
+       (4, 24.3, 1, 1),
+       (4, 24.3, 2, 1),
+       (10, 24.3, 2, 1);
+SELECT DISTINCT
+       chunk_id,
+       dimension_slice_id,
+       constraint_name,
+       pg_get_expr(conbin, conrelid) AS constraint_expr
+FROM _timescaledb_catalog.chunk_constraint,
+     LATERAL (
+     	     SELECT *
+	     FROM pg_constraint JOIN pg_namespace ns ON connamespace = ns.oid
+	     WHERE conname = constraint_name
+     ) AS con
+ORDER BY chunk_id, dimension_slice_id;
+ chunk_id | dimension_slice_id | constraint_name |                        constraint_expr                        
+----------+--------------------+-----------------+---------------------------------------------------------------
+        4 |                  5 | constraint_5    | (("time" >= 3) AND ("time" < 6))
+        4 |                  6 | constraint_6    | (_timescaledb_internal.get_partition_hash(tag) < 1073741823)
+        5 |                  5 | constraint_5    | (("time" >= 3) AND ("time" < 6))
+        5 |                  7 | constraint_7    | (_timescaledb_internal.get_partition_hash(tag) >= 1073741823)
+        6 |                  7 | constraint_7    | (_timescaledb_internal.get_partition_hash(tag) >= 1073741823)
+        6 |                  8 | constraint_8    | (("time" >= 9) AND ("time" < 12))
+(6 rows)
+
+DELETE FROM _timescaledb_catalog.dimension_slice WHERE id = 5;
+SELECT * FROM missing_slices;
+ dimension_slice_id | constraint_name | column_name |         constraint_expr          
+--------------------+-----------------+-------------+----------------------------------
+                  5 | constraint_5    | time        | (("time" >= 3) AND ("time" < 6))
+(1 row)
+
+DROP TABLE chunk_test_int;
+WARNING:  dimension slice 5 was missing, proceeding anyway
+WARNING:  dimension slice 5 was missing, proceeding anyway

--- a/test/isolation/expected/dropchunks_race.out
+++ b/test/isolation/expected/dropchunks_race.out
@@ -1,0 +1,22 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1a s2a s3a s3b
+debug_waitpoint_enable
+
+               
+step s1a: SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
+step s2a: SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
+step s3a: SELECT debug_waitpoint_release('drop_chunks_chunks_found');
+debug_waitpoint_release
+
+               
+step s1a: <... completed>
+count          
+
+1              
+step s2a: <... completed>
+error in steps s3a s1a s2a: ERROR:  some chunks could not be read since they are being concurrently updated
+step s3b: SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
+count          
+
+0              

--- a/test/isolation/specs/CMakeLists.txt
+++ b/test/isolation/specs/CMakeLists.txt
@@ -15,7 +15,8 @@ set(TEST_TEMPLATES
 )
 
 set(TEST_TEMPLATES_DEBUG
- bgw_job_delete.spec.in
+  bgw_job_delete.spec.in
+  dropchunks_race.spec.in
 )
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)

--- a/test/isolation/specs/dropchunks_race.spec.in
+++ b/test/isolation/specs/dropchunks_race.spec.in
@@ -1,0 +1,33 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and
+# LICENSE-APACHE for a copy of the license.
+
+setup {
+  DROP TABLE IF EXISTS dropchunks_race_t1;
+  CREATE TABLE dropchunks_race_t1 (time timestamptz, device int, temp float);
+  SELECT create_hypertable('dropchunks_race_t1', 'time', 'device', 2);
+  INSERT INTO dropchunks_race_t1 VALUES ('2020-01-03 10:30', 1, 32.2);
+
+  CREATE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_enable';
+
+  CREATE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_release';
+}
+
+teardown {
+  DROP TABLE dropchunks_race_t1;
+}
+
+session "s1"
+step "s1a"	{ SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); }
+
+session "s2"
+step "s2a"	{ SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); }
+
+session "s3"
+setup           { SELECT debug_waitpoint_enable('drop_chunks_chunks_found'); }
+step "s3a"      { SELECT debug_waitpoint_release('drop_chunks_chunks_found'); }
+step "s3b" 	{ SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice); }
+
+permutation "s1a" "s2a" "s3a" "s3b"

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_FILES
   alter.sql
   alternate_users.sql
+  broken_tables.sql
   chunks.sql
   chunk_utils.sql
   cluster.sql

--- a/test/sql/broken_tables.sql
+++ b/test/sql/broken_tables.sql
@@ -55,8 +55,12 @@ ORDER BY chunk_id, dimension_slice_id;
 DELETE FROM _timescaledb_catalog.dimension_slice WHERE id = 1;
 SELECT * FROM missing_slices;
 
+-- Setting level to ERROR since warnings are printed in different
+-- order on PG11 and PG12.
+SET client_min_messages TO error;
 TRUNCATE TABLE chunk_test_int;
 DROP TABLE chunk_test_int;
+RESET client_min_messages;
 
 CREATE TABLE chunk_test_int(time integer, temp float8, tag integer, color integer);
 SELECT create_hypertable('chunk_test_int', 'time', 'tag', 2, chunk_time_interval => 3);
@@ -82,4 +86,8 @@ ORDER BY chunk_id, dimension_slice_id;
 DELETE FROM _timescaledb_catalog.dimension_slice WHERE id = 5;
 SELECT * FROM missing_slices;
 
+-- Setting level to ERROR since warnings are printed in different
+-- order on PG11 and PG12.
+SET client_min_messages TO error;
 DROP TABLE chunk_test_int;
+RESET client_min_messages;

--- a/test/sql/broken_tables.sql
+++ b/test/sql/broken_tables.sql
@@ -1,0 +1,85 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Hypertables can break as a result of race conditions, but we should
+-- still not crash when trying to truncate or delete the broken table.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE VIEW missing_slices AS
+SELECT DISTINCT
+    dimension_slice_id,
+    constraint_name,
+    attname AS column_name,
+    pg_get_expr(conbin, conrelid) AS constraint_expr
+FROM
+    _timescaledb_catalog.chunk_constraint cc
+    JOIN _timescaledb_catalog.chunk ch ON cc.chunk_id = ch.id
+    JOIN pg_constraint ON conname = constraint_name
+    JOIN pg_namespace ns ON connamespace = ns.oid
+        AND ns.nspname = ch.schema_name
+    JOIN pg_attribute ON attnum = conkey[1]
+        AND attrelid = conrelid
+WHERE
+    dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
+
+-- To drop rows from dimension_slice table, we need to remove some
+-- constraints.
+ALTER TABLE _timescaledb_catalog.chunk_constraint
+      DROP CONSTRAINT chunk_constraint_dimension_slice_id_fkey;
+
+CREATE TABLE chunk_test_int(time integer, temp float8, tag integer, color integer);
+SELECT create_hypertable('chunk_test_int', 'time', 'tag', 2, chunk_time_interval => 3);
+
+INSERT INTO chunk_test_int VALUES
+       (4, 24.3, 1, 1),
+       (4, 24.3, 2, 1),
+       (10, 24.3, 2, 1);
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+
+SELECT DISTINCT
+       chunk_id,
+       dimension_slice_id,
+       constraint_name,
+       pg_get_expr(conbin, conrelid) AS constraint_expr
+FROM _timescaledb_catalog.chunk_constraint,
+     LATERAL (
+     	     SELECT *
+	     FROM pg_constraint JOIN pg_namespace ns ON connamespace = ns.oid
+	     WHERE conname = constraint_name
+     ) AS con
+ORDER BY chunk_id, dimension_slice_id;
+
+DELETE FROM _timescaledb_catalog.dimension_slice WHERE id = 1;
+SELECT * FROM missing_slices;
+
+TRUNCATE TABLE chunk_test_int;
+DROP TABLE chunk_test_int;
+
+CREATE TABLE chunk_test_int(time integer, temp float8, tag integer, color integer);
+SELECT create_hypertable('chunk_test_int', 'time', 'tag', 2, chunk_time_interval => 3);
+
+INSERT INTO chunk_test_int VALUES
+       (4, 24.3, 1, 1),
+       (4, 24.3, 2, 1),
+       (10, 24.3, 2, 1);
+
+SELECT DISTINCT
+       chunk_id,
+       dimension_slice_id,
+       constraint_name,
+       pg_get_expr(conbin, conrelid) AS constraint_expr
+FROM _timescaledb_catalog.chunk_constraint,
+     LATERAL (
+     	     SELECT *
+	     FROM pg_constraint JOIN pg_namespace ns ON connamespace = ns.oid
+	     WHERE conname = constraint_name
+     ) AS con
+ORDER BY chunk_id, dimension_slice_id;
+
+DELETE FROM _timescaledb_catalog.dimension_slice WHERE id = 5;
+SELECT * FROM missing_slices;
+
+DROP TABLE chunk_test_int;


### PR DESCRIPTION
If a hypercube is built from constraints in
`ts_hypercube_from_constraints`, which can happen during a run of
`drop_chunks` or when a chunk is explicitly dropped as part of other
operations, dimension slices will be removed and the hypercube will
contain references that are not valid.

This is fixed by adding a tuple lock on the dimension slices
that are used to build the hypercube.

In addition, commits for the following were added:
- A simple implementation of debug waitpoints are added.
- Dropping or truncating a broken table will not crash.
- A deleted dimension slice while running concurrent drop chunks will not error out and rather ignore the dimension slice (since the last chunk associated with the dimension slice is removed by the concurrently executing `drop_chunks`).

Fixes #1986 