### PR TITLE
Test detach_tablespaces on distributed hypertable

### DIFF
--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -3133,6 +3133,12 @@ ERROR:  cannot attach tablespace to distributed hypertable
 SELECT detach_tablespace('tablespace1', 'disttable');
 ERROR:  tablespace "tablespace1" is not attached to hypertable "disttable"
 \set ON_ERROR_STOP 1
+SELECT detach_tablespaces('disttable');
+ detach_tablespaces 
+--------------------
+                  0
+(1 row)
+
 -- Continue to use previously attached tablespace, but block attach/detach
 CREATE TABLE disttable2(time timestamptz, device int, temp float) TABLESPACE tablespace1;
 SELECT create_distributed_hypertable('disttable2', 'time', chunk_time_interval => 1000000::bigint);
@@ -3173,6 +3179,12 @@ ERROR:  cannot attach tablespace to distributed hypertable
 SELECT detach_tablespace('tablespace2', 'disttable2');
 ERROR:  tablespace "tablespace2" is not attached to hypertable "disttable2"
 \set ON_ERROR_STOP 1
+SELECT detach_tablespaces('disttable2');
+ detach_tablespaces 
+--------------------
+                  0
+(1 row)
+
 SELECT * FROM show_tablespaces('disttable2');
  show_tablespaces 
 ------------------
@@ -3189,6 +3201,22 @@ $$);
 
 SELECT * FROM distributed_exec($$
 SELECT detach_tablespace('tablespace2', 'disttable2');
+$$);
+ distributed_exec 
+------------------
+ 
+(1 row)
+
+SELECT * FROM distributed_exec($$
+SELECT attach_tablespace('tablespace2', 'disttable2');
+$$);
+ distributed_exec 
+------------------
+ 
+(1 row)
+
+SELECT * FROM distributed_exec($$
+SELECT detach_tablespaces('disttable2');
 $$);
  distributed_exec 
 ------------------

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -3114,6 +3114,12 @@ ERROR:  cannot attach tablespace to distributed hypertable
 SELECT detach_tablespace('tablespace1', 'disttable');
 ERROR:  tablespace "tablespace1" is not attached to hypertable "disttable"
 \set ON_ERROR_STOP 1
+SELECT detach_tablespaces('disttable');
+ detach_tablespaces 
+--------------------
+                  0
+(1 row)
+
 -- Continue to use previously attached tablespace, but block attach/detach
 CREATE TABLE disttable2(time timestamptz, device int, temp float) TABLESPACE tablespace1;
 SELECT create_distributed_hypertable('disttable2', 'time', chunk_time_interval => 1000000::bigint);
@@ -3154,6 +3160,12 @@ ERROR:  cannot attach tablespace to distributed hypertable
 SELECT detach_tablespace('tablespace2', 'disttable2');
 ERROR:  tablespace "tablespace2" is not attached to hypertable "disttable2"
 \set ON_ERROR_STOP 1
+SELECT detach_tablespaces('disttable2');
+ detach_tablespaces 
+--------------------
+                  0
+(1 row)
+
 SELECT * FROM show_tablespaces('disttable2');
  show_tablespaces 
 ------------------
@@ -3170,6 +3182,22 @@ $$);
 
 SELECT * FROM distributed_exec($$
 SELECT detach_tablespace('tablespace2', 'disttable2');
+$$);
+ distributed_exec 
+------------------
+ 
+(1 row)
+
+SELECT * FROM distributed_exec($$
+SELECT attach_tablespace('tablespace2', 'disttable2');
+$$);
+ distributed_exec 
+------------------
+ 
+(1 row)
+
+SELECT * FROM distributed_exec($$
+SELECT detach_tablespaces('disttable2');
 $$);
  distributed_exec 
 ------------------

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -908,6 +908,7 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_1 LOCATION :TEST_TABLESPACE2_PATH;
 SELECT attach_tablespace('tablespace1', 'disttable');
 SELECT detach_tablespace('tablespace1', 'disttable');
 \set ON_ERROR_STOP 1
+SELECT detach_tablespaces('disttable');
 
 -- Continue to use previously attached tablespace, but block attach/detach
 CREATE TABLE disttable2(time timestamptz, device int, temp float) TABLESPACE tablespace1;
@@ -930,6 +931,7 @@ WHERE cl.oid = ch.chunk::regclass;
 SELECT attach_tablespace('tablespace2', 'disttable2');
 SELECT detach_tablespace('tablespace2', 'disttable2');
 \set ON_ERROR_STOP 1
+SELECT detach_tablespaces('disttable2');
 
 SELECT * FROM show_tablespaces('disttable2');
 
@@ -939,6 +941,12 @@ SELECT attach_tablespace('tablespace2', 'disttable2');
 $$);
 SELECT * FROM distributed_exec($$
 SELECT detach_tablespace('tablespace2', 'disttable2');
+$$);
+SELECT * FROM distributed_exec($$
+SELECT attach_tablespace('tablespace2', 'disttable2');
+$$);
+SELECT * FROM distributed_exec($$
+SELECT detach_tablespaces('disttable2');
 $$);
 DROP TABLE disttable2;
 


### PR DESCRIPTION
Adds a test to call detach_tablespaces on a distributed hypertable.
Since no tablespaces can be attached to distributed hyperatbles, the
test detaches 0 tablespaces. Also a test to detach tablespaces on a
data node is added.