### PR TITLE
Only run chunk_api test on debug build

### DIFF
--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -5,13 +5,18 @@
 --list all extension functions in public schema
 SELECT DISTINCT proname
 FROM pg_proc
-WHERE OID IN (
+WHERE oid IN (
     SELECT objid
-    FROM pg_catalog.pg_depend                                                                                                               WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
-    refobjid = (select oid from pg_extension where extname='timescaledb') AND
-    deptype = 'e' and classid = 'pg_catalog.pg_proc'::regclass
-) AND pronamespace = 'public'::regnamespace
-ORDER BY proname;
+    FROM pg_catalog.pg_depend
+    WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+      AND refobjid = (
+        SELECT oid
+        FROM pg_extension
+        WHERE extname = 'timescaledb')
+        AND deptype = 'e'
+        AND classid = 'pg_catalog.pg_proc'::regclass)
+    AND pronamespace = 'public'::regnamespace
+  ORDER BY proname;
              proname              
 ----------------------------------
  add_compress_chunks_policy

--- a/test/sql/extension.sql
+++ b/test/sql/extension.sql
@@ -3,14 +3,19 @@
 -- LICENSE-APACHE for a copy of the license.
 
 \c :TEST_DBNAME
-
 --list all extension functions in public schema
 SELECT DISTINCT proname
 FROM pg_proc
-WHERE OID IN (
+WHERE oid IN (
     SELECT objid
-    FROM pg_catalog.pg_depend                                                                                                               WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
-    refobjid = (select oid from pg_extension where extname='timescaledb') AND
-    deptype = 'e' and classid = 'pg_catalog.pg_proc'::regclass
-) AND pronamespace = 'public'::regnamespace
-ORDER BY proname;
+    FROM pg_catalog.pg_depend
+    WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+      AND refobjid = (
+        SELECT oid
+        FROM pg_extension
+        WHERE extname = 'timescaledb')
+        AND deptype = 'e'
+        AND classid = 'pg_catalog.pg_proc'::regclass)
+    AND pronamespace = 'public'::regnamespace
+  ORDER BY proname;
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -57,7 +57,6 @@ set(TEST_FILES_DEBUG
 )
 
 set(TEST_TEMPLATES
-  chunk_api.sql.in
   compression_qualpushdown.sql.in
   continuous_aggs_union_view.sql.in
   move.sql.in
@@ -69,6 +68,7 @@ set(TEST_TEMPLATES
 if (CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_TEMPLATES
     #current_timestamp_mock available only in debug mode
+    chunk_api.sql.in
     continuous_aggs_query.sql.in
     dist_hypertable.sql.in
     dist_query.sql.in


### PR DESCRIPTION
The chunk_api test requires a debug build for certain test functions
this patch changes the chunk_api test to only run for debug builds.