### PR TITLE
 Process invalidations when refreshing continuous aggregate 

### DIFF
--- a/src/catalog.h
+++ b/src/catalog.h
@@ -1314,18 +1314,18 @@ extern TSDLLEXPORT bool ts_catalog_database_info_become_owner(CatalogDatabaseInf
 															  CatalogSecurityContext *sec_ctx);
 extern TSDLLEXPORT void ts_catalog_restore_user(CatalogSecurityContext *sec_ctx);
 
+extern TSDLLEXPORT void ts_catalog_insert_only(Relation rel, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_insert(Relation rel, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_insert_values(Relation rel, TupleDesc tupdesc, Datum *values,
 												 bool *nulls);
+extern TSDLLEXPORT void ts_catalog_update_tid_only(Relation rel, ItemPointer tid, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_update_tid(Relation rel, ItemPointer tid, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_update(Relation rel, HeapTuple tuple);
+extern TSDLLEXPORT void ts_catalog_delete_tid_only(Relation rel, ItemPointer tid);
 extern TSDLLEXPORT void ts_catalog_delete_tid(Relation rel, ItemPointer tid);
-extern void ts_catalog_delete_tid_only(Relation rel, ItemPointer tid);
+extern TSDLLEXPORT void ts_catalog_delete_only(Relation rel, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_delete(Relation rel, HeapTuple tuple);
 extern void ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
-
-/* Delete only: do not increment command counter or invalidate caches */
-extern void ts_catalog_delete_only(Relation rel, HeapTuple tuple);
 
 bool TSDLLEXPORT ts_catalog_scan_one(CatalogTable table, int indexid, ScanKeyData *scankey,
 									 int num_keys, tuple_found_func tuple_found, LOCKMODE lockmode,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -13,6 +13,7 @@
 #include <storage/procarray.h>
 #include <utils/rel.h>
 #include <utils/palloc.h>
+#include <utils/snapmgr.h>
 
 #include "scanner.h"
 
@@ -105,7 +106,6 @@ index_scanner_beginscan(InternalScannerCtx *ctx)
 
 	ctx->scan.index_scan =
 		index_beginscan(ctx->tablerel, ctx->indexrel, sctx->snapshot, sctx->nkeys, sctx->norderbys);
-
 	ctx->scan.index_scan->xs_want_itup = ctx->sctx->want_itup;
 	index_rescan(ctx->scan.index_scan, sctx->scankey, sctx->nkeys, NULL, sctx->norderbys);
 	return ctx->scan;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -10,9 +10,9 @@
 #include <access/genam.h>
 #include <access/heapam.h>
 #include <nodes/lockoptions.h>
-#include <utils.h>
 #include <utils/fmgroids.h>
 
+#include "utils.h"
 #include "compat.h"
 
 typedef struct ScanTupLock
@@ -74,13 +74,16 @@ typedef struct ScannerCtx
 	int nkeys, norderbys, limit; /* Limit on number of tuples to return. 0 or
 								  * less means no limit */
 	bool want_itup;
+	bool keeplock; /* Keep the table lock after the scan finishes */
 	LOCKMODE lockmode;
 	MemoryContext result_mctx; /* The memory context to allocate the result
 								* on */
 	ScanTupLock *tuplock;
 	ScanDirection scandirection;
-	void *data; /* User-provided data passed on to filter()
-				 * and tuple_found() */
+	Snapshot snapshot; /* Snapshot requested by the caller. Set automatically
+						* when NULL */
+	void *data;		   /* User-provided data passed on to filter()
+						* and tuple_found() */
 
 	/*
 	 * Optional handler called before a scan starts, but relation locks are
@@ -138,6 +141,7 @@ typedef struct InternalScannerCtx
 	TupleInfo tinfo;
 	ScanDesc scan;
 	ScannerCtx *sctx;
+	bool registered_snapshot;
 	bool closed;
 } InternalScannerCtx;
 

--- a/tsl/src/continuous_aggs/CMakeLists.txt
+++ b/tsl/src/continuous_aggs/CMakeLists.txt
@@ -6,5 +6,6 @@ set(SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/materialize.c
   ${CMAKE_CURRENT_SOURCE_DIR}/options.c
   ${CMAKE_CURRENT_SOURCE_DIR}/refresh.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/invalidation.c
 )
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1,0 +1,492 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include <utils/memutils.h>
+#include <utils/palloc.h>
+#include <utils/snapmgr.h>
+#include <nodes/memnodes.h>
+#include <storage/lockdefs.h>
+#include <access/htup_details.h>
+#include <access/htup.h>
+#include <access/xact.h>
+
+#include <catalog.h>
+#include <scanner.h>
+#include <scan_iterator.h>
+
+#include "continuous_agg.h"
+#include "continuous_aggs/materialize.h"
+#include "invalidation.h"
+
+typedef struct CaggInvalidationState
+{
+	ContinuousAgg cagg;
+	MemoryContext per_tuple_mctx;
+	Relation cagg_log_rel;
+	Snapshot snapshot;
+} CaggInvalidationState;
+
+typedef enum LogType
+{
+	LOG_HYPER,
+	LOG_CAGG,
+} LogType;
+
+static Relation
+open_invalidation_log(LogType type, LOCKMODE lockmode)
+{
+	static const CatalogTable logmappings[] = {
+		[LOG_HYPER] = CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG,
+		[LOG_CAGG] = CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
+	};
+	Catalog *catalog = ts_catalog_get();
+	Oid relid = catalog_get_table_id(catalog, logmappings[type]);
+
+	return table_open(relid, lockmode);
+}
+
+static void
+cagg_scan_by_hypertable_init(ScanIterator *iterator, int32 hyper_id, LOCKMODE lockmode)
+{
+	*iterator = ts_scan_iterator_create(CONTINUOUS_AGG, lockmode, CurrentMemoryContext);
+	iterator->ctx.index =
+		catalog_get_index(ts_catalog_get(), CONTINUOUS_AGG, CONTINUOUS_AGG_RAW_HYPERTABLE_ID_IDX);
+	ts_scan_iterator_scan_key_init(iterator,
+								   Anum_continuous_agg_raw_hypertable_id_idx_raw_hypertable_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(hyper_id));
+}
+
+/*
+ * Get a list of continuous aggregate IDs for a hypertable.
+ *
+ * Since this is just an integer list, the memory cost is not big even if
+ * there are a lot of continuous aggregates.
+ */
+static List *
+get_cagg_ids(int32 hyper_id)
+{
+	List *cagg_ids = NIL;
+	ScanIterator iterator;
+
+	cagg_scan_by_hypertable_init(&iterator, hyper_id, AccessShareLock);
+
+	ts_scanner_foreach(&iterator)
+	{
+		bool isnull;
+		TupleInfo *ti_cagg = ts_scan_iterator_tuple_info(&iterator);
+		Datum cagg_hyper_id =
+			slot_getattr(ti_cagg->slot, Anum_continuous_agg_mat_hypertable_id, &isnull);
+		Assert(!isnull);
+		cagg_ids = lappend_int(cagg_ids, DatumGetInt32(cagg_hyper_id));
+	}
+
+	ts_scan_iterator_close(&iterator);
+
+	return cagg_ids;
+}
+
+static void
+hypertable_invalidation_scan_init(ScanIterator *iterator, int32 hyper_id, LOCKMODE lockmode)
+{
+	*iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG,
+										lockmode,
+										CurrentMemoryContext);
+	iterator->ctx.index = catalog_get_index(ts_catalog_get(),
+											CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG,
+											CONTINUOUS_AGGS_HYPERTABLE_INVALIDATION_LOG_IDX);
+	ts_scan_iterator_scan_key_init(
+		iterator,
+		Anum_continuous_aggs_hypertable_invalidation_log_idx_hypertable_id,
+		BTEqualStrategyNumber,
+		F_INT4EQ,
+		Int32GetDatum(hyper_id));
+}
+
+static HeapTuple
+create_invalidation_tup(const TupleDesc tupdesc, int32 cagg_hyper_id, int64 modtime, int64 start,
+						int64 end)
+{
+	Datum values[Natts_continuous_aggs_materialization_invalidation_log] = { 0 };
+	bool isnull[Natts_continuous_aggs_materialization_invalidation_log] = { false };
+
+	values[AttrNumberGetAttrOffset(
+		Anum_continuous_aggs_materialization_invalidation_log_materialization_id)] =
+		Int32GetDatum(cagg_hyper_id);
+	values[AttrNumberGetAttrOffset(
+		Anum_continuous_aggs_materialization_invalidation_log_modification_time)] =
+		Int64GetDatum(modtime);
+	values[AttrNumberGetAttrOffset(
+		Anum_continuous_aggs_materialization_invalidation_log_lowest_modified_value)] =
+		Int64GetDatum(start);
+	values[AttrNumberGetAttrOffset(
+		Anum_continuous_aggs_materialization_invalidation_log_greatest_modified_value)] =
+		Int64GetDatum(end);
+
+	return heap_form_tuple(tupdesc, values, isnull);
+}
+
+typedef enum InvalidationResult
+{
+	INVAL_NOMATCH,
+	INVAL_DELETE,
+	INVAL_CUT,
+} InvalidationResult;
+
+/*
+ * Try to cut an invalidation against the refresh window.
+ *
+ * If an invalidation entry overlaps with the refresh window, it needs
+ * additional processing: it is either cut, deleted, or left unmodified.
+ */
+static InvalidationResult
+cut_invalidation_along_refresh_window(const CaggInvalidationState *state, int64 modification_time,
+									  int64 lowest_modified_value, int64 greatest_modified_value,
+									  const InternalTimeRange *refresh_window,
+									  const ItemPointer tid)
+{
+	int32 cagg_hyper_id = state->cagg.data.mat_hypertable_id;
+	TupleDesc tupdesc = RelationGetDescr(state->cagg_log_rel);
+	InvalidationResult result = INVAL_NOMATCH;
+	HeapTuple lower = NULL;
+	HeapTuple upper = NULL;
+
+	/* Entry is completely enclosed by the refresh window */
+	if (lowest_modified_value >= refresh_window->start &&
+		greatest_modified_value < refresh_window->end)
+	{
+		/*
+		 * Entry completely enclosed so can be deleted:
+		 *
+		 * |---------------|
+		 *     [+++++]
+		 */
+
+		result = INVAL_DELETE;
+	}
+	else
+	{
+		if (lowest_modified_value < refresh_window->start &&
+			greatest_modified_value >= refresh_window->start)
+		{
+			/*
+			 * Need to cut in right end:
+			 *
+			 *     |------|
+			 * [++++++]
+			 *
+			 * [++]
+			 */
+			lower = create_invalidation_tup(tupdesc,
+											cagg_hyper_id,
+											modification_time,
+											lowest_modified_value,
+											refresh_window->start - 1);
+			result = INVAL_CUT;
+		}
+
+		if (lowest_modified_value < refresh_window->end &&
+			greatest_modified_value >= refresh_window->end)
+		{
+			/*
+			 * Need to cut in left end:
+			 *
+			 * |------|
+			 *    [++++++++]
+			 *
+			 *         [+++]
+			 */
+			upper = create_invalidation_tup(tupdesc,
+											cagg_hyper_id,
+											modification_time,
+											refresh_window->end,
+											greatest_modified_value);
+
+			result = INVAL_CUT;
+		}
+	}
+
+	/* Insert any modifications into the cagg invalidation log */
+	if (result == INVAL_CUT)
+	{
+		CatalogSecurityContext sec_ctx;
+		HeapTuple other_range = NULL;
+
+		ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+
+		/* We'd like to do one update (unless the TID is not set), and
+		 * optionally one insert. We pick one of the tuples for an update, and
+		 * the other one will be an insert. */
+		if (lower || upper)
+		{
+			HeapTuple tup = lower ? lower : upper;
+			other_range = lower ? upper : lower;
+
+			/* If the TID is set, we are updating an existing tuple, i.e., we
+			 * are processing and entry in the cagg log itself. Otherwise, we
+			 * are processing the hypertable invalidation log and need to
+			 * insert a new entry. */
+			if (tid)
+				ts_catalog_update_tid_only(state->cagg_log_rel, tid, tup);
+			else
+				ts_catalog_insert_only(state->cagg_log_rel, tup);
+
+			heap_freetuple(tup);
+		}
+
+		if (other_range)
+		{
+			ts_catalog_insert_only(state->cagg_log_rel, other_range);
+			heap_freetuple(other_range);
+		}
+
+		ts_catalog_restore_user(&sec_ctx);
+	}
+
+	return result;
+}
+
+/*
+ * Process invalidations in the hypertable invalidation log.
+ *
+ * Copy and delete all entries from the hypertable invalidation log.  For the
+ * continuous aggregate that is getting refreshed, we also match the
+ * invalidation against the refresh window and perform additional processing
+ * (cutting or deleting); work that we'd otherwise have to do later in the
+ * cagg invalidation log.
+ *
+ * Note that each entry gets one copy per continuous aggregate in the cagg
+ * invalidation log (unless it matched the refresh window). These copied
+ * entries are later used to track invalidations across refreshes on a
+ * per-cagg basis.
+ *
+ * After this function has run, there are no entries left in the hypertable
+ * invalidation log.
+ */
+static void
+move_invalidations_from_hyper_to_cagg_log(const CaggInvalidationState *state,
+										  const InternalTimeRange *refresh_window)
+{
+	int32 hyper_id = state->cagg.data.raw_hypertable_id;
+	List *cagg_ids = get_cagg_ids(hyper_id);
+	int32 last_cagg_hyper_id = llast_int(cagg_ids);
+	ScanIterator iterator;
+	ListCell *lc;
+
+	Assert(list_length(cagg_ids) > 0);
+
+	/* We use a per-tuple memory context in the scan loop since we could be
+	 * processing a lot of invalidations (basically an unbounded
+	 * amount). Initialize it here by resetting it. */
+	MemoryContextReset(state->per_tuple_mctx);
+	hypertable_invalidation_scan_init(&iterator, hyper_id, RowExclusiveLock);
+	iterator.ctx.snapshot = state->snapshot;
+
+	/*
+	 * Looping over all continuous aggregates in the outer loop ensures all
+	 * tuples for a specific continuous aggregate is inserted consecutively in
+	 * the cagg invalidation log. This creates better locality for scanning
+	 * the invalidations later.
+	 */
+	foreach (lc, cagg_ids)
+	{
+		int32 cagg_hyper_id = lfirst_int(lc);
+
+		/* Scan all invalidations */
+		ts_scanner_foreach(&iterator)
+		{
+			TupleInfo *ti;
+			Form_continuous_aggs_hypertable_invalidation_log form;
+			CatalogSecurityContext sec_ctx;
+			MemoryContext oldmctx;
+			bool should_free;
+			HeapTuple tuple;
+			bool should_insert = false;
+
+			oldmctx = MemoryContextSwitchTo(state->per_tuple_mctx);
+			ti = ts_scan_iterator_tuple_info(&iterator);
+			tuple = ts_scan_iterator_fetch_heap_tuple(&iterator, false, &should_free);
+			form = (Form_continuous_aggs_hypertable_invalidation_log) GETSTRUCT(tuple);
+
+			/* If we're processing an invalidation for the continuous
+			 * aggregate that is getting refreshed, then we can cut or delete
+			 * the invalidation immediately, instead of doing it later in the
+			 * cagg invalidation log. */
+			if (cagg_hyper_id == state->cagg.data.mat_hypertable_id)
+			{
+				InvalidationResult result;
+
+				result = cut_invalidation_along_refresh_window(state,
+															   form->modification_time,
+															   form->lowest_modified_value,
+															   form->greatest_modified_value,
+															   refresh_window,
+															   NULL);
+
+				switch (result)
+				{
+					case INVAL_CUT:
+					case INVAL_DELETE:
+						/* Work already done, so nothing more to do. */
+						break;
+					case INVAL_NOMATCH:
+						/* The tuple didn't match the refresh window, so we need
+						 * to copy this entry over to the cagg invalidation log. */
+						should_insert = true;
+						break;
+				}
+			}
+			else
+			{
+				/* We aren't refreshing this continuous aggregate, so the only
+				 * work to do is to insert a new entry in the cagg
+				 * invalidation log. */
+				should_insert = true;
+			}
+
+			if (should_insert)
+			{
+				TupleDesc tupdesc = RelationGetDescr(state->cagg_log_rel);
+				HeapTuple newtup;
+
+				newtup = create_invalidation_tup(tupdesc,
+												 cagg_hyper_id,
+												 form->modification_time,
+												 form->lowest_modified_value,
+												 form->greatest_modified_value);
+
+				ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+				ts_catalog_insert_only(state->cagg_log_rel, newtup);
+				ts_catalog_restore_user(&sec_ctx);
+			}
+
+			if (cagg_hyper_id == last_cagg_hyper_id)
+			{
+				/* The invalidation has been processed for all caggs, so the
+				 * only thing left is to delete it from the source hypertable
+				 * invalidation log. */
+				ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+				ts_catalog_delete_only(ti->scanrel, tuple);
+				ts_catalog_restore_user(&sec_ctx);
+			}
+
+			if (should_free)
+				heap_freetuple(tuple);
+
+			MemoryContextSwitchTo(oldmctx);
+			MemoryContextReset(state->per_tuple_mctx);
+		}
+	}
+
+	ts_scan_iterator_close(&iterator);
+}
+
+static void
+cagg_invalidations_scan_by_hypertable_init(ScanIterator *iterator, int32 cagg_hyper_id,
+										   LOCKMODE lockmode)
+{
+	*iterator = ts_scan_iterator_create(CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
+										lockmode,
+										CurrentMemoryContext);
+	iterator->ctx.index = catalog_get_index(ts_catalog_get(),
+											CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG,
+											CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_IDX);
+	ts_scan_iterator_scan_key_init(
+		iterator,
+		Anum_continuous_aggs_materialization_invalidation_log_materialization_id,
+		BTEqualStrategyNumber,
+		F_INT4EQ,
+		Int32GetDatum(cagg_hyper_id));
+}
+/*
+ * Clear all cagg invalidations that match a refresh window.
+ *
+ * This function clears all invalidations in the cagg invalidation log that
+ * matches a window. Note that the refresh currently doesn't make use of the
+ * invalidations to optimize the materialization.
+ *
+ * An invalidation entry that gets processed is either completely enclosed
+ * (covered) by the refresh window, or it partially overlaps. In the former
+ * case, the invalidation entry is removed and for the latter case it is
+ * cut. Thus, an entry can either disappear, reduce in size, or be cut in two.
+ *
+ * Note that the refresh window is inclusive at the start and exclusive at the
+ * end.
+ */
+static void
+clear_cagg_invalidations_for_refresh(const CaggInvalidationState *state,
+									 const InternalTimeRange *refresh_window)
+{
+	ScanIterator iterator;
+	int32 cagg_hyper_id = state->cagg.data.mat_hypertable_id;
+
+	/* The scanner defaults to SnapshotSelf, which would show the
+	 * modifications we do (new and updated tuples) within the scan loop
+	 * below. Therefore, we use our own snapshot here. */
+	cagg_invalidations_scan_by_hypertable_init(&iterator, cagg_hyper_id, RowExclusiveLock);
+	iterator.ctx.snapshot = state->snapshot;
+	MemoryContextReset(state->per_tuple_mctx);
+
+	/* Process all invalidations for the continuous aggregate */
+	ts_scanner_foreach(&iterator)
+	{
+		Form_continuous_aggs_materialization_invalidation_log form;
+		MemoryContext oldmctx;
+		InvalidationResult result;
+		bool should_free;
+		HeapTuple tuple;
+
+		oldmctx = MemoryContextSwitchTo(state->per_tuple_mctx);
+		tuple = ts_scan_iterator_fetch_heap_tuple(&iterator, false, &should_free);
+		form = (Form_continuous_aggs_materialization_invalidation_log) GETSTRUCT(tuple);
+		result = cut_invalidation_along_refresh_window(state,
+													   form->modification_time,
+													   form->lowest_modified_value,
+													   form->greatest_modified_value,
+													   refresh_window,
+													   &tuple->t_self);
+
+		switch (result)
+		{
+			case INVAL_NOMATCH:
+			case INVAL_CUT:
+				/* Nothing to do */
+				break;
+			case INVAL_DELETE:
+				ts_catalog_delete_tid_only(state->cagg_log_rel, &tuple->t_self);
+				break;
+		}
+
+		MemoryContextSwitchTo(oldmctx);
+		MemoryContextReset(state->per_tuple_mctx);
+	}
+
+	ts_scan_iterator_close(&iterator);
+}
+
+void
+continuous_agg_invalidation_process(const ContinuousAgg *cagg,
+									const InternalTimeRange *refresh_window)
+{
+	CaggInvalidationState state = {
+		.cagg = *cagg,
+		.cagg_log_rel = open_invalidation_log(LOG_CAGG, RowExclusiveLock),
+		.per_tuple_mctx = AllocSetContextCreate(CurrentMemoryContext,
+												"Continuous aggregate invalidations",
+												ALLOCSET_DEFAULT_SIZES),
+		.snapshot = RegisterSnapshot(GetTransactionSnapshot()),
+	};
+
+	/* Clear the cagg invalidation log first, so that we don't need to
+	 * unnecessarily scan any hew entries that we might insert when we move
+	 * invalidations from the hypertable invalidation log. */
+	clear_cagg_invalidations_for_refresh(&state, refresh_window);
+	move_invalidations_from_hyper_to_cagg_log(&state, refresh_window);
+	table_close(state.cagg_log_rel, NoLock);
+	UnregisterSnapshot(state.snapshot);
+	MemoryContextDelete(state.per_tuple_mctx);
+}

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -1,0 +1,17 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H
+#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H
+
+#include <postgres.h>
+
+#include "continuous_agg.h"
+#include "continuous_aggs/materialize.h"
+
+extern void continuous_agg_invalidation_process(const ContinuousAgg *cagg,
+												const InternalTimeRange *refresh_window);
+
+#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H */

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -20,6 +20,7 @@
 
 #include "refresh.h"
 #include "materialize.h"
+#include "invalidation.h"
 
 typedef struct CaggRefreshState
 {
@@ -365,6 +366,7 @@ continuous_agg_refresh(PG_FUNCTION_ARGS)
 				 errmsg("invalid refresh window"),
 				 errhint("The start of the window must be before the end.")));
 
+	continuous_agg_invalidation_process(cagg, &refresh_window);
 	continuous_agg_refresh_with_window(cagg, &refresh_window);
 
 	PG_RETURN_VOID();

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -1,0 +1,375 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Disable background workers since we are testing manual refresh
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SET datestyle TO 'ISO, YMD';
+SET timezone TO 'UTC';
+CREATE TABLE conditions (time int NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => 10);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+CREATE TABLE measurements (time int NOT NULL, device int, temp float);
+SELECT create_hypertable('measurements', 'time', chunk_time_interval => 10);
+     create_hypertable     
+---------------------------
+ (2,public,measurements,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION cond_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM conditions
+$$;
+CREATE OR REPLACE FUNCTION measure_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM measurements
+$$;
+SELECT set_integer_now_func('conditions', 'cond_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT set_integer_now_func('measurements', 'measure_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO conditions
+SELECT t, ceil(abs(timestamp_hash(to_timestamp(t)::timestamp))%4)::int,
+       abs(timestamp_hash(to_timestamp(t)::timestamp))%40
+FROM generate_series(1, 100, 1) t;
+INSERT INTO measurements
+SELECT * FROM conditions;
+-- Show the most recent data
+SELECT * FROM conditions
+ORDER BY time DESC, device
+LIMIT 10;
+ time | device | temp 
+------+--------+------
+  100 |      0 |    8
+   99 |      1 |    5
+   98 |      2 |   26
+   97 |      2 |   10
+   96 |      2 |   34
+   95 |      2 |   30
+   94 |      3 |   31
+   93 |      0 |    4
+   92 |      0 |   32
+   91 |      3 |   15
+(10 rows)
+
+-- Create two continuous aggregates on the same hypertable to test
+-- that invalidations are handled correctly across both of them.
+CREATE VIEW cond_10
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(10, time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2;
+NOTICE:  adding index _materialized_hypertable_3_device_day_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device, day)
+CREATE VIEW cond_20
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(20, time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2;
+NOTICE:  adding index _materialized_hypertable_4_device_day_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, day)
+CREATE VIEW measure_10
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(10, time) AS day, device, avg(temp) AS avg_temp
+FROM measurements
+GROUP BY 1,2;
+NOTICE:  adding index _materialized_hypertable_5_device_day_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(device, day)
+-- There should be three continuous aggregates, two on one hypertable
+-- and one on the other:
+SELECT mat_hypertable_id, raw_hypertable_id, user_view_name
+FROM _timescaledb_catalog.continuous_agg;
+ mat_hypertable_id | raw_hypertable_id | user_view_name 
+-------------------+-------------------+----------------
+                 3 |                 1 | cond_10
+                 4 |                 1 | cond_20
+                 5 |                 2 | measure_10
+(3 rows)
+
+-- The continuous aggregates should be empty
+SELECT * FROM cond_10
+ORDER BY day DESC, device;
+ day | device | avg_temp 
+-----+--------+----------
+(0 rows)
+
+SELECT * FROM cond_20
+ORDER BY day DESC, device;
+ day | device | avg_temp 
+-----+--------+----------
+(0 rows)
+
+SELECT * FROM measure_10
+ORDER BY day DESC, device;
+ day | device | avg_temp 
+-----+--------+----------
+(0 rows)
+
+-- Must refresh with "legacy" functionality to move the invalidation
+-- threshold, or no invalidations will be generated.
+REFRESH MATERIALIZED VIEW cond_10;
+REFRESH MATERIALIZED VIEW measure_10;
+-- There should be no invalidations initially:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+(0 rows)
+
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+ cagg_id | start | end 
+---------+-------+-----
+(0 rows)
+
+-- Create invalidations across different ranges. Some of these should
+-- be deleted and others cut in different ways when a refresh is
+-- run. Note that the refresh window is inclusive in the start of the
+-- window but exclusive at the end.
+-- Entries that should be left unmodified:
+INSERT INTO conditions VALUES (10, 4, 23.7);
+INSERT INTO conditions VALUES (10, 5, 23.8), (19, 3, 23.6);
+INSERT INTO conditions VALUES (60, 3, 23.7), (70, 4, 23.7);
+-- Should see some invaliations in the hypertable invalidation log:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        1 |    10 |  10
+        1 |    10 |  19
+        1 |    60 |  70
+(3 rows)
+
+-- Generate some invalidations for the other hypertable
+INSERT INTO measurements VALUES (20, 4, 23.7);
+INSERT INTO measurements VALUES (30, 5, 23.8), (80, 3, 23.6);
+-- Should now see invalidations for both hypertables
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        1 |    10 |  10
+        1 |    10 |  19
+        1 |    60 |  70
+        2 |    20 |  20
+        2 |    30 |  80
+(5 rows)
+
+-- First refresh a window where we don't have any invalidations. This
+-- allows us to see only the copying of the invalidations to the per
+-- cagg log without additional processing.
+SELECT refresh_continuous_aggregate('cond_10', 20, 60);
+ refresh_continuous_aggregate 
+------------------------------
+ 
+(1 row)
+
+-- Invalidations should be moved from the hypertable invalidation log
+-- to the continuous aggregate log, but only for the hypertable that
+-- the refreshed aggregate belongs to:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        2 |    20 |  20
+        2 |    30 |  80
+(2 rows)
+
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+ cagg_id | start | end 
+---------+-------+-----
+       3 |    10 |  10
+       3 |    10 |  19
+       3 |    60 |  70
+       4 |    10 |  10
+       4 |    10 |  19
+       4 |    60 |  70
+(6 rows)
+
+-- Now add more invalidations to test a refresh that overlaps with them.
+-- Entries that should be deleted:
+INSERT INTO conditions VALUES (30, 1, 23.4), (59, 1, 23.4);
+INSERT INTO conditions VALUES (20, 1, 23.4), (30, 1, 23.4);
+-- Entries that should be cut to the right, leaving an invalidation to
+-- the left of the refresh window:
+INSERT INTO conditions VALUES (1, 4, 23.7), (25, 1, 23.4);
+INSERT INTO conditions VALUES (19, 4, 23.7), (59, 1, 23.4);
+-- Entries that should be cut to the left and right, leaving two
+-- invalidation entries on each side of the refresh window:
+INSERT INTO conditions VALUES (2, 2, 23.5), (60, 1, 23.4);
+INSERT INTO conditions VALUES (3, 2, 23.5), (80, 1, 23.4);
+-- Entries that should be cut to the left, leaving an invalidation to
+-- the right of the refresh window:
+INSERT INTO conditions VALUES (60, 3, 23.6), (90, 3, 23.6);
+INSERT INTO conditions VALUES (20, 5, 23.8), (100, 3, 23.6);
+-- New invalidations in the hypertable invalidation log:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        1 |     1 |  25
+        1 |     2 |  60
+        1 |     3 |  80
+        1 |    19 |  59
+        1 |    20 |  30
+        1 |    20 | 100
+        1 |    30 |  59
+        1 |    60 |  90
+        2 |    20 |  20
+        2 |    30 |  80
+(10 rows)
+
+-- But nothing has yet changed in the cagg invalidation log:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+ cagg_id | start | end 
+---------+-------+-----
+       3 |    10 |  10
+       3 |    10 |  19
+       3 |    60 |  70
+       4 |    10 |  10
+       4 |    10 |  19
+       4 |    60 |  70
+(6 rows)
+
+-- Refresh to process invalidations for daily temperature:
+SELECT refresh_continuous_aggregate('cond_10', 20, 60);
+ refresh_continuous_aggregate 
+------------------------------
+ 
+(1 row)
+
+-- Invalidations should be moved from the hypertable invalidation log
+-- to the continuous aggregate log.
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        2 |    20 |  20
+        2 |    30 |  80
+(2 rows)
+
+-- Only the cond_10 cagg should have its entries cut:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+ cagg_id | start | end 
+---------+-------+-----
+       3 |     1 |  19
+       3 |     2 |  19
+       3 |     3 |  19
+       3 |    10 |  10
+       3 |    10 |  19
+       3 |    19 |  19
+       3 |    60 |  60
+       3 |    60 |  70
+       3 |    60 |  80
+       3 |    60 |  90
+       3 |    60 | 100
+       4 |     1 |  25
+       4 |     2 |  60
+       4 |     3 |  80
+       4 |    10 |  10
+       4 |    10 |  19
+       4 |    19 |  59
+       4 |    20 |  30
+       4 |    20 | 100
+       4 |    30 |  59
+       4 |    60 |  70
+       4 |    60 |  90
+(22 rows)
+
+-- Refresh also cond_20:
+SELECT refresh_continuous_aggregate('cond_20', 20, 60);
+ refresh_continuous_aggregate 
+------------------------------
+ 
+(1 row)
+
+-- The cond_20 cagg should also have its entries cut:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+ cagg_id | start | end 
+---------+-------+-----
+       3 |     1 |  19
+       3 |     2 |  19
+       3 |     3 |  19
+       3 |    10 |  10
+       3 |    10 |  19
+       3 |    19 |  19
+       3 |    60 |  60
+       3 |    60 |  70
+       3 |    60 |  80
+       3 |    60 |  90
+       3 |    60 | 100
+       4 |     1 |  19
+       4 |     2 |  19
+       4 |     3 |  19
+       4 |    10 |  10
+       4 |    10 |  19
+       4 |    19 |  19
+       4 |    60 |  60
+       4 |    60 |  70
+       4 |    60 |  80
+       4 |    60 |  90
+       4 |    60 | 100
+(22 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_FILES
   continuous_aggs_permissions.sql
   continuous_aggs_watermark.sql
   continuous_aggs_refresh.sql
+  continuous_aggs_invalidation.sql
   edition.sql
   gapfill.sql
   partialize_finalize.sql

--- a/tsl/test/sql/continuous_aggs_invalidation.sql
+++ b/tsl/test/sql/continuous_aggs_invalidation.sql
@@ -1,0 +1,212 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Disable background workers since we are testing manual refresh
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT _timescaledb_internal.stop_background_workers();
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SET datestyle TO 'ISO, YMD';
+SET timezone TO 'UTC';
+
+CREATE TABLE conditions (time int NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval => 10);
+
+CREATE TABLE measurements (time int NOT NULL, device int, temp float);
+SELECT create_hypertable('measurements', 'time', chunk_time_interval => 10);
+
+CREATE OR REPLACE FUNCTION cond_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM conditions
+$$;
+
+CREATE OR REPLACE FUNCTION measure_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM measurements
+$$;
+
+SELECT set_integer_now_func('conditions', 'cond_now');
+SELECT set_integer_now_func('measurements', 'measure_now');
+
+INSERT INTO conditions
+SELECT t, ceil(abs(timestamp_hash(to_timestamp(t)::timestamp))%4)::int,
+       abs(timestamp_hash(to_timestamp(t)::timestamp))%40
+FROM generate_series(1, 100, 1) t;
+
+INSERT INTO measurements
+SELECT * FROM conditions;
+
+-- Show the most recent data
+SELECT * FROM conditions
+ORDER BY time DESC, device
+LIMIT 10;
+
+-- Create two continuous aggregates on the same hypertable to test
+-- that invalidations are handled correctly across both of them.
+CREATE VIEW cond_10
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(10, time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2;
+
+CREATE VIEW cond_20
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(20, time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2;
+
+CREATE VIEW measure_10
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(10, time) AS day, device, avg(temp) AS avg_temp
+FROM measurements
+GROUP BY 1,2;
+
+-- There should be three continuous aggregates, two on one hypertable
+-- and one on the other:
+SELECT mat_hypertable_id, raw_hypertable_id, user_view_name
+FROM _timescaledb_catalog.continuous_agg;
+
+-- The continuous aggregates should be empty
+SELECT * FROM cond_10
+ORDER BY day DESC, device;
+
+SELECT * FROM cond_20
+ORDER BY day DESC, device;
+
+SELECT * FROM measure_10
+ORDER BY day DESC, device;
+
+-- Must refresh with "legacy" functionality to move the invalidation
+-- threshold, or no invalidations will be generated.
+REFRESH MATERIALIZED VIEW cond_10;
+REFRESH MATERIALIZED VIEW measure_10;
+
+-- There should be no invalidations initially:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+
+-- Create invalidations across different ranges. Some of these should
+-- be deleted and others cut in different ways when a refresh is
+-- run. Note that the refresh window is inclusive in the start of the
+-- window but exclusive at the end.
+
+-- Entries that should be left unmodified:
+INSERT INTO conditions VALUES (10, 4, 23.7);
+INSERT INTO conditions VALUES (10, 5, 23.8), (19, 3, 23.6);
+INSERT INTO conditions VALUES (60, 3, 23.7), (70, 4, 23.7);
+
+-- Should see some invaliations in the hypertable invalidation log:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+
+-- Generate some invalidations for the other hypertable
+INSERT INTO measurements VALUES (20, 4, 23.7);
+INSERT INTO measurements VALUES (30, 5, 23.8), (80, 3, 23.6);
+
+-- Should now see invalidations for both hypertables
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+
+-- First refresh a window where we don't have any invalidations. This
+-- allows us to see only the copying of the invalidations to the per
+-- cagg log without additional processing.
+SELECT refresh_continuous_aggregate('cond_10', 20, 60);
+
+-- Invalidations should be moved from the hypertable invalidation log
+-- to the continuous aggregate log, but only for the hypertable that
+-- the refreshed aggregate belongs to:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+
+-- Now add more invalidations to test a refresh that overlaps with them.
+-- Entries that should be deleted:
+INSERT INTO conditions VALUES (30, 1, 23.4), (59, 1, 23.4);
+INSERT INTO conditions VALUES (20, 1, 23.4), (30, 1, 23.4);
+-- Entries that should be cut to the right, leaving an invalidation to
+-- the left of the refresh window:
+INSERT INTO conditions VALUES (1, 4, 23.7), (25, 1, 23.4);
+INSERT INTO conditions VALUES (19, 4, 23.7), (59, 1, 23.4);
+-- Entries that should be cut to the left and right, leaving two
+-- invalidation entries on each side of the refresh window:
+INSERT INTO conditions VALUES (2, 2, 23.5), (60, 1, 23.4);
+INSERT INTO conditions VALUES (3, 2, 23.5), (80, 1, 23.4);
+-- Entries that should be cut to the left, leaving an invalidation to
+-- the right of the refresh window:
+INSERT INTO conditions VALUES (60, 3, 23.6), (90, 3, 23.6);
+INSERT INTO conditions VALUES (20, 5, 23.8), (100, 3, 23.6);
+
+-- New invalidations in the hypertable invalidation log:
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+
+-- But nothing has yet changed in the cagg invalidation log:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+
+-- Refresh to process invalidations for daily temperature:
+SELECT refresh_continuous_aggregate('cond_10', 20, 60);
+
+-- Invalidations should be moved from the hypertable invalidation log
+-- to the continuous aggregate log.
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+
+-- Only the cond_10 cagg should have its entries cut:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+
+-- Refresh also cond_20:
+SELECT refresh_continuous_aggregate('cond_20', 20, 60);
+
+-- The cond_20 cagg should also have its entries cut:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;


### PR DESCRIPTION
This change adds intitial support for invalidation processing when
refreshing a continuous aggregate. Note that, currently, invalidations
are only cleared during a refresh, but not yet used to optimize
refreshes. There are two steps to this processing:

1. Invalidations are moved from hypertable invalidation log to the
   cagg invalidation log
2. The cagg invalidation entries are then processed for the continuous
   aggregate that gets refreshed.

The second step involves finding all invalidations that overlap with
the given refresh window and then either deleting them or cutting
them, depending on how they overlap.

Currently, the "invalidation threshold" is not moved up during a
refresh. This would only be required if the refresh window crosses
that threshold and will be addressed in a future change.

An additional commit adds support for setting the snapshot to use in 
scans using the Scanner, which is required by the invalidation code.

Closes #2128 