### PR TITLE
Remove cascade_to_materialization

### DIFF
--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -32,8 +32,7 @@ ON CONFLICT (id) DO NOTHING;
 CREATE OR REPLACE FUNCTION add_retention_policy(
        hypertable REGCLASS,
        retention_window "any",
-       if_not_exists BOOL = false,
-       cascade_to_materializations BOOL = false
+       if_not_exists BOOL = false
 )
 RETURNS INTEGER AS '@MODULE_PATHNAME@', 'ts_add_retention_policy'
 LANGUAGE C VOLATILE STRICT;

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -95,8 +95,7 @@ CREATE OR REPLACE FUNCTION drop_chunks(
     hypertable_or_cagg  REGCLASS,
     older_than "any" = NULL,
     newer_than "any" = NULL,
-    verbose BOOLEAN = FALSE,
-    cascade_to_materializations BOOLEAN = NULL
+    verbose BOOLEAN = FALSE
 ) RETURNS SETOF TEXT AS '@MODULE_PATHNAME@', 'ts_chunk_drop_chunks'
 LANGUAGE C VOLATILE PARALLEL UNSAFE;
 

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -233,7 +233,6 @@ CREATE TABLE IF NOT EXISTS _timescaledb_config.bgw_policy_drop_chunks (
     job_id          		    INTEGER                 PRIMARY KEY REFERENCES _timescaledb_config.bgw_job(id) ON DELETE CASCADE,
     hypertable_id   		    INTEGER     UNIQUE      NOT NULL REFERENCES _timescaledb_catalog.hypertable(id) ON DELETE CASCADE,
     older_than	    _timescaledb_catalog.ts_interval    NOT NULL,
-    cascade_to_materializations BOOLEAN,
     CONSTRAINT valid_older_than CHECK(_timescaledb_internal.valid_ts_interval(older_than))
 );
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_config.bgw_policy_drop_chunks', '');

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -85,15 +85,13 @@ CREATE TABLE _timescaledb_config.bgw_policy_drop_chunks_tmp (
     		  REFERENCES _timescaledb_catalog.hypertable(id)
 		  ON DELETE CASCADE,
     older_than _timescaledb_catalog.ts_interval NOT NULL,
-    cascade_to_materializations BOOLEAN,
     CONSTRAINT valid_older_than CHECK(_timescaledb_internal.valid_ts_interval(older_than))
 );
 
 INSERT INTO _timescaledb_config.bgw_policy_drop_chunks_tmp (
     SELECT job_id,
     	   hypertable_id,
-	   older_than,
-	   cascade_to_materializations
+	   older_than
       FROM _timescaledb_config.bgw_policy_drop_chunks
 );
 
@@ -110,7 +108,6 @@ CREATE TABLE _timescaledb_config.bgw_policy_drop_chunks (
     		  REFERENCES _timescaledb_catalog.hypertable(id)
 		  ON DELETE CASCADE,
     older_than _timescaledb_catalog.ts_interval NOT NULL,
-    cascade_to_materializations BOOLEAN,
     CONSTRAINT valid_older_than CHECK(_timescaledb_internal.valid_ts_interval(older_than))
 );
 INSERT INTO _timescaledb_config.bgw_policy_drop_chunks (

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -47,7 +47,7 @@ CREATE OR REPLACE VIEW timescaledb_information.license AS
 
 CREATE OR REPLACE VIEW timescaledb_information.drop_chunks_policies as
   SELECT format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as hypertable, p.older_than, p.job_id, j.schedule_interval,
-    j.max_runtime, j.max_retries, j.retry_period, p.cascade_to_materializations
+    j.max_runtime, j.max_retries, j.retry_period
   FROM _timescaledb_config.bgw_policy_drop_chunks p
     INNER JOIN _timescaledb_catalog.hypertable ht ON p.hypertable_id = ht.id
     INNER JOIN _timescaledb_config.bgw_job j ON p.job_id = j.id;

--- a/src/bgw_policy/drop_chunks.c
+++ b/src/bgw_policy/drop_chunks.c
@@ -50,15 +50,6 @@ bgw_policy_drop_chunks_tuple_found(TupleInfo *ti, void *const data)
 	(*policy)->older_than = *ts_interval_from_tuple(
 		values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_older_than)]);
 
-	if (nulls[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade_to_materializations)])
-		(*policy)->cascade_to_materializations = CASCADE_TO_MATERIALIZATION_UNKNOWN;
-	else
-		(*policy)->cascade_to_materializations =
-			(DatumGetBool(values[AttrNumberGetAttrOffset(
-				 Anum_bgw_policy_drop_chunks_cascade_to_materializations)]) ?
-				 CASCADE_TO_MATERIALIZATION_TRUE :
-				 CASCADE_TO_MATERIALIZATION_FALSE);
-
 	if (should_free)
 		heap_freetuple(tuple);
 
@@ -159,19 +150,6 @@ ts_bgw_policy_drop_chunks_insert_with_relation(Relation rel, BgwPolicyDropChunks
 
 	values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_older_than)] =
 		HeapTupleGetDatum(ht_older_than);
-
-	if (policy->cascade_to_materializations == CASCADE_TO_MATERIALIZATION_UNKNOWN)
-	{
-		nulls[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade_to_materializations)] =
-			true;
-	}
-	else
-	{
-		values[AttrNumberGetAttrOffset(Anum_bgw_policy_drop_chunks_cascade_to_materializations)] =
-			BoolGetDatum((policy->cascade_to_materializations == CASCADE_TO_MATERIALIZATION_TRUE ?
-							  true :
-							  false));
-	}
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_insert_values(rel, tupdesc, values, nulls);

--- a/src/bgw_policy/drop_chunks.h
+++ b/src/bgw_policy/drop_chunks.h
@@ -16,7 +16,6 @@ typedef struct BgwPolicyDropChunks
 	int32 job_id;
 	int32 hypertable_id;
 	FormData_ts_interval older_than;
-	CascadeToMaterializationOption cascade_to_materializations;
 } BgwPolicyDropChunks;
 
 extern TSDLLEXPORT BgwPolicyDropChunks *ts_bgw_policy_drop_chunks_find_by_job(int32 job_id);

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -832,14 +832,10 @@ typedef enum Anum_bgw_policy_drop_chunks
 	Anum_bgw_policy_drop_chunks_job_id = 1,
 	Anum_bgw_policy_drop_chunks_hypertable_id,
 	Anum_bgw_policy_drop_chunks_older_than,
-	Anum_bgw_policy_drop_chunks_cascade_to_materializations,
 	_Anum_bgw_policy_drop_chunks_max,
 } Anum_bgw_policy_drop_chunks;
 
 #define Natts_bgw_policy_drop_chunks (_Anum_bgw_policy_drop_chunks_max - 1)
-
-/* Do NOT define FormData here because cascade_to_materializations as bool is semantically wrong
- * this is a tri-state variable. NULL matters here. */
 
 enum
 {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -101,13 +101,6 @@ typedef struct ChunkScanEntry
 	ChunkStub *stub;
 } ChunkScanEntry;
 
-typedef enum CascadeToMaterializationOption
-{
-	CASCADE_TO_MATERIALIZATION_UNKNOWN = -1,
-	CASCADE_TO_MATERIALIZATION_FALSE = 0,
-	CASCADE_TO_MATERIALIZATION_TRUE = 1
-} CascadeToMaterializationOption;
-
 extern Chunk *ts_chunk_create_from_point(Hypertable *ht, Point *p, const char *schema,
 										 const char *prefix);
 
@@ -153,11 +146,10 @@ extern TSDLLEXPORT bool ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compre
 extern TSDLLEXPORT void ts_chunk_drop(Chunk *chunk, DropBehavior behavior, int32 log_level);
 extern TSDLLEXPORT void ts_chunk_drop_preserve_catalog_row(Chunk *chunk, DropBehavior behavior,
 														   int32 log_level);
-extern TSDLLEXPORT List *
-ts_chunk_do_drop_chunks(Hypertable *ht, Datum older_than_datum, Datum newer_than_datum,
-						Oid older_than_type, Oid newer_than_type,
-						CascadeToMaterializationOption cascades_to_materializations,
-						int32 log_level, List **affected_data_nodes);
+extern TSDLLEXPORT List *ts_chunk_do_drop_chunks(Hypertable *ht, Datum older_than_datum,
+												 Datum newer_than_datum, Oid older_than_type,
+												 Oid newer_than_type, int32 log_level,
+												 List **affected_data_nodes);
 extern TSDLLEXPORT Chunk *
 ts_chunk_get_chunks_in_time_range(Oid table_relid, Datum older_than_datum, Datum newer_than_datum,
 								  Oid older_than_type, Oid newer_than_type, char *caller_name,

--- a/tsl/src/bgw_policy/drop_chunks_api.c
+++ b/tsl/src/bgw_policy/drop_chunks_api.c
@@ -127,10 +127,6 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 	Oid ht_oid = PG_GETARG_OID(0);
 	Datum older_than_datum = PG_GETARG_DATUM(1);
 	bool if_not_exists = PG_GETARG_BOOL(2);
-	CascadeToMaterializationOption cascade_to_materializations =
-		(PG_ARGISNULL(3) ? CASCADE_TO_MATERIALIZATION_UNKNOWN :
-						   (PG_GETARG_BOOL(3) ? CASCADE_TO_MATERIALIZATION_TRUE :
-												CASCADE_TO_MATERIALIZATION_FALSE));
 	Oid older_than_type = PG_ARGISNULL(1) ? InvalidOid : get_fn_expr_argtype(fcinfo->flinfo, 1);
 	BgwPolicyDropChunks policy;
 	Hypertable *hypertable;
@@ -163,8 +159,7 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 							get_rel_name(ht_oid))));
 		}
 
-		if (ts_interval_equal(&existing->older_than, older_than) &&
-			existing->cascade_to_materializations == cascade_to_materializations)
+		if (ts_interval_equal(&existing->older_than, older_than))
 		{
 			/* If all arguments are the same, do nothing */
 			ts_cache_release(hcache);
@@ -210,7 +205,6 @@ drop_chunks_add_policy(PG_FUNCTION_ARGS)
 		.job_id = job_id,
 		.hypertable_id = ts_hypertable_relid_to_id(mapped_oid),
 		.older_than = *older_than,
-		.cascade_to_materializations = cascade_to_materializations,
 	};
 
 	/* Now, insert a new row in the drop_chunks args table */

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -285,7 +285,6 @@ execute_drop_chunks_policy(int32 job_id)
 									  InvalidOid,
 									  older_than_type,
 									  InvalidOid,
-									  args->cascade_to_materializations,
 									  DEBUG2,
 									  NULL);
 	num_dropped = list_length(dc_temp);

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -190,8 +190,7 @@ chunk_set_default_data_node(PG_FUNCTION_ARGS)
  * Returns the number of dropped chunks.
  */
 int
-chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type,
-						 bool cascade_to_materializations)
+chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type)
 {
 	EState *estate;
 	ExprContext *econtext;
@@ -218,7 +217,6 @@ chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type,
 				  get_typbyval(older_than_type)),
 		makeNullConst(INT8OID, -1, InvalidOid),
 		castNode(Const, makeBoolConst(false, true)),
-		castNode(Const, makeBoolConst(cascade_to_materializations, false))
 	};
 
 	char *const schema_name = ts_extension_schema_name();

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -13,7 +13,6 @@
 
 extern void chunk_update_foreign_server_if_needed(int32 chunk_id, Oid existing_server_id);
 extern Datum chunk_set_default_data_node(PG_FUNCTION_ARGS);
-extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type,
-									bool cascade_to_materializations);
+extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_H */

--- a/tsl/src/continuous_aggs/drop.c
+++ b/tsl/src/continuous_aggs/drop.c
@@ -49,7 +49,6 @@ ts_continuous_agg_drop_chunks_by_chunk_id(int32 raw_hypertable_id, Chunk **chunk
 								newer_than_datum,
 								older_than_type,
 								newer_than_type,
-								CASCADE_TO_MATERIALIZATION_FALSE,
 								log_level,
 								NULL);
 

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -48,8 +48,8 @@ SELECT * FROM _timescaledb_config.bgw_job;
 (0 rows)
 
 SELECT * FROM timescaledb_information.drop_chunks_policies;
- hypertable | older_than | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
-------------+------------+--------+-------------------+-------------+-------------+--------------+-----------------------------
+ hypertable | older_than | job_id | schedule_interval | max_runtime | max_retries | retry_period 
+------------+------------+--------+-------------------+-------------+-------------+--------------
 (0 rows)
 
 SELECT * FROM timescaledb_information.reorder_policies;
@@ -420,9 +420,9 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
- job_id | hypertable_id |   older_than    | cascade_to_materializations 
---------+---------------+-----------------+-----------------------------
-   1001 |             2 | (t,"@ 4 mons",) | f
+ job_id | hypertable_id |   older_than    
+--------+---------------+-----------------
+   1001 |             2 | (t,"@ 4 mons",)
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
@@ -580,9 +580,9 @@ SELECT show_chunks('test_drop_chunks_table');
 
 --test that views work
 SELECT * FROM timescaledb_information.drop_chunks_policies;
-       hypertable       |   older_than    | job_id | schedule_interval | max_runtime | max_retries | retry_period | cascade_to_materializations 
-------------------------+-----------------+--------+-------------------+-------------+-------------+--------------+-----------------------------
- test_drop_chunks_table | (t,"@ 4 mons",) |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | f
+       hypertable       |   older_than    | job_id | schedule_interval | max_runtime | max_retries | retry_period 
+------------------------+-----------------+--------+-------------------+-------------+-------------+--------------
+ test_drop_chunks_table | (t,"@ 4 mons",) |   1001 | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins
 (1 row)
 
 SELECT * FROM timescaledb_information.policy_stats;

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -87,9 +87,9 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks where job_id=:drop_chunks_job_id;
- job_id | hypertable_id |   older_than    | cascade_to_materializations 
---------+---------------+-----------------+-----------------------------
-   1000 |             1 | (t,"@ 4 mons",) | f
+ job_id | hypertable_id |   older_than    
+--------+---------------+-----------------
+   1000 |             1 | (t,"@ 4 mons",)
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -227,8 +227,7 @@ ALTER VIEW conditions_summary SET (
       timescaledb.ignore_invalidation_older_than = '15 days'
 );
 SELECT COUNT(*) AS dropped_chunks_count
-  FROM drop_chunks('conditions', TIMESTAMPTZ '2018-12-15 00:00',
-                   cascade_to_materializations => FALSE);
+  FROM drop_chunks('conditions', TIMESTAMPTZ '2018-12-15 00:00');
 NOTICE:  making sure all invalidations for public.conditions_summary have been processed prior to dropping chunks
  dropped_chunks_count 
 ----------------------

--- a/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
@@ -69,7 +69,7 @@ REFRESH MATERIALIZED VIEW drop_chunks_view1;
 --TEST1  specify drop chunks policy on mat. hypertable by
 -- directly does not work
 \set ON_ERROR_STOP 0
-SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', retention_window=> -50, cascade_to_materializations=>false ) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', retention_window=> -50) as drop_chunks_job_id1 \gset
 ERROR:  cannot add drop chunks policy to materialized hypertable "_materialized_hypertable_2" 
 \set ON_ERROR_STOP 1
 --TEST2  specify drop chunks policy on cont. aggregate
@@ -95,7 +95,7 @@ WHERE hypertable_name = '_materialized_hypertable_2' ORDER BY range_start_intege
  _hyper_2_43_chunk |                  30 |                40
 (4 rows)
 
-SELECT add_retention_policy( 'drop_chunks_view1', retention_window=> 10, cascade_to_materializations=>false ) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( 'drop_chunks_view1', retention_window=> 10) as drop_chunks_job_id1 \gset
 SELECT alter_job_schedule(:drop_chunks_job_id1, schedule_interval => INTERVAL '1 second');
                  alter_job_schedule                  
 -----------------------------------------------------

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -231,8 +231,7 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(:'drop_chunks_mat_table',
     newer_than => -20,
-    verbose => true,
-    cascade_to_materializations=>true);
+    verbose => true);
 ERROR:  cannot drop chunks on a continuous aggregate materialization hypertable
 \set ON_ERROR_STOP 1
 SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
@@ -254,78 +253,6 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
            5 |     5
           10 |     5
 (3 rows)
-
--- cannot drop from the raw table without specifying cascade_to_materializations
-\set ON_ERROR_STOP 0
-SELECT drop_chunks('drop_chunks_table', older_than => 10);
-ERROR:  cascade_to_materializations options must be set explicitly
-\set ON_ERROR_STOP 1
-SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
- count 
--------
-     3
-(1 row)
-
-SELECT count(c) FROM show_chunks(:'drop_chunks_mat_table') AS c;
- count 
--------
-     1
-(1 row)
-
-SELECT * FROM drop_chunks_view ORDER BY 1;
- time_bucket | count 
--------------+-------
-           0 |     5
-           5 |     5
-          10 |     5
-(3 rows)
-
-SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
- count 
--------
-     3
-(1 row)
-
-SELECT count(c) FROM show_chunks(:'drop_chunks_mat_table') AS c;
- count 
--------
-     1
-(1 row)
-
-SELECT * FROM drop_chunks_view ORDER BY 1;
- time_bucket | count 
--------------+-------
-           0 |     5
-           5 |     5
-          10 |     5
-(3 rows)
-
--- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(\'drop_chunks_table\', older_than => 13)::REGCLASS::TEXT'
-\set QUERY2 'SELECT drop_chunks(\'drop_chunks_table\', older_than => 13, cascade_to_materializations => true)::TEXT'
-\set ECHO errors
- Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
-----------------+-------------------------+-------------------------
-              0 |                       1 |                       1
-(1 row)
-
-SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
- count 
--------
-     2
-(1 row)
-
-SELECT count(c) FROM show_chunks(:'drop_chunks_mat_table') AS c;
- count 
--------
-     1
-(1 row)
-
-SELECT * FROM drop_chunks_view ORDER BY 1;
- time_bucket | count 
--------------+-------
-          10 |     5
-(1 row)
 
 -- drop chunks when the chunksize and time_bucket aren't aligned
 DROP TABLE drop_chunks_table CASCADE;
@@ -383,38 +310,6 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
           12 |     3
 (5 rows)
 
--- show_chunks and drop_chunks output should be the same
-\set QUERY1 'SELECT show_chunks(\'drop_chunks_table_u\', older_than => 13)::REGCLASS::TEXT'
-\set QUERY2 'SELECT drop_chunks(\'drop_chunks_table_u\', older_than => 13, cascade_to_materializations => true)::TEXT'
-\set ECHO errors
- Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
-----------------+-------------------------+-------------------------
-              0 |                       1 |                       1
-(1 row)
-
--- everything in the first chunk (values within [0, 6]) should be dropped
--- the time_bucket [6, 8] will lose it's first value, but should still have
--- the other two
-SELECT count(c) FROM show_chunks('drop_chunks_table_u') AS c;
- count 
--------
-     3
-(1 row)
-
-SELECT count(c) FROM show_chunks(:'drop_chunks_mat_table_u') AS c;
- count 
--------
-     1
-(1 row)
-
-SELECT * FROM drop_chunks_view ORDER BY 1;
- time_bucket | count 
--------------+-------
-           6 |     2
-           9 |     3
-          12 |     3
-(3 rows)
-
 -- TRUNCATE test
 \set ON_ERROR_STOP 0
 TRUNCATE drop_chunks_table_u;
@@ -460,19 +355,24 @@ CREATE INDEX new_name_idx ON new_name(chunk_id);
 SELECT * FROM new_name;
  time_bucket |      agg_2_2       | chunk_id 
 -------------+--------------------+----------
+           0 | \x0000000000000003 |        5
+           3 | \x0000000000000003 |        5
+           6 | \x0000000000000001 |        5
            6 | \x0000000000000002 |        6
            9 | \x0000000000000003 |        6
           12 | \x0000000000000002 |        6
           12 | \x0000000000000001 |        7
-(4 rows)
+(7 rows)
 
 SELECT * FROM drop_chunks_view ORDER BY 1;
  time_bucket | count 
 -------------+-------
-           6 |     2
+           0 |     3
+           3 |     3
+           6 |     3
            9 |     3
           12 |     3
-(3 rows)
+(5 rows)
 
 \set ON_ERROR_STOP 0
 -- no continuous aggregates on a continuous aggregate materialization table
@@ -540,9 +440,7 @@ SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
  Tue Jan 04 16:00:00 2000 PST | Const |     4.3 | ("Tue Jan 04 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
 (5 rows)
 
---
--- cascade_to_materialization = false tests
---
+--test materialization of invalidation before drop
 DROP TABLE IF EXISTS drop_chunks_table CASCADE;
 NOTICE:  table "drop_chunks_table" does not exist, skipping
 DROP TABLE IF EXISTS drop_chunks_table_u CASCADE;
@@ -572,14 +470,14 @@ AS SELECT time_bucket('5', time), max(data)
     GROUP BY 1;
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 \set ON_ERROR_STOP 0
-SELECT drop_chunks('drop_chunks_table', older_than => 13, cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => 13);
 ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 ALTER VIEW drop_chunks_view SET (timescaledb.ignore_invalidation_older_than = 9);
 -- 9 is too small (less than timescaledb.ignore_invalidation_older_than)
-SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-8), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-8));
 ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
 -- 10 works but we don't have the completion threshold far enough along
-SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
@@ -588,7 +486,7 @@ LOG:  materializing continuous aggregate public.drop_chunks_view: nothing to inv
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
 \set ON_ERROR_STOP 0
 --still too far behind
-SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 ERROR:  the continuous aggregate public.drop_chunks_view is too far behind
 \set ON_ERROR_STOP 1
 REFRESH MATERIALIZED VIEW drop_chunks_view;
@@ -598,7 +496,7 @@ WARNING:  REFRESH did not materialize the entire range since it was limited by t
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 LOG:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 25
 --now, this works
-SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, no new range
 LOG:  materializing continuous aggregate public.drop_chunks_view: no new range to materialize or invalidations found, exiting early
@@ -609,11 +507,11 @@ LOG:  materializing continuous aggregate public.drop_chunks_view: no new range t
 
 \set ON_ERROR_STOP 0
 --must have older_than set and no newer than
-SELECT drop_chunks('drop_chunks_table', cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table');
 ERROR:  older_than and newer_than timestamps provided to drop_chunks cannot both be NULL
-SELECT drop_chunks('drop_chunks_table', newer_than=>10, cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', newer_than=>10);
 ERROR:  cannot use newer_than parameter to drop_chunks with cascade_to_materializations
-SELECT drop_chunks('drop_chunks_table', older_than => 20, newer_than=>10, cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => 20, newer_than=>10);
 ERROR:  cannot use newer_than parameter to drop_chunks with cascade_to_materializations
 \set ON_ERROR_STOP 1
 --test materialization of invalidation before drop
@@ -654,7 +552,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (8 rows)
 
 --dropping tables will cause the invalidation to be processed
-SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
                drop_chunks                
@@ -780,7 +678,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (8 rows)
 
 --should see multiple rounds of invalidation in the log messages
-SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
@@ -836,7 +734,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
            0 |   4
 (12 rows)
 
-SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9), cascade_to_materializations => false);
+SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 NOTICE:  making sure all invalidations for public.drop_chunks_view have been processed prior to dropping chunks
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
                drop_chunks                
@@ -923,142 +821,34 @@ WHERE hypertable_name = 'drop_chunks_table' ORDER BY range_start_integer;
  _hyper_10_19_chunk |                  50 |                60
 (2 rows)
 
--- TEST drop_chunks with cascade_to_materialization set to true (github 1644)
--- This checks if chunks from mat. hypertable are actually dropped
--- and deletes data from chunks that cannot be dropped from that mat. hypertable.
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_tablen,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
     WHERE _timescaledb_catalog.continuous_agg.raw_hypertable_id = :drop_chunks_table_nid
         AND _timescaledb_catalog.hypertable.id = _timescaledb_catalog.continuous_agg.mat_hypertable_id \gset
-SELECT drop_chunks('drop_chunks_table', older_than=>integer_now_test2() + 200, cascade_to_materializations => true);
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_10_19_chunk
- _timescaledb_internal._hyper_10_15_chunk
-(2 rows)
-
-SELECT count(c) FROM show_chunks('drop_chunks_table') AS c;
- count 
--------
-     0
-(1 row)
-
-SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
- count 
--------
-     0
-(1 row)
-
-SELECT set_chunk_time_interval('drop_chunks_table', 10);
- set_chunk_time_interval 
--------------------------
- 
-(1 row)
-
-SELECT set_chunk_time_interval(:'drop_chunks_mat_tablen', 20);
- set_chunk_time_interval 
--------------------------
- 
-(1 row)
-
-INSERT INTO drop_chunks_table SELECT generate_series(1,35), 100;
-update drop_chunks_table set data = 250 where time = 25;
-update drop_chunks_table set data = 290 where time = 29;
-REFRESH materialized view drop_chunks_view;
-LOG:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 35
-LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
-REFRESH materialized view drop_chunks_view;
-LOG:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 35
-LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
---now we have chunks in both mat and raw hypertables
-select * from drop_chunks_view order by 1;
- time_bucket | max 
--------------+-----
-           0 | 100
-           5 | 100
-          10 | 100
-          15 | 100
-          20 | 100
-          25 | 290
-          30 | 100
-          35 | 100
-(8 rows)
-
-SELECT chunk_name, range_start_integer, range_end_integer
-FROM timescaledb_information.chunks 
-WHERE hypertable_name = 'drop_chunks_table' ORDER BY range_start_integer;
-     chunk_name     | range_start_integer | range_end_integer 
---------------------+---------------------+-------------------
- _hyper_10_13_chunk |                   0 |                10
- _hyper_10_14_chunk |                  10 |                20
- _hyper_10_20_chunk |                  20 |                30
- _hyper_10_17_chunk |                  30 |                40
-(4 rows)
-
-SELECT chunk_name, range_start_integer, range_end_integer
-FROM timescaledb_information.chunks 
-WHERE hypertable_name = :'drop_chunks_mat_table_name' ORDER BY range_start_integer;
-     chunk_name     | range_start_integer | range_end_integer 
---------------------+---------------------+-------------------
- _hyper_11_21_chunk |                   0 |                20
- _hyper_11_22_chunk |                  20 |                40
-(2 rows)
-
---1 chunk from the mat. hypertable will be dropped and the other will
---need deletes when the chunks from the raw hypertable are dropped.
-SELECT drop_chunks('drop_chunks_table', older_than=>integer_now_test2() - 4 , cascade_to_materializations => true);
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_10_13_chunk
- _timescaledb_internal._hyper_10_14_chunk
- _timescaledb_internal._hyper_10_20_chunk
-(3 rows)
-
-SELECT * from drop_chunks_view ORDER BY 1;
- time_bucket | max 
--------------+-----
-          30 | 100
-          35 | 100
-(2 rows)
-
-SELECT count(c) FROM show_chunks(:'drop_chunks_mat_tablen') AS c;
- count 
--------
-     1
-(1 row)
-
-SELECT chunk_name, range_start_integer, range_end_integer
-FROM timescaledb_information.chunks 
-WHERE hypertable_name = :'drop_chunks_mat_table_name' ORDER BY range_start_integer;
-     chunk_name     | range_start_integer | range_end_integer 
---------------------+---------------------+-------------------
- _hyper_11_22_chunk |                  20 |                40
-(1 row)
-
 -- TEST drop chunks from continuous aggregates by specifying view name
 SELECT drop_chunks('drop_chunks_view',
     newer_than => -20,
     verbose => true);
-INFO:  dropping chunk _timescaledb_internal._hyper_11_22_chunk
+INFO:  dropping chunk _timescaledb_internal._hyper_11_16_chunk
                drop_chunks                
 ------------------------------------------
- _timescaledb_internal._hyper_11_22_chunk
+ _timescaledb_internal._hyper_11_16_chunk
 (1 row)
 
 -- Test that we cannot drop chunks when specifying materialized
 -- hypertable
 INSERT INTO drop_chunks_table SELECT generate_series(45, 55), 500;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
-LOG:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 55
+LOG:  new materialization range not found for public.drop_chunks_table (time column time): not enough new data past completion threshold of 60 as of 59
 LOG:  materializing continuous aggregate public.drop_chunks_view: processing invalidations, no new range
 SELECT chunk_name, range_start_integer, range_end_integer
 FROM timescaledb_information.chunks 
 WHERE hypertable_name = :'drop_chunks_mat_table_name' ORDER BY range_start_integer;
      chunk_name     | range_start_integer | range_end_integer 
 --------------------+---------------------+-------------------
- _hyper_11_24_chunk |                  40 |                60
+ _hyper_11_20_chunk |                   0 |               100
 (1 row)
 
 \set ON_ERROR_STOP 0

--- a/tsl/test/expected/deparse.out
+++ b/tsl/test/expected/deparse.out
@@ -11,27 +11,21 @@
 
 -- test drop_chunks function deparsing
 SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', '2019-01-01'::timestamptz, verbose => true);
-                                                                                              tsl_test_deparse_drop_chunks                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'myschema.table10',older_than => 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone,newer_than => NULL,verbose => 't',cascade_to_materializations => NULL)
-(1 row)
-
-SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', interval '1 day', cascade_to_materializations => true);
-                                                                           tsl_test_deparse_drop_chunks                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'myschema.table10',older_than => '@ 1 day'::interval,newer_than => NULL,verbose => 'f',cascade_to_materializations => 't')
+                                                                            tsl_test_deparse_drop_chunks                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'myschema.table10',older_than => 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone,newer_than => NULL,verbose => 't')
 (1 row)
 
 SELECT * FROM tsl_test_deparse_drop_chunks('table1', newer_than => 12345);
-                                                                         tsl_test_deparse_drop_chunks                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'public.table1',older_than => NULL,newer_than => '12345'::integer,verbose => 'f',cascade_to_materializations => NULL)
+                                                       tsl_test_deparse_drop_chunks                                                       
+------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'public.table1',older_than => NULL,newer_than => '12345'::integer,verbose => 'f')
 (1 row)
 
 SELECT * FROM tsl_test_deparse_drop_chunks('table1', older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
-                                                                                                     tsl_test_deparse_drop_chunks                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'public.table1',older_than => '@ 2 years'::interval,newer_than => 'Thu Jan 01 00:00:00 2015'::timestamp without time zone,verbose => 'f',cascade_to_materializations => NULL)
+                                                                                   tsl_test_deparse_drop_chunks                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ SELECT * FROM public.drop_chunks(hypertable_or_cagg => 'public.table1',older_than => '@ 2 years'::interval,newer_than => 'Thu Jan 01 00:00:00 2015'::timestamp without time zone,verbose => 'f')
 (1 row)
 
 -- test generalized deparsing function

--- a/tsl/test/expected/deparse_fail.out
+++ b/tsl/test/expected/deparse_fail.out
@@ -12,8 +12,7 @@ CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(
     table_name REGCLASS,
     older_than "any" = NULL,
     newer_than "any" = NULL,
-    verbose BOOLEAN = FALSE,
-    cascade_to_materializations BOOLEAN = NULL) RETURNS TEXT
+    verbose BOOLEAN = FALSE) RETURNS TEXT
 AS :TSL_MODULE_PATHNAME, 'ts_test_deparse_drop_chunks' LANGUAGE C VOLATILE;
 CREATE OR REPLACE FUNCTION tsl_test_deparse_scalar_func(
     schema_name NAME = NULL,

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -38,8 +38,6 @@ ERROR:  cannot execute set_adaptive_chunking() in a read-only transaction
 --
 SELECT * FROM drop_chunks('test_table', older_than => 10);
 ERROR:  cannot execute drop_chunks() in a read-only transaction
-SELECT * FROM drop_chunks('test_table', older_than => 10, cascade_to_materializations => true);
-ERROR:  cannot execute drop_chunks() in a read-only transaction
 -- add_dimension()
 --
 SELECT * FROM add_dimension('test_table', 'device', chunk_time_interval => 100);

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -11,8 +11,8 @@ AS :TSL_MODULE_PATHNAME, 'ts_test_bgw_job_delete_by_id'
 LANGUAGE C VOLATILE STRICT;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade_to_materializations 
---------+---------------+------------+-----------------------------
+ job_id | hypertable_id | older_than 
+--------+---------------+------------
 (0 rows)
 
 select * from _timescaledb_config.bgw_job WHERE job_type IN ('reorder');
@@ -163,17 +163,10 @@ WARNING:  could not add drop chunks policy due to existing policy on hypertable 
                    -1
 (1 row)
 
-select add_retention_policy('test_table', INTERVAL '3 days', if_not_exists => true, cascade_to_materializations => true);
-WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
- add_retention_policy 
-----------------------
-                   -1
-(1 row)
-
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade_to_materializations 
---------+---------------+-----------------+-----------------------------
-   1002 |             1 | (t,"@ 3 mons",) | f
+ job_id | hypertable_id |   older_than    
+--------+---------------+-----------------
+   1002 |             1 | (t,"@ 3 mons",)
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -181,13 +174,11 @@ select add_retention_policy('test_table', INTERVAL '1 year');
 ERROR:  drop chunks policy already exists for hypertable "test_table"
 select add_retention_policy('test_table', INTERVAL '3 days');
 ERROR:  drop chunks policy already exists for hypertable "test_table"
-select add_retention_policy('test_table', INTERVAL '3 days', cascade_to_materializations => true);
-ERROR:  drop chunks policy already exists for hypertable "test_table"
 \set ON_ERROR_STOP 1
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade_to_materializations 
---------+---------------+-----------------+-----------------------------
-   1002 |             1 | (t,"@ 3 mons",) | f
+ job_id | hypertable_id |   older_than    
+--------+---------------+-----------------
+   1002 |             1 | (t,"@ 3 mons",)
 (1 row)
 
 select r.job_id,r.hypertable_id,r.older_than from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
@@ -230,8 +221,8 @@ select * from _timescaledb_catalog.dimension;
 (2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade_to_materializations 
---------+---------------+------------+-----------------------------
+ job_id | hypertable_id | older_than 
+--------+---------------+------------
 (0 rows)
 
 select r.job_id,r.hypertable_id,r.older_than from _timescaledb_config.bgw_policy_drop_chunks as r, _timescaledb_catalog.hypertable as h where r.hypertable_id=h.id and h.table_name='test_table';
@@ -257,9 +248,9 @@ select add_retention_policy('test_table', INTERVAL '3 month');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade_to_materializations 
---------+---------------+-----------------+-----------------------------
-   1003 |             1 | (t,"@ 3 mons",) | f
+ job_id | hypertable_id |   older_than    
+--------+---------------+-----------------
+   1003 |             1 | (t,"@ 3 mons",)
 (1 row)
 
 select remove_retention_policy('test_table');
@@ -269,8 +260,8 @@ select remove_retention_policy('test_table');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade_to_materializations 
---------+---------------+------------+-----------------------------
+ job_id | hypertable_id | older_than 
+--------+---------------+------------
 (0 rows)
 
 select add_retention_policy('test_table_int', 1);
@@ -280,20 +271,13 @@ select add_retention_policy('test_table_int', 1);
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade_to_materializations 
---------+---------------+------------+-----------------------------
-   1004 |             2 | (f,,1)     | f
+ job_id | hypertable_id | older_than 
+--------+---------------+------------
+   1004 |             2 | (f,,1)
 (1 row)
 
 -- Should not add new policy with different parameters
 select add_retention_policy('test_table_int', 2, true);
-WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
- add_retention_policy 
-----------------------
-                   -1
-(1 row)
-
-select add_retention_policy('test_table_int', 1, true, true);
 WARNING:  could not add drop chunks policy due to existing policy on hypertable with different arguments
  add_retention_policy 
 ----------------------
@@ -307,8 +291,8 @@ select remove_retention_policy('test_table_int');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade_to_materializations 
---------+---------------+------------+-----------------------------
+ job_id | hypertable_id | older_than 
+--------+---------------+------------
 (0 rows)
 
 -- Make sure remove works when there's nothing to remove
@@ -509,10 +493,10 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (2 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than    | cascade_to_materializations 
---------+---------------+-----------------+-----------------------------
-   1009 |             4 | (t,"@ 2 days",) | f
-   1010 |             5 | (t,"@ 1 day",)  | f
+ job_id | hypertable_id |   older_than    
+--------+---------------+-----------------
+   1009 |             4 | (t,"@ 2 days",)
+   1010 |             5 | (t,"@ 1 day",)
 (2 rows)
 
 DROP TABLE test_table;
@@ -524,9 +508,9 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (1 row)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id |   older_than   | cascade_to_materializations 
---------+---------------+----------------+-----------------------------
-   1010 |             5 | (t,"@ 1 day",) | f
+ job_id | hypertable_id |   older_than   
+--------+---------------+----------------
+   1010 |             5 | (t,"@ 1 day",)
 (1 row)
 
 DROP TABLE test_table2;
@@ -536,8 +520,8 @@ select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
 (0 rows)
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
- job_id | hypertable_id | older_than | cascade_to_materializations 
---------+---------------+------------+-----------------------------
+ job_id | hypertable_id | older_than 
+--------+---------------+------------
 (0 rows)
 
 -- Now test chunk_stat insertion

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -140,8 +140,7 @@ ALTER VIEW conditions_summary SET (
 );
 
 SELECT COUNT(*) AS dropped_chunks_count
-  FROM drop_chunks('conditions', TIMESTAMPTZ '2018-12-15 00:00',
-                   cascade_to_materializations => FALSE);
+  FROM drop_chunks('conditions', TIMESTAMPTZ '2018-12-15 00:00');
 
 -- We need to have some chunks that are marked as dropped, otherwise
 -- we will not have a problem below.

--- a/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
@@ -66,7 +66,7 @@ REFRESH MATERIALIZED VIEW drop_chunks_view1;
 -- directly does not work
 
 \set ON_ERROR_STOP 0
-SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', retention_window=> -50, cascade_to_materializations=>false ) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', retention_window=> -50) as drop_chunks_job_id1 \gset
 \set ON_ERROR_STOP 1
 
 --TEST2  specify drop chunks policy on cont. aggregate
@@ -80,7 +80,7 @@ SELECT chunk_name, range_start_integer, range_end_integer
 FROM timescaledb_information.chunks 
 WHERE hypertable_name = '_materialized_hypertable_2' ORDER BY range_start_integer;
 
-SELECT add_retention_policy( 'drop_chunks_view1', retention_window=> 10, cascade_to_materializations=>false ) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( 'drop_chunks_view1', retention_window=> 10) as drop_chunks_job_id1 \gset
 SELECT alter_job_schedule(:drop_chunks_job_id1, schedule_interval => INTERVAL '1 second');
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(2000000);
 SELECT count(c) from show_chunks('_timescaledb_internal._materialized_hypertable_2') as c ;

--- a/tsl/test/sql/continuous_aggs_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_drop_chunks.sql
@@ -57,6 +57,5 @@ REFRESH MATERIALIZED VIEW records_monthly;
 REFRESH MATERIALIZED VIEW records_monthly;
 
 \set VERBOSITY default
-SELECT drop_chunks('2000-03-16'::timestamptz, 'records',
-       cascade_to_materializations => FALSE);
+SELECT drop_chunks('2000-03-16'::timestamptz, 'records');
 

--- a/tsl/test/sql/deparse.sql
+++ b/tsl/test/sql/deparse.sql
@@ -32,7 +32,6 @@ SELECT 'TABLE DEPARSE TEST DONE';
 \set ECHO all
 -- test drop_chunks function deparsing
 SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', '2019-01-01'::timestamptz, verbose => true);
-SELECT * FROM tsl_test_deparse_drop_chunks('myschema.table10', interval '1 day', cascade_to_materializations => true);
 SELECT * FROM tsl_test_deparse_drop_chunks('table1', newer_than => 12345);
 SELECT * FROM tsl_test_deparse_drop_chunks('table1', older_than => interval '2 years', newer_than => '2015-01-01'::timestamp);
 

--- a/tsl/test/sql/include/deparse_func.sql
+++ b/tsl/test/sql/include/deparse_func.sql
@@ -11,8 +11,7 @@ CREATE OR REPLACE FUNCTION tsl_test_deparse_drop_chunks(
     table_name REGCLASS,
     older_than "any" = NULL,
     newer_than "any" = NULL,
-    verbose BOOLEAN = FALSE,
-    cascade_to_materializations BOOLEAN = NULL) RETURNS TEXT
+    verbose BOOLEAN = FALSE) RETURNS TEXT
 AS :TSL_MODULE_PATHNAME, 'ts_test_deparse_drop_chunks' LANGUAGE C VOLATILE;
 
 CREATE OR REPLACE FUNCTION tsl_test_deparse_scalar_func(

--- a/tsl/test/sql/read_only.sql
+++ b/tsl/test/sql/read_only.sql
@@ -40,7 +40,6 @@ SELECT * FROM set_adaptive_chunking('test_table', '2MB');
 -- drop_chunks()
 --
 SELECT * FROM drop_chunks('test_table', older_than => 10);
-SELECT * FROM drop_chunks('test_table', older_than => 10, cascade_to_materializations => true);
 
 -- add_dimension()
 --

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -74,14 +74,12 @@ select add_retention_policy('test_table', INTERVAL '3 month', true);
 select add_retention_policy('test_table', INTERVAL '1 year', if_not_exists => true);
 select add_retention_policy('test_table', INTERVAL '3 days', if_not_exists => true);
 select add_retention_policy('test_table', INTERVAL '3 days', if_not_exists => true);
-select add_retention_policy('test_table', INTERVAL '3 days', if_not_exists => true, cascade_to_materializations => true);
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
 
 \set ON_ERROR_STOP 0
 select add_retention_policy('test_table', INTERVAL '1 year');
 select add_retention_policy('test_table', INTERVAL '3 days');
-select add_retention_policy('test_table', INTERVAL '3 days', cascade_to_materializations => true);
 \set ON_ERROR_STOP 1
 
 select * from _timescaledb_config.bgw_policy_drop_chunks;
@@ -119,7 +117,6 @@ select add_retention_policy('test_table_int', 1);
 select * from _timescaledb_config.bgw_policy_drop_chunks;
 -- Should not add new policy with different parameters
 select add_retention_policy('test_table_int', 2, true);
-select add_retention_policy('test_table_int', 1, true, true);
 
 select remove_retention_policy('test_table_int');
 select * from _timescaledb_config.bgw_policy_drop_chunks;

--- a/tsl/test/src/deparse.c
+++ b/tsl/test/src/deparse.c
@@ -33,7 +33,7 @@ ts_test_deparse_drop_chunks(PG_FUNCTION_ARGS)
 {
 	FmgrInfo flinfo;
 	FunctionCallInfo fcinfo2 = palloc(SizeForFunctionCallInfo(fcinfo->nargs));
-	Oid argtypes[] = { REGCLASSOID, ANYOID, ANYOID, BOOLOID, BOOLOID };
+	Oid argtypes[] = { REGCLASSOID, ANYOID, ANYOID, BOOLOID };
 	Oid funcid = ts_get_function_oid("drop_chunks",
 									 ts_extension_schema_name(),
 									 sizeof(argtypes) / sizeof(*argtypes),


### PR DESCRIPTION
The parameter `cascade_to_materialization` is removed from
`drop_chunks` and `add_drop_chunks_policy` as well as associated tables
and test functions.

Fixes #2137