### PR TITLE
Fix telemetry installed_time format

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -36,7 +36,9 @@ jobs:
     steps:
     - name: Install Dependencies
       if: runner.os == 'Linux'
-      run: sudo apt install flex bison lcov systemd-coredump gdb ${{ matrix.extra_packages }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install flex bison lcov systemd-coredump gdb ${{ matrix.extra_packages }}
 
     # on macOS the path used is depending on the runner version leading to cache failure
     # when the runner version changes so we extract runner version from path and add it

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -295,6 +295,15 @@ get_pgversion_string()
 	return buf->data;
 }
 
+#define ISO8601_FORMAT "YYYY-MM-DD\"T\"HH24:MI:SSOF"
+
+static char *
+format_iso8601(Datum value)
+{
+	return TextDatumGetCString(
+		DirectFunctionCall2(timestamptz_to_char, value, CStringGetTextDatum(ISO8601_FORMAT)));
+}
+
 static StringInfo
 build_version_body(void)
 {
@@ -319,9 +328,7 @@ build_version_body(void)
 						 DirectFunctionCall1(uuid_out, ts_telemetry_metadata_get_exported_uuid())));
 	ts_jsonb_add_str(parse_state,
 					 REQ_INSTALL_TIME,
-					 DatumGetCString(
-						 DirectFunctionCall1(timestamptz_out,
-											 ts_telemetry_metadata_get_install_timestamp())));
+					 format_iso8601(ts_telemetry_metadata_get_install_timestamp()));
 
 	ts_jsonb_add_str(parse_state, REQ_INSTALL_METHOD, TIMESCALEDB_INSTALL_METHOD);
 

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -491,3 +491,17 @@ SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
  "1"
 (1 row)
 
+set datestyle to iso;
+-- check that installed_time formatting in telemetry report does not depend on local date settings
+SELECT json_object_field_text(get_telemetry_report()::json,'installed_time') as installed_time
+\gset
+set datestyle to sql;
+SELECT json_object_field_text(get_telemetry_report()::json,'installed_time') as installed_time2
+\gset
+SELECT :'installed_time' = :'installed_time2' AS equal, length(:'installed_time'), length(:'installed_time2');
+ equal | length | length 
+-------+--------+--------
+ t     |     22 |     22
+(1 row)
+
+RESET datestyle;

--- a/test/sql/telemetry.sql
+++ b/test/sql/telemetry.sql
@@ -187,3 +187,16 @@ CREATE TABLE device_readings (
 SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
 
 SELECT json_object_field(get_telemetry_report()::json,'num_hypertables');
+
+set datestyle to iso;
+-- check that installed_time formatting in telemetry report does not depend on local date settings
+SELECT json_object_field_text(get_telemetry_report()::json,'installed_time') as installed_time
+\gset
+set datestyle to sql;
+SELECT json_object_field_text(get_telemetry_report()::json,'installed_time') as installed_time2
+\gset
+
+SELECT :'installed_time' = :'installed_time2' AS equal, length(:'installed_time'), length(:'installed_time2');
+
+RESET datestyle;
+


### PR DESCRIPTION
This patch changes the telemetry code to always send the installed_time
timestamp AS ISO8601. Previously it was depending on local settings
leading to timestamps not processable by the telemetry receiver.