### PR TITLE
Remove requirement of CASCADE from DROP VIEW

### DIFF
--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -658,5 +658,5 @@ SELECT show_chunks('test_drop_chunks_table');
 (4 rows)
 
 --drop the view to allow drop chunks to work
-DROP VIEW tdc_view CASCADE;
+DROP VIEW tdc_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_13_chunk

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -91,7 +91,7 @@ order by tgname;
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- TEST2 ---
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 SELECT * FROM _timescaledb_config.bgw_job;
  id | application_name | job_type | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
@@ -241,7 +241,7 @@ order by time_bucket('1week', timec);
 -- use previous data from conditions
 --drop only the view.
 -- apply where clause on result of mat_m1 --
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
 create or replace view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -295,7 +295,7 @@ order by time_bucket('1week', timec);
 
 -- TEST5 --
 ---------test with having clause ----------------------
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
 create or replace view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -370,7 +370,6 @@ insert into conditions
 select generate_series('2018-11-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'NYC', 35, 45, 50, 40;
 insert into conditions
 select generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, 71, 28;
---drop view mat_m1 cascade;
 --naming with AS clauses
 create or replace view mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -405,7 +404,7 @@ order by attnum, attname;
       8 | chunk_id
 (8 rows)
 
-DROP VIEW mat_naming CASCADE;
+DROP VIEW mat_naming;
 --naming with default names
 create or replace view mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -440,7 +439,7 @@ order by attnum, attname;
       8 | chunk_id
 (8 rows)
 
-DROP VIEW mat_naming CASCADE;
+DROP VIEW mat_naming;
 --naming with view col names
 create or replace view mat_naming (bucket, loc, sum_t_h, stdd)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -475,7 +474,7 @@ order by attnum, attname;
       8 | chunk_id
 (8 rows)
 
-DROP VIEW mat_naming CASCADE;
+DROP VIEW mat_naming;
 create or replace view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
@@ -561,7 +560,7 @@ insert into :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select * from :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 --lets drop the view and check
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
 drop table conditions;
 CREATE TABLE conditions (
@@ -636,8 +635,6 @@ DROP VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 ERROR:  cannot drop the partial/direct view because it is required by a continuous aggregate
 DROP VIEW :"DIR_VIEW_SCHEMA".:"DIR_VIEW_NAME";
 ERROR:  cannot drop the partial/direct view because it is required by a continuous aggregate
-DROP VIEW mat_test;
-ERROR:  dropping a continuous aggregate requires using CASCADE
 \set ON_ERROR_STOP 1
 --catalog entry still there;
 SELECT count(*)
@@ -673,7 +670,7 @@ select count(*) from pg_class where relname = 'mat_test';
      1
 (1 row)
 
-DROP VIEW mat_test CASCADE;
+DROP VIEW mat_test;
 NOTICE:  drop cascades to 2 other objects
 --catalog entry should be gone
 SELECT count(*)
@@ -904,7 +901,7 @@ order by indexname;
  _materialized_hypertable_20_timec_idx         | CREATE INDEX _materialized_hypertable_20_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (timec DESC)
 (4 rows)
 
-drop view mat_with_test cascade;
+DROP VIEW mat_with_test;
 --no additional indexes
 create or replace view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h', timescaledb.create_group_indexes=false)
@@ -1166,7 +1163,7 @@ WARNING:  type integer text
          100 | 
 (3 rows)
 
-DROP view mat_ffunc_test cascade;
+DROP view mat_ffunc_test;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_67_chunk
 create or replace view mat_ffunc_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
@@ -1188,7 +1185,7 @@ WARNING:  type integer bigint
 (3 rows)
 
 --refresh mat view test when time_bucket is not projected --
-drop view mat_ffunc_test cascade;
+DROP VIEW mat_ffunc_test;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_68_chunk
 create or replace view mat_refresh_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -342,7 +342,7 @@ SELECT ts_bgw_params_reset_time();
  
 (1 row)
 
-DROP VIEW test_continuous_agg_view CASCADE;
+DROP VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
 CREATE VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
@@ -486,7 +486,7 @@ job_status             | Scheduled
 last_run_duration      | 
 
 \x off
-DROP VIEW test_continuous_agg_view CASCADE;
+DROP VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute
 CREATE VIEW test_continuous_agg_view

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -82,7 +82,7 @@ SELECT
   replace(:'QUERY_TEMPLATE', 'TABLE', 'conditions_before') AS "QUERY_BEFORE",
   replace(:'QUERY_TEMPLATE', 'TABLE', 'conditions_after') AS "QUERY_AFTER"
 \gset
-DROP VIEW if exists mat_test cascade;
+DROP VIEW IF EXISTS mat_test;
 NOTICE:  view "mat_test" does not exist, skipping
 --materialize this VIEW before dump this tests
 --that the partial state survives the dump intact
@@ -176,10 +176,6 @@ DROP table :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME";
 ERROR:  cannot drop table _timescaledb_internal._materialized_hypertable_3 because other objects depend on it
 DROP VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 ERROR:  cannot drop the partial/direct view because it is required by a continuous aggregate
-DROP VIEW mat_before;
-ERROR:  dropping a continuous aggregate requires using CASCADE
-DROP VIEW mat_after;
-ERROR:  dropping a continuous aggregate requires using CASCADE
 \set ON_ERROR_STOP 1
 --materialize mat_after
 SET timescaledb.current_timestamp_mock = '2019-02-01 00:00';
@@ -219,7 +215,7 @@ SELECT count(*) FROM conditions_after;
  Number of rows different between view and original (expect 0) | mat_after |     0
 (1 row)
 
-DROP VIEW mat_after cascade;
+DROP VIEW mat_after;
 NOTICE:  drop cascades to 2 other objects
-DROP VIEW mat_before cascade;
+DROP VIEW mat_before;
 NOTICE:  drop cascades to 2 other objects

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -489,7 +489,7 @@ ERROR:  timescaledb.refresh_lag out of range
 ALTER TABLE conditions ALTER timec type bigint;
 ERROR:  cannot alter type of a column used by a view or rule
 \set ON_ERROR_STOP
-drop view mat_with_test CASCADE;
+DROP VIEW mat_with_test;
 ALTER TABLE conditions ALTER timec type bigint;
 create or replace view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647', timescaledb.refresh_interval = '2h')

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -955,9 +955,9 @@ SELECT hypertable_id, watermark
 (1 row)
 
 --cleanup of continuous agg views --
-DROP view test_t_mat_view CASCADE;
+DROP view test_t_mat_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_16_chunk
-DROP view extreme_view CASCADE;
+DROP view extreme_view;
 NOTICE:  drop cascades to 4 other objects
 -- negative lag test
 CREATE TABLE continuous_agg_negative(time BIGINT, data BIGINT);
@@ -1032,7 +1032,7 @@ SELECT * FROM negative_view_5 ORDER BY 1;
           10 |     5
 (3 rows)
 
-DROP VIEW negative_view_5 CASCADE;
+DROP VIEW negative_view_5;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_10_27_chunk
 TRUNCATE continuous_agg_negative;
 CREATE VIEW negative_view_5

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -215,7 +215,7 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
 (1 row)
 
 --now drop cagg_1, should still have materialization_invalidation_log
-drop view cagg_1 cascade;
+DROP VIEW cagg_1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_5_chunk
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
  count 
@@ -386,9 +386,9 @@ select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   6 |                18 |                    18 |                      18
 (2 rows)
 
-DROP VIEW cagg_1 cascade;
+DROP VIEW cagg_1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_11_chunk
-DROP VIEW cagg_2 cascade;
+DROP VIEW cagg_2;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_12_chunk
 --TEST6 test the ignore_invalidation_older_than setting
 CREATE TABLE continuous_agg_test_ignore_invalidation_older_than(timeval integer, col1 integer, col2 integer);

--- a/tsl/test/expected/continuous_aggs_permissions.out
+++ b/tsl/test/expected/continuous_aggs_permissions.out
@@ -111,7 +111,7 @@ ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.ref
 ERROR:  must be owner of view mat_refresh_test
 ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
 ERROR:  must be owner of view mat_refresh_test
-DROP VIEW mat_refresh_test CASCADE; 
+DROP VIEW mat_refresh_test; 
 ERROR:  must be owner of view mat_refresh_test
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 ERROR:  permission denied for table conditions
@@ -152,7 +152,7 @@ NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 ERROR:  permission denied for function get_constant
-DROP VIEW mat_perm_view_test CASCADE;
+DROP VIEW mat_perm_view_test;
 --can create a mat view on something with select and trigger grants
 create or replace view mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -177,7 +177,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
  Fri Dec 31 16:00:00 1999 PST | 0.5
 (1 row)
 
-DROP VIEW metrics_summary CASCADE;
+DROP VIEW metrics_summary;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 -- check default view for new continuous aggregate with materialized_only to true
 CREATE VIEW metrics_summary
@@ -259,7 +259,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -------------+-----
 (0 rows)
 
-DROP VIEW metrics_summary CASCADE;
+DROP VIEW metrics_summary;
 --
 -- test queries on union view
 --
@@ -548,7 +548,7 @@ ORDER BY 1;
           31 |     2 | 129 |       56 |  50
 (3 rows)
 
-DROP VIEW mat_m1 cascade;
+DROP VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_12_chunk
 --- TEST union view with multiple WHERE and HAVING clauses
 CREATE VIEW mat_m1

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -177,7 +177,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
  Fri Dec 31 16:00:00 1999 PST | 0.5
 (1 row)
 
-DROP VIEW metrics_summary CASCADE;
+DROP VIEW metrics_summary;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 -- check default view for new continuous aggregate with materialized_only to true
 CREATE VIEW metrics_summary
@@ -259,7 +259,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -------------+-----
 (0 rows)
 
-DROP VIEW metrics_summary CASCADE;
+DROP VIEW metrics_summary;
 --
 -- test queries on union view
 --
@@ -548,7 +548,7 @@ ORDER BY 1;
           31 |     2 | 129 |       56 |  50
 (3 rows)
 
-DROP VIEW mat_m1 cascade;
+DROP VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_12_chunk
 --- TEST union view with multiple WHERE and HAVING clauses
 CREATE VIEW mat_m1

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -203,7 +203,7 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 -- For example you cannot cast to the local time. This is because
 -- a timezone setting can alter from user-to-user and thus
 -- cannot be materialized.
-DROP VIEW device_summary CASCADE;
+DROP VIEW device_summary;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
 CREATE VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -221,7 +221,7 @@ ERROR:  only immutable functions are supported for continuous aggregate query
 --note the error.
 -- You have two options:
 -- Option 1: be explicit in your timezone:
-DROP VIEW device_summary CASCADE;
+DROP VIEW device_summary;
 ERROR:  view "device_summary" does not exist
 CREATE VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -236,10 +236,10 @@ FROM
   device_readings
 GROUP BY bucket, device_id;
 NOTICE:  adding index _materialized_hypertable_3_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device_id, bucket)
-DROP VIEW device_summary CASCADE;
+DROP VIEW device_summary;
 -- Option 2: Keep things as TIMESTAMPTZ in the view and convert to local time when
 -- querying from the view
-DROP VIEW device_summary CASCADE;
+DROP VIEW device_summary;
 ERROR:  view "device_summary" does not exist
 CREATE VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -391,3 +391,55 @@ SELECT * FROM device_readings_jit ORDER BY time_bucket;
           60 | 600
 (6 rows)
 
+-- START OF BASIC USAGE TESTS --
+-- Check that continuous aggregate and materialized table is dropped
+-- together.
+CREATE TABLE whatever(time TIMESTAMPTZ NOT NULL, metric INTEGER);
+SELECT * FROM create_hypertable('whatever', 'time');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             8 | public      | whatever   | t
+(1 row)
+
+CREATE VIEW whatever_summary WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 hour', time) AS bucket, avg(metric)
+  FROM whatever GROUP BY bucket;
+SELECT (SELECT format('%1$I.%2$I', schema_name, table_name)::regclass::oid
+          FROM _timescaledb_catalog.hypertable
+	 WHERE id = raw_hypertable_id) AS raw_table
+     , (SELECT format('%1$I.%2$I', schema_name, table_name)::regclass::oid
+          FROM _timescaledb_catalog.hypertable
+	 WHERE id = mat_hypertable_id) AS mat_table
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'whatever_summary' \gset
+SELECT relname FROM pg_class WHERE oid = :mat_table;
+          relname           
+----------------------------
+ _materialized_hypertable_9
+(1 row)
+
+----------------------------------------------------------------
+-- Should generate an error since the cagg is dependent on the table.
+DROP TABLE whatever;
+ERROR:  cannot drop table whatever because other objects depend on it
+----------------------------------------------------------------
+-- Checking that a cagg cannot be dropped if there is a dependent
+-- object on it.
+CREATE VIEW whatever_summary_dependency AS SELECT * FROM whatever_summary;
+-- Should generate an error
+DROP VIEW whatever_summary;
+ERROR:  cannot drop view whatever_summary because other objects depend on it
+-- Dropping the dependent view so that we can do a proper drop below.
+DROP VIEW whatever_summary_dependency;
+----------------------------------------------------------------
+-- Dropping the cagg should also remove the materialized table
+DROP VIEW whatever_summary;
+SELECT relname FROM pg_class WHERE oid = :mat_table;
+ relname 
+---------
+(0 rows)
+
+----------------------------------------------------------------
+-- Cleanup
+DROP TABLE whatever;
+-- END OF BASIC USAGE TESTS --

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -2998,7 +2998,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test CASCADE;
+DROP VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
@@ -6785,7 +6785,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test CASCADE;
+DROP VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -2968,7 +2968,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test CASCADE;
+DROP VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
@@ -6714,7 +6714,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test CASCADE;
+DROP VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -308,4 +308,4 @@ SELECT job_id, time_bucket('1m',next_start) AS next_start, time_bucket('1m',last
 SELECT show_chunks('test_drop_chunks_table');
 
 --drop the view to allow drop chunks to work
-DROP VIEW tdc_view CASCADE;
+DROP VIEW tdc_view;

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -75,7 +75,7 @@ order by tgname;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 -- TEST2 ---
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 
 SELECT * FROM _timescaledb_config.bgw_job;
 
@@ -201,7 +201,7 @@ order by time_bucket('1week', timec);
 --drop only the view.
 
 -- apply where clause on result of mat_m1 --
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 create or replace view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
@@ -247,7 +247,7 @@ order by time_bucket('1week', timec);
 
 -- TEST5 --
 ---------test with having clause ----------------------
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 create or replace view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
@@ -312,7 +312,6 @@ select generate_series('2018-11-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 insert into conditions
 select generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, 71, 28;
 
---drop view mat_m1 cascade;
 --naming with AS clauses
 create or replace view mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -337,7 +336,7 @@ where attnum > 0 and attrelid =
 (Select oid from pg_class where relname like :'MAT_TABLE_NAME')
 order by attnum, attname;
 
-DROP VIEW mat_naming CASCADE;
+DROP VIEW mat_naming;
 
 --naming with default names
 create or replace view mat_naming
@@ -363,7 +362,7 @@ where attnum > 0 and attrelid =
 (Select oid from pg_class where relname like :'MAT_TABLE_NAME')
 order by attnum, attname;
 
-DROP VIEW mat_naming CASCADE;
+DROP VIEW mat_naming;
 
 --naming with view col names
 create or replace view mat_naming (bucket, loc, sum_t_h, stdd)
@@ -389,7 +388,7 @@ where attnum > 0 and attrelid =
 (Select oid from pg_class where relname like :'MAT_TABLE_NAME')
 order by attnum, attname;
 
-DROP VIEW mat_naming CASCADE;
+DROP VIEW mat_naming;
 
 create or replace view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
@@ -449,7 +448,7 @@ select * from :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 --lets drop the view and check
-drop view mat_m1 cascade;
+DROP VIEW mat_m1;
 
 drop table conditions;
 CREATE TABLE conditions (
@@ -517,7 +516,6 @@ WHERE user_view_name = 'mat_test'
 DROP TABLE :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME";
 DROP VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 DROP VIEW :"DIR_VIEW_SCHEMA".:"DIR_VIEW_NAME";
-DROP VIEW mat_test;
 \set ON_ERROR_STOP 1
 
 --catalog entry still there;
@@ -531,7 +529,7 @@ select count(*) from pg_class where relname = :'MAT_TABLE_NAME';
 select count(*) from pg_class where relname = :'DIR_VIEW_NAME';
 select count(*) from pg_class where relname = 'mat_test';
 
-DROP VIEW mat_test CASCADE;
+DROP VIEW mat_test;
 
 --catalog entry should be gone
 SELECT count(*)
@@ -657,7 +655,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_with_test')
 order by indexname;
 
-drop view mat_with_test cascade;
+DROP VIEW mat_with_test;
 --no additional indexes
 create or replace view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.refresh_interval = '1h', timescaledb.create_group_indexes=false)
@@ -844,7 +842,7 @@ REFRESH MATERIALIZED VIEW mat_ffunc_test;
 
 SELECT * FROM mat_ffunc_test;
 
-DROP view mat_ffunc_test cascade;
+DROP view mat_ffunc_test;
 
 create or replace view mat_ffunc_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
@@ -858,7 +856,7 @@ REFRESH MATERIALIZED VIEW mat_ffunc_test;
 SELECT * FROM mat_ffunc_test;
 
 --refresh mat view test when time_bucket is not projected --
-drop view mat_ffunc_test cascade;
+DROP VIEW mat_ffunc_test;
 create or replace view mat_refresh_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -219,7 +219,7 @@ SELECT * FROM test_continuous_agg_view ORDER BY 1;
 -- fast restart test
 SELECT ts_bgw_params_reset_time();
 
-DROP VIEW test_continuous_agg_view CASCADE;
+DROP VIEW test_continuous_agg_view;
 
 CREATE VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
@@ -283,7 +283,7 @@ select view_name, completed_threshold, invalidation_threshold, job_status, last_
 
 \x off
 
-DROP VIEW test_continuous_agg_view CASCADE;
+DROP VIEW test_continuous_agg_view;
 
 --create a view with a function that it has no permission to execute
 CREATE VIEW test_continuous_agg_view

--- a/tsl/test/sql/continuous_aggs_dump.sql
+++ b/tsl/test/sql/continuous_aggs_dump.sql
@@ -81,7 +81,7 @@ SELECT
 \gset
 
 
-DROP VIEW if exists mat_test cascade;
+DROP VIEW IF EXISTS mat_test;
 
 --materialize this VIEW before dump this tests
 --that the partial state survives the dump intact
@@ -138,8 +138,6 @@ SELECT _timescaledb_internal.stop_background_workers();
 \set ON_ERROR_STOP 0
 DROP table :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME";
 DROP VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
-DROP VIEW mat_before;
-DROP VIEW mat_after;
 \set ON_ERROR_STOP 1
 
 --materialize mat_after
@@ -161,5 +159,5 @@ SELECT count(*) FROM conditions_after;
 \ir include/cont_agg_test_equal.sql
 \set ECHO all
 
-DROP VIEW mat_after cascade;
-DROP VIEW mat_before cascade;
+DROP VIEW mat_after;
+DROP VIEW mat_before;

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -471,7 +471,7 @@ ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1h');
 ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '2147483648');
 ALTER TABLE conditions ALTER timec type bigint;
 \set ON_ERROR_STOP
-drop view mat_with_test CASCADE;
+DROP VIEW mat_with_test;
 
 ALTER TABLE conditions ALTER timec type bigint;
 create or replace view mat_with_test( timec, minl, sumt , sumh)

--- a/tsl/test/sql/continuous_aggs_materialize.sql
+++ b/tsl/test/sql/continuous_aggs_materialize.sql
@@ -434,8 +434,8 @@ SELECT hypertable_id, watermark
     WHERE hypertable_id=:raw_table_id;
 
 --cleanup of continuous agg views --
-DROP view test_t_mat_view CASCADE;
-DROP view extreme_view CASCADE;
+DROP view test_t_mat_view;
+DROP view extreme_view;
 
 -- negative lag test
 CREATE TABLE continuous_agg_negative(time BIGINT, data BIGINT);
@@ -472,7 +472,7 @@ INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
 REFRESH MATERIALIZED VIEW negative_view_5;
 SELECT * FROM negative_view_5 ORDER BY 1;
 
-DROP VIEW negative_view_5 CASCADE;
+DROP VIEW negative_view_5;
 TRUNCATE continuous_agg_negative;
 
 CREATE VIEW negative_view_5

--- a/tsl/test/sql/continuous_aggs_multi.sql
+++ b/tsl/test/sql/continuous_aggs_multi.sql
@@ -83,7 +83,7 @@ select count(*) from _timescaledb_catalog.continuous_aggs_hypertable_invalidatio
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
 
 --now drop cagg_1, should still have materialization_invalidation_log
-drop view cagg_1 cascade;
+DROP VIEW cagg_1;
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
 --cagg_2 still exists
 select view_name from timescaledb_information.continuous_aggregates;
@@ -145,8 +145,8 @@ refresh materialized view cagg_1;
 select * from cagg_1 where timed = 18 ;
 --copied over for cagg_2 to process later?
 select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
-DROP VIEW cagg_1 cascade;
-DROP VIEW cagg_2 cascade;
+DROP VIEW cagg_1;
+DROP VIEW cagg_2;
 
 --TEST6 test the ignore_invalidation_older_than setting
 CREATE TABLE continuous_agg_test_ignore_invalidation_older_than(timeval integer, col1 integer, col2 integer);

--- a/tsl/test/sql/continuous_aggs_permissions.sql
+++ b/tsl/test/sql/continuous_aggs_permissions.sql
@@ -103,7 +103,7 @@ select from alter_job_schedule(:cagg_job_id, max_runtime => NULL);
 
 ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
 ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
-DROP VIEW mat_refresh_test CASCADE; 
+DROP VIEW mat_refresh_test; 
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 SELECT * FROM mat_refresh_test;
 SELECT * FROM :materialization_hypertable;
@@ -136,7 +136,7 @@ group by time_bucket(100, timec), location;
 
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-DROP VIEW mat_perm_view_test CASCADE;
+DROP VIEW mat_perm_view_test;
 
 --can create a mat view on something with select and trigger grants
 create or replace view mat_perm_view_test

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -66,7 +66,7 @@ SELECT pg_get_viewdef('metrics_summary',true);
 -- view should have results now after refresh
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
-DROP VIEW metrics_summary CASCADE;
+DROP VIEW metrics_summary;
 
 -- check default view for new continuous aggregate with materialized_only to true
 CREATE VIEW metrics_summary
@@ -93,7 +93,7 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
-DROP VIEW metrics_summary CASCADE;
+DROP VIEW metrics_summary;
 
 --
 -- test queries on union view
@@ -245,7 +245,7 @@ GROUP BY time_bucket(1, a)
 HAVING sum(c) > 50
 ORDER BY 1;
 
-DROP VIEW mat_m1 cascade;
+DROP VIEW mat_m1;
 
 --- TEST union view with multiple WHERE and HAVING clauses
 CREATE VIEW mat_m1

--- a/tsl/test/sql/include/cont_agg_equal.sql
+++ b/tsl/test/sql/include/cont_agg_equal.sql
@@ -5,7 +5,7 @@
 --expects QUERY to be set
 \o /dev/null
 
-drop view if exists mat_test cascade;
+DROP VIEW IF EXISTS mat_test;
 
 create view mat_test
 WITH ( timescaledb.continuous)

--- a/tsl/test/sql/include/transparent_decompression_query.sql
+++ b/tsl/test/sql/include/transparent_decompression_query.sql
@@ -827,7 +827,7 @@ FROM cagg_test
 ORDER BY time
 LIMIT 1;
 
-DROP VIEW cagg_test CASCADE;
+DROP VIEW cagg_test;
 
 RESET client_min_messages;
 


### PR DESCRIPTION
To drop a continuous aggregate it was necessary to use the `CASCADE`
keyword, which would then cascade to the materialized hypertable. Since
this can cascade the drop to other objects that are dependent on the
continuous aggregate, this could accidentally drop more objects than
intended.

This commit fixes this by removing the check for `CASCADE` and adding
the materialized hypertable to the list of objects to drop.

Fixes timescale/timescaledb-private#659