### PR TITLE
Fix linter issues and bug in bgw jobs code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          '-*,clang-analyzer-core.*,clang-diagnostic-*'
-WarningsAsErrors: 'clang-analyzer-unix.*,clang-analyzer-core.NullDereference'
+WarningsAsErrors: 'clang-analyzer-unix.*,clang-analyzer-core.NullDereference,-clang-diagnostic-implicit-fallthrough'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 ...

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -25,17 +25,14 @@ typedef enum JobResult
 extern TSDLLEXPORT BgwJobStat *ts_bgw_job_stat_find(int job_id);
 extern void ts_bgw_job_stat_delete(int job_id);
 extern TSDLLEXPORT void ts_bgw_job_stat_mark_start(int32 bgw_job_id);
-extern void ts_bgw_job_stat_mark_end(BgwJob *job, JobResult result);
-extern bool ts_bgw_job_stat_end_was_marked(BgwJobStat *jobstat);
+extern void ts_bgw_job_stat_mark_end(const BgwJob *job, JobResult result);
+extern bool ts_bgw_job_stat_end_was_marked(const BgwJobStat *jobstat);
 
-extern TSDLLEXPORT void ts_bgw_job_stat_set_next_start(BgwJob *job, TimestampTz next_start);
-extern TSDLLEXPORT bool ts_bgw_job_stat_update_next_start(BgwJob *job, TimestampTz next_start,
+extern TSDLLEXPORT void ts_bgw_job_stat_set_next_start(const BgwJob *job, TimestampTz next_start);
+extern TSDLLEXPORT bool ts_bgw_job_stat_update_next_start(const BgwJob *job, TimestampTz next_start,
 														  bool allow_unset);
-
 extern TSDLLEXPORT void ts_bgw_job_stat_upsert_next_start(int32 bgw_job_id, TimestampTz next_start);
-
-extern bool ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
-
-extern TimestampTz ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job);
+extern bool ts_bgw_job_stat_should_execute(const BgwJobStat *jobstat, const BgwJob *job);
+extern TimestampTz ts_bgw_job_stat_next_start(const BgwJobStat *jobstat, const BgwJob *job);
 
 #endif /* BGW_JOB_STAT_H */

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -168,7 +168,7 @@ add_tsl_telemetry_info_default(JsonbParseState **parse_state)
 }
 
 static bool
-bgw_policy_job_execute_default_fn(BgwJob *job)
+bgw_policy_job_execute_default_fn(const BgwJob *job)
 {
 	error_no_default_fn_enterprise();
 	pg_unreachable();

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -45,7 +45,7 @@ typedef struct CrossModuleFunctions
 	void (*print_tsl_license_expiration_info_hook)(void);
 	void (*module_shutdown_hook)(void);
 	void (*add_tsl_telemetry_info)(JsonbParseState **parse_state);
-	bool (*bgw_policy_job_execute)(BgwJob *job);
+	bool (*bgw_policy_job_execute)(const BgwJob *job);
 	bool (*continuous_agg_materialize)(int32 materialization_id, ContinuousAggMatOptions *options);
 
 	PGFunction add_retention_policy;

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -807,7 +807,7 @@ ts_dimension_set_type(Dimension *dim, Oid newtype)
 }
 
 TSDLLEXPORT Oid
-ts_dimension_get_partition_type(Dimension *dim)
+ts_dimension_get_partition_type(const Dimension *dim)
 {
 	Assert(dim != NULL);
 	return dim->partitioning != NULL ? dim->partitioning->partfunc.rettype : dim->fd.column_type;

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -135,7 +135,7 @@ ts_hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionType type, const ch
 extern DimensionVec *ts_dimension_get_slices(Dimension *dim);
 extern int32 ts_dimension_get_hypertable_id(int32 dimension_id);
 extern int ts_dimension_set_type(Dimension *dim, Oid newtype);
-extern TSDLLEXPORT Oid ts_dimension_get_partition_type(Dimension *dim);
+extern TSDLLEXPORT Oid ts_dimension_get_partition_type(const Dimension *dim);
 extern int ts_dimension_set_name(Dimension *dim, const char *newname);
 extern int ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
 extern TSDLLEXPORT int ts_dimension_set_number_of_slices(Dimension *dim, int16 num_slices);

--- a/src/interval.c
+++ b/src/interval.c
@@ -124,11 +124,12 @@ ts_interval_from_sql_input(Oid relid, Datum interval, Oid interval_type, const c
  * related materialization hypertables
  */
 TSDLLEXPORT FormData_ts_interval *
-ts_interval_from_sql_input_internal(Dimension *open_dim, Datum interval, Oid interval_type,
+ts_interval_from_sql_input_internal(const Dimension *open_dim, Datum interval, Oid interval_type,
 									const char *parameter_name, const char *caller_name)
 {
 	FormData_ts_interval *invl = palloc0(sizeof(FormData_ts_interval));
 	Oid partitioning_type = ts_dimension_get_partition_type(open_dim);
+
 	switch (interval_type)
 	{
 		case INTERVALOID:
@@ -315,7 +316,7 @@ noarg_integer_now_func_filter(Form_pg_proc form, void *arg)
  * to access the integer_now_func
  */
 Oid
-ts_get_integer_now_func(Dimension *open_dim)
+ts_get_integer_now_func(const Dimension *open_dim)
 {
 	Oid rettype;
 	Oid now_func;
@@ -337,7 +338,7 @@ ts_get_integer_now_func(Dimension *open_dim)
 }
 
 int64
-ts_get_now_internal(Dimension *open_dim)
+ts_get_now_internal(const Dimension *open_dim)
 {
 	Oid dim_post_part_type = ts_dimension_get_partition_type(open_dim);
 
@@ -387,7 +388,7 @@ ts_get_now_internal(Dimension *open_dim)
  * datum (which incapsulates data of time column type)
  */
 Datum
-ts_interval_subtract_from_now(FormData_ts_interval *invl, Dimension *open_dim)
+ts_interval_subtract_from_now(FormData_ts_interval *invl, const Dimension *open_dim)
 {
 	Oid type_oid;
 	AssertArg(invl != NULL);

--- a/src/interval.h
+++ b/src/interval.h
@@ -19,13 +19,14 @@ TSDLLEXPORT FormData_ts_interval *ts_interval_from_sql_input(Oid relid, Datum in
 TSDLLEXPORT HeapTuple ts_interval_form_heaptuple(FormData_ts_interval *invl);
 TSDLLEXPORT bool ts_interval_equal(FormData_ts_interval *invl1, FormData_ts_interval *invl2);
 TSDLLEXPORT void ts_interval_now_func_validate(Oid now_func_oid, Oid open_dim_type);
-TSDLLEXPORT Datum ts_interval_subtract_from_now(FormData_ts_interval *invl, Dimension *open_dim);
-TSDLLEXPORT int64 ts_get_now_internal(Dimension *open_dim);
+TSDLLEXPORT Datum ts_interval_subtract_from_now(FormData_ts_interval *invl,
+												const Dimension *open_dim);
+TSDLLEXPORT int64 ts_get_now_internal(const Dimension *open_dim);
 TSDLLEXPORT FormData_ts_interval *
-ts_interval_from_sql_input_internal(Dimension *open_dim, Datum interval, Oid interval_type,
+ts_interval_from_sql_input_internal(const Dimension *open_dim, Datum interval, Oid interval_type,
 									const char *parameter_name, const char *caller_name);
 TSDLLEXPORT Datum ts_interval_from_now_func_get_datum(int64 interval, Oid time_dim_type,
 													  Oid now_func);
-TSDLLEXPORT Oid ts_get_integer_now_func(Dimension *open_dim);
+TSDLLEXPORT Oid ts_get_integer_now_func(const Dimension *open_dim);
 
 #endif /* TIMESCALEDB_INTERVAL */

--- a/src/planner.c
+++ b/src/planner.c
@@ -777,7 +777,7 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 					ts_cm_functions->set_rel_pathlist_dml(root, rel, rti, rte, ht);
 				break;
 			}
-			/* Fall through */
+			/* fall through */
 		default:
 			apply_optimizations(root, reltype, rel, rte, ht);
 			break;

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3638,6 +3638,7 @@ process_utility_xact_abort(XactEvent event, void *arg)
 			 * transactions.
 			 */
 			expect_chunk_modification = false;
+			break;
 		default:
 			break;
 	}
@@ -3652,6 +3653,7 @@ process_utility_subxact_abort(SubXactEvent event, SubTransactionId mySubid,
 		case SUBXACT_EVENT_ABORT_SUB:
 			/* see note in process_utility_xact_abort */
 			expect_chunk_modification = false;
+			break;
 		default:
 			break;
 	}

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -116,6 +116,7 @@ ts_subspace_store_add(SubspaceStore *store, const Hypercube *hc, void *object,
 			 * create one now. (There will always be one for time)
 			 */
 			Assert(last != NULL);
+			/* NOLINTNEXTLINE(clang-analyzer-core.NullDereference) */
 			last->storage = subspace_store_internal_node_create(i == (hc->num_slices - 1));
 			last->storage_free = subspace_store_internal_node_free;
 			node = last->storage;
@@ -189,6 +190,7 @@ ts_subspace_store_add(SubspaceStore *store, const Hypercube *hc, void *object,
 	}
 
 	Assert(last != NULL && last->storage == NULL);
+	/* NOLINTNEXTLINE(clang-analyzer-core.NullDereference) */
 	last->storage = object; /* at the end we store the object */
 	last->storage_free = object_free;
 	MemoryContextSwitchTo(old);
@@ -213,6 +215,7 @@ ts_subspace_store_get(SubspaceStore *store, Point *target)
 		vec = ((SubspaceStoreInternalNode *) match->storage)->vector;
 	}
 	Assert(match != NULL);
+	/* NOLINTNEXTLINE(clang-analyzer-core.NullDereference) */
 	return match->storage;
 }
 

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -18,11 +18,11 @@ typedef void (*reorder_func)(Oid tableOid, Oid indexOid, bool verbose, Oid wait_
 							 Oid destination_tablespace, Oid index_tablespace);
 
 /* Functions exposed only for testing */
-extern bool policy_reorder_execute(int32 job_id, Jsonb *config, reorder_func reorder,
+extern bool policy_reorder_execute(int32 job_id, const Jsonb *config, reorder_func reorder,
 								   bool fast_continue);
 extern bool execute_drop_chunks_policy(int32 job_id);
-extern bool policy_compression_execute(int32 job_id, Jsonb *config);
-extern bool tsl_bgw_policy_job_execute(BgwJob *job);
+extern bool policy_compression_execute(int32 job_id, const Jsonb *config);
+extern bool tsl_bgw_policy_job_execute(const BgwJob *job);
 extern Datum bgw_policy_alter_job_schedule(PG_FUNCTION_ARGS);
 
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_JOB_H */

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -82,7 +82,7 @@ policy_reorder_get_index_name(const Jsonb *config)
 }
 
 static void
-check_valid_index(Hypertable *ht, Name index_name)
+check_valid_index(const Hypertable *ht, const Name index_name)
 {
 	Oid index_oid;
 	HeapTuple idxtuple;
@@ -234,9 +234,7 @@ policy_reorder_remove(PG_FUNCTION_ARGS)
 {
 	Oid hypertable_oid = PG_GETARG_OID(0);
 	bool if_exists = PG_GETARG_BOOL(1);
-
 	int ht_id = ts_hypertable_relid_to_id(hypertable_oid);
-
 	List *jobs = ts_bgw_job_find_by_proc_and_hypertable_id(POLICY_REORDER_PROC_NAME,
 														   INTERNAL_SCHEMA_NAME,
 														   ht_id);
@@ -248,7 +246,7 @@ policy_reorder_remove(PG_FUNCTION_ARGS)
 					 errmsg("cannot remove reorder policy, no such policy exists")));
 		else
 		{
-			char *hypertable_name = get_rel_name(hypertable_oid);
+			const char *hypertable_name = get_rel_name(hypertable_oid);
 
 			if (hypertable_name != NULL)
 				ereport(NOTICE,

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -139,12 +139,13 @@ chunk_update_foreign_server_if_needed(int32 chunk_id, Oid existing_server_id)
 	foreach (lc, chunk->data_nodes)
 	{
 		new_server = lfirst(lc);
-		if (new_server->foreign_server_oid != existing_server_id)
-			break;
-	}
-	Assert(new_server != NULL);
 
-	chunk_set_foreign_server(chunk, GetForeignServer(new_server->foreign_server_oid));
+		if (new_server->foreign_server_oid != existing_server_id)
+		{
+			chunk_set_foreign_server(chunk, GetForeignServer(new_server->foreign_server_oid));
+			break;
+		}
+	}
 }
 
 Datum

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -443,8 +443,8 @@ chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht)
 	{
 		PGresult *pgres = async_response_result_get_pg_result(res);
 		ChunkDataNode *cdn = async_response_result_get_user_data(res);
-		Datum values[Natts_create_chunk];
-		bool nulls[Natts_create_chunk];
+		Datum values[Natts_create_chunk] = { 0 };
+		bool nulls[Natts_create_chunk] = { false };
 		const char *schema_name, *table_name;
 		bool created;
 

--- a/tsl/src/remote/tuplefactory.c
+++ b/tsl/src/remote/tuplefactory.c
@@ -192,8 +192,10 @@ tuplefactory_create(Relation rel, ScanState *ss, List *retrieved_attrs)
 
 	if (NULL != rel)
 		tupdesc = RelationGetDescr(rel);
-	else
+	else if (NULL != ss)
 		tupdesc = ss->ss_ScanTupleSlot->tts_tupleDescriptor;
+	else
+		elog(ERROR, "cannot create tuple without a tuple descriptor");
 
 	tf =
 		tuplefactory_create_common(tupdesc, retrieved_attrs, !ts_guc_enable_connection_binary_data);


### PR DESCRIPTION
This fixes a bug and other static analyzer issues introduced by recent
refactoring. General hardening is also done by better use of const
pointers, e.g., for jobs objects that shouldn't be modified.

The bug was caused by an uninitialized boolean in the `job_execute`
function, which could cause a read of a garbage value with
undeterministic results.