### PR TITLE
Fix background worker scheduler memory consumption

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -33,6 +33,7 @@
 #include "bgw_policy/chunk_stats.h"
 #include "bgw_policy/policy.h"
 #include "scan_iterator.h"
+#include "bgw/scheduler.h"
 
 #include <cross_module_fn.h>
 
@@ -76,30 +77,6 @@ typedef enum JobLockLifetime
 	SESSION_LOCK = 0,
 	TXN_LOCK,
 } JobLockLifetime;
-
-BackgroundWorkerHandle *
-ts_bgw_start_worker(const char *function, const char *name, const char *extra)
-{
-	BackgroundWorker worker = {
-		.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
-		.bgw_start_time = BgWorkerStart_RecoveryFinished,
-		.bgw_restart_time = BGW_NEVER_RESTART,
-		.bgw_notify_pid = MyProcPid,
-		.bgw_main_arg = ObjectIdGetDatum(MyDatabaseId),
-	};
-	BackgroundWorkerHandle *handle = NULL;
-
-	StrNCpy(worker.bgw_name, name, BGW_MAXLEN);
-	StrNCpy(worker.bgw_library_name, ts_extension_get_so_name(), BGW_MAXLEN);
-	StrNCpy(worker.bgw_function_name, function, BGW_MAXLEN);
-
-	Assert(strlen(extra) < BGW_EXTRALEN);
-	StrNCpy(worker.bgw_extra, extra, BGW_EXTRALEN);
-
-	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
-		return NULL;
-	return handle;
-}
 
 Oid
 ts_bgw_job_owner(BgwJob *job)

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -36,9 +36,6 @@ typedef bool job_main_func(void);
 typedef bool (*unknown_job_type_hook_type)(BgwJob *job);
 typedef Oid (*unknown_job_type_owner_hook_type)(BgwJob *job);
 
-extern BackgroundWorkerHandle *ts_bgw_start_worker(const char *function, const char *name,
-												   const char *extra);
-
 extern BackgroundWorkerHandle *ts_bgw_job_start(BgwJob *job, Oid user_oid);
 
 extern List *ts_bgw_job_get_scheduled(size_t alloc_size, MemoryContext mctx);

--- a/src/bgw/scheduler.h
+++ b/src/bgw/scheduler.h
@@ -31,5 +31,9 @@ extern void ts_bgw_scheduler_setup_callbacks(void);
 
 extern void ts_bgw_job_cache_invalidate_callback(void);
 extern void ts_bgw_scheduler_register_signal_handlers(void);
+extern void ts_bgw_scheduler_setup_mctx(void);
+
+extern BackgroundWorkerHandle *ts_bgw_start_worker(const char *function, const char *name,
+												   const char *extra);
 
 #endif /* BGW_SCHEDULER_H */

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -151,6 +151,8 @@ ts_bgw_db_scheduler_test_main(PG_FUNCTION_ARGS)
 
 	pgstat_report_appname("DB Scheduler Test");
 
+	ts_bgw_scheduler_setup_mctx();
+
 	ts_bgw_scheduler_process(ttl, ts_timer_mock_register_bgw_handle);
 
 	PG_RETURN_VOID();
@@ -163,6 +165,8 @@ start_test_scheduler(char *params)
 	 * This is where we would increment the number of bgw used, if we
 	 * decide to do so
 	 */
+	ts_bgw_scheduler_setup_mctx();
+
 	return ts_bgw_start_worker("ts_bgw_db_scheduler_test_main",
 							   "ts_bgw_db_scheduler_test_main",
 							   params);


### PR DESCRIPTION
This patch changes the scheduler main loop to use a scratch
context during operation which gets reset after every scheduling
loop iteration.

Fixes #2115 