### PR TITLE
Add dist compression policy test, fix policy name

### DIFF
--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -149,7 +149,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 		ts_cache_release(hcache);
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("can add compress_chunks policy only on hypertables with compression "
+				 errmsg("can add compression policy only on hypertables with compression "
 						"enabled")));
 	}
 
@@ -191,7 +191,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 		{
 			ts_cache_release(hcache);
 			elog(WARNING,
-				 "could not add compress_chunks policy due to existing policy on hypertable with "
+				 "could not add compression policy due to existing policy on hypertable with "
 				 "different arguments");
 			PG_RETURN_INT32(-1);
 		}

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -32,7 +32,7 @@ select create_hypertable( 'conditions', 'time', chunk_time_interval=> '31days'::
 --cannot set policy without enabling compression --
 \set ON_ERROR_STOP 0
 select add_compression_policy('conditions', '60d'::interval);
-ERROR:  can add compress_chunks policy only on hypertables with compression enabled
+ERROR:  can add compression policy only on hypertables with compression enabled
 \set ON_ERROR_STOP 1
 -- TEST2 --
 --add a policy to compress chunks --
@@ -91,7 +91,7 @@ NOTICE:  compress chunks policy already exists on hypertable "conditions", skipp
 select add_compression_policy('conditions', '60d'::interval);
 ERROR:  compress chunks policy already exists for hypertable "conditions"
 select add_compression_policy('conditions', '30d'::interval, if_not_exists=>true);
-WARNING:  could not add compress_chunks policy due to existing policy on hypertable with different arguments
+WARNING:  could not add compression policy due to existing policy on hypertable with different arguments
  add_compression_policy 
 ------------------------
                      -1

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -324,7 +324,7 @@ ORDER BY chunk_name, node_name;
  _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | data_node_3
 (6 rows)
 
-SELECT * FROM hypertable_detailed_size('compressed'::regclass) 
+SELECT * FROM hypertable_detailed_size('compressed'::regclass);
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
        16384 |       65536 |           0 |       81920 | data_node_1
@@ -332,3 +332,12 @@ SELECT * FROM hypertable_detailed_size('compressed'::regclass)
        16384 |       65536 |           0 |       81920 | data_node_2
 (3 rows)
 
+------------------------------------------------------
+-- Test compression policy on a distributed hypertable
+------------------------------------------------------
+INSERT INTO compressed VALUES 
+(now()::TIMESTAMPTZ, 1, 0.1), (now()::TIMESTAMPTZ, 2, 0.2);
+\set ON_ERROR_STOP 0
+SELECT add_compression_policy('compressed', '60d'::interval);
+ERROR:  can add compression policy only on hypertables with compression enabled
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -103,4 +103,15 @@ ORDER BY hypertable_name, dimension_number;
 
 SELECT * FROM chunks_detailed_size('compressed'::regclass) 
 ORDER BY chunk_name, node_name;
-SELECT * FROM hypertable_detailed_size('compressed'::regclass) 
+SELECT * FROM hypertable_detailed_size('compressed'::regclass);
+
+------------------------------------------------------
+-- Test compression policy on a distributed hypertable
+------------------------------------------------------
+
+INSERT INTO compressed VALUES 
+(now()::TIMESTAMPTZ, 1, 0.1), (now()::TIMESTAMPTZ, 2, 0.2);
+
+\set ON_ERROR_STOP 0
+SELECT add_compression_policy('compressed', '60d'::interval);
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Adds test of the compression policy on a distributed hypertable. 
Currently the policy cannot be added as the distributed hypertables 
are not marked with enabled compression.

Fixes error messages to use new name for compression policy.

**PR note**
Issue to support or block compression policy on distributed hypertable is https://github.com/timescale/timescaledb/issues/2193