### PR TITLE
Set invalidation threshold during continuous aggregate refresh

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -214,8 +214,8 @@ CREATE OR REPLACE FUNCTION  set_replication_factor(
 AS '@MODULE_PATHNAME@', 'ts_hypertable_distributed_set_replication_factor' LANGUAGE C VOLATILE;
 
 -- Refresh a continuous aggregate across the given window.
-CREATE OR REPLACE FUNCTION refresh_continuous_aggregate(
+CREATE OR REPLACE PROCEDURE refresh_continuous_aggregate(
     cagg                     REGCLASS,
     window_start             "any",
     window_end               "any"
-) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh' LANGUAGE C VOLATILE;
+) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh';

--- a/tsl/src/continuous_aggs/CMakeLists.txt
+++ b/tsl/src/continuous_aggs/CMakeLists.txt
@@ -7,5 +7,6 @@ set(SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/options.c
   ${CMAKE_CURRENT_SOURCE_DIR}/refresh.c
   ${CMAKE_CURRENT_SOURCE_DIR}/invalidation.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/invalidation_threshold.c
 )
 target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -1,0 +1,261 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include <access/htup_details.h>
+#include <access/htup.h>
+#include <access/xact.h>
+#include <nodes/memnodes.h>
+#include <storage/lockdefs.h>
+#include <storage/lmgr.h>
+#include <utils/memutils.h>
+#include <utils/snapmgr.h>
+
+#include <catalog.h>
+#include <scanner.h>
+#include <scan_iterator.h>
+#include <compat.h>
+
+#include "continuous_agg.h"
+#include "continuous_aggs/materialize.h"
+#include "invalidation_threshold.h"
+
+/*
+ * Invalidation threshold.
+ *
+ * The invalidation threshold acts as a dampener on a hypertable to make sure
+ * that invalidations written during inserts won't cause too much write
+ * amplification in "hot" regions---typically the "head" of the table. The
+ * presumption is that most inserts happen at recent time intervals, and those
+ * intervals will be invalid until writes move out of them. Therefore, it
+ * isnt't worth writing invalidations in that region since it is presumed
+ * out-of-date anyway. Further, although it is possible to refresh a
+ * continuous aggregate in those "hot" regions, it will lead to partially
+ * filled buckets. Thus, refreshing those intervals is discouraged since the
+ * aggregate will be immediately out-of-date until the buckets are filled. The
+ * invalidation threshold is, in other words, used as a marker that lags
+ * behind the head of the hypertable, where invalidations are written before
+ * the threshold but not after it.
+ *
+ * The invalidation threshold is moved forward (and only forward) by refreshes
+ * on continuous aggregates when it covers a window that streches beyond the
+ * current threshold. The invalidation threshold needs to be moved in its own
+ * transaction, with exclusive access, before the refresh starts to
+ * materialize data. This is to avoid losing any invalidations that occur
+ * between the start of the transaction that moves the threshold and its end
+ * (when the new threshold becomes visible).
+ *
+ * ______________________________________________
+ * |_______________________________________|_____| recent data
+ *                                        ^
+ *      invalidations written here        |  no invalidations
+ *                                        |
+ *                               invalidation threshold
+ *
+ */
+
+typedef struct InvalidationThresholdData
+{
+	int64 threshold;
+	bool was_updated;
+} InvalidationThresholdData;
+
+static ScanTupleResult
+scan_update_invalidation_threshold(TupleInfo *ti, void *data)
+{
+	InvalidationThresholdData *invthresh = data;
+	bool should_free;
+	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
+	Form_continuous_aggs_invalidation_threshold form =
+		(Form_continuous_aggs_invalidation_threshold) GETSTRUCT(tuple);
+
+	if (invthresh->threshold > form->watermark)
+	{
+		HeapTuple new_tuple = heap_copytuple(tuple);
+		form = (Form_continuous_aggs_invalidation_threshold) GETSTRUCT(new_tuple);
+
+		form->watermark = invthresh->threshold;
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
+		invthresh->was_updated = true;
+	}
+	else
+	{
+		elog(DEBUG1,
+			 "hypertable %d existing  watermark >= new invalidation threshold " INT64_FORMAT
+			 " " INT64_FORMAT,
+			 form->hypertable_id,
+			 form->watermark,
+			 invthresh->threshold);
+	}
+
+	if (should_free)
+		heap_freetuple(tuple);
+
+	return SCAN_DONE;
+}
+
+/* every cont. agg calculates its invalidation_threshold point based on its
+ *refresh_lag etc. We update the raw hypertable's invalidation threshold
+ * only if this new value is greater than the existsing one.
+ */
+bool
+continuous_agg_invalidation_threshold_set(int32 raw_hypertable_id, int64 invalidation_threshold)
+{
+	bool threshold_found;
+	InvalidationThresholdData data = {
+		.threshold = invalidation_threshold,
+		.was_updated = false,
+	};
+	ScanKeyData scankey[1];
+
+	ScanKeyInit(&scankey[0],
+				Anum_continuous_aggs_invalidation_threshold_pkey_hypertable_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(raw_hypertable_id));
+
+	/* NOTE: this function deliberately takes an AccessExclusiveLock when updating the invalidation
+	 * threshold, instead of the weaker RowExclusiveLock lock normally held for such operations: in
+	 * order to ensure we do not lose invalidations from concurrent mutations, we must ensure that
+	 * all transactions which read the invalidation threshold have either completed, or not yet read
+	 * the value; if we used a RowExclusiveLock we could race such a transaction and update the
+	 * threshold between the time it is read but before the other transaction commits. This would
+	 * cause us to lose the updates. The AccessExclusiveLock ensures no one else can possibly be
+	 * reading the threshold.
+	 */
+	threshold_found =
+		ts_catalog_scan_one(CONTINUOUS_AGGS_INVALIDATION_THRESHOLD /*=table*/,
+							CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_PKEY /*=indexid*/,
+							scankey /*=scankey*/,
+							1 /*=num_keys*/,
+							scan_update_invalidation_threshold /*=tuple_found*/,
+							AccessExclusiveLock /*=lockmode*/,
+							CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_TABLE_NAME /*=table_name*/,
+							&data /*=data*/);
+
+	if (!threshold_found)
+	{
+		Catalog *catalog = ts_catalog_get();
+		/* NOTE: this function deliberately takes a stronger lock than RowExclusive, see the comment
+		 * above for the rationale
+		 */
+		Relation rel =
+			table_open(catalog_get_table_id(catalog, CONTINUOUS_AGGS_INVALIDATION_THRESHOLD),
+					   AccessExclusiveLock);
+		TupleDesc desc = RelationGetDescr(rel);
+		Datum values[Natts_continuous_aggs_invalidation_threshold];
+		bool nulls[Natts_continuous_aggs_invalidation_threshold] = { false };
+
+		values[AttrNumberGetAttrOffset(Anum_continuous_aggs_invalidation_threshold_hypertable_id)] =
+			Int32GetDatum(raw_hypertable_id);
+		values[AttrNumberGetAttrOffset(Anum_continuous_aggs_invalidation_threshold_watermark)] =
+			Int64GetDatum(invalidation_threshold);
+
+		ts_catalog_insert_values(rel, desc, values, nulls);
+		table_close(rel, NoLock);
+		data.was_updated = true;
+	}
+
+	return data.was_updated;
+}
+
+static ScanTupleResult
+invalidation_threshold_tuple_found(TupleInfo *ti, void *data)
+{
+	int64 *threshold = data;
+	bool isnull;
+	Datum datum =
+		slot_getattr(ti->slot, Anum_continuous_aggs_invalidation_threshold_watermark, &isnull);
+
+	Assert(!isnull);
+	*threshold = DatumGetInt64(datum);
+
+	return SCAN_CONTINUE;
+}
+
+int64
+continuous_agg_invalidation_threshold_get(int32 hypertable_id)
+{
+	int64 threshold = 0;
+	ScanKeyData scankey[1];
+
+	ScanKeyInit(&scankey[0],
+				Anum_continuous_aggs_invalidation_threshold_pkey_hypertable_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(hypertable_id));
+
+	if (!ts_catalog_scan_one(CONTINUOUS_AGGS_INVALIDATION_THRESHOLD /*=table*/,
+							 CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_PKEY /*=indexid*/,
+							 scankey /*=scankey*/,
+							 1 /*=num_keys*/,
+							 invalidation_threshold_tuple_found /*=tuple_found*/,
+							 AccessShareLock /*=lockmode*/,
+							 CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_TABLE_NAME /*=table_name*/,
+							 &threshold /*=data*/))
+		elog(ERROR, "could not find invalidation threshold for hypertable %d", hypertable_id);
+
+	return threshold;
+}
+
+static ScanTupleResult
+invalidation_threshold_htid_found(TupleInfo *tinfo, void *data)
+{
+	if (tinfo->lockresult != TM_Ok)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not acquire lock for invalidation threshold row %d",
+						tinfo->lockresult),
+				 errhint("Retry the operation again.")));
+	}
+	return SCAN_DONE;
+}
+
+/* lock row corresponding to hypertable id in
+ * continuous_aggs_invalidation_threshold table in AccessExclusive mode,
+ * block till lock is acquired.
+ */
+void
+continuous_agg_invalidation_threshold_lock(int32 raw_hypertable_id)
+{
+	ScanTupLock scantuplock = {
+		.waitpolicy = LockWaitBlock,
+		.lockmode = LockTupleExclusive,
+	};
+	Catalog *catalog = ts_catalog_get();
+	ScanKeyData scankey[1];
+	int retcnt = 0;
+	ScannerCtx scanctx;
+
+	ScanKeyInit(&scankey[0],
+				Anum_continuous_aggs_invalidation_threshold_pkey_hypertable_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(raw_hypertable_id));
+
+	/* lock table in AccessShare mode and the row with AccessExclusive */
+	scanctx = (ScannerCtx){ .table = catalog_get_table_id(catalog,
+														  CONTINUOUS_AGGS_INVALIDATION_THRESHOLD),
+							.index = catalog_get_index(catalog,
+													   CONTINUOUS_AGGS_INVALIDATION_THRESHOLD,
+													   CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_PKEY),
+							.nkeys = 1,
+							.scankey = scankey,
+							.limit = 1,
+							.tuple_found = invalidation_threshold_htid_found,
+							.lockmode = AccessShareLock,
+							.scandirection = ForwardScanDirection,
+							.result_mctx = CurrentMemoryContext,
+							.tuplock = &scantuplock };
+	retcnt = ts_scanner_scan(&scanctx);
+	if (retcnt > 1)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("found multiple invalidation rows for hypertable %d", raw_hypertable_id)));
+	}
+}

--- a/tsl/src/continuous_aggs/invalidation_threshold.h
+++ b/tsl/src/continuous_aggs/invalidation_threshold.h
@@ -1,0 +1,16 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_H
+#define TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_H
+
+#include <postgres.h>
+
+extern int64 continuous_agg_invalidation_threshold_get(int32 hypertable_id);
+extern bool continuous_agg_invalidation_threshold_set(int32 raw_hypertable_id,
+													  int64 invalidation_threshold);
+extern void continuous_agg_invalidation_threshold_lock(int32 raw_hypertable_id);
+
+#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_H */

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -55,5 +55,7 @@ void continuous_agg_update_materialization(SchemaAndName partial_view,
 										   InternalTimeRange new_materialization_range,
 										   InternalTimeRange invalidation_range,
 										   int64 bucket_width);
+bool continuous_agg_invalidation_threshold_set(int32 raw_hypertable_id,
+											   int64 invalidation_threshold);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H */

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -42,7 +42,6 @@ typedef struct InternalTimeRange
 	int64 end;   /* exclusive */
 } InternalTimeRange;
 
-int64 invalidation_threshold_get(int32 raw_hypertable_id);
 bool continuous_agg_materialize(int32 materialization_id, ContinuousAggMatOptions *options);
 void continuous_agg_execute_materialization(int64 bucket_width, int32 hypertable_id,
 											int32 materialization_id, SchemaAndName partial_view,
@@ -55,7 +54,5 @@ void continuous_agg_update_materialization(SchemaAndName partial_view,
 										   InternalTimeRange new_materialization_range,
 										   InternalTimeRange invalidation_range,
 										   int64 bucket_width);
-bool continuous_agg_invalidation_threshold_set(int32 raw_hypertable_id,
-											   int64 invalidation_threshold);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H */

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -23,6 +23,7 @@
 #include "refresh.h"
 #include "materialize.h"
 #include "invalidation.h"
+#include "invalidation_threshold.h"
 
 typedef struct CaggRefreshState
 {

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -89,13 +89,19 @@ get_max_window(Oid timetype)
 			maxrange.start = MIN_TIMESTAMP;
 			maxrange.end = (END_TIMESTAMP - TS_EPOCH_DIFF_MICROSECONDS) - 1;
 			break;
-		case INT8OID:
-		case INT4OID:
-		case INT2OID:
 			/* There is no "date"/"time" range for integers so they can take
 			 * any value. */
+		case INT8OID:
 			maxrange.start = PG_INT64_MIN;
 			maxrange.end = PG_INT64_MAX;
+			break;
+		case INT4OID:
+			maxrange.start = PG_INT32_MIN;
+			maxrange.end = PG_INT32_MAX;
+			break;
+		case INT2OID:
+			maxrange.start = PG_INT16_MIN;
+			maxrange.end = PG_INT16_MAX;
 			break;
 		default:
 			elog(ERROR, "unrecognized time type %d", timetype);

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -195,12 +195,7 @@ SELECT hypertable_id AS hyper_id,
 -- First refresh a window where we don't have any invalidations. This
 -- allows us to see only the copying of the invalidations to the per
 -- cagg log without additional processing.
-SELECT refresh_continuous_aggregate('cond_10', 20, 60);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('cond_10', 20, 60);
 -- Invalidations should be moved from the hypertable invalidation log
 -- to the continuous aggregate log, but only for the hypertable that
 -- the refreshed aggregate belongs to:
@@ -283,12 +278,7 @@ SELECT materialization_id AS cagg_id,
 (6 rows)
 
 -- Refresh to process invalidations for daily temperature:
-SELECT refresh_continuous_aggregate('cond_10', 20, 60);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('cond_10', 20, 60);
 -- Invalidations should be moved from the hypertable invalidation log
 -- to the continuous aggregate log.
 SELECT hypertable_id AS hyper_id,
@@ -335,12 +325,7 @@ SELECT materialization_id AS cagg_id,
 (22 rows)
 
 -- Refresh also cond_20:
-SELECT refresh_continuous_aggregate('cond_20', 20, 60);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('cond_20', 20, 60);
 -- The cond_20 cagg should also have its entries cut:
 SELECT materialization_id AS cagg_id,
        lowest_modified_value AS start,

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -130,10 +130,54 @@ ORDER BY day DESC, device;
 -----+--------+----------
 (0 rows)
 
--- Must refresh with "legacy" functionality to move the invalidation
--- threshold, or no invalidations will be generated.
-REFRESH MATERIALIZED VIEW cond_10;
-REFRESH MATERIALIZED VIEW measure_10;
+-- Must refresh to move the invalidation threshold, or no
+-- invalidations will be generated. Initially, there is no threshold
+-- set:
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+(0 rows)
+
+-- Now refresh up to 50, and the threshold should be updated accordingly:
+CALL refresh_continuous_aggregate('cond_10', 1, 50);
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             1 |        50
+(1 row)
+
+-- Refreshing below the threshold does not move it:
+CALL refresh_continuous_aggregate('cond_10', 20, 49);
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             1 |        50
+(1 row)
+
+-- Refreshing measure_10 moves the threshold only for the other hypertable:
+CALL refresh_continuous_aggregate('measure_10', 1, 30);
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             1 |        50
+             2 |        30
+(2 rows)
+
+-- Refresh on the second continuous aggregate, cond_20, on the first
+-- hypertable moves the same threshold as when refreshing cond_10:
+CALL refresh_continuous_aggregate('cond_20', 60, 100);
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             1 |       100
+             2 |        30
+(2 rows)
+
 -- There should be no invalidations initially:
 SELECT hypertable_id AS hyper_id,
        lowest_modified_value AS start,
@@ -189,13 +233,21 @@ SELECT hypertable_id AS hyper_id,
         1 |    10 |  19
         1 |    60 |  70
         2 |    20 |  20
-        2 |    30 |  80
-(5 rows)
+(4 rows)
 
 -- First refresh a window where we don't have any invalidations. This
 -- allows us to see only the copying of the invalidations to the per
 -- cagg log without additional processing.
 CALL refresh_continuous_aggregate('cond_10', 20, 60);
+-- Invalidation threshold remains at 100:
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             1 |       100
+             2 |        30
+(2 rows)
+
 -- Invalidations should be moved from the hypertable invalidation log
 -- to the continuous aggregate log, but only for the hypertable that
 -- the refreshed aggregate belongs to:
@@ -207,8 +259,7 @@ SELECT hypertable_id AS hyper_id,
  hyper_id | start | end 
 ----------+-------+-----
         2 |    20 |  20
-        2 |    30 |  80
-(2 rows)
+(1 row)
 
 SELECT materialization_id AS cagg_id,
        lowest_modified_value AS start,
@@ -258,8 +309,7 @@ SELECT hypertable_id AS hyper_id,
         1 |    30 |  59
         1 |    60 |  90
         2 |    20 |  20
-        2 |    30 |  80
-(10 rows)
+(9 rows)
 
 -- But nothing has yet changed in the cagg invalidation log:
 SELECT materialization_id AS cagg_id,
@@ -289,8 +339,7 @@ SELECT hypertable_id AS hyper_id,
  hyper_id | start | end 
 ----------+-------+-----
         2 |    20 |  20
-        2 |    30 |  80
-(2 rows)
+(1 row)
 
 -- Only the cond_10 cagg should have its entries cut:
 SELECT materialization_id AS cagg_id,

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -60,12 +60,7 @@ ORDER BY day DESC, device;
 (0 rows)
 
 -- Refresh the most recent few days:
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-05');
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-05');
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;
              day              | device |     avg_temp     
@@ -85,12 +80,7 @@ ORDER BY day DESC, device;
 (12 rows)
 
 -- Refresh the rest
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-03');
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-03');
 -- Compare the aggregate to the equivalent query on the source table
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;
@@ -147,68 +137,48 @@ ORDER BY 1 DESC,2;
 (20 rows)
 
 -- Test unusual, but valid input
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01'::timestamptz, '2020-05-03'::date);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'::date);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
-SELECT refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::timestamptz, '2020-05-03'::date);
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'::date);
+CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
 -- Unbounded window forward in time
 \set ON_ERROR_STOP 0
 -- Currently doesn't work due to timestamp overflow bug in a query optimization
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
 ERROR:  timestamp out of range
-SELECT refresh_continuous_aggregate('daily_temp', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
 ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
 -- Unbounded window back in time
-SELECT refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');
 -- Test bad input
 \set ON_ERROR_STOP 0
 -- Bad continuous aggregate name
-SELECT refresh_continuous_aggregate(NULL, '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate(NULL, '2020-05-03', '2020-05-05');
 ERROR:  invalid continuous aggregate
-SELECT refresh_continuous_aggregate('xyz', '2020-05-03', '2020-05-05');
-ERROR:  relation "xyz" does not exist at character 37
+CALL refresh_continuous_aggregate('xyz', '2020-05-03', '2020-05-05');
+ERROR:  relation "xyz" does not exist at character 35
 -- Valid object, but not a continuous aggregate
-SELECT refresh_continuous_aggregate('conditions', '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate('conditions', '2020-05-03', '2020-05-05');
 ERROR:  relation "conditions" is not a continuous aggregate
 -- Object ID with no object
-SELECT refresh_continuous_aggregate(1, '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate(1, '2020-05-03', '2020-05-05');
 ERROR:  continuous aggregate does not exist
 -- Lacking arguments
-SELECT refresh_continuous_aggregate('daily_temp');
-ERROR:  function refresh_continuous_aggregate(unknown) does not exist at character 8
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03');
-ERROR:  function refresh_continuous_aggregate(unknown, unknown) does not exist at character 8
+CALL refresh_continuous_aggregate('daily_temp');
+ERROR:  procedure refresh_continuous_aggregate(unknown) does not exist at character 6
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03');
+ERROR:  procedure refresh_continuous_aggregate(unknown, unknown) does not exist at character 6
 -- Bad time ranges
-SELECT refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
+CALL refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
 ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
 ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
 ERROR:  invalid refresh window
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-03');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-03');
 ERROR:  invalid refresh window
 -- Bad time input
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
 ERROR:  unknown time type OID 25
 \set ON_ERROR_STOP 1
 -- Test different time types
@@ -227,12 +197,7 @@ SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions_date
 GROUP BY 1,2;
 NOTICE:  adding index _materialized_hypertable_4_device_day_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, day)
-SELECT refresh_continuous_aggregate('daily_temp_date', '2020-05-01', '2020-05-03');
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('daily_temp_date', '2020-05-01', '2020-05-03');
 -- Test smallint-based continuous aggregate
 CREATE TABLE conditions_smallint (time smallint NOT NULL, device int, temp float);
 SELECT create_hypertable('conditions_smallint', 'time', chunk_time_interval => 20);
@@ -264,12 +229,7 @@ SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
 GROUP BY 1,2;
 NOTICE:  adding index _materialized_hypertable_6_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, bucket)
-SELECT refresh_continuous_aggregate('cond_20_smallint', 5, 50);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('cond_20_smallint', 5, 50);
 SELECT * FROM cond_20_smallint
 ORDER BY 1,2;
  bucket | device |     avg_temp     
@@ -319,12 +279,7 @@ SELECT time_bucket(INT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_int
 GROUP BY 1,2;
 NOTICE:  adding index _materialized_hypertable_8_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, bucket)
-SELECT refresh_continuous_aggregate('cond_20_int', 5, 50);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('cond_20_int', 5, 50);
 SELECT * FROM cond_20_int
 ORDER BY 1,2;
  bucket | device |     avg_temp     
@@ -374,12 +329,7 @@ SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_bigint
 GROUP BY 1,2;
 NOTICE:  adding index _materialized_hypertable_10_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(device, bucket)
-SELECT refresh_continuous_aggregate('cond_20_bigint', 5, 50);
- refresh_continuous_aggregate 
-------------------------------
- 
-(1 row)
-
+CALL refresh_continuous_aggregate('cond_20_bigint', 5, 50);
 SELECT * FROM cond_20_bigint
 ORDER BY 1,2;
  bucket | device |     avg_temp     

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -233,36 +233,168 @@ SELECT refresh_continuous_aggregate('daily_temp_date', '2020-05-01', '2020-05-03
  
 (1 row)
 
-CREATE TABLE conditions_int (time int NOT NULL, device int, temp float);
-SELECT create_hypertable('conditions_int', 'time', chunk_time_interval => 10);
-      create_hypertable      
------------------------------
- (5,public,conditions_int,t)
+-- Test smallint-based continuous aggregate
+CREATE TABLE conditions_smallint (time smallint NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions_smallint', 'time', chunk_time_interval => 20);
+        create_hypertable         
+----------------------------------
+ (5,public,conditions_smallint,t)
 (1 row)
 
-CREATE OR REPLACE FUNCTION integer_now_conditions()
-RETURNS int LANGUAGE SQL STABLE AS
+INSERT INTO conditions_smallint
+SELECT t, ceil(abs(timestamp_hash(to_timestamp(t)::timestamp))%4)::smallint, abs(timestamp_hash(to_timestamp(t)::timestamp))%40
+FROM generate_series(1, 100, 1) t;
+CREATE OR REPLACE FUNCTION smallint_now()
+RETURNS smallint LANGUAGE SQL STABLE AS
 $$
-    SELECT coalesce(max(time), 0)
-    FROM conditions_int
+    SELECT coalesce(max(time), 0)::smallint
+    FROM conditions_smallint
 $$;
-SELECT set_integer_now_func('conditions_int', 'integer_now_conditions');
+SELECT set_integer_now_func('conditions_smallint', 'smallint_now');
  set_integer_now_func 
 ----------------------
  
 (1 row)
 
-CREATE VIEW daily_temp_int
+CREATE VIEW cond_20_smallint
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
-SELECT time_bucket(4, time) AS day, device, avg(temp) AS avg_temp
-FROM conditions_int
+SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions_smallint c
 GROUP BY 1,2;
-NOTICE:  adding index _materialized_hypertable_6_device_day_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, day)
-SELECT refresh_continuous_aggregate('daily_temp_int', 5, 10);
+NOTICE:  adding index _materialized_hypertable_6_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, bucket)
+SELECT refresh_continuous_aggregate('cond_20_smallint', 5, 50);
  refresh_continuous_aggregate 
 ------------------------------
  
 (1 row)
+
+SELECT * FROM cond_20_smallint
+ORDER BY 1,2;
+ bucket | device |     avg_temp     
+--------+--------+------------------
+      0 |      0 |                6
+      0 |      1 |               19
+      0 |      2 |             14.5
+      0 |      3 |             21.4
+     20 |      0 |               15
+     20 |      1 |               16
+     20 |      2 | 23.3333333333333
+     20 |      3 | 13.6666666666667
+     40 |      0 |               21
+     40 |      1 |             19.4
+     40 |      2 |               22
+     40 |      3 |             21.4
+(12 rows)
+
+-- Test int-based continuous aggregate
+CREATE TABLE conditions_int (time int NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions_int', 'time', chunk_time_interval => 20);
+      create_hypertable      
+-----------------------------
+ (7,public,conditions_int,t)
+(1 row)
+
+INSERT INTO conditions_int
+SELECT t, ceil(abs(timestamp_hash(to_timestamp(t)::timestamp))%4)::int, abs(timestamp_hash(to_timestamp(t)::timestamp))%40
+FROM generate_series(1, 100, 1) t;
+CREATE OR REPLACE FUNCTION int_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM conditions_int
+$$;
+SELECT set_integer_now_func('conditions_int', 'int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE VIEW cond_20_int
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(INT '20', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions_int
+GROUP BY 1,2;
+NOTICE:  adding index _materialized_hypertable_8_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, bucket)
+SELECT refresh_continuous_aggregate('cond_20_int', 5, 50);
+ refresh_continuous_aggregate 
+------------------------------
+ 
+(1 row)
+
+SELECT * FROM cond_20_int
+ORDER BY 1,2;
+ bucket | device |     avg_temp     
+--------+--------+------------------
+      0 |      0 |                6
+      0 |      1 |               19
+      0 |      2 |             14.5
+      0 |      3 |             21.4
+     20 |      0 |               15
+     20 |      1 |               16
+     20 |      2 | 23.3333333333333
+     20 |      3 | 13.6666666666667
+     40 |      0 |               21
+     40 |      1 |             19.4
+     40 |      2 |               22
+     40 |      3 |             21.4
+(12 rows)
+
+-- Test bigint-based continuous aggregate
+CREATE TABLE conditions_bigint (time bigint NOT NULL, device int, temp float);
+SELECT create_hypertable('conditions_bigint', 'time', chunk_time_interval => 20);
+       create_hypertable        
+--------------------------------
+ (9,public,conditions_bigint,t)
+(1 row)
+
+INSERT INTO conditions_bigint
+SELECT t, ceil(abs(timestamp_hash(to_timestamp(t)::timestamp))%4)::bigint, abs(timestamp_hash(to_timestamp(t)::timestamp))%40
+FROM generate_series(1, 100, 1) t;
+CREATE OR REPLACE FUNCTION bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)::bigint
+    FROM conditions_bigint
+$$;
+SELECT set_integer_now_func('conditions_bigint', 'bigint_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE VIEW cond_20_bigint
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions_bigint
+GROUP BY 1,2;
+NOTICE:  adding index _materialized_hypertable_10_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(device, bucket)
+SELECT refresh_continuous_aggregate('cond_20_bigint', 5, 50);
+ refresh_continuous_aggregate 
+------------------------------
+ 
+(1 row)
+
+SELECT * FROM cond_20_bigint
+ORDER BY 1,2;
+ bucket | device |     avg_temp     
+--------+--------+------------------
+      0 |      0 |                6
+      0 |      1 |               19
+      0 |      2 |             14.5
+      0 |      3 |             21.4
+     20 |      0 |               15
+     20 |      1 |               16
+     20 |      2 | 23.3333333333333
+     20 |      3 | 13.6666666666667
+     40 |      0 |               21
+     40 |      1 |             19.4
+     40 |      2 |               22
+     40 |      3 |             21.4
+(12 rows)
 

--- a/tsl/test/isolation/expected/continuous_aggs_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/continuous_aggs_concurrent_refresh.out
@@ -1,194 +1,393 @@
-Parsed test spec with 5 sessions
+Parsed test spec with 8 sessions
 
-starting permutation: R1_refresh R1_commit S1_select R2_commit R3_commit R4_commit
+starting permutation: R1_refresh S1_select R3_refresh S1_select L2_read_unlock_threshold_table L3_unlock_cagg_table L1_unlock_threshold_table
 step R1_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-02');
-
-refresh_continuous_aggregate
-
-               
-step R1_commit: 
-    COMMIT;
+    CALL refresh_continuous_aggregate('cond_10', 35, 62);
 
 step S1_select: 
-    SELECT day, avg_temp
-    FROM daily_temp
+    SELECT bucket, avg_temp
+    FROM cond_10
     ORDER BY 1;
 
-    SELECT * FROM cagg_bucket_count('daily_temp');
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
 
-day            avg_temp       
+bucket         avg_temp       
 
-Thu Apr 30 17:00:00 2020 PDT18.4411764705882
-Fri May 01 17:00:00 2020 PDT18.8541666666667
+30             18.3           
+40             15.1           
+50             26.9           
+60             18.9           
 cagg_bucket_count
 
-2              
-step R2_commit: 
-    COMMIT;
+4              
+hypertable     threshold      
 
-step R3_commit: 
-    COMMIT;
+conditions     62             
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 71, 97);
 
-step R4_commit: 
-    COMMIT;
+step S1_select: 
+    SELECT bucket, avg_temp
+    FROM cond_10
+    ORDER BY 1;
+
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
+
+bucket         avg_temp       
+
+30             18.3           
+40             15.1           
+50             26.9           
+60             18.9           
+70             24.6           
+80             23.6           
+90             21.3           
+cagg_bucket_count
+
+7              
+hypertable     threshold      
+
+conditions     97             
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
+
+step L3_unlock_cagg_table: 
+    ROLLBACK;
+
+step L1_unlock_threshold_table: 
+    ROLLBACK;
 
 
-starting permutation: R1_refresh R2_refresh R1_commit R2_commit S1_select R3_commit R4_commit
-step R1_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-02');
+starting permutation: L2_read_lock_threshold_table R3_refresh L2_read_unlock_threshold_table S1_select L3_unlock_cagg_table L1_unlock_threshold_table
+step L2_read_lock_threshold_table: 
+    LOCK _timescaledb_catalog.continuous_aggs_invalidation_threshold
+    IN ACCESS SHARE MODE;
 
-refresh_continuous_aggregate
-
-               
-step R2_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-02');
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 71, 97);
  <waiting ...>
-step R1_commit: 
-    COMMIT;
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
 
-step R2_refresh: <... completed>
-refresh_continuous_aggregate
-
-               
-step R2_commit: 
-    COMMIT;
-
+step R3_refresh: <... completed>
 step S1_select: 
-    SELECT day, avg_temp
-    FROM daily_temp
+    SELECT bucket, avg_temp
+    FROM cond_10
     ORDER BY 1;
 
-    SELECT * FROM cagg_bucket_count('daily_temp');
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
 
-day            avg_temp       
+bucket         avg_temp       
 
-Thu Apr 30 17:00:00 2020 PDT18.4411764705882
-Fri May 01 17:00:00 2020 PDT18.8541666666667
+70             24.6           
+80             23.6           
+90             21.3           
 cagg_bucket_count
 
-2              
-step R3_commit: 
-    COMMIT;
+3              
+hypertable     threshold      
 
-step R4_commit: 
-    COMMIT;
+conditions     97             
+step L3_unlock_cagg_table: 
+    ROLLBACK;
+
+step L1_unlock_threshold_table: 
+    ROLLBACK;
 
 
-starting permutation: R1_refresh R2_refresh R2_commit R1_commit S1_select R3_commit R4_commit
+starting permutation: R1_refresh L2_read_lock_threshold_table R3_refresh L2_read_unlock_threshold_table S1_select L3_unlock_cagg_table L1_unlock_threshold_table
 step R1_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-02');
+    CALL refresh_continuous_aggregate('cond_10', 35, 62);
 
-refresh_continuous_aggregate
+step L2_read_lock_threshold_table: 
+    LOCK _timescaledb_catalog.continuous_aggs_invalidation_threshold
+    IN ACCESS SHARE MODE;
 
-               
-step R2_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-02');
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 71, 97);
  <waiting ...>
-step R2_refresh: <... completed>
-ERROR:  canceling statement due to lock timeout
-step R2_commit: 
-    COMMIT;
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
 
-step R1_commit: 
-    COMMIT;
-
+step R3_refresh: <... completed>
 step S1_select: 
-    SELECT day, avg_temp
-    FROM daily_temp
+    SELECT bucket, avg_temp
+    FROM cond_10
     ORDER BY 1;
 
-    SELECT * FROM cagg_bucket_count('daily_temp');
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
 
-day            avg_temp       
+bucket         avg_temp       
 
-Thu Apr 30 17:00:00 2020 PDT18.4411764705882
-Fri May 01 17:00:00 2020 PDT18.8541666666667
+30             18.3           
+40             15.1           
+50             26.9           
+60             18.9           
+70             24.6           
+80             23.6           
+90             21.3           
 cagg_bucket_count
 
-2              
-step R3_commit: 
-    COMMIT;
+7              
+hypertable     threshold      
 
-step R4_commit: 
-    COMMIT;
+conditions     97             
+step L3_unlock_cagg_table: 
+    ROLLBACK;
+
+step L1_unlock_threshold_table: 
+    ROLLBACK;
 
 
-starting permutation: R1_refresh R3_refresh R3_commit R1_commit S1_select R2_commit R4_commit
+starting permutation: R3_refresh L2_read_lock_threshold_table R1_refresh L2_read_unlock_threshold_table S1_select L3_unlock_cagg_table L1_unlock_threshold_table
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 71, 97);
+
+step L2_read_lock_threshold_table: 
+    LOCK _timescaledb_catalog.continuous_aggs_invalidation_threshold
+    IN ACCESS SHARE MODE;
+
 step R1_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-02');
+    CALL refresh_continuous_aggregate('cond_10', 35, 62);
+ <waiting ...>
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
 
-refresh_continuous_aggregate
+step R1_refresh: <... completed>
+step S1_select: 
+    SELECT bucket, avg_temp
+    FROM cond_10
+    ORDER BY 1;
+
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
+
+bucket         avg_temp       
+
+30             18.3           
+40             15.1           
+50             26.9           
+60             18.9           
+70             24.6           
+80             23.6           
+90             21.3           
+cagg_bucket_count
+
+7              
+hypertable     threshold      
+
+conditions     97             
+step L3_unlock_cagg_table: 
+    ROLLBACK;
+
+step L1_unlock_threshold_table: 
+    ROLLBACK;
+
+
+starting permutation: L3_lock_cagg_table R1_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+step L3_lock_cagg_table: 
+    SELECT lock_cagg('cond_10');
+
+lock_cagg      
+
+               
+step R1_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 35, 62);
+ <waiting ...>
+step L3_unlock_cagg_table: 
+    ROLLBACK;
+
+step R1_refresh: <... completed>
+step S1_select: 
+    SELECT bucket, avg_temp
+    FROM cond_10
+    ORDER BY 1;
+
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
+
+bucket         avg_temp       
+
+30             18.3           
+40             15.1           
+50             26.9           
+60             18.9           
+cagg_bucket_count
+
+4              
+hypertable     threshold      
+
+conditions     62             
+step L1_unlock_threshold_table: 
+    ROLLBACK;
+
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
+
+
+starting permutation: L3_lock_cagg_table R1_refresh R2_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+step L3_lock_cagg_table: 
+    SELECT lock_cagg('cond_10');
+
+lock_cagg      
+
+               
+step R1_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 35, 62);
+ <waiting ...>
+step R2_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 35, 62);
+ <waiting ...>
+step L3_unlock_cagg_table: 
+    ROLLBACK;
+
+step R1_refresh: <... completed>
+step R2_refresh: <... completed>
+step S1_select: 
+    SELECT bucket, avg_temp
+    FROM cond_10
+    ORDER BY 1;
+
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
+
+bucket         avg_temp       
+
+30             18.3           
+40             15.1           
+50             26.9           
+60             18.9           
+cagg_bucket_count
+
+4              
+hypertable     threshold      
+
+conditions     62             
+step L1_unlock_threshold_table: 
+    ROLLBACK;
+
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
+
+
+starting permutation: L3_lock_cagg_table R1_refresh R3_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+step L3_lock_cagg_table: 
+    SELECT lock_cagg('cond_10');
+
+lock_cagg      
+
+               
+step R1_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 35, 62);
+ <waiting ...>
+step R3_refresh: 
+    CALL refresh_continuous_aggregate('cond_10', 71, 97);
+ <waiting ...>
+step L3_unlock_cagg_table: 
+    ROLLBACK;
+
+step R1_refresh: <... completed>
+step R3_refresh: <... completed>
+step S1_select: 
+    SELECT bucket, avg_temp
+    FROM cond_10
+    ORDER BY 1;
+
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
+
+bucket         avg_temp       
+
+30             18.3           
+40             15.1           
+50             26.9           
+60             18.9           
+70             24.6           
+80             23.6           
+90             21.3           
+cagg_bucket_count
+
+7              
+hypertable     threshold      
+
+conditions     97             
+step L1_unlock_threshold_table: 
+    ROLLBACK;
+
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
+
+
+starting permutation: L3_lock_cagg_table R3_refresh R4_refresh L3_unlock_cagg_table S1_select L1_unlock_threshold_table L2_read_unlock_threshold_table
+step L3_lock_cagg_table: 
+    SELECT lock_cagg('cond_10');
+
+lock_cagg      
 
                
 step R3_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-08', '2020-05-10');
+    CALL refresh_continuous_aggregate('cond_10', 71, 97);
  <waiting ...>
-step R3_refresh: <... completed>
-ERROR:  canceling statement due to lock timeout
-step R3_commit: 
-    COMMIT;
-
-step R1_commit: 
-    COMMIT;
-
-step S1_select: 
-    SELECT day, avg_temp
-    FROM daily_temp
-    ORDER BY 1;
-
-    SELECT * FROM cagg_bucket_count('daily_temp');
-
-day            avg_temp       
-
-Thu Apr 30 17:00:00 2020 PDT18.4411764705882
-Fri May 01 17:00:00 2020 PDT18.8541666666667
-cagg_bucket_count
-
-2              
-step R2_commit: 
-    COMMIT;
-
-step R4_commit: 
-    COMMIT;
-
-
-starting permutation: R1_refresh R4_refresh R4_commit R1_commit S1_select R2_commit R3_commit
-step R1_refresh: 
-    SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-02');
-
-refresh_continuous_aggregate
-
-               
 step R4_refresh: 
-    SELECT refresh_continuous_aggregate('weekly_temp', '2020-05-01', '2020-05-10');
+    CALL refresh_continuous_aggregate('cond_20', 39, 84);
 
-refresh_continuous_aggregate
+step L3_unlock_cagg_table: 
+    ROLLBACK;
 
-               
-step R4_commit: 
-    COMMIT;
-
-step R1_commit: 
-    COMMIT;
-
+step R3_refresh: <... completed>
 step S1_select: 
-    SELECT day, avg_temp
-    FROM daily_temp
+    SELECT bucket, avg_temp
+    FROM cond_10
     ORDER BY 1;
 
-    SELECT * FROM cagg_bucket_count('daily_temp');
+    SELECT * FROM cagg_bucket_count('cond_10');
+    SELECT h.table_name AS hypertable, it.watermark AS threshold
+    FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold it,
+    _timescaledb_catalog.hypertable h
+    WHERE it.hypertable_id = h.id;
 
-day            avg_temp       
+bucket         avg_temp       
 
-Thu Apr 30 17:00:00 2020 PDT18.4411764705882
-Fri May 01 17:00:00 2020 PDT18.8541666666667
+70             24.6           
+80             23.6           
+90             21.3           
 cagg_bucket_count
 
-2              
-step R2_commit: 
-    COMMIT;
+3              
+hypertable     threshold      
 
-step R3_commit: 
-    COMMIT;
+conditions     97             
+step L1_unlock_threshold_table: 
+    ROLLBACK;
+
+step L2_read_unlock_threshold_table: 
+    ROLLBACK;
 

--- a/tsl/test/sql/continuous_aggs_invalidation.sql
+++ b/tsl/test/sql/continuous_aggs_invalidation.sql
@@ -135,7 +135,7 @@ SELECT hypertable_id AS hyper_id,
 -- First refresh a window where we don't have any invalidations. This
 -- allows us to see only the copying of the invalidations to the per
 -- cagg log without additional processing.
-SELECT refresh_continuous_aggregate('cond_10', 20, 60);
+CALL refresh_continuous_aggregate('cond_10', 20, 60);
 
 -- Invalidations should be moved from the hypertable invalidation log
 -- to the continuous aggregate log, but only for the hypertable that
@@ -184,7 +184,7 @@ SELECT materialization_id AS cagg_id,
        ORDER BY 1,2,3;
 
 -- Refresh to process invalidations for daily temperature:
-SELECT refresh_continuous_aggregate('cond_10', 20, 60);
+CALL refresh_continuous_aggregate('cond_10', 20, 60);
 
 -- Invalidations should be moved from the hypertable invalidation log
 -- to the continuous aggregate log.
@@ -202,7 +202,7 @@ SELECT materialization_id AS cagg_id,
        ORDER BY 1,2,3;
 
 -- Refresh also cond_20:
-SELECT refresh_continuous_aggregate('cond_20', 20, 60);
+CALL refresh_continuous_aggregate('cond_20', 20, 60);
 
 -- The cond_20 cagg should also have its entries cut:
 SELECT materialization_id AS cagg_id,

--- a/tsl/test/sql/continuous_aggs_refresh.sql
+++ b/tsl/test/sql/continuous_aggs_refresh.sql
@@ -34,13 +34,13 @@ SELECT * FROM daily_temp
 ORDER BY day DESC, device;
 
 -- Refresh the most recent few days:
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-05');
 
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;
 
 -- Refresh the rest
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-03');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-03');
 
 -- Compare the aggregate to the equivalent query on the source table
 SELECT * FROM daily_temp
@@ -52,39 +52,39 @@ GROUP BY 1,2
 ORDER BY 1 DESC,2;
 
 -- Test unusual, but valid input
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01'::timestamptz, '2020-05-03'::date);
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'::date);
-SELECT refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::timestamptz, '2020-05-03'::date);
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'::date);
+CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
 
 -- Unbounded window forward in time
 \set ON_ERROR_STOP 0
 -- Currently doesn't work due to timestamp overflow bug in a query optimization
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
-SELECT refresh_continuous_aggregate('daily_temp', NULL, NULL);
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
+CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
 \set ON_ERROR_STOP 1
 
 -- Unbounded window back in time
-SELECT refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');
+CALL refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');
 
 -- Test bad input
 \set ON_ERROR_STOP 0
 -- Bad continuous aggregate name
-SELECT refresh_continuous_aggregate(NULL, '2020-05-03', '2020-05-05');
-SELECT refresh_continuous_aggregate('xyz', '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate(NULL, '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate('xyz', '2020-05-03', '2020-05-05');
 -- Valid object, but not a continuous aggregate
-SELECT refresh_continuous_aggregate('conditions', '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate('conditions', '2020-05-03', '2020-05-05');
 -- Object ID with no object
-SELECT refresh_continuous_aggregate(1, '2020-05-03', '2020-05-05');
+CALL refresh_continuous_aggregate(1, '2020-05-03', '2020-05-05');
 -- Lacking arguments
-SELECT refresh_continuous_aggregate('daily_temp');
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03');
+CALL refresh_continuous_aggregate('daily_temp');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03');
 -- Bad time ranges
-SELECT refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-03');
+CALL refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-03');
 -- Bad time input
-SELECT refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
+CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
 
 \set ON_ERROR_STOP 1
 
@@ -100,7 +100,7 @@ SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions_date
 GROUP BY 1,2;
 
-SELECT refresh_continuous_aggregate('daily_temp_date', '2020-05-01', '2020-05-03');
+CALL refresh_continuous_aggregate('daily_temp_date', '2020-05-01', '2020-05-03');
 
 -- Test smallint-based continuous aggregate
 CREATE TABLE conditions_smallint (time smallint NOT NULL, device int, temp float);
@@ -127,7 +127,7 @@ SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
 GROUP BY 1,2;
 
-SELECT refresh_continuous_aggregate('cond_20_smallint', 5, 50);
+CALL refresh_continuous_aggregate('cond_20_smallint', 5, 50);
 
 SELECT * FROM cond_20_smallint
 ORDER BY 1,2;
@@ -157,7 +157,7 @@ SELECT time_bucket(INT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_int
 GROUP BY 1,2;
 
-SELECT refresh_continuous_aggregate('cond_20_int', 5, 50);
+CALL refresh_continuous_aggregate('cond_20_int', 5, 50);
 
 SELECT * FROM cond_20_int
 ORDER BY 1,2;
@@ -187,7 +187,7 @@ SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_bigint
 GROUP BY 1,2;
 
-SELECT refresh_continuous_aggregate('cond_20_bigint', 5, 50);
+CALL refresh_continuous_aggregate('cond_20_bigint', 5, 50);
 
 SELECT * FROM cond_20_bigint
 ORDER BY 1,2;

--- a/tsl/test/src/test_continuous_aggs.c
+++ b/tsl/test/src/test_continuous_aggs.c
@@ -10,6 +10,7 @@
 #include <export.h>
 
 #include <continuous_aggs/materialize.h>
+#include <continuous_aggs/invalidation_threshold.h>
 #include <hypertable_cache.h>
 #include <utils.h>
 #include <time_bucket.h>
@@ -54,7 +55,7 @@ ts_run_continuous_agg_materialization(PG_FUNCTION_ARGS)
 
 	if (partial_view.name == NULL)
 		elog(ERROR, "view cannot be NULL");
-	invalidation_threshold = invalidation_threshold_get(hypertable_id);
+	invalidation_threshold = continuous_agg_invalidation_threshold_get(hypertable_id);
 	completed_threshold = ts_continuous_agg_get_completed_threshold(materialization_id);
 
 	if (lmv > completed_threshold)


### PR DESCRIPTION
The invalidation threshold governs the window of data from the head of
a hypertable that shouldn't be subject to invalidations in order to
reduce write amplification during inserts on the hypertable.

When a continuous aggregate is refreshed, the invalidation threshold
must be moved forward (or initialized if it doesn't previously exist)
whenever the refresh window stretches beyond the current threshold.

This change implements the functionality that initializes or moves the
invalidation threshold. This happens in its own transaction during a
refresh of a continuous aggregate in order to "publish" the new
threshold before materialization. The extra transaction requires an
access exclusive lock in order to avoid losing invalidations.

Some care has been taken to not unnecessarily lock the threshold table
with an access exclusive lock when the threshold needs no update. This
also avoids the extra transaction that "publishes" the new threshold
during a refresh of a continuous aggregate.

Note that the invalidation threshold currently cannot be moved
back. It might make sense to reset the threshold to the max time value
of a hypertable (or lower) in case recent data is deleted. However,
functionally it won't matter if the threshold remains---it will only
mean more write amplification until the data once again reaches beyond
the threshold.

Tests for setting the invalidation threshold are also added, including new
isolation tests for concurrency.

Closes #2177 