### PR TITLE
Add check for distributed hypertable to continuous aggs

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -784,6 +784,11 @@ cagg_validate_query(Query *query)
 		Dimension *part_dimension = NULL;
 		ht = ts_hypertable_cache_get_cache_and_entry(rte->relid, CACHE_FLAG_NONE, &hcache);
 
+		if (hypertable_is_distributed(ht))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("continuous aggregates are not supported on distributed hypertables")));
+
 		/* there can only be one continuous aggregate per table */
 		switch (ts_continuous_agg_hypertable_status(ht->fd.id))
 		{

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -1820,6 +1820,36 @@ DROP INDEX disttable_device_idx;
 ERROR:  [data_node_1]: index "disttable_device_idx" does not exist
 \set ON_ERROR_STOP 1
 DROP TABLE disttable;
+-- Ensure that continuous aggregates are not supported on
+-- distributed hypertables
+CREATE TABLE disttable(
+    time timestamptz NOT NULL,
+    device int,
+    value float
+);
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            19 | public      | disttable  | t
+(1 row)
+
+INSERT INTO disttable VALUES
+       ('2017-01-01 06:01', 1, 1.2),
+       ('2017-01-01 09:11', 3, 4.3),
+       ('2017-01-01 08:01', 1, 7.3),
+       ('2017-01-02 08:01', 2, 0.23),
+       ('2018-07-02 08:01', 87, 0.0),
+       ('2018-07-01 06:01', 13, 3.1),
+       ('2018-07-01 09:11', 90, 10303.12),
+       ('2018-07-01 08:01', 29, 64);
+\set ON_ERROR_STOP 0
+CREATE VIEW disttable_cagg WITH (timescaledb.continuous)
+AS SELECT time_bucket('2 days', time), device, max(value)
+    FROM disttable
+    GROUP BY 1, 2;
+ERROR:  continuous aggregates are not supported on distributed hypertables
+\set ON_ERROR_STOP 1
+DROP TABLE disttable;
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP SCHEMA disttable_schema CASCADE;

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -494,6 +494,33 @@ DROP INDEX disttable_device_idx;
 
 DROP TABLE disttable;
 
+-- Ensure that continuous aggregates are not supported on
+-- distributed hypertables
+CREATE TABLE disttable(
+    time timestamptz NOT NULL,
+    device int,
+    value float
+);
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', 3);
+INSERT INTO disttable VALUES
+       ('2017-01-01 06:01', 1, 1.2),
+       ('2017-01-01 09:11', 3, 4.3),
+       ('2017-01-01 08:01', 1, 7.3),
+       ('2017-01-02 08:01', 2, 0.23),
+       ('2018-07-02 08:01', 87, 0.0),
+       ('2018-07-01 06:01', 13, 3.1),
+       ('2018-07-01 09:11', 90, 10303.12),
+       ('2018-07-01 08:01', 29, 64);
+
+\set ON_ERROR_STOP 0
+CREATE VIEW disttable_cagg WITH (timescaledb.continuous)
+AS SELECT time_bucket('2 days', time), device, max(value)
+    FROM disttable
+    GROUP BY 1, 2;
+\set ON_ERROR_STOP 1
+
+DROP TABLE disttable;
+
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP SCHEMA disttable_schema CASCADE;


### PR DESCRIPTION
Show an error message in case if a distributed hypertable being used.

Issue: https://github.com/timescale/timescaledb-private/issues/835