### PR TITLE
Add check for unreferenced test files

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -27,6 +27,9 @@ jobs:
       run: |
         python2 ./scripts/githooks/commit_msg_tests.py
         python3 ./scripts/githooks/commit_msg_tests.py
+    - name: Check for unreferenced test files
+      if: always()
+      run: ./scripts/check_unreferenced_files.sh
     - name: Check code formatting
       if: always()
       run: |

--- a/scripts/check_unreferenced_files.sh
+++ b/scripts/check_unreferenced_files.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname ${0})
+BASE_DIR=$(pwd)/$SCRIPT_DIR/..
+
+unreferenced=0
+
+function get_filenames {
+  echo *.$2 *.$2.in | xargs git ls-files | xargs -IFILE basename FILE
+}
+
+function check_directory {
+  cd $BASE_DIR/$1
+  test_files=$(get_filenames $1 $2)
+
+  for file in $test_files; do
+    output=$(grep --files-without-match $file CMakeLists.txt)
+
+    # return value from grep --files-without-match seems to differ
+    # between grep versions so we use output instead of return value
+    if [ "$output" != "" ]; then
+      echo -e "\nUnreferenced file in $1: $file\n"
+      unreferenced=1
+    fi
+  done
+}
+
+check_directory test/sql sql
+check_directory tsl/test/sql sql
+check_directory tsl/test/shared/sql sql
+
+check_directory test/isolation/specs spec
+check_directory tsl/test/isolation/specs spec
+
+exit $unreferenced


### PR DESCRIPTION
This patch adds a check for test files not referenced in the
CMakeLists.txt file to CI.