### PR TITLE
Add check for distributed hypertable to reorder/move_chunk

### DIFF
--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -235,6 +235,12 @@ reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id, Oid destina
 		aclcheck_error(ACLCHECK_NOT_OWNER, OBJECT_TABLE, get_rel_name(main_table_relid));
 	}
 
+	if (hypertable_is_distributed(ht))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("move_chunk() and reorder_chunk() cannot be used "
+						"with distributed hypertables")));
+
 	if (!chunk_get_reorder_index(ht, chunk, index_id, &cim))
 	{
 		ts_cache_release(hcache);

--- a/tsl/test/expected/dist_api_calls.out
+++ b/tsl/test/expected/dist_api_calls.out
@@ -205,3 +205,18 @@ _timescaledb_internal._dist_hyper_1_8_chunk
  
 (1 row)
 
+-- Ensure that move_chunk() and reorder_chunk() functions cannot be used
+-- with distributed hypertable
+SET ROLE TO DEFAULT;
+SET client_min_messages TO error;
+DROP TABLESPACE IF EXISTS tablespace1;
+RESET client_min_messages;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_CLUSTER_SUPERUSER LOCATION :TEST_TABLESPACE1_PATH;
+\set ON_ERROR_STOP 0
+SELECT move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_4_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1', reorder_index=>'disttable_time_idx', verbose=>TRUE);
+WARNING:  Timescale License expired
+ERROR:  move_chunk() and reorder_chunk() cannot be used with distributed hypertables
+SELECT reorder_chunk('_timescaledb_internal._dist_hyper_1_4_chunk', verbose => TRUE);
+ERROR:  move_chunk() and reorder_chunk() cannot be used with distributed hypertables
+\set ON_ERROR_STOP 1
+DROP TABLESPACE tablespace1;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TEST_FILES_DEBUG
   transparent_decompression_queries.sql
   tsl_tables.sql
   read_only.sql
+  dist_api_calls.sql
 )
 
 set(TEST_TEMPLATES
@@ -116,7 +117,7 @@ set(SOLO_TESTS
   data_fetcher
   data_node
   debug_notice
-  dist_api_calls.sql
+  dist_api_calls
   dist_commands
   dist_compression
   dist_ddl

--- a/tsl/test/sql/dist_api_calls.sql
+++ b/tsl/test/sql/dist_api_calls.sql
@@ -65,3 +65,18 @@ INSERT INTO disttable VALUES
        ('2017-01-02 08:01', 2, 0.23);
 SELECT * FROM disttable ORDER BY time;
 SELECT * FROM test.remote_exec(NULL, $$ SELECT show_chunks('disttable'); $$);
+
+-- Ensure that move_chunk() and reorder_chunk() functions cannot be used
+-- with distributed hypertable
+SET ROLE TO DEFAULT;
+SET client_min_messages TO error;
+DROP TABLESPACE IF EXISTS tablespace1;
+RESET client_min_messages;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_CLUSTER_SUPERUSER LOCATION :TEST_TABLESPACE1_PATH;
+
+\set ON_ERROR_STOP 0
+SELECT move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_4_chunk', destination_tablespace=>'tablespace1', index_destination_tablespace=>'tablespace1', reorder_index=>'disttable_time_idx', verbose=>TRUE);
+SELECT reorder_chunk('_timescaledb_internal._dist_hyper_1_4_chunk', verbose => TRUE);
+\set ON_ERROR_STOP 1
+
+DROP TABLESPACE tablespace1;


### PR DESCRIPTION
Ensure that move_chunk() and reorder_chunk() functions cannot be used with distributed hypertable