### PR TITLE
Allow use of infinite refresh windows 

### DIFF
--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -157,15 +157,38 @@ SELECT _timescaledb_internal.to_unix_microseconds('2017-02-07 15:09:36.236538+00
      1486480176236538
 (1 row)
 
--- In UNIX microseconds, BIGINT MAX is smaller than internal date upper bound
--- and should therefore be OK. Further, converting to the internal postgres
--- epoch cannot overflow a 64-bit INTEGER since the postgres epoch is at a
--- later date compared to the UNIX epoch, and is therefore represented by a
--- smaller number
+-- For timestamps, BIGINT MAX represents +Infinity and BIGINT MIN
+-- -Infinity. We keep this notion for UNIX epoch time:
+SELECT _timescaledb_internal.to_unix_microseconds('+infinity');
+ERROR:  invalid input syntax for type timestamp with time zone: "+infinity" at character 51
 SELECT _timescaledb_internal.to_timestamp(9223372036854775807);
+ to_timestamp 
+--------------
+ infinity
+(1 row)
+
+SELECT _timescaledb_internal.to_unix_microseconds('-infinity');
+ to_unix_microseconds 
+----------------------
+ -9223372036854775808
+(1 row)
+
+SELECT _timescaledb_internal.to_timestamp(-9223372036854775808);
+ to_timestamp 
+--------------
+ -infinity
+(1 row)
+
+-- In UNIX microseconds, the largest bigint value below infinity
+-- (BIGINT MAX) is smaller than internal date upper bound and should
+-- therefore be OK. Further, converting to the internal postgres epoch
+-- cannot overflow a 64-bit INTEGER since the postgres epoch is at a
+-- later date compared to the UNIX epoch, and is therefore represented
+-- by a smaller number
+SELECT _timescaledb_internal.to_timestamp(9223372036854775806);
              to_timestamp              
 ---------------------------------------
- Sun Jan 10 04:00:54.775807 294247 UTC
+ Sun Jan 10 04:00:54.775806 294247 UTC
 (1 row)
 
 -- Julian day zero is -210866803200000000 microseconds from UNIX epoch

--- a/test/sql/timestamp.sql
+++ b/test/sql/timestamp.sql
@@ -100,12 +100,20 @@ SELECT _timescaledb_internal.to_timestamp(1486480176236538);
 -- Should be the inverse of the statement above.
 SELECT _timescaledb_internal.to_unix_microseconds('2017-02-07 15:09:36.236538+00');
 
--- In UNIX microseconds, BIGINT MAX is smaller than internal date upper bound
--- and should therefore be OK. Further, converting to the internal postgres
--- epoch cannot overflow a 64-bit INTEGER since the postgres epoch is at a
--- later date compared to the UNIX epoch, and is therefore represented by a
--- smaller number
+-- For timestamps, BIGINT MAX represents +Infinity and BIGINT MIN
+-- -Infinity. We keep this notion for UNIX epoch time:
+SELECT _timescaledb_internal.to_unix_microseconds('+infinity');
 SELECT _timescaledb_internal.to_timestamp(9223372036854775807);
+SELECT _timescaledb_internal.to_unix_microseconds('-infinity');
+SELECT _timescaledb_internal.to_timestamp(-9223372036854775808);
+
+-- In UNIX microseconds, the largest bigint value below infinity
+-- (BIGINT MAX) is smaller than internal date upper bound and should
+-- therefore be OK. Further, converting to the internal postgres epoch
+-- cannot overflow a 64-bit INTEGER since the postgres epoch is at a
+-- later date compared to the UNIX epoch, and is therefore represented
+-- by a smaller number
+SELECT _timescaledb_internal.to_timestamp(9223372036854775806);
 
 -- Julian day zero is -210866803200000000 microseconds from UNIX epoch
 SELECT _timescaledb_internal.to_timestamp(-210866803200000000);

--- a/test/src/test_time_to_internal.c
+++ b/test/src/test_time_to_internal.c
@@ -111,7 +111,10 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPOID),
 													TIMESTAMPOID));
 
-	TestEnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPOID));
+	TestAssertInt64Eq(PG_INT64_MIN, ts_time_value_to_internal(DT_NOBEGIN, TIMESTAMPOID));
+	TestAssertInt64Eq(PG_INT64_MAX, ts_time_value_to_internal(DT_NOEND, TIMESTAMPOID));
+
+	TestAssertInt64Eq(DT_NOBEGIN, ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPOID));
 	TestEnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPOID));
 
 	TestAssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
@@ -119,10 +122,10 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 																		  TIMESTAMPOID),
 												TIMESTAMPOID));
 
-	TestAssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
-					  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID)));
-	TestEnsureError(ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPOID),
-											  TIMESTAMPOID));
+	TestAssertInt64Eq(DT_NOEND,
+					  (ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX,
+																		   TIMESTAMPOID),
+												 TIMESTAMPOID)));
 
 	/* TIMESTAMPTZ */
 	for (i64 = -100; i64 < 100; i64++)
@@ -140,7 +143,10 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 						  ts_time_value_to_internal(ts_internal_to_time_value(i64, TIMESTAMPTZOID),
 													TIMESTAMPTZOID));
 
-	TestEnsureError(ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPTZOID));
+	TestAssertInt64Eq(PG_INT64_MIN, ts_time_value_to_internal(DT_NOBEGIN, TIMESTAMPTZOID));
+	TestAssertInt64Eq(PG_INT64_MAX, ts_time_value_to_internal(DT_NOEND, TIMESTAMPTZOID));
+
+	TestAssertInt64Eq(DT_NOBEGIN, ts_internal_to_time_value(PG_INT64_MIN, TIMESTAMPTZOID));
 	TestEnsureError(ts_internal_to_time_value(TS_INTERNAL_TIMESTAMP_MIN - 1, TIMESTAMPTZOID));
 
 	TestAssertInt64Eq(TS_INTERNAL_TIMESTAMP_MIN,
@@ -148,21 +154,19 @@ ts_test_time_to_internal_conversion(PG_FUNCTION_ARGS)
 																		  TIMESTAMPTZOID),
 												TIMESTAMPTZOID));
 
-	TestAssertInt64Eq(PG_INT64_MAX - TS_EPOCH_DIFF_MICROSECONDS,
-					  DatumGetInt64(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID)));
-	TestEnsureError(
-		ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX, TIMESTAMPTZOID),
-								  TIMESTAMPTZOID));
+	TestAssertInt64Eq(DT_NOEND,
+					  ts_time_value_to_internal(ts_internal_to_time_value(PG_INT64_MAX,
+																		  TIMESTAMPTZOID),
+												TIMESTAMPTZOID));
 
 	/* DATE */
+
 	for (i64 = -100 * USECS_PER_DAY; i64 < 100 * USECS_PER_DAY; i64 += USECS_PER_DAY)
 		TestAssertInt64Eq(i64,
 						  ts_time_value_to_internal(ts_internal_to_time_value(i64, DATEOID),
 													DATEOID));
-
-	TestEnsureError(ts_internal_to_time_value(PG_INT64_MIN, DATEOID));
-	TestAssertInt64Eq(106741034, DatumGetDateADT(ts_internal_to_time_value(PG_INT64_MAX, DATEOID)));
-
+	TestAssertInt64Eq(DATEVAL_NOBEGIN, ts_internal_to_time_value(PG_INT64_MIN, DATEOID));
+	TestAssertInt64Eq(DATEVAL_NOEND, ts_internal_to_time_value(PG_INT64_MAX, DATEOID));
 	TestEnsureError(ts_time_value_to_internal((DATEVAL_NOBEGIN + 1), DATEOID));
 	TestEnsureError(ts_time_value_to_internal((DATEVAL_NOEND - 1), DATEOID));
 


### PR DESCRIPTION
When clearing invalidations during a refresh of a continuous
aggregate, one should use the bucketed refresh window rather than the
"raw" user-defined window. This ensures that the window is capped at
the allowable timestamp range (e.g., when using an infinite window)
and that the window used to clear invalidations actually matches what
gets materialized.

Note, however, that, since the end of the refresh window is not
inclusive, the last possible time value is no included in the refresh.
To include that value, there needs exist a time-type agnostic
definition of "infinity" and both the invalidation code and
the materialization code must be able to handle such windows.

From other commit:

The internal conversion functions for timestamps didn't account for
timestamps that are infinite (`-Infinity` or `+Infinity`), and they
would therefore generate an error if such timestamps were
encountered. This change adds extra checks to the conversion functions
to allow infinite timestamps.

The first commit is also part of another PR.

Fixes #2129 (At least partly. There's still a bug in the time_bucket optimization code that prohibits large timestamps #2127)