### PR TITLE
Make application name for bgw jobs unique

### DIFF
--- a/sql/bgw_scheduler.sql
+++ b/sql/bgw_scheduler.sql
@@ -17,17 +17,17 @@ RETURNS BOOL
 AS '@LOADER_PATHNAME@', 'ts_bgw_db_workers_start'
 LANGUAGE C VOLATILE;
 
-INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedule_INTERVAL, max_runtime, max_retries, retry_period) VALUES
-(1, 'Telemetry Reporter', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h')
+INSERT INTO _timescaledb_config.bgw_job (id, application_name, job_type, schedule_interval, max_runtime, max_retries, retry_period, proc_schema, proc_name, owner, scheduled) VALUES
+(1, 'Telemetry Reporter [1]', 'telemetry_and_version_check_if_enabled', INTERVAL '24h', INTERVAL '100s', -1, INTERVAL '1h', '_timescaledb_internal', 'policy_telemetry_proc', CURRENT_ROLE, true)
 ON CONFLICT (id) DO NOTHING;
 
 -- Add a retention policy to a hypertable or continuous aggregate.
--- The retention_window (typically an INTERVAL) determines the 
+-- The retention_window (typically an INTERVAL) determines the
 -- window beyond which data is dropped at the time
--- of execution of the policy (e.g., '1 week'). Note that the retention 
--- window will always align with chunk boundaries, thus the window 
+-- of execution of the policy (e.g., '1 week'). Note that the retention
+-- window will always align with chunk boundaries, thus the window
 -- might be larger than the given one, but never smaller. In other
--- words, some data beyond the retention window 
+-- words, some data beyond the retention window
 -- might be kept, but data within the window will never be deleted.
 CREATE OR REPLACE FUNCTION add_retention_policy(
        hypertable REGCLASS,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -104,6 +104,19 @@ ALTER TABLE _timescaledb_config.bgw_job ADD COLUMN config JSONB;
 ALTER TABLE _timescaledb_config.bgw_job DROP CONSTRAINT valid_job_type;
 ALTER TABLE _timescaledb_config.bgw_job ADD CONSTRAINT valid_job_type CHECK (job_type IN ('telemetry_and_version_check_if_enabled', 'reorder', 'drop_chunks', 'continuous_aggregate', 'compress_chunks', 'custom'));
 
+-- add job id to application name
+UPDATE
+  _timescaledb_config.bgw_job job
+SET application_name = format('%s [%s]', application_name, id);
+
+-- migrate telemetry jobs
+UPDATE
+  _timescaledb_config.bgw_job job
+SET proc_name = 'policy_telemetry_proc',
+  proc_schema = '_timescaledb_internal',
+  OWNER = CURRENT_ROLE
+WHERE job_type = 'telemetry_and_version_check_if_enabled';
+
 -- migrate reorder jobs
 UPDATE
   _timescaledb_config.bgw_job job

--- a/test/expected/bgw_db_scheduler.out
+++ b/test/expected/bgw_db_scheduler.out
@@ -151,12 +151,12 @@ SELECT * FROM _timescaledb_internal.bgw_job_stat;
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time | application_name |                      msg                      
---------+-----------+------------------+-----------------------------------------------
-      0 |         0 | DB Scheduler     | [TESTING] Wait until 50000, started at 0
-      0 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
-      1 |     50000 | DB Scheduler     | [TESTING] Wait until 100000, started at 50000
-      0 |     50000 | unscheduled      | Execute job 1
+ msg_no | mock_time |  application_name  |                      msg                      
+--------+-----------+--------------------+-----------------------------------------------
+      0 |         0 | DB Scheduler       | [TESTING] Wait until 50000, started at 0
+      0 |     50000 | DB Scheduler       | [TESTING] Registered new background worker
+      1 |     50000 | DB Scheduler       | [TESTING] Wait until 100000, started at 50000
+      0 |     50000 | unscheduled [1000] | Execute job 1
 (4 rows)
 
 SELECT delete_job(1000);
@@ -1404,19 +1404,19 @@ SELECT * FROM sorted_bgw_log;
       0 |         0 | DB Scheduler     | [TESTING] Wait until 500000, started at 0
       1 |     50000 | DB Scheduler     | [TESTING] Registered new background worker
       2 |     50000 | DB Scheduler     | [TESTING] Wait until 500000, started at 50000
-      0 |     50000 | another          | Execute job 1
+      0 |     50000 | another [1026]   | Execute job 1
       3 |    150000 | DB Scheduler     | [TESTING] Registered new background worker
       4 |    150000 | DB Scheduler     | [TESTING] Wait until 500000, started at 150000
-      0 |    150000 | another          | Execute job 1
+      0 |    150000 | another [1026]   | Execute job 1
       5 |    200000 | DB Scheduler     | [TESTING] Wait until 500000, started at 200000
       6 |    300000 | DB Scheduler     | [TESTING] Wait until 500000, started at 300000
       7 |    400000 | DB Scheduler     | [TESTING] Wait until 500000, started at 400000
       8 |    450000 | DB Scheduler     | [TESTING] Registered new background worker
       9 |    450000 | DB Scheduler     | [TESTING] Wait until 500000, started at 450000
-      0 |    450000 | new_job          | Execute job 1
+      0 |    450000 | new_job [1027]   | Execute job 1
      10 |    480000 | DB Scheduler     | [TESTING] Registered new background worker
      11 |    480000 | DB Scheduler     | [TESTING] Wait until 500000, started at 480000
-      0 |    480000 | new_job          | Execute job 1
+      0 |    480000 | new_job [1027]   | Execute job 1
 (16 rows)
 
 select * from _timescaledb_internal.bgw_job_stat;

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -57,9 +57,9 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
 -- by starting with oldest chunks
 select add_reorder_policy('test_table', 'test_table_time_idx') as reorder_job_id \gset
 select * from _timescaledb_config.bgw_job where job_type IN ('reorder');
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 select job_id, chunk_id, num_times_job_run from _timescaledb_internal.bgw_policy_chunk_stats;

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -101,9 +101,9 @@ SELECT json_object_field(get_telemetry_report(always_display_report := true)::js
 
 -- job was created
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 -- no stats
@@ -137,9 +137,9 @@ SELECT * FROM sorted_bgw_log;
 (2 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 -- job ran once, successfully
@@ -177,9 +177,9 @@ SELECT * FROM sorted_bgw_log;
 (4 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 -- two runs
@@ -221,9 +221,9 @@ SELECT * FROM sorted_bgw_log;
 (6 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 SELECT *
@@ -265,9 +265,9 @@ SELECT * FROM sorted_bgw_log;
 (7 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:reorder_job_id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                              config                               
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 4 days          | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_reorder_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 SELECT *
@@ -420,9 +420,9 @@ SELECT alter_job_schedule(:drop_chunks_job_id, schedule_interval => INTERVAL '1 
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1001 | Retention Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1001 | Retention Background Job [1001] | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
 (1 row)
 
 -- no stats
@@ -459,9 +459,9 @@ SELECT * FROM sorted_bgw_log;
 (2 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1001 | Retention Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1001 | Retention Background Job [1001] | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
 (1 row)
 
 -- job ran once, successfully
@@ -498,9 +498,9 @@ SELECT * FROM sorted_bgw_log;
 (3 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1001 | Retention Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1001 | Retention Background Job [1001] | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
 (1 row)
 
 -- still only 1 run
@@ -550,9 +550,9 @@ SELECT * FROM sorted_bgw_log;
 (6 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1001 | Retention Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1001 | Retention Background Job [1001] | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
 (1 row)
 
 -- 2 runs
@@ -628,9 +628,9 @@ SELECT * FROM sorted_bgw_log;
 (9 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:drop_chunks_job_id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1001 | Retention Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |           0 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1001 | Retention Background Job [1001] | drop_chunks | @ 1 sec           | @ 5 mins    |           0 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": "@ 4 mons"}
 (1 row)
 
 -- should now have a failure

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -87,9 +87,9 @@ SELECT alter_job_schedule(:retention_job_id, schedule_interval => INTERVAL '1 se
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:retention_job_id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1000 | Retention Background Job | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 4 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1000 | Retention Background Job [1000] | drop_chunks | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 4 mons"}
 (1 row)
 
 --turn on compression and compress all chunks

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -37,9 +37,9 @@ select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 select add_compression_policy('conditions', '60d'::interval) AS compressjob_id
 \gset
 select * from _timescaledb_config.bgw_job where id = :compressjob_id;
-  id  |        application_name        |    job_type     | schedule_interval  | max_runtime | max_retries | retry_period |     proc_name      |      proc_schema      |       owner       | scheduled | hypertable_id |                     config                      
-------+--------------------------------+-----------------+--------------------+-------------+-------------+--------------+--------------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------
- 1000 | Compress Chunks Background Job | compress_chunks | @ 15 days 12 hours | @ 0         |          -1 | @ 1 hour     | policy_compression | _timescaledb_internal | default_perm_user | t         |             1 | {"older_than": "@ 60 days", "hypertable_id": 1}
+  id  |           application_name            |    job_type     | schedule_interval  | max_runtime | max_retries | retry_period |     proc_name      |      proc_schema      |       owner       | scheduled | hypertable_id |                     config                      
+------+---------------------------------------+-----------------+--------------------+-------------+-------------+--------------+--------------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------
+ 1000 | Compress Chunks Background Job [1000] | compress_chunks | @ 15 days 12 hours | @ 0         |          -1 | @ 1 hour     | policy_compression | _timescaledb_internal | default_perm_user | t         |             1 | {"older_than": "@ 60 days", "hypertable_id": 1}
 (1 row)
 
 select * from alter_job_schedule(:compressjob_id, schedule_interval=>'1s');
@@ -49,9 +49,9 @@ select * from alter_job_schedule(:compressjob_id, schedule_interval=>'1s');
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type like 'compress%';
-  id  |        application_name        |    job_type     | schedule_interval | max_runtime | max_retries | retry_period |     proc_name      |      proc_schema      |       owner       | scheduled | hypertable_id |                     config                      
-------+--------------------------------+-----------------+-------------------+-------------+-------------+--------------+--------------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------
- 1000 | Compress Chunks Background Job | compress_chunks | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | policy_compression | _timescaledb_internal | default_perm_user | t         |             1 | {"older_than": "@ 60 days", "hypertable_id": 1}
+  id  |           application_name            |    job_type     | schedule_interval | max_runtime | max_retries | retry_period |     proc_name      |      proc_schema      |       owner       | scheduled | hypertable_id |                     config                      
+------+---------------------------------------+-----------------+-------------------+-------------+-------------+--------------+--------------------+-----------------------+-------------------+-----------+---------------+-------------------------------------------------
+ 1000 | Compress Chunks Background Job [1000] | compress_chunks | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | policy_compression | _timescaledb_internal | default_perm_user | t         |             1 | {"older_than": "@ 60 days", "hypertable_id": 1}
 (1 row)
 
 insert into conditions
@@ -137,9 +137,9 @@ alter table test_table_int set (timescaledb.compress);
 select add_compression_policy('test_table_int', 2::int) AS compressjob_id
 \gset
 select * from _timescaledb_config.bgw_job where id=:compressjob_id;
-  id  |        application_name        |    job_type     | schedule_interval | max_runtime | max_retries | retry_period |     proc_name      |      proc_schema      |       owner       | scheduled | hypertable_id |                config                 
-------+--------------------------------+-----------------+-------------------+-------------+-------------+--------------+--------------------+-----------------------+-------------------+-----------+---------------+---------------------------------------
- 1001 | Compress Chunks Background Job | compress_chunks | @ 1 day           | @ 0         |          -1 | @ 1 hour     | policy_compression | _timescaledb_internal | default_perm_user | t         |             3 | {"older_than": 2, "hypertable_id": 3}
+  id  |           application_name            |    job_type     | schedule_interval | max_runtime | max_retries | retry_period |     proc_name      |      proc_schema      |       owner       | scheduled | hypertable_id |                config                 
+------+---------------------------------------+-----------------+-------------------+-------------+-------------+--------------+--------------------+-----------------------+-------------------+-----------+---------------+---------------------------------------
+ 1001 | Compress Chunks Background Job [1001] | compress_chunks | @ 1 day           | @ 0         |          -1 | @ 1 hour     | policy_compression | _timescaledb_internal | default_perm_user | t         |             3 | {"older_than": 2, "hypertable_id": 3}
 (1 row)
 
 \gset

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -50,9 +50,9 @@ from foo
 group by time_bucket(1, a), a;
 NOTICE:  adding index _materialized_hypertable_2_a_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(a, time_partition_col)
 SELECT * FROM _timescaledb_config.bgw_job;
-  id  |          application_name           |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
-------+-------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
- 1000 | Continuous Aggregate Background Job | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
+  id  |              application_name              |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
+------+--------------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
+ 1000 | Continuous Aggregate Background Job [1000] | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
 (1 row)
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -107,9 +107,9 @@ SELECT  mat_hypertable_id, user_view_schema, user_view_name, bucket_width, job_i
 SELECT job_id FROM _timescaledb_catalog.continuous_agg \gset
 -- job was created
 SELECT * FROM _timescaledb_config.bgw_job where id=:job_id;
-  id  |          application_name           |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
-------+-------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
- 1000 | Continuous Aggregate Background Job | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
+  id  |              application_name              |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
+------+--------------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
+ 1000 | Continuous Aggregate Background Job [1000] | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
 (1 row)
 
 -- create 10 time buckets
@@ -145,9 +145,9 @@ SELECT * FROM sorted_bgw_log;
 (2 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:job_id;
-  id  |          application_name           |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
-------+-------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
- 1000 | Continuous Aggregate Background Job | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
+  id  |              application_name              |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
+------+--------------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
+ 1000 | Continuous Aggregate Background Job [1000] | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
 (1 row)
 
 -- job ran once, successfully
@@ -432,9 +432,9 @@ SELECT * FROM sorted_bgw_log;
 (6 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:job_id;
-  id  |          application_name           |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
-------+-------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
- 1001 | Continuous Aggregate Background Job | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
+  id  |              application_name              |       job_type       | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
+------+--------------------------------------------+----------------------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
+ 1001 | Continuous Aggregate Background Job [1001] | continuous_aggregate | @ 12 hours        | @ 0         |          -1 | @ 12 hours   |           |             |       | t         |               | 
 (1 row)
 
 -- job ran again, fast restart

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -70,9 +70,9 @@ select add_reorder_policy('test_table', 'third_index');
 ERROR:  reorder policy already exists for hypertable "test_table"
 \set ON_ERROR_STOP 1
 select * from _timescaledb_config.bgw_job where id=:job_id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 -- Now check that default scheduling interval for reorder policy is calculated correctly
@@ -92,18 +92,18 @@ select add_reorder_policy('test_table2', 'test_table2_time_idx');
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks', 'reorder') ORDER BY id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                           config                           
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
- 1001 | Reorder Background Job | reorder  | @ 12 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             3 | {"index_name": "test_table2_time_idx", "hypertable_id": 3}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                           config                           
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
+ 1001 | Reorder Background Job [1001] | reorder  | @ 12 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             3 | {"index_name": "test_table2_time_idx", "hypertable_id": 3}
 (2 rows)
 
 DROP TABLE test_table2;
 -- Make sure that test_table2 reorder policy gets dropped
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks', 'reorder') ORDER BY id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
- 1000 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
+ 1000 | Reorder Background Job [1000] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "test_table_time_idx", "hypertable_id": 1}
 (1 row)
 
 -- Error whenever incorrect arguments are applied (must have table and interval)
@@ -159,9 +159,9 @@ WARNING:  could not add retention policy due to existing policy on hypertable wi
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks') ORDER BY id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1002 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1002 | Retention Background Job [1002] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -171,9 +171,9 @@ select add_retention_policy('test_table', INTERVAL '3 days');
 ERROR:  retention policy already exists for hypertable "test_table"
 \set ON_ERROR_STOP 1
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks') ORDER BY id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1002 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1002 | Retention Background Job [1002] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
 (1 row)
 
 select remove_retention_policy('test_table');
@@ -232,9 +232,9 @@ select add_retention_policy('test_table', INTERVAL '3 month');
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks') ORDER BY id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1003 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1003 | Retention Background Job [1003] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
 (1 row)
 
 select remove_retention_policy('test_table');
@@ -255,9 +255,9 @@ select add_retention_policy('test_table_int', 1);
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks') ORDER BY id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                   config                    
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+---------------------------------------------
- 1004 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": 1}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                   config                    
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+---------------------------------------------
+ 1004 | Retention Background Job [1004] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": 1}
 (1 row)
 
 -- Should not add new policy with different parameters
@@ -384,11 +384,11 @@ select count(*) from _timescaledb_config.bgw_job where id=:reorder_job_id;
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job ORDER BY id;
-  id  |     application_name     |                job_type                | schedule_interval |   max_runtime   | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+----------------------------------------+-------------------+-----------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
-    1 | Telemetry Reporter       | telemetry_and_version_check_if_enabled | @ 24 hours        | @ 1 min 40 secs |          -1 | @ 1 hour     |                  |                       | super_user        | t         |               | 
- 1007 | Retention Background Job | drop_chunks                            | @ 1 day           | @ 5 mins        |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 2 mons"}
- 1008 | Reorder Background Job   | reorder                                | @ 84 hours        | @ 0             |          -1 | @ 5 mins     | policy_reorder   | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "third_index", "hypertable_id": 1}
+  id  |        application_name         |                job_type                | schedule_interval |   max_runtime   | max_retries | retry_period |       proc_name       |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+----------------------------------------+-------------------+-----------------+-------------+--------------+-----------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+    1 | Telemetry Reporter [1]          | telemetry_and_version_check_if_enabled | @ 24 hours        | @ 1 min 40 secs |          -1 | @ 1 hour     | policy_telemetry_proc | _timescaledb_internal | super_user        | t         |               | 
+ 1007 | Retention Background Job [1007] | drop_chunks                            | @ 1 day           | @ 5 mins        |          -1 | @ 5 mins     | policy_retention      | _timescaledb_internal | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 2 mons"}
+ 1008 | Reorder Background Job [1008]   | reorder                                | @ 84 hours        | @ 0             |          -1 | @ 5 mins     | policy_reorder        | _timescaledb_internal | default_perm_user | t         |             1 | {"index_name": "third_index", "hypertable_id": 1}
 (3 rows)
 
 DROP TABLE test_table;
@@ -445,18 +445,18 @@ select add_retention_policy('test_table2', INTERVAL '1 days');
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1009 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             4 | {"hypertable_id": 4, "retention_window": "@ 2 days"}
- 1010 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             5 | {"hypertable_id": 5, "retention_window": "@ 1 day"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                        config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+------------------------------------------------------
+ 1009 | Retention Background Job [1009] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             4 | {"hypertable_id": 4, "retention_window": "@ 2 days"}
+ 1010 | Retention Background Job [1010] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             5 | {"hypertable_id": 5, "retention_window": "@ 1 day"}
 (2 rows)
 
 DROP TABLE test_table;
 DROP TABLE test_table_int;
 select * from _timescaledb_config.bgw_job where job_type IN ('drop_chunks');
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                       config                        
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------
- 1010 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             5 | {"hypertable_id": 5, "retention_window": "@ 1 day"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                       config                        
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------
+ 1010 | Retention Background Job [1010] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             5 | {"hypertable_id": 5, "retention_window": "@ 1 day"}
 (1 row)
 
 DROP TABLE test_table2;
@@ -521,9 +521,9 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type='reorder';
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                       config                       
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+----------------------------------------------------
- 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             6 | {"index_name": "second_index", "hypertable_id": 6}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                       config                       
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+----------------------------------------------------
+ 1011 | Reorder Background Job [1011] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             6 | {"index_name": "second_index", "hypertable_id": 6}
 (1 row)
 
 -- Deleting a chunk that has nothing to do with the job should do nothing
@@ -537,9 +537,9 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 (1 row)
 
 select * from _timescaledb_config.bgw_job where job_type='reorder';
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                       config                       
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+----------------------------------------------------
- 1011 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             6 | {"index_name": "second_index", "hypertable_id": 6}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                       config                       
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+----------------------------------------------------
+ 1011 | Reorder Background Job [1011] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             6 | {"index_name": "second_index", "hypertable_id": 6}
 (1 row)
 
 -- Dropping the hypertable should drop the chunk, which should drop the reorder policy
@@ -583,10 +583,10 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks', 'reorder') ORDER BY id;
-  id  |     application_name     |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
-------+--------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
- 1012 | Reorder Background Job   | reorder     | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder   | _timescaledb_internal | default_perm_user | t         |             7 | {"index_name": "test_table_time_idx", "hypertable_id": 7}
- 1013 | Retention Background Job | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             7 | {"hypertable_id": 7, "retention_window": "@ 2 days"}
+  id  |        application_name         |  job_type   | schedule_interval | max_runtime | max_retries | retry_period |    proc_name     |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
+------+---------------------------------+-------------+-------------------+-------------+-------------+--------------+------------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
+ 1012 | Reorder Background Job [1012]   | reorder     | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder   | _timescaledb_internal | default_perm_user | t         |             7 | {"index_name": "test_table_time_idx", "hypertable_id": 7}
+ 1013 | Retention Background Job [1013] | drop_chunks | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | policy_retention | _timescaledb_internal | default_perm_user | t         |             7 | {"hypertable_id": 7, "retention_window": "@ 2 days"}
 (2 rows)
 
 -- Dropping the drop_chunks job should not affect the chunk_stats row
@@ -603,9 +603,9 @@ select job_id,chunk_id,num_times_job_run from _timescaledb_internal.bgw_policy_c
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks', 'reorder') ORDER BY id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
- 1012 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             7 | {"index_name": "test_table_time_idx", "hypertable_id": 7}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
+ 1012 | Reorder Background Job [1012] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             7 | {"index_name": "test_table_time_idx", "hypertable_id": 7}
 (1 row)
 
 select remove_reorder_policy('test_table');
@@ -628,9 +628,9 @@ SELECT * FROM _timescaledb_config.bgw_job WHERE job_type IN ('drop_chunks', 'reo
 -- Now test if alter_job_schedule works
 select add_reorder_policy('test_table', 'test_table_time_idx') as job_id \gset
  select * from _timescaledb_config.bgw_job where id=:job_id;
-  id  |    application_name    | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
-------+------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
- 1014 | Reorder Background Job | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             7 | {"index_name": "test_table_time_idx", "hypertable_id": 7}
+  id  |       application_name        | job_type | schedule_interval | max_runtime | max_retries | retry_period |   proc_name    |      proc_schema      |       owner       | scheduled | hypertable_id |                          config                           
+------+-------------------------------+----------+-------------------+-------------+-------------+--------------+----------------+-----------------------+-------------------+-----------+---------------+-----------------------------------------------------------
+ 1014 | Reorder Background Job [1014] | reorder  | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | policy_reorder | _timescaledb_internal | default_perm_user | t         |             7 | {"index_name": "test_table_time_idx", "hypertable_id": 7}
 (1 row)
 
 -- No change


### PR DESCRIPTION
This patch changes the application name for background worker jobs
to include the job_id which makes the application name unique and
allows joining against pg_stat_activity to get a list of currently
running background worker processes. This change also makes
identifying misbehaving jobs easier from the postgres log as the
application name can be included in the log line.