### PR TITLE
Merge continuous aggregate invalidations

### DIFF
--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -11,7 +11,27 @@
 #include "continuous_agg.h"
 #include "continuous_aggs/materialize.h"
 
-extern void continuous_agg_invalidation_process(const ContinuousAgg *cagg,
+/*
+ * Invalidation.
+ *
+ * A common representation of an invalidation that works across both the
+ * hypertable invalidation log and the continuous aggregate invalidation log.
+ */
+typedef struct Invalidation
+{
+	int32 hyper_id;
+	int64 modification_time;
+	int64 lowest_modified_value;
+	int64 greatest_modified_value;
+	bool is_modified;
+	ItemPointerData tid;
+} Invalidation;
+
+extern void invalidation_entry_set_from_hyper_invalidation(Invalidation *entry, const TupleInfo *ti,
+														   int32 hyper_id);
+extern void invalidation_process_hypertable_log(const ContinuousAgg *cagg,
 												const InternalTimeRange *refresh_window);
+extern void invalidation_process_cagg_log(const ContinuousAgg *cagg,
+										  const InternalTimeRange *refresh_window);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H */

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -17,13 +17,6 @@ typedef struct SchemaAndName
 	Name name;
 } SchemaAndName;
 
-typedef struct Invalidation
-{
-	int64 modification_time;
-	int64 lowest_modified_value;
-	int64 greatest_modified_value;
-} Invalidation;
-
 /***********************
  * Time ranges
  ***********************/

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -178,7 +178,7 @@ ORDER BY 1,2;
              2 |        30
 (2 rows)
 
--- There should be no invalidations initially:
+-- There should be no hypertable invalidations initially:
 SELECT hypertable_id AS hyper_id,
        lowest_modified_value AS start,
        greatest_modified_value AS end
@@ -268,13 +268,11 @@ SELECT materialization_id AS cagg_id,
        ORDER BY 1,2,3;
  cagg_id | start | end 
 ---------+-------+-----
-       3 |    10 |  10
        3 |    10 |  19
        3 |    60 |  70
-       4 |    10 |  10
        4 |    10 |  19
        4 |    60 |  70
-(6 rows)
+(4 rows)
 
 -- Now add more invalidations to test a refresh that overlaps with them.
 -- Entries that should be deleted:
@@ -319,13 +317,11 @@ SELECT materialization_id AS cagg_id,
        ORDER BY 1,2,3;
  cagg_id | start | end 
 ---------+-------+-----
-       3 |    10 |  10
        3 |    10 |  19
        3 |    60 |  70
-       4 |    10 |  10
        4 |    10 |  19
        4 |    60 |  70
-(6 rows)
+(4 rows)
 
 -- Refresh to process invalidations for daily temperature:
 CALL refresh_continuous_aggregate('cond_10', 20, 60);
@@ -350,28 +346,11 @@ SELECT materialization_id AS cagg_id,
  cagg_id | start | end 
 ---------+-------+-----
        3 |     1 |  19
-       3 |     2 |  19
-       3 |     3 |  19
-       3 |    10 |  10
-       3 |    10 |  19
-       3 |    19 |  19
-       3 |    60 |  60
-       3 |    60 |  70
-       3 |    60 |  80
-       3 |    60 |  90
        3 |    60 | 100
-       4 |     1 |  25
-       4 |     2 |  60
-       4 |     3 |  80
-       4 |    10 |  10
+       4 |     1 | 100
        4 |    10 |  19
-       4 |    19 |  59
-       4 |    20 |  30
-       4 |    20 | 100
-       4 |    30 |  59
        4 |    60 |  70
-       4 |    60 |  90
-(22 rows)
+(5 rows)
 
 -- Refresh also cond_20:
 CALL refresh_continuous_aggregate('cond_20', 20, 60);
@@ -384,26 +363,23 @@ SELECT materialization_id AS cagg_id,
  cagg_id | start | end 
 ---------+-------+-----
        3 |     1 |  19
-       3 |     2 |  19
-       3 |     3 |  19
-       3 |    10 |  10
-       3 |    10 |  19
-       3 |    19 |  19
-       3 |    60 |  60
-       3 |    60 |  70
-       3 |    60 |  80
-       3 |    60 |  90
        3 |    60 | 100
        4 |     1 |  19
-       4 |     2 |  19
-       4 |     3 |  19
-       4 |    10 |  10
-       4 |    10 |  19
-       4 |    19 |  19
-       4 |    60 |  60
-       4 |    60 |  70
-       4 |    60 |  80
-       4 |    60 |  90
        4 |    60 | 100
-(22 rows)
+(4 rows)
+
+-- Refresh cond_10 to completely remove an invalidation:
+CALL refresh_continuous_aggregate('cond_10', 1, 20);
+-- The 1-19 invalidation should be deleted:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+ cagg_id | start | end 
+---------+-------+-----
+       3 |    60 | 100
+       4 |     1 |  19
+       4 |    60 | 100
+(3 rows)
 

--- a/tsl/test/sql/continuous_aggs_invalidation.sql
+++ b/tsl/test/sql/continuous_aggs_invalidation.sql
@@ -113,7 +113,7 @@ CALL refresh_continuous_aggregate('cond_20', 60, 100);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
 
--- There should be no invalidations initially:
+-- There should be no hypertable invalidations initially:
 SELECT hypertable_id AS hyper_id,
        lowest_modified_value AS start,
        greatest_modified_value AS end
@@ -230,6 +230,16 @@ SELECT materialization_id AS cagg_id,
 CALL refresh_continuous_aggregate('cond_20', 20, 60);
 
 -- The cond_20 cagg should also have its entries cut:
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       ORDER BY 1,2,3;
+
+-- Refresh cond_10 to completely remove an invalidation:
+CALL refresh_continuous_aggregate('cond_10', 1, 20);
+
+-- The 1-19 invalidation should be deleted:
 SELECT materialization_id AS cagg_id,
        lowest_modified_value AS start,
        greatest_modified_value AS end


### PR DESCRIPTION
This change implements deduplication and merging of invalidation
entries for continuous aggregates in order to reduce the number of
reduntant entries in the continuous aggregate invalidation
log. Merging is done both when copying over entries from the
hypertable to the continuous aggregate invalidation log and when
cutting already existing invalidations in the latter log. Doing this
merging in both steps helps reduce the number of invalidations also
for the continuous aggregates that don't get refreshed by the active
refresh command.

Merging works by scanning invalidations in order of the lowest
modified value, and given this ordering it is possible to merge the
current and next entry into one large entry if they are
overlapping. This can continue until the current and next invalidation
are disjoint or there are no more invalidations to process.

Note, however, that only the continuous aggregate that gets refreshed
will be fully deduplicated. Some redundant entries might exists for
other aggregates since their entries in the continuous aggregate log
aren't cut against the refresh window.

Full deduplication for the refreshed continuous aggregate is only
possible if the continuous aggregate invalidation log is processed
last, since that also includes "old" entries. Therefore, this change
also changes the ordering of how the logs are processed. This also
makes it possible to process the hypertable invalidation log in the
first transaction of the refresh.

Closes #2179