### PR TITLE
Improve locking when processing invalidations

### DIFF
--- a/tsl/test/isolation/expected/continuous_aggs_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/continuous_aggs_concurrent_refresh.out
@@ -26,7 +26,7 @@ cagg_bucket_count
 4              
 hypertable     threshold      
 
-conditions     62             
+conditions     70             
 step R3_refresh: 
     CALL refresh_continuous_aggregate('cond_10', 71, 97);
 
@@ -55,7 +55,7 @@ cagg_bucket_count
 7              
 hypertable     threshold      
 
-conditions     97             
+conditions     100            
 step L2_read_unlock_threshold_table: 
     ROLLBACK;
 
@@ -99,7 +99,7 @@ cagg_bucket_count
 3              
 hypertable     threshold      
 
-conditions     97             
+conditions     100            
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
@@ -147,7 +147,7 @@ cagg_bucket_count
 7              
 hypertable     threshold      
 
-conditions     97             
+conditions     100            
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
@@ -195,7 +195,7 @@ cagg_bucket_count
 7              
 hypertable     threshold      
 
-conditions     97             
+conditions     100            
 step L3_unlock_cagg_table: 
     ROLLBACK;
 
@@ -239,7 +239,7 @@ cagg_bucket_count
 4              
 hypertable     threshold      
 
-conditions     62             
+conditions     70             
 step L1_unlock_threshold_table: 
     ROLLBACK;
 
@@ -287,7 +287,7 @@ cagg_bucket_count
 4              
 hypertable     threshold      
 
-conditions     62             
+conditions     70             
 step L1_unlock_threshold_table: 
     ROLLBACK;
 
@@ -338,7 +338,7 @@ cagg_bucket_count
 7              
 hypertable     threshold      
 
-conditions     97             
+conditions     100            
 step L1_unlock_threshold_table: 
     ROLLBACK;
 
@@ -384,7 +384,7 @@ cagg_bucket_count
 3              
 hypertable     threshold      
 
-conditions     97             
+conditions     100            
 step L1_unlock_threshold_table: 
     ROLLBACK;
 

--- a/tsl/test/isolation/expected/continuous_aggs_concurrent_refresh.out
+++ b/tsl/test/isolation/expected/continuous_aggs_concurrent_refresh.out
@@ -17,13 +17,16 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 30             18.3           
-40             15.1           
+40             16.0909090909091
 50             26.9           
 60             18.9           
 cagg_bucket_count
 
-4              
+7              
 hypertable     threshold      
 
 conditions     70             
@@ -43,8 +46,11 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 30             18.3           
-40             15.1           
+40             16.0909090909091
 50             26.9           
 60             18.9           
 70             24.6           
@@ -52,7 +58,7 @@ bucket         avg_temp
 90             21.3           
 cagg_bucket_count
 
-7              
+10             
 hypertable     threshold      
 
 conditions     100            
@@ -91,12 +97,15 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 70             24.6           
 80             23.6           
 90             21.3           
 cagg_bucket_count
 
-3              
+6              
 hypertable     threshold      
 
 conditions     100            
@@ -135,8 +144,11 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 30             18.3           
-40             15.1           
+40             16.0909090909091
 50             26.9           
 60             18.9           
 70             24.6           
@@ -144,7 +156,7 @@ bucket         avg_temp
 90             21.3           
 cagg_bucket_count
 
-7              
+10             
 hypertable     threshold      
 
 conditions     100            
@@ -183,8 +195,11 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 30             18.3           
-40             15.1           
+40             16.0909090909091
 50             26.9           
 60             18.9           
 70             24.6           
@@ -192,7 +207,7 @@ bucket         avg_temp
 90             21.3           
 cagg_bucket_count
 
-7              
+10             
 hypertable     threshold      
 
 conditions     100            
@@ -230,13 +245,16 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 30             18.3           
-40             15.1           
+40             16.0909090909091
 50             26.9           
 60             18.9           
 cagg_bucket_count
 
-4              
+7              
 hypertable     threshold      
 
 conditions     70             
@@ -278,13 +296,16 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 30             18.3           
-40             15.1           
+40             16.0909090909091
 50             26.9           
 60             18.9           
 cagg_bucket_count
 
-4              
+7              
 hypertable     threshold      
 
 conditions     70             
@@ -326,8 +347,11 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 30             18.3           
-40             15.1           
+40             16.0909090909091
 50             26.9           
 60             18.9           
 70             24.6           
@@ -335,7 +359,7 @@ bucket         avg_temp
 90             21.3           
 cagg_bucket_count
 
-7              
+10             
 hypertable     threshold      
 
 conditions     100            
@@ -376,12 +400,15 @@ step S1_select:
 
 bucket         avg_temp       
 
+0              15.8888888888889
+10             14.2           
+20             13.4           
 70             24.6           
 80             23.6           
 90             21.3           
 cagg_bucket_count
 
-3              
+6              
 hypertable     threshold      
 
 conditions     100            


### PR DESCRIPTION
Invalidation processing during refreshing of a continuous aggregate is
now better protected against concurrent refreshes by taking the lock
on the materialized hypertable before invalidation processing.

Since invalidation processing is now split across two transactions,
the first one processing the hypertable invalidation log and the
second one processing the continuous aggregate invalidation lock, they
are now separately protected by serializing around the invalidation
threshold lock and the materialized hypertable lock, respectively.

In separate commits, refreshing now uses the bucketed refresh 
window for all operations (including invalidation processing) and the 
concurrent refresh test has been improved to also process invalidations.