### PR TITLE
Run regression tests on PG 11.9 and 12.4

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [ 11.8, 12.3 ]
+        pg: [ 11.9, 12.4 ]
         build_type: [ Debug ]
         include:
-          - pg: 11.8
+          - pg: 11.9
             installcheck_ignores: append-11 continuous_aggs_bgw chunk_adaptive-11 ordered_append-11 transparent_decompression-11
-          - pg: 12.3
+          - pg: 12.4
             installcheck_ignores: append-12 continuous_aggs_bgw chunk_adaptive-12 ordered_append-12 transparent_decompression-12
 
     steps:

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [11.8, 12.3]
+        pg: [11.9, 12.4]
         os: [ubuntu-18.04]
     env:
       PG_SRC_DIR: pgbuild

--- a/.github/workflows/cron-tests.yaml
+++ b/.github/workflows/cron-tests.yaml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      PG_VERSION: 12.3
+      PG_VERSION: 12.4
 
     steps:
     - name: Checkout TimescaleDB

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: 'ubuntu-18.04'
     strategy:
       matrix:
-        pg: ["11.8","12.3"]
+        pg: [11.9,12.4]
         include:
-          - pg: "11.8"
+          - pg: 11.9
             pg_major: 11
-          - pg: "12.3"
+          - pg: 12.4
             pg_major: 12
       fail-fast: false
     env:

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -21,9 +21,9 @@ import sys
 event_type = sys.argv[1]
 
 PG11_EARLIEST = "11.0"
-PG11_LATEST = "11.8"
+PG11_LATEST = "11.9"
 PG12_EARLIEST = "12.0"
-PG12_LATEST = "12.3"
+PG12_LATEST = "12.4"
 
 PG_DEBUG = "--enable-debug --enable-cassert"
 PG_MAC_PATH = "--with-libraries=/usr/local/opt/openssl/lib --with-includes=/usr/local/opt/openssl/include"


### PR DESCRIPTION
This patch changes all regression tests that were running on 11.8
and 12.3 to 11.9 and 12.4.