### PR TITLE
Fix negative bitmapset member not allowed in decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #2090 Fix index creation with IF NOT EXISTS for existing indexes
 * #2092 Fix delete on tables involving hypertables with compression
+* #2222 Fix `negative bitmapset member not allowed` in decompression
 
 **Thanks**
 * @PichetGoulu for reporting an issue with index creation and IF NOT EXISTS

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -84,6 +84,7 @@ make_pathkey_from_compressed(PlannerInfo *root, Index compressed_relid, Expr *ex
 	/* Because SortGroupClause doesn't carry collation, consult the expr */
 	collation = exprCollation((Node *) expr);
 
+	Assert(compressed_relid < root->simple_rel_array_size);
 	return ts_make_pathkey_from_sortinfo(root,
 										 expr,
 										 NULL,
@@ -253,7 +254,7 @@ build_compressed_scan_pathkeys(SortInfo *sort_info, PlannerInfo *root, List *chu
 		prepend_ec_for_seqnum(root, info, sort_info, var, sortop, nulls_first);
 
 		pk = make_pathkey_from_compressed(root,
-										  info->compressed_rte->relid,
+										  info->compressed_rel->relid,
 										  (Expr *) var,
 										  sortop,
 										  nulls_first);


### PR DESCRIPTION
Due to a typo in the code the relid of the relation instead of the
rangetable index was used when building the pathkey for the
DecompressChunk node. Since relids are unsigned but bitmapsets
use signed int32 this lead to 'negative bitmapset member not allowed'
being thrown as error when the relid is greater than INT32_MAX.
This patch also adds an assert to prevent this from happening again.