### PR TITLE
Remove unnecessary exports in tsl library

### DIFF
--- a/src/telemetry/telemetry_metadata.h
+++ b/src/telemetry/telemetry_metadata.h
@@ -9,6 +9,8 @@
 #include <postgres.h>
 #include <utils/jsonb.h>
 
+#include <export.h>
+
 extern void ts_telemetry_metadata_add_values(JsonbParseState *state);
 extern TSDLLEXPORT Datum ts_telemetry_metadata_get_uuid(void);
 extern Datum ts_telemetry_metadata_get_exported_uuid(void);

--- a/tsl/src/compression/array.h
+++ b/tsl/src/compression/array.h
@@ -17,7 +17,6 @@
 
 #include <fmgr.h>
 
-#include <export.h>
 #include "compression/compression.h"
 
 typedef struct ArrayCompressor ArrayCompressor;

--- a/tsl/src/compression/deltadelta.h
+++ b/tsl/src/compression/deltadelta.h
@@ -22,7 +22,6 @@
 #include <fmgr.h>
 #include <lib/stringinfo.h>
 
-#include <export.h>
 #include "compression/compression.h"
 
 typedef struct DeltaDeltaCompressor DeltaDeltaCompressor;

--- a/tsl/src/compression/dictionary.h
+++ b/tsl/src/compression/dictionary.h
@@ -19,8 +19,6 @@
 
 #include <fmgr.h>
 
-#include <export.h>
-
 typedef struct DictionaryCompressor DictionaryCompressor;
 typedef struct DictionaryCompressed DictionaryCompressed;
 typedef struct DictionaryDecompressionIterator DictionaryDecompressionIterator;

--- a/tsl/src/compression/gorilla.h
+++ b/tsl/src/compression/gorilla.h
@@ -66,7 +66,6 @@
 #include <lib/stringinfo.h>
 
 #include "compression/compression.h"
-#include "export.h"
 
 typedef struct GorillaCompressor GorillaCompressor;
 typedef struct GorillaCompressed GorillaCompressed;

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -12,7 +12,6 @@
 #include <lib/stringinfo.h>
 #include <libpq/pqformat.h>
 
-#include <export.h>
 #include <adts/bit_array.h>
 
 #include <adts/uint64_vec.h>

--- a/tsl/src/fdw/fdw.c
+++ b/tsl/src/fdw/fdw.c
@@ -21,16 +21,17 @@
 
 #include <guc.h>
 
-#include "option.h"
-#include "relinfo.h"
-#include "scan_plan.h"
-#include "scan_exec.h"
-#include "modify_plan.h"
-#include "modify_exec.h"
 #include "data_node_scan_plan.h"
 #include "debug_guc.h"
 #include "debug.h"
+#include "fdw.h"
 #include "fdw_utils.h"
+#include "modify_exec.h"
+#include "modify_plan.h"
+#include "option.h"
+#include "relinfo.h"
+#include "scan_exec.h"
+#include "scan_plan.h"
 
 /*
  * Parse options from foreign table and apply them to fpinfo.
@@ -393,15 +394,11 @@ static FdwRoutine timescaledb_fdw_routine = {
 	.AnalyzeForeignTable = NULL,
 };
 
-TS_FUNCTION_INFO_V1(timescaledb_fdw_handler);
-
 Datum
 timescaledb_fdw_handler(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_POINTER(&timescaledb_fdw_routine);
 }
-
-PG_FUNCTION_INFO_V1(timescaledb_fdw_validator);
 
 Datum
 timescaledb_fdw_validator(PG_FUNCTION_ARGS)

--- a/tsl/src/license.c
+++ b/tsl/src/license.c
@@ -9,17 +9,15 @@
  * for more detail.
  */
 #include <postgres.h>
-
 #include <access/xact.h>
 #include <common/base64.h>
 #include <utils/builtins.h>
-#include <utils/elog.h>
-#include <utils/json.h>
-#include <utils/jsonb.h>
-#include <utils/jsonapi.h>
-#include <utils/memutils.h>
 #include <utils/datetime.h>
+#include <utils/elog.h>
+#include <utils/jsonb.h>
+#include <utils/memutils.h>
 
+#include <export.h>
 #include <license_guc.h>
 #include <jsonb_utils.h>
 
@@ -72,7 +70,7 @@ static bool printed_license_expiration_warning = false;
 
 TS_FUNCTION_INFO_V1(tsl_license_update_check);
 
-PGDLLEXPORT Datum
+Datum
 tsl_license_update_check(PG_FUNCTION_ARGS)
 {
 	bool license_deserialized;

--- a/tsl/src/nodes/gapfill/gapfill.c
+++ b/tsl/src/nodes/gapfill/gapfill.c
@@ -21,7 +21,6 @@ gapfill_marker(PG_FUNCTION_ARGS)
 }
 
 #define GAPFILL_TIMEBUCKET_WRAPPER(datatype)                                                       \
-	TS_FUNCTION_INFO_V1(ts_gapfill_##datatype##_bucket);                                           \
 	Datum gapfill_##datatype##_time_bucket(PG_FUNCTION_ARGS)                    \
 	{                                                                                              \
 		/*                                                                                         \

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -11,7 +11,6 @@
  * the PostgreSQL License.
  */
 #include <postgres.h>
-#include <access/htup_details.h>
 #include <access/xact.h>
 #include <catalog/pg_foreign_server.h>
 #include <commands/defrem.h>
@@ -21,27 +20,20 @@
 #include <mb/pg_wchar.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
-#include <pgstat.h>
 #include <port.h>
 #include <postmaster/postmaster.h>
-#include <storage/latch.h>
 #include <utils/builtins.h>
-#include <utils/hsearch.h>
+#include <utils/fmgrprotos.h>
 #include <utils/inval.h>
-#include <utils/memutils.h>
-#include <utils/syscache.h>
-#include <utils/uuid.h>
 #include <utils/guc.h>
 
-#include <export.h>
-#include <telemetry/telemetry_metadata.h>
+#include <dist_util.h>
+#include <errors.h>
 #include <extension_constants.h>
-#include "compat.h"
+#include <guc.h>
+#include <telemetry/telemetry_metadata.h>
 #include "connection.h"
-#include "guc.h"
 #include "utils.h"
-#include "dist_util.h"
-#include "errors.h"
 
 /*
  * Connection library for TimescaleDB.


### PR DESCRIPTION
Since almost all the functions in the tsl library are accessed via
cross module functions there is no need to export the indivial
functions.