### PR TITLE
Block data migration for distributed hypertables

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1835,6 +1835,11 @@ ts_hypertable_create_internal(PG_FUNCTION_ARGS, bool is_dist_call)
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid main_table: cannot be NULL")));
 
+	if (migrate_data && is_dist_call)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot migrate data for distributed hypertable")));
+
 	if (NULL == time_dim_name)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -1695,7 +1695,7 @@ SET ROLE :ROLE_1;
 CREATE TABLE "Table\\Schema"."Param_Table"("time Col %#^#@$#" timestamptz, __region text, reading float);
 SELECT * FROM create_distributed_hypertable('"Table\\Schema"."Param_Table"', 'time Col %#^#@$#', partitioning_column => '__region',
 associated_schema_name => 'T3sTSch', associated_table_prefix => 'test*pre_', chunk_time_interval => interval '1 week',
-create_default_indexes => FALSE, if_not_exists => TRUE, migrate_data => TRUE, replication_factor => 2,
+create_default_indexes => FALSE, if_not_exists => TRUE, replication_factor => 2,
 data_nodes => '{ "data_node_3" }');
 WARNING:  only one data node was assigned to the hypertable
 NOTICE:  adding not-null constraint to column "time Col %#^#@$#"
@@ -4544,3 +4544,24 @@ SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
          24 |      23 | t
 (1 row)
 
+-- Test that creating a distributed hypertable from a table with data
+-- fails, and that migrate_data blocked.
+CREATE TABLE dist_hypertable_1 (
+  time TIMESTAMPTZ NOT NULL,
+  device INTEGER,
+  temp FLOAT
+);
+INSERT INTO dist_hypertable_1 VALUES
+       ('2017-01-01 06:01', 1),
+       ('2017-01-01 09:11', 3),
+       ('2017-01-01 08:01', 1),
+       ('2017-01-02 08:01', 2),
+       ('2018-07-02 08:01', 87);
+\set ON_ERROR_STOP 0
+SELECT * FROM create_distributed_hypertable('dist_hypertable_1', 'time', 'device', 3,
+       migrate_data => FALSE);
+ERROR:  table "dist_hypertable_1" is not empty
+SELECT * FROM create_distributed_hypertable('dist_hypertable_1', 'time', 'device', 3,
+       migrate_data => TRUE);
+ERROR:  cannot migrate data for distributed hypertable
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -1695,7 +1695,7 @@ SET ROLE :ROLE_1;
 CREATE TABLE "Table\\Schema"."Param_Table"("time Col %#^#@$#" timestamptz, __region text, reading float);
 SELECT * FROM create_distributed_hypertable('"Table\\Schema"."Param_Table"', 'time Col %#^#@$#', partitioning_column => '__region',
 associated_schema_name => 'T3sTSch', associated_table_prefix => 'test*pre_', chunk_time_interval => interval '1 week',
-create_default_indexes => FALSE, if_not_exists => TRUE, migrate_data => TRUE, replication_factor => 2,
+create_default_indexes => FALSE, if_not_exists => TRUE, replication_factor => 2,
 data_nodes => '{ "data_node_3" }');
 WARNING:  only one data node was assigned to the hypertable
 NOTICE:  adding not-null constraint to column "time Col %#^#@$#"
@@ -4524,3 +4524,24 @@ SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
          24 |      23 | t
 (1 row)
 
+-- Test that creating a distributed hypertable from a table with data
+-- fails, and that migrate_data blocked.
+CREATE TABLE dist_hypertable_1 (
+  time TIMESTAMPTZ NOT NULL,
+  device INTEGER,
+  temp FLOAT
+);
+INSERT INTO dist_hypertable_1 VALUES
+       ('2017-01-01 06:01', 1),
+       ('2017-01-01 09:11', 3),
+       ('2017-01-01 08:01', 1),
+       ('2017-01-02 08:01', 2),
+       ('2018-07-02 08:01', 87);
+\set ON_ERROR_STOP 0
+SELECT * FROM create_distributed_hypertable('dist_hypertable_1', 'time', 'device', 3,
+       migrate_data => FALSE);
+ERROR:  table "dist_hypertable_1" is not empty
+SELECT * FROM create_distributed_hypertable('dist_hypertable_1', 'time', 'device', 3,
+       migrate_data => TRUE);
+ERROR:  cannot migrate data for distributed hypertable
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -528,7 +528,7 @@ SET ROLE :ROLE_1;
 CREATE TABLE "Table\\Schema"."Param_Table"("time Col %#^#@$#" timestamptz, __region text, reading float);
 SELECT * FROM create_distributed_hypertable('"Table\\Schema"."Param_Table"', 'time Col %#^#@$#', partitioning_column => '__region',
 associated_schema_name => 'T3sTSch', associated_table_prefix => 'test*pre_', chunk_time_interval => interval '1 week',
-create_default_indexes => FALSE, if_not_exists => TRUE, migrate_data => TRUE, replication_factor => 2,
+create_default_indexes => FALSE, if_not_exists => TRUE, replication_factor => 2,
 data_nodes => '{ "data_node_3" }');
 
 -- Test attach_data_node. First show dimensions and currently attached
@@ -1446,3 +1446,27 @@ SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
 SELECT * FROM create_distributed_hypertable('whatever', 'timestamp', 'user_id',
                                             if_not_exists => true, chunk_time_interval => INTERVAL '1 day');
 SELECT  * FROM _timescaledb_catalog.hypertable_id_seq;
+
+-- Test that creating a distributed hypertable from a table with data
+-- fails, and that migrate_data blocked.
+
+CREATE TABLE dist_hypertable_1 (
+  time TIMESTAMPTZ NOT NULL,
+  device INTEGER,
+  temp FLOAT
+);
+
+INSERT INTO dist_hypertable_1 VALUES
+       ('2017-01-01 06:01', 1),
+       ('2017-01-01 09:11', 3),
+       ('2017-01-01 08:01', 1),
+       ('2017-01-02 08:01', 2),
+       ('2018-07-02 08:01', 87);
+
+
+\set ON_ERROR_STOP 0
+SELECT * FROM create_distributed_hypertable('dist_hypertable_1', 'time', 'device', 3,
+       migrate_data => FALSE);
+SELECT * FROM create_distributed_hypertable('dist_hypertable_1', 'time', 'device', 3,
+       migrate_data => TRUE);
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Option `migrate_data` does not currently work for distributed
hypertables, so we block it for the time being and generate an error if
an attempt is made to migrate data when creating a distributed
hypertable.

Fixes #2230