### PR TITLE
Fix segfault in alter_job

### DIFF
--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -230,7 +230,12 @@ job_alter(PG_FUNCTION_ARGS)
 	values[3] = Int32GetDatum(job->fd.max_retries);
 	values[4] = IntervalPGetDatum(&job->fd.retry_period);
 	values[5] = BoolGetDatum(job->fd.scheduled);
-	values[6] = JsonbPGetDatum(job->fd.config);
+
+	if (job->fd.config == NULL)
+		nulls[6] = true;
+	else
+		values[6] = JsonbPGetDatum(job->fd.config);
+
 	values[7] = TimestampTzGetDatum(next_start);
 
 	tuple = heap_form_tuple(tupdesc, values, nulls);

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -108,3 +108,11 @@ SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000;
 ----+------------------+----------+-------------------+-------------+-------------+--------------+-----------+-------------+-------+-----------+---------------+--------
 (0 rows)
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- test altering job with NULL config
+SELECT job_id FROM alter_job(1,scheduled:=false);
+ job_id 
+--------
+      1
+(1 row)
+

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -56,3 +56,7 @@ SELECT delete_job(1004);
 -- check jobs got removed
 SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000;
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- test altering job with NULL config
+SELECT job_id FROM alter_job(1,scheduled:=false);
+


### PR DESCRIPTION
When trying to alter a job with NULL config alter_job did not
set the isnull field for config and would segfault when trying
to build the resultset tuple.