### PR TITLE
Changing syntax to use MATERIALIZED VIEW for continuous aggregates

### DIFF
--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -3,12 +3,24 @@ DO $$
 DECLARE
  vname regclass;
  altercmd text;
+ ts_version TEXT;
 BEGIN
+    SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
+
     FOR vname IN select format('%I.%I', user_view_schema, user_view_name)::regclass from _timescaledb_catalog.continuous_agg where materialized_only = false
     LOOP
-        -- the cast from oid to text returns quote_qualified_identifier
-        -- (see regclassout)
-        altercmd := format('ALTER VIEW %s SET (timescaledb.materialized_only=false) ', vname::text);
+        -- the cast from oid to text returns
+        -- quote_qualified_identifier (see regclassout).
+        --
+        -- We use the if statement to handle pre-2.0 as well as
+        -- post-2.0.  This could be turned into a procedure if we want
+        -- to have something more generic, but right now it is just
+        -- this case.
+        IF ts_version < '2.0.0' THEN
+            altercmd := format('ALTER VIEW %s SET (timescaledb.materialized_only=false) ', vname::text);
+        ELSE
+            altercmd := format('ALTER MATERIALIZED VIEW %s SET (timescaledb.materialized_only=false) ', vname::text);
+        END IF;
         RAISE INFO 'cmd executed: %', altercmd;
         EXECUTE altercmd;
     END LOOP;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -77,6 +77,7 @@ int64 ts_continuous_agg_get_completed_threshold(int32 materialization_id);
 extern TSDLLEXPORT ContinuousAgg *ts_continuous_agg_find_by_view_name(const char *schema,
 																	  const char *name);
 extern TSDLLEXPORT ContinuousAgg *ts_continuous_agg_find_by_relid(Oid relid);
+extern TSDLLEXPORT ContinuousAgg *ts_continuous_agg_find_by_rv(const RangeVar *rv);
 
 extern void ts_continuous_agg_drop_view_callback(ContinuousAgg *ca, const char *schema,
 												 const char *name);
@@ -87,8 +88,9 @@ extern TSDLLEXPORT ContinuousAggViewType ts_continuous_agg_view_type(FormData_co
 																	 const char *schema,
 																	 const char *name);
 extern void ts_continuous_agg_rename_schema_name(char *old_schema, char *new_schema);
-extern void ts_continuous_agg_rename_view(char *old_schema, char *name, char *new_schema,
-										  char *new_name);
+extern void ts_continuous_agg_rename_view(const char *old_schema, const char *name,
+										  const char *new_schema, const char *new_name,
+										  ObjectType *object_type);
 
 extern TSDLLEXPORT int32 ts_number_of_continuous_aggs(void);
 

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -245,7 +245,7 @@ error_no_default_fn_pg_enterprise(PG_FUNCTION_ARGS)
 }
 
 static DDLResult
-process_cagg_viewstmt_default(ViewStmt *stmt, const char *query_string, void *pstmt,
+process_cagg_viewstmt_default(Node *stmt, const char *query_string, void *pstmt,
 							  WithClauseResult *with_clause_options)
 {
 	return error_no_default_fn_bool_void_community();

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -88,7 +88,7 @@ typedef struct CrossModuleFunctions
 	PGFunction partialize_agg;
 	PGFunction finalize_agg_sfunc;
 	PGFunction finalize_agg_ffunc;
-	DDLResult (*process_cagg_viewstmt)(ViewStmt *stmt, const char *query_string, void *pstmt,
+	DDLResult (*process_cagg_viewstmt)(Node *stmt, const char *query_string, void *pstmt,
 									   WithClauseResult *with_clause_options);
 	PGFunction continuous_agg_invalidation_trigger;
 	PGFunction continuous_agg_refresh;

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2038,8 +2038,10 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 					 errmsg("table \"%s\" is already partitioned", get_rel_name(table_relid)),
 					 errdetail("It is not possible to turn partitioned tables into hypertables.")));
+		case RELKIND_MATVIEW:
 		case RELKIND_RELATION:
 			break;
+
 		default:
 			ereport(ERROR, (errcode(ERRCODE_WRONG_OBJECT_TYPE), errmsg("invalid relation type")));
 	}

--- a/test/expected/telemetry_community.out
+++ b/test/expected/telemetry_community.out
@@ -38,7 +38,7 @@ SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
  device_readings
 (1 row)
 
-CREATE VIEW device_summary
+CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous) AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,

--- a/test/sql/telemetry_community.sql
+++ b/test/sql/telemetry_community.sql
@@ -19,7 +19,7 @@ CREATE TABLE device_readings (
       observation_time  TIMESTAMPTZ       NOT NULL
 );
 SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
-CREATE VIEW device_summary
+CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous) AS
 SELECT
   time_bucket('1 hour', observation_time) as bucket,

--- a/test/sql/updates/setup.continuous_aggs.sql
+++ b/test/sql/updates/setup.continuous_aggs.sql
@@ -26,48 +26,102 @@ SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 INSERT INTO conditions_before
 SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, NULL, 28, NULL, NULL, 8, true;
 
-CREATE VIEW mat_before
-WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
-AS
-  SELECT time_bucket('1week', timec) as bucket,
-    location,
-    min(allnull) as min_allnull,
-    max(temperature) as max_temp,
-    sum(temperature)+sum(humidity) as agg_sum_expr,
-    avg(humidity),
-    stddev(humidity),
-    bit_and(bit_int),
-    bit_or(bit_int),
-    bool_and(good_life),
-    every(temperature > 0),
-    bool_or(good_life),
-    count(*) as count_rows,
-    count(temperature) as count_temp,
-    count(allnull) as count_zero,
-    corr(temperature, humidity),
-    covar_pop(temperature, humidity),
-    covar_samp(temperature, humidity),
-    regr_avgx(temperature, humidity),
-    regr_avgy(temperature, humidity),
-    regr_count(temperature, humidity),
-    regr_intercept(temperature, humidity),
-    regr_r2(temperature, humidity),
-    regr_slope(temperature, humidity),
-    regr_sxx(temperature, humidity),
-    regr_sxy(temperature, humidity),
-    regr_syy(temperature, humidity),
-    stddev(temperature) as stddev_temp,
-    stddev_pop(temperature),
-    stddev_samp(temperature),
-    variance(temperature),
-    var_pop(temperature),
-    var_samp(temperature),
-    last(temperature, timec) as last_temp,
-    last(highlow, timec) as last_hl,
-    first(highlow, timec) as first_hl,
-    histogram(temperature, 0, 100, 5)
-  FROM conditions_before
-  GROUP BY bucket, location
-  HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+DO LANGUAGE PLPGSQL $$
+DECLARE
+  ts_version TEXT;
+BEGIN
+  SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
 
-  REFRESH MATERIALIZED VIEW mat_before;
+  IF ts_version < '2.0.0' THEN
+    CREATE VIEW mat_before
+    WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
+    AS
+      SELECT time_bucket('1week', timec) as bucket,
+	location,
+	min(allnull) as min_allnull,
+	max(temperature) as max_temp,
+	sum(temperature)+sum(humidity) as agg_sum_expr,
+	avg(humidity),
+	stddev(humidity),
+	bit_and(bit_int),
+	bit_or(bit_int),
+	bool_and(good_life),
+	every(temperature > 0),
+	bool_or(good_life),
+	count(*) as count_rows,
+	count(temperature) as count_temp,
+	count(allnull) as count_zero,
+	corr(temperature, humidity),
+	covar_pop(temperature, humidity),
+	covar_samp(temperature, humidity),
+	regr_avgx(temperature, humidity),
+	regr_avgy(temperature, humidity),
+	regr_count(temperature, humidity),
+	regr_intercept(temperature, humidity),
+	regr_r2(temperature, humidity),
+	regr_slope(temperature, humidity),
+	regr_sxx(temperature, humidity),
+	regr_sxy(temperature, humidity),
+	regr_syy(temperature, humidity),
+	stddev(temperature) as stddev_temp,
+	stddev_pop(temperature),
+	stddev_samp(temperature),
+	variance(temperature),
+	var_pop(temperature),
+	var_samp(temperature),
+	last(temperature, timec) as last_temp,
+	last(highlow, timec) as last_hl,
+	first(highlow, timec) as first_hl,
+	histogram(temperature, 0, 100, 5)
+      FROM conditions_before
+      GROUP BY bucket, location
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+  ELSE
+    CREATE MATERIALIZED VIEW mat_before
+    WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
+    AS
+      SELECT time_bucket('1week', timec) as bucket,
+	location,
+	min(allnull) as min_allnull,
+	max(temperature) as max_temp,
+	sum(temperature)+sum(humidity) as agg_sum_expr,
+	avg(humidity),
+	stddev(humidity),
+	bit_and(bit_int),
+	bit_or(bit_int),
+	bool_and(good_life),
+	every(temperature > 0),
+	bool_or(good_life),
+	count(*) as count_rows,
+	count(temperature) as count_temp,
+	count(allnull) as count_zero,
+	corr(temperature, humidity),
+	covar_pop(temperature, humidity),
+	covar_samp(temperature, humidity),
+	regr_avgx(temperature, humidity),
+	regr_avgy(temperature, humidity),
+	regr_count(temperature, humidity),
+	regr_intercept(temperature, humidity),
+	regr_r2(temperature, humidity),
+	regr_slope(temperature, humidity),
+	regr_sxx(temperature, humidity),
+	regr_sxy(temperature, humidity),
+	regr_syy(temperature, humidity),
+	stddev(temperature) as stddev_temp,
+	stddev_pop(temperature),
+	stddev_samp(temperature),
+	variance(temperature),
+	var_pop(temperature),
+	var_samp(temperature),
+	last(temperature, timec) as last_temp,
+	last(highlow, timec) as last_hl,
+	first(highlow, timec) as first_hl,
+	histogram(temperature, 0, 100, 5)
+      FROM conditions_before
+      GROUP BY bucket, location
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+
+  END IF;
+END $$;
+
+REFRESH MATERIALIZED VIEW mat_before;

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -26,49 +26,102 @@ SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 INSERT INTO conditions_before
 SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, NULL, 28, NULL, NULL, 8, true;
 
-CREATE VIEW mat_before
-WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
-AS
-  SELECT time_bucket('1week', timec) as bucket,
-    location,
-    min(allnull) as min_allnull,
-    max(temperature) as max_temp,
-    sum(temperature)+sum(humidity) as agg_sum_expr,
-    avg(humidity),
-    stddev(humidity),
-    bit_and(bit_int),
-    bit_or(bit_int),
-    bool_and(good_life),
-    every(temperature > 0),
-    bool_or(good_life),
-    count(*) as count_rows,
-    count(temperature) as count_temp,
-    count(allnull) as count_zero,
-    corr(temperature, humidity),
-    covar_pop(temperature, humidity),
-    covar_samp(temperature, humidity),
-    regr_avgx(temperature, humidity),
-    regr_avgy(temperature, humidity),
-    regr_count(temperature, humidity),
-    regr_intercept(temperature, humidity),
-    regr_r2(temperature, humidity),
-    regr_slope(temperature, humidity),
-    regr_sxx(temperature, humidity),
-    regr_sxy(temperature, humidity),
-    regr_syy(temperature, humidity),
-    stddev(temperature) as stddev_temp,
-    stddev_pop(temperature),
-    stddev_samp(temperature),
-    variance(temperature),
-    var_pop(temperature),
-    var_samp(temperature),
-    last(temperature, timec) as last_temp,
-    last(highlow, timec) as last_hl,
-    first(highlow, timec) as first_hl,
-    histogram(temperature, 0, 100, 5)
-  FROM conditions_before
-  GROUP BY bucket, location
-  HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+DO LANGUAGE PLPGSQL $$
+DECLARE
+  ts_version TEXT;
+BEGIN
+  SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
+
+  IF ts_version < '2.0.0' THEN
+    CREATE VIEW mat_before
+    WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
+    AS
+      SELECT time_bucket('1week', timec) as bucket,
+	location,
+	min(allnull) as min_allnull,
+	max(temperature) as max_temp,
+	sum(temperature)+sum(humidity) as agg_sum_expr,
+	avg(humidity),
+	stddev(humidity),
+	bit_and(bit_int),
+	bit_or(bit_int),
+	bool_and(good_life),
+	every(temperature > 0),
+	bool_or(good_life),
+	count(*) as count_rows,
+	count(temperature) as count_temp,
+	count(allnull) as count_zero,
+	corr(temperature, humidity),
+	covar_pop(temperature, humidity),
+	covar_samp(temperature, humidity),
+	regr_avgx(temperature, humidity),
+	regr_avgy(temperature, humidity),
+	regr_count(temperature, humidity),
+	regr_intercept(temperature, humidity),
+	regr_r2(temperature, humidity),
+	regr_slope(temperature, humidity),
+	regr_sxx(temperature, humidity),
+	regr_sxy(temperature, humidity),
+	regr_syy(temperature, humidity),
+	stddev(temperature) as stddev_temp,
+	stddev_pop(temperature),
+	stddev_samp(temperature),
+	variance(temperature),
+	var_pop(temperature),
+	var_samp(temperature),
+	last(temperature, timec) as last_temp,
+	last(highlow, timec) as last_hl,
+	first(highlow, timec) as first_hl,
+	histogram(temperature, 0, 100, 5)
+      FROM conditions_before
+      GROUP BY bucket, location
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+  ELSE
+    CREATE MATERIALIZED VIEW mat_before
+    WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
+    AS
+      SELECT time_bucket('1week', timec) as bucket,
+	location,
+	min(allnull) as min_allnull,
+	max(temperature) as max_temp,
+	sum(temperature)+sum(humidity) as agg_sum_expr,
+	avg(humidity),
+	stddev(humidity),
+	bit_and(bit_int),
+	bit_or(bit_int),
+	bool_and(good_life),
+	every(temperature > 0),
+	bool_or(good_life),
+	count(*) as count_rows,
+	count(temperature) as count_temp,
+	count(allnull) as count_zero,
+	corr(temperature, humidity),
+	covar_pop(temperature, humidity),
+	covar_samp(temperature, humidity),
+	regr_avgx(temperature, humidity),
+	regr_avgy(temperature, humidity),
+	regr_count(temperature, humidity),
+	regr_intercept(temperature, humidity),
+	regr_r2(temperature, humidity),
+	regr_slope(temperature, humidity),
+	regr_sxx(temperature, humidity),
+	regr_sxy(temperature, humidity),
+	regr_syy(temperature, humidity),
+	stddev(temperature) as stddev_temp,
+	stddev_pop(temperature),
+	stddev_samp(temperature),
+	variance(temperature),
+	var_pop(temperature),
+	var_samp(temperature),
+	last(temperature, timec) as last_temp,
+	last(highlow, timec) as last_hl,
+	first(highlow, timec) as first_hl,
+	histogram(temperature, 0, 100, 5)
+      FROM conditions_before
+      GROUP BY bucket, location
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+  END IF;
+END $$;
 
 REFRESH MATERIALIZED VIEW mat_before;
 
@@ -76,49 +129,101 @@ REFRESH MATERIALIZED VIEW mat_before;
 -- but realtime agg view definition is not stable across versions
 CREATE SCHEMA cagg;
 
-CREATE VIEW cagg.realtime_mat
-WITH ( timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
-AS
-  SELECT time_bucket('1week', timec) as bucket,
-    location,
-    min(allnull) as min_allnull,
-    max(temperature) as max_temp,
-    sum(temperature)+sum(humidity) as agg_sum_expr,
-    avg(humidity),
-    stddev(humidity),
-    bit_and(bit_int),
-    bit_or(bit_int),
-    bool_and(good_life),
-    every(temperature > 0),
-    bool_or(good_life),
-    count(*) as count_rows,
-    count(temperature) as count_temp,
-    count(allnull) as count_zero,
-    corr(temperature, humidity),
-    covar_pop(temperature, humidity),
-    covar_samp(temperature, humidity),
-    regr_avgx(temperature, humidity),
-    regr_avgy(temperature, humidity),
-    regr_count(temperature, humidity),
-    regr_intercept(temperature, humidity),
-    regr_r2(temperature, humidity),
-    regr_slope(temperature, humidity),
-    regr_sxx(temperature, humidity),
-    regr_sxy(temperature, humidity),
-    regr_syy(temperature, humidity),
-    stddev(temperature) as stddev_temp,
-    stddev_pop(temperature),
-    stddev_samp(temperature),
-    variance(temperature),
-    var_pop(temperature),
-    var_samp(temperature),
-    last(temperature, timec) as last_temp,
-    last(highlow, timec) as last_hl,
-    first(highlow, timec) as first_hl,
-    histogram(temperature, 0, 100, 5)
-  FROM conditions_before
-  GROUP BY bucket, location
-  HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+DO LANGUAGE PLPGSQL $$
+DECLARE
+  ts_version TEXT;
+BEGIN
+  SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
+
+  IF ts_version < '2.0.0' THEN
+    CREATE VIEW cagg.realtime_mat
+    WITH ( timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
+    AS
+      SELECT time_bucket('1week', timec) as bucket,
+	location,
+	min(allnull) as min_allnull,
+	max(temperature) as max_temp,
+	sum(temperature)+sum(humidity) as agg_sum_expr,
+	avg(humidity),
+	stddev(humidity),
+	bit_and(bit_int),
+	bit_or(bit_int),
+	bool_and(good_life),
+	every(temperature > 0),
+	bool_or(good_life),
+	count(*) as count_rows,
+	count(temperature) as count_temp,
+	count(allnull) as count_zero,
+	corr(temperature, humidity),
+	covar_pop(temperature, humidity),
+	covar_samp(temperature, humidity),
+	regr_avgx(temperature, humidity),
+	regr_avgy(temperature, humidity),
+	regr_count(temperature, humidity),
+	regr_intercept(temperature, humidity),
+	regr_r2(temperature, humidity),
+	regr_slope(temperature, humidity),
+	regr_sxx(temperature, humidity),
+	regr_sxy(temperature, humidity),
+	regr_syy(temperature, humidity),
+	stddev(temperature) as stddev_temp,
+	stddev_pop(temperature),
+	stddev_samp(temperature),
+	variance(temperature),
+	var_pop(temperature),
+	var_samp(temperature),
+	last(temperature, timec) as last_temp,
+	last(highlow, timec) as last_hl,
+	first(highlow, timec) as first_hl,
+	histogram(temperature, 0, 100, 5)
+      FROM conditions_before
+      GROUP BY bucket, location
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+  ELSE
+    CREATE MATERIALIZED VIEW cagg.realtime_mat
+    WITH ( timescaledb.continuous, timescaledb.materialized_only=false, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
+    AS
+      SELECT time_bucket('1week', timec) as bucket,
+	location,
+	min(allnull) as min_allnull,
+	max(temperature) as max_temp,
+	sum(temperature)+sum(humidity) as agg_sum_expr,
+	avg(humidity),
+	stddev(humidity),
+	bit_and(bit_int),
+	bit_or(bit_int),
+	bool_and(good_life),
+	every(temperature > 0),
+	bool_or(good_life),
+	count(*) as count_rows,
+	count(temperature) as count_temp,
+	count(allnull) as count_zero,
+	corr(temperature, humidity),
+	covar_pop(temperature, humidity),
+	covar_samp(temperature, humidity),
+	regr_avgx(temperature, humidity),
+	regr_avgy(temperature, humidity),
+	regr_count(temperature, humidity),
+	regr_intercept(temperature, humidity),
+	regr_r2(temperature, humidity),
+	regr_slope(temperature, humidity),
+	regr_sxx(temperature, humidity),
+	regr_sxy(temperature, humidity),
+	regr_syy(temperature, humidity),
+	stddev(temperature) as stddev_temp,
+	stddev_pop(temperature),
+	stddev_samp(temperature),
+	variance(temperature),
+	var_pop(temperature),
+	var_samp(temperature),
+	last(temperature, timec) as last_temp,
+	last(highlow, timec) as last_hl,
+	first(highlow, timec) as first_hl,
+	histogram(temperature, 0, 100, 5)
+      FROM conditions_before
+      GROUP BY bucket, location
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+  END IF;
+END $$;
 
 REFRESH MATERIALIZED VIEW cagg.realtime_mat;
-

--- a/tsl/src/continuous_aggs/create.h
+++ b/tsl/src/continuous_aggs/create.h
@@ -13,7 +13,7 @@
 
 #define CONTINUOUS_AGG_CHUNK_ID_COL_NAME "chunk_id"
 
-DDLResult tsl_process_continuous_agg_viewstmt(ViewStmt *stmt, const char *query_string, void *pstmt,
+DDLResult tsl_process_continuous_agg_viewstmt(Node *stmt, const char *query_string, void *pstmt,
 											  WithClauseResult *with_clause_options);
 
 void cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht,

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -587,7 +587,7 @@ SELECT * FROM timescaledb_information.policy_stats;
 
 -- continuous aggregate blocks drop_chunks
 INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '12 months', 0);
-CREATE VIEW tdc_view
+CREATE MATERIALIZED VIEW tdc_view
   WITH (timescaledb.continuous)
   AS SELECT time_bucket('1 hour', time), count(drop_order)
      FROM test_drop_chunks_table
@@ -652,5 +652,5 @@ SELECT show_chunks('test_drop_chunks_table');
 (4 rows)
 
 --drop the view to allow drop chunks to work
-DROP VIEW tdc_view;
+DROP MATERIALIZED VIEW tdc_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_13_chunk

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -931,7 +931,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
 -- check expressions in view definition
-CREATE VIEW cagg_expr WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW cagg_expr WITH (timescaledb.continuous)
 AS
 SELECT
   time_bucket('1d', time) AS time,

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -184,7 +184,7 @@ SELECT * FROM create_hypertable('conditions', 'time',
 INSERT INTO conditions
 SELECT time, (random()*30)::int, random()*80 - 40
 FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '10 min') AS time;
-CREATE VIEW conditions_summary
+CREATE MATERIALIZED VIEW conditions_summary
 WITH (timescaledb.continuous,
       timescaledb.max_interval_per_job = '60 days') AS
 SELECT device,
@@ -197,7 +197,7 @@ GROUP BY device, time_bucket(INTERVAL '1 hour', "time");
 NOTICE:  adding index _materialized_hypertable_8_device_day_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, day)
 REFRESH MATERIALIZED VIEW conditions_summary;
 ALTER TABLE conditions SET (timescaledb.compress);
-ALTER VIEW conditions_summary SET (
+ALTER MATERIALIZED VIEW conditions_summary SET (
       timescaledb.ignore_invalidation_older_than = '15 days'
 );
 SELECT COUNT(*) AS dropped_chunks_count

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -505,7 +505,7 @@ ROLLBACK;
 DROP VIEW dependent_1;
 --create a cont agg view on the ht as well then the drop should nuke everything
 SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
-CREATE VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+CREATE MATERIALIZED VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1
    GROUP BY 1;

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -42,7 +42,7 @@ SELECT set_integer_now_func('foo', 'integer_now_foo');
  
 (1 row)
 
-create or replace view mat_m1( a, countb )
+CREATE MATERIALIZED VIEW mat_m1(a, countb)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select a, count(b)
@@ -91,7 +91,7 @@ order by tgname;
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- TEST2 ---
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 SELECT * FROM _timescaledb_config.bgw_job;
  id | application_name | job_type | schedule_interval | max_runtime | max_retries | retry_period | proc_name | proc_schema | owner | scheduled | hypertable_id | config 
@@ -116,7 +116,7 @@ insert into conditions values ( '2010-01-02 09:00:00-08', 'SFO', 65, 45);
 insert into conditions values ( '2010-01-02 09:00:00-08', 'NYC', 65, 45);
 insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 35);
 insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 35, 15);
-create or replace view mat_m1( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_m1( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -189,7 +189,7 @@ insert into conditions values ( '2010-01-05 09:00:00-08', 'SFO', 75, 100);
 insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 35);
 insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 35, 15);
 insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', 35, 25);
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+CREATE MATERIALIZED VIEW mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -241,9 +241,9 @@ order by time_bucket('1week', timec);
 -- use previous data from conditions
 --drop only the view.
 -- apply where clause on result of mat_m1 --
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+CREATE MATERIALIZED VIEW mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -295,9 +295,9 @@ order by time_bucket('1week', timec);
 
 -- TEST5 --
 ---------test with having clause ----------------------
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+create materialized view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -371,7 +371,7 @@ select generate_series('2018-11-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 insert into conditions
 select generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, 71, 28;
 --naming with AS clauses
-create or replace view mat_naming
+CREATE MATERIALIZED VIEW mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity), stddev(humidity)
@@ -404,9 +404,9 @@ order by attnum, attname;
       8 | chunk_id
 (8 rows)
 
-DROP VIEW mat_naming;
+DROP MATERIALIZED VIEW mat_naming;
 --naming with default names
-create or replace view mat_naming
+CREATE MATERIALIZED VIEW mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
@@ -439,9 +439,9 @@ order by attnum, attname;
       8 | chunk_id
 (8 rows)
 
-DROP VIEW mat_naming;
+DROP MATERIALIZED VIEW mat_naming;
 --naming with view col names
-create or replace view mat_naming (bucket, loc, sum_t_h, stdd)
+CREATE MATERIALIZED VIEW mat_naming(bucket, loc, sum_t_h, stdd)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
@@ -474,8 +474,8 @@ order by attnum, attname;
       8 | chunk_id
 (8 rows)
 
-DROP VIEW mat_naming;
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+DROP MATERIALIZED VIEW mat_naming;
+CREATE MATERIALIZED VIEW mat_m1(timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -560,7 +560,7 @@ insert into :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select * from :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 --lets drop the view and check
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to 2 other objects
 drop table conditions;
 CREATE TABLE conditions (
@@ -594,7 +594,7 @@ SELECT
   $$ AS "QUERY"
 \gset
 \set ECHO errors
-psql:include/cont_agg_equal.sql:8: NOTICE:  view "mat_test" does not exist, skipping
+psql:include/cont_agg_equal.sql:8: NOTICE:  materialized view "mat_test" does not exist, skipping
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
  Number of rows different between view and original (expect 0) |     0
@@ -670,7 +670,7 @@ select count(*) from pg_class where relname = 'mat_test';
      1
 (1 row)
 
-DROP VIEW mat_test;
+DROP MATERIALIZED VIEW mat_test;
 NOTICE:  drop cascades to 2 other objects
 --catalog entry should be gone
 SELECT count(*)
@@ -724,7 +724,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 (1 row)
 
 --no data in hyper table on purpose so that CASCADE is not required because of chunks
-create or replace view mat_drop_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_drop_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -853,7 +853,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
  conditions
 (1 row)
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -880,7 +880,7 @@ SELECT _timescaledb_internal.to_interval(refresh_lag) FROM _timescaledb_catalog.
  @ 5 hours
 (1 row)
 
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '6 h');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '6 h');
 SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job;
                                      alter_job                                      
 ------------------------------------------------------------------------------------
@@ -913,9 +913,9 @@ order by indexname;
  _materialized_hypertable_20_timec_idx         | CREATE INDEX _materialized_hypertable_20_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (timec DESC)
 (4 rows)
 
-DROP VIEW mat_with_test;
+DROP MATERIALIZED VIEW mat_with_test;
 --no additional indexes
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.create_group_indexes=false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -956,7 +956,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_conditions');
  
 (1 row)
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '500')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -980,7 +980,7 @@ SELECT refresh_lag FROM _timescaledb_catalog.continuous_agg WHERE user_view_name
          500
 (1 row)
 
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '100');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '100');
 SELECT refresh_lag FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_with_test';
  refresh_lag 
 -------------
@@ -988,7 +988,7 @@ SELECT refresh_lag FROM _timescaledb_catalog.continuous_agg WHERE user_view_name
 (1 row)
 
 -- we can SET multiple options in one commad
-ALTER VIEW mat_with_test SET (timescaledb.refresh_lag = '100', timescaledb.max_interval_per_job='400');
+ALTER MATERIALIZED VIEW mat_with_test SET (timescaledb.refresh_lag = '100', timescaledb.max_interval_per_job='400');
 SELECT refresh_lag, max_interval_per_job FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_with_test';
  refresh_lag | max_interval_per_job 
 -------------+----------------------
@@ -1022,7 +1022,7 @@ SELECT set_integer_now_func('space_table', 'integer_now_space_table');
  
 (1 row)
 
-CREATE VIEW space_view
+CREATE MATERIALIZED VIEW space_view
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-2')
 AS SELECT time_bucket('4', time), COUNT(data)
    FROM space_table
@@ -1162,7 +1162,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_conditions');
 
 insert into conditions
 select generate_series(0, 200, 10), 'POR', 55, 75, 40, 70, NULL;
-create or replace view mat_ffunc_test
+CREATE MATERIALIZED VIEW mat_ffunc_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test'::text)
@@ -1181,9 +1181,9 @@ WARNING:  type integer text
          100 | 
 (3 rows)
 
-DROP view mat_ffunc_test;
+DROP MATERIALIZED view mat_ffunc_test;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_67_chunk
-create or replace view mat_ffunc_test
+CREATE MATERIALIZED VIEW mat_ffunc_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigint '123')
@@ -1203,9 +1203,9 @@ WARNING:  type integer bigint
 (3 rows)
 
 --refresh mat view test when time_bucket is not projected --
-DROP VIEW mat_ffunc_test;
+DROP MATERIALIZED VIEW mat_ffunc_test;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_68_chunk
-create or replace view mat_refresh_test
+CREATE MATERIALIZED VIEW mat_refresh_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -1226,7 +1226,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 (4 rows)
 
 -- test for bug when group by is not in project list
-create view conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
 select time_bucket(100, timec),  sum(humidity) 
 from conditions 
 group by time_bucket(100, timec), location;
@@ -1242,7 +1242,7 @@ select * from conditions_grpby_view order by 1, 2;
          200 |  75
 (4 rows)
 
-create view conditions_grpby_view2 with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location  
@@ -1276,7 +1276,7 @@ select table_name from create_hypertable( 'conditions', 'time');
  conditions
 (1 row)
 
-create or replace view mat_test5( timec, maxt)
+create materialized view mat_test5( timec, maxt)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='30 day', timescaledb.refresh_lag='-1day',
                timescaledb.max_interval_per_job='260 day')
 as

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -83,7 +83,7 @@ SELECT set_integer_now_func('test_continuous_agg_table', 'integer_now_test');
  
 (1 row)
 
-CREATE VIEW test_continuous_agg_view
+CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
@@ -348,9 +348,9 @@ SELECT ts_bgw_params_reset_time();
  
 (1 row)
 
-DROP VIEW test_continuous_agg_view;
+DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
-CREATE VIEW test_continuous_agg_view
+CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
         timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
@@ -492,10 +492,10 @@ job_status             | Scheduled
 last_run_duration      | 
 
 \x off
-DROP VIEW test_continuous_agg_view;
+DROP MATERIALIZED VIEW test_continuous_agg_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
 --create a view with a function that it has no permission to execute
-CREATE VIEW test_continuous_agg_view
+CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
         timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
@@ -544,7 +544,7 @@ INSERT INTO test_continuous_agg_table_w_grant
         (SELECT generate_series(0, 10) as i) AS j;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 -- make sure view can be created
-CREATE VIEW test_continuous_agg_view_user_2
+CREATE MATERIALIZED VIEW test_continuous_agg_view_user_2
     WITH ( timescaledb.continuous,
         timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',

--- a/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
@@ -50,7 +50,7 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
  
 (1 row)
 
-CREATE VIEW drop_chunks_view1 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.max_interval_per_job=100)
+CREATE MATERIALIZED VIEW drop_chunks_view1 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.max_interval_per_job=100)
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
     GROUP BY 1;

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -33,7 +33,7 @@ NOTICE:  adding not-null constraint to column "time"
  (2,public,foo,t)
 (1 row)
 
-CREATE VIEW rename_test
+CREATE MATERIALIZED VIEW rename_test
   WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1week', time), COUNT(data)
     FROM foo
@@ -45,7 +45,7 @@ SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
  public           | rename_test    | _timescaledb_internal | _partial_view_3
 (1 row)
 
-ALTER VIEW rename_test SET SCHEMA rename_schema;
+ALTER MATERIALIZED VIEW rename_test SET SCHEMA rename_schema;
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name |  partial_view_schema  | partial_view_name 
@@ -121,7 +121,7 @@ SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
  foo_name_schema  | rename_test    | foo_name_schema     | _partial_view_3
 (1 row)
 
-ALTER VIEW foo_name_schema.rename_test SET SCHEMA public;
+ALTER MATERIALIZED VIEW foo_name_schema.rename_test SET SCHEMA public;
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name | partial_view_schema | partial_view_name 
@@ -140,7 +140,7 @@ SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
  public           | rename_test    | rename_schema       | _partial_view_3
 (1 row)
 
-ALTER VIEW rename_test RENAME TO rename_c_aggregate;
+ALTER MATERIALIZED VIEW rename_test RENAME TO rename_c_aggregate;
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema |   user_view_name   | partial_view_schema | partial_view_name 
@@ -187,7 +187,7 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test');
  
 (1 row)
 
-CREATE VIEW drop_chunks_view
+CREATE MATERIALIZED VIEW drop_chunks_view
   WITH (
     timescaledb.continuous,
     timescaledb.materialized_only=true
@@ -268,7 +268,7 @@ SELECT set_integer_now_func('drop_chunks_table_u', 'integer_now_test1');
  
 (1 row)
 
-CREATE VIEW drop_chunks_view
+CREATE MATERIALIZED VIEW drop_chunks_view
   WITH (
     timescaledb.continuous,
     timescaledb.materialized_only=true
@@ -374,7 +374,7 @@ SELECT * FROM drop_chunks_view ORDER BY 1;
 
 \set ON_ERROR_STOP 0
 -- no continuous aggregates on a continuous aggregate materialization table
-CREATE VIEW new_name_view
+CREATE MATERIALIZED VIEW new_name_view
   WITH (
     timescaledb.continuous,
     timescaledb.materialized_only=true
@@ -384,7 +384,7 @@ AS SELECT time_bucket('6', time_bucket), COUNT(agg_2_2)
     GROUP BY 1;
 ERROR:  hypertable is a continuous aggregate materialization table
 -- cannot create a continuous aggregate on a continuous aggregate view
-CREATE VIEW drop_chunks_view_view
+CREATE MATERIALIZED VIEW drop_chunks_view_view
   WITH (
     timescaledb.continuous,
     timescaledb.materialized_only=true
@@ -405,7 +405,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
 -- check expressions in view definition
-CREATE VIEW cagg_expr
+CREATE MATERIALIZED VIEW cagg_expr
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
@@ -453,7 +453,7 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
  
 (1 row)
 
-CREATE VIEW drop_chunks_view
+CREATE MATERIALIZED VIEW drop_chunks_view
   WITH (
     timescaledb.continuous,
     timescaledb.materialized_only=true,
@@ -467,7 +467,7 @@ INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 \set ON_ERROR_STOP 0
 SELECT drop_chunks('drop_chunks_table', older_than => 13);
 ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
-ALTER VIEW drop_chunks_view SET (timescaledb.ignore_invalidation_older_than = 9);
+ALTER MATERIALIZED VIEW drop_chunks_view SET (timescaledb.ignore_invalidation_older_than = 9);
 -- 9 is too small (less than timescaledb.ignore_invalidation_older_than)
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-8));
 ERROR:  older_than must be greater than the timescaledb.ignore_invalidation_older_than parameter of public.drop_chunks_view
@@ -655,7 +655,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (8 rows)
 
 --show that the invalidation processed during drop aren't limited by max_interval_per_job
-ALTER VIEW drop_chunks_view SET (timescaledb.max_interval_per_job = 5);
+ALTER MATERIALIZED VIEW drop_chunks_view SET (timescaledb.max_interval_per_job = 5);
 INSERT INTO drop_chunks_table SELECT i, 300+i FROM generate_series(31, 39) AS i;
 --move the time up to 49
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(40, 49) AS i;
@@ -704,7 +704,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (8 rows)
 
 --test splitting one range for invalidation in drop_chunks and then later
-ALTER VIEW drop_chunks_view SET (timescaledb.max_interval_per_job = 100);
+ALTER MATERIALIZED VIEW drop_chunks_view SET (timescaledb.max_interval_per_job = 100);
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(50,55) AS i;
 REFRESH MATERIALIZED VIEW drop_chunks_view;
 LOG:  materializing continuous aggregate public.drop_chunks_view: nothing to invalidate, new range up to 60

--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -23,7 +23,7 @@ SELECT * FROM create_hypertable('records', 'time',
              1 | public      | records    | t
 (1 row)
 
-CREATE VIEW records_monthly 
+CREATE MATERIALIZED VIEW records_monthly 
     WITH (timescaledb.continuous)
     AS 
         SELECT time_bucket('1d', time) as bucket, 
@@ -73,7 +73,7 @@ SELECT * FROM records_monthly;
  Fri Mar 03 16:00:00 2000 PST |        1 |      3.14 |            0
 (32 rows)
 
-ALTER VIEW records_monthly SET (
+ALTER MATERIALIZED VIEW records_monthly SET (
    timescaledb.ignore_invalidation_older_than = '15 days'
 );
 SELECT chunk_name, range_start, range_end 

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -82,18 +82,18 @@ SELECT
   replace(:'QUERY_TEMPLATE', 'TABLE', 'conditions_before') AS "QUERY_BEFORE",
   replace(:'QUERY_TEMPLATE', 'TABLE', 'conditions_after') AS "QUERY_AFTER"
 \gset
-DROP VIEW IF EXISTS mat_test;
-NOTICE:  view "mat_test" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS mat_test;
+NOTICE:  materialized view "mat_test" does not exist, skipping
 --materialize this VIEW before dump this tests
 --that the partial state survives the dump intact
-CREATE VIEW mat_before
+CREATE MATERIALIZED VIEW mat_before
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_BEFORE;
 NOTICE:  adding index _materialized_hypertable_3_location_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, bucket)
 --materialize this VIEW after dump this tests
 --that the partialize VIEW and refresh mechanics
 --survives the dump intact
-CREATE VIEW mat_after
+CREATE MATERIALIZED VIEW mat_after
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_AFTER;
 NOTICE:  adding index _materialized_hypertable_4_location_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(location, bucket)
@@ -215,7 +215,7 @@ SELECT count(*) FROM conditions_after;
  Number of rows different between view and original (expect 0) | mat_after |     0
 (1 row)
 
-DROP VIEW mat_after;
+DROP MATERIALIZED VIEW mat_after;
 NOTICE:  drop cascades to 2 other objects
-DROP VIEW mat_before;
+DROP MATERIALIZED VIEW mat_before;
 NOTICE:  drop cascades to 2 other objects

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -18,56 +18,56 @@ select table_name from create_hypertable( 'conditions', 'timec');
  conditions
 (1 row)
 
-create  view mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location;
 ERROR:  unrecognized parameter "timescaledb.myfill"
 --valid PG option
-create  view mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
 as
-select * from conditions , matt1;
-ERROR:  only timescaledb parameters allowed in WITH clause for continuous aggregate
+select * from conditions , mat_t1;
+ERROR:  unsupported combination of storage parameters
 -- join multiple tables
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
 group by location;
 ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 -- join multiple tables WITH explicit JOIN
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions JOIN mat_t1 ON true
 where conditions.location = mat_t1.c
 group by location;
 ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 -- LATERAL multiple tables
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions,
 LATERAL (Select * from mat_t1 where c = conditions.location) q
 group by location;
 ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 --non-hypertable
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select a, count(*) from mat_t1
 group by a;
 ERROR:  table "mat_t1" is not a hypertable
 -- no group by
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select count(*) from conditions ;
 ERROR:  SELECT query for continuous aggregate should have at least 1 aggregate function and a GROUP BY clause with time_bucket
 -- no time_bucket in group by
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select count(*) from conditions group by location;
 ERROR:  no valid bucketing function found for continuous aggregate query
 -- with valid query in a CTE
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 with m1 as (
 Select location, count(*) from conditions
@@ -75,26 +75,26 @@ Select location, count(*) from conditions
 select * from m1;
 ERROR:  invalid SELECT query for continuous aggregate
 --with DISTINCT ON
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec) ;
 ERROR:  invalid SELECT query for continuous aggregate
 --aggregate with DISTINCT
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  count(location) , sum(distinct temperature) from conditions
  group by time_bucket('1week', timec) , location;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 --aggregate with FILTER
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  sum(temperature) filter ( where humidity > 20 ) from conditions
  group by time_bucket('1week', timec) , location;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 -- aggregate with filter in having clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec), max(temperature)
 from conditions
@@ -102,63 +102,63 @@ from conditions
  having sum(temperature) filter ( where humidity > 20 ) > 50;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 -- time_bucket on non partitioning column of hypertable
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location;
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
 --time_bucket on expression
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location;
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
 --multiple time_bucket functions
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location;
 ERROR:  multiple time_bucket functions not permitted in continuous aggregate query
 --time_bucket using additional args
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location;
 ERROR:  no valid bucketing function found for continuous aggregate query
 --time_bucket using non-const for first argument
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( timeinterval, timec) , location;
 ERROR:  first argument to time_bucket function should be a constant for continuous aggregate query
 -- ordered set aggr
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select mode() within group( order by humidity)
 from conditions
  group by time_bucket('1week', timec) ;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 --window function
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
 ;
 ERROR:  invalid SELECT query for continuous aggregate
 --aggregate without combine function
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select json_agg(location)
 from conditions
  group by time_bucket('1week', timec) , location;
 ERROR:  aggregates which are not parallelizable are not supported by continuous aggregate query
 ;
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature), array_agg(location)
 from conditions
@@ -171,7 +171,7 @@ CREATE AGGREGATE newavg (
    finalfunc = int8_avg,
    initcond1 = '{0,0}'
 );
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), newavg(temperature::int4)
 from conditions
@@ -179,7 +179,7 @@ from conditions
 ERROR:  aggregates which are not parallelizable are not supported by continuous aggregate query
 ;
 -- using subqueries
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
@@ -187,7 +187,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location ;
 ERROR:  invalid SELECT query for continuous aggregate
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
@@ -195,14 +195,14 @@ from conditions
  group by time_bucket('1week', timec) , location )  q;
 ERROR:  SELECT query for continuous aggregate should have at least 1 aggregate function and a GROUP BY clause with time_bucket
 --using limit /limit offset
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 limit 10 ;
 ERROR:  invalid SELECT query for continuous aggregate
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -210,7 +210,7 @@ from conditions
 offset 10;
 ERROR:  invalid SELECT query for continuous aggregate
 --using ORDER BY in view defintion
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -218,7 +218,7 @@ from conditions
 ORDER BY 1;
 ERROR:  invalid SELECT query for continuous aggregate
 --using FETCH
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -227,28 +227,28 @@ fetch first 10 rows only;
 ERROR:  invalid SELECT query for continuous aggregate
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE;
 ERROR:  FOR KEY SHARE is not allowed with GROUP BY clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR SHARE;
 ERROR:  FOR SHARE is not allowed with GROUP BY clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE;
 ERROR:  FOR UPDATE is not allowed with GROUP BY clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -256,7 +256,7 @@ from conditions
 FOR NO KEY UPDATE;
 ERROR:  FOR NO KEY UPDATE is not allowed with GROUP BY clause
 --tablesample clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
@@ -264,20 +264,20 @@ from conditions tablesample bernoulli(0.2)
 ;
 ERROR:  invalid SELECT query for continuous aggregate
 -- ONLY in from clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location ;
 ERROR:  invalid SELECT query for continuous aggregate
 --grouping sets and variants
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by grouping sets(time_bucket('1week', timec) , location ) ;
 ERROR:  invalid SELECT query for continuous aggregate
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -286,31 +286,37 @@ ERROR:  invalid SELECT query for continuous aggregate
 --NO immutable functions -- check all clauses
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location  ;
 ERROR:  only immutable functions are supported for continuous aggregate query
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), min(location)
 from conditions
 group by time_bucket('1week', timec)
 having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08';
 ERROR:  only immutable functions are supported for continuous aggregate query
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec);
 ERROR:  only immutable functions are supported for continuous aggregate query
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec), test_stablefunc(humidity::int);
 ERROR:  only immutable functions are supported for continuous aggregate query
+-- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
+CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', timec)
+  FROM conditions
+GROUP BY time_bucket('1 week', timec);
+ERROR:  cannot create continuous aggregate with CREATE VIEW
 -- row security on table
 create table rowsec_tab( a bigint, b integer, c integer);
 select table_name from create_hypertable( 'rowsec_tab', 'a', chunk_time_interval=>10);
@@ -329,7 +335,7 @@ SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( b), min(c)
 from rowsec_tab
@@ -353,7 +359,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 (1 row)
 
 \set ON_ERROR_STOP 0
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 joules')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -361,13 +367,13 @@ from conditions
 group by time_bucket('1day', timec);
 ERROR:  invalid input syntax for type interval: "5 joules"
 \set ON_ERROR_STOP 1
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec);
-create or replace view mat_with_test_no_inval( timec, minl, sumt , sumh)
+create materialized view mat_with_test_no_inval( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours',
                timescaledb.ignore_invalidation_older_than='0')
 as
@@ -383,15 +389,15 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_with_test'
 \gset
 \set ON_ERROR_STOP 0
-ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
 ERROR:  cannot alter create_group_indexes option for continuous aggregates
-ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
 ERROR:  cannot alter create_group_indexes option for continuous aggregates
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1 joule');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '1 joule');
 ERROR:  invalid input syntax for type interval: "1 joule"
-ALTER VIEW mat_with_test RESET(timescaledb.refresh_lag);
+ALTER MATERIALIZED VIEW mat_with_test RESET(timescaledb.refresh_lag);
 ERROR:  cannot alter only SET options of a continuous aggregate
-ALTER VIEW mat_with_test ALTER timec DROP default;
+ALTER MATERIALIZED VIEW mat_with_test ALTER timec DROP default;
 ERROR:  cannot alter only SET options of a continuous aggregate
 ALTER VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME" SET(timescaledb.refresh_lag = '1 hour');
 ERROR:  cannot alter the internal view of a continuous aggregate
@@ -422,14 +428,14 @@ SELECT set_integer_now_func('conditions', 'integer_now_test_s');
 (1 row)
 
 \set ON_ERROR_STOP 0
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '32768')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -437,7 +443,7 @@ from conditions
 group by time_bucket(100, timec);
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
 ALTER TABLE conditions ALTER timec type int;
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483648')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -445,7 +451,7 @@ from conditions
 group by time_bucket(100, timec);
 ERROR:  timescaledb.refresh_lag out of range
 -- max_interval_per_job must be at least time_bucket
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='10')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -453,14 +459,14 @@ from conditions
 group by time_bucket(100, timec);
 ERROR:  parameter timescaledb.max_interval_per_job must be at least the size of the time_bucket width
 --ignore_invalidation_older_than must be positive
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='-10')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
 ERROR:  parameter timescaledb.ignore_invalidation_older_than must not be negative
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -468,23 +474,30 @@ from conditions
 group by time_bucket(100, timec);
 ERROR:  parameter timescaledb.ignore_invalidation_older_than must be an integer for hypertables with integer time values
 \set ON_ERROR_STOP 1
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
+-- Should print a useful error message, but not fail.
+CREATE MATERIALIZED VIEW IF NOT EXISTS mat_with_test
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
+  FROM conditions
+GROUP BY time_bucket(100, timec);
+NOTICE:  continuous aggregate "mat_with_test" already exists, skipping
 \set ON_ERROR_STOP 0
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1h');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '1h');
 ERROR:  parameter timescaledb.refresh_lag must be an integer for hypertables with integer time values
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '2147483648');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '2147483648');
 ERROR:  timescaledb.refresh_lag out of range
 ALTER TABLE conditions ALTER timec type bigint;
 ERROR:  cannot alter type of a column used by a view or rule
-\set ON_ERROR_STOP
-DROP VIEW mat_with_test;
+\set ON_ERROR_STOP 1
+DROP MATERIALIZED VIEW mat_with_test;
 ALTER TABLE conditions ALTER timec type bigint;
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
@@ -503,11 +516,22 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 \set ON_ERROR_STOP 0
-CREATE VIEW text_view
-    WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW text_view
+    WITH (timescaledb.continuous)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
         GROUP BY 1;
 ERROR:  continuous aggregate do not support custom partitioning functions
 \set ON_ERROR_STOP 1
+-- Check that we get an error when mixing normal materialized views
+-- and continuous aggregates.
+CREATE MATERIALIZED VIEW normal_mat_view AS
+SELECT time_bucket('5', text_part_func(time)), COUNT(time)
+  FROM text_time
+GROUP BY 1;
+\set ON_ERROR_STOP 0
+DROP MATERIALIZED VIEW normal_mat_view, mat_with_test;
+ERROR:  mixing continuous aggregates and other objects not allowed
+\set ON_ERROR_STOP 1
 DROP TABLE text_time CASCADE;
+NOTICE:  drop cascades to materialized view normal_mat_view

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -76,7 +76,7 @@ LIMIT 10;
 
 -- Create two continuous aggregates on the same hypertable to test
 -- that invalidations are handled correctly across both of them.
-CREATE VIEW cond_10
+CREATE MATERIALIZED VIEW cond_10
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -84,7 +84,7 @@ SELECT time_bucket(10, time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2;
 NOTICE:  adding index _materialized_hypertable_3_device_day_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device, day)
-CREATE VIEW cond_20
+CREATE MATERIALIZED VIEW cond_20
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -92,7 +92,7 @@ SELECT time_bucket(20, time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2;
 NOTICE:  adding index _materialized_hypertable_4_device_day_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, day)
-CREATE VIEW measure_10
+CREATE MATERIALIZED VIEW measure_10
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -613,7 +613,7 @@ SELECT * FROM continuous_agg_test_t;
  2019-02-02 05:00:00+00 |    1
 (4 rows)
 
-CREATE VIEW test_t_mat_view
+CREATE MATERIALIZED VIEW test_t_mat_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_test_t
@@ -830,7 +830,7 @@ SELECT set_integer_now_func('continuous_agg_extreme', 'integer_now_continuous_ag
 
 -- We should be able to use time_bucket(5, ...) (note lack of '), but that is currently not
 --      recognized as a constant
-CREATE VIEW extreme_view
+CREATE MATERIALIZED VIEW extreme_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('1', time), SUM(data) as value
         FROM continuous_agg_extreme
@@ -954,9 +954,9 @@ SELECT hypertable_id, watermark
 (1 row)
 
 --cleanup of continuous agg views --
-DROP view test_t_mat_view;
+DROP MATERIALIZED view test_t_mat_view;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_16_chunk
-DROP view extreme_view;
+DROP MATERIALIZED view extreme_view;
 NOTICE:  drop cascades to 4 other objects
 -- negative lag test
 CREATE TABLE continuous_agg_negative(time BIGINT, data BIGINT);
@@ -974,7 +974,7 @@ SELECT set_integer_now_func('continuous_agg_negative', 'integer_now_continuous_a
  
 (1 row)
 
-CREATE VIEW negative_view_5
+CREATE MATERIALIZED VIEW negative_view_5
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('5', time), COUNT(data) as value
         FROM continuous_agg_negative
@@ -1031,10 +1031,10 @@ SELECT * FROM negative_view_5 ORDER BY 1;
           10 |     5
 (3 rows)
 
-DROP VIEW negative_view_5;
+DROP MATERIALIZED VIEW negative_view_5;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_10_27_chunk
 TRUNCATE continuous_agg_negative;
-CREATE VIEW negative_view_5
+CREATE MATERIALIZED VIEW negative_view_5
             WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
 AS SELECT time_bucket('5', time), COUNT(data) as value
    FROM continuous_agg_negative
@@ -1081,7 +1081,7 @@ SELECT set_integer_now_func('continuous_agg_max_mat', 'integer_now_continuous_ag
 (1 row)
 
 -- only allow two time_buckets per run
-CREATE VIEW max_mat_view
+CREATE MATERIALIZED VIEW max_mat_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4', timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), COUNT(data) as value
         FROM continuous_agg_max_mat
@@ -1271,7 +1271,7 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 -- only allow two time_buckets per run
-CREATE VIEW max_mat_view_t
+CREATE MATERIALIZED VIEW max_mat_view_t
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4 hours', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_max_mat_t
@@ -1343,7 +1343,7 @@ NOTICE:  adding not-null constraint to column "time"
  (16,public,continuous_agg_max_mat_timestamp,t)
 (1 row)
 
-CREATE VIEW max_mat_view_timestamp
+CREATE MATERIALIZED VIEW max_mat_view_timestamp
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time)
         FROM continuous_agg_max_mat_timestamp
@@ -1373,7 +1373,7 @@ NOTICE:  adding not-null constraint to column "time"
  (18,public,continuous_agg_max_mat_date,t)
 (1 row)
 
-CREATE VIEW max_mat_view_date
+CREATE MATERIALIZED VIEW max_mat_view_date
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-7 days')
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
@@ -1449,7 +1449,7 @@ INSERT INTO timezone_test VALUES
     (:NOW_TEST - '30m'::interval),
     (:NOW_TEST),
     (:NOW_TEST + '30m'::interval);
-CREATE VIEW timezone_test_summary
+CREATE MATERIALIZED VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
@@ -1478,7 +1478,7 @@ INSERT INTO timezone_test VALUES
     (:NOW_TEST - '30m'::interval),
     (:NOW_TEST),
     (:NOW_TEST + '30m'::interval);
-CREATE VIEW timezone_test_summary
+CREATE MATERIALIZED VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
@@ -1512,7 +1512,7 @@ SELECT set_integer_now_func('continuous_agg_int', 'integer_now_continuous_agg_ma
  
 (1 row)
 
-CREATE VIEW continuous_agg_int_max 
+CREATE MATERIALIZED VIEW continuous_agg_int_max 
     WITH (timescaledb.continuous, timescaledb.refresh_lag='0')
     AS SELECT time_bucket('10', time), COUNT(data) as value
         FROM continuous_agg_int
@@ -1557,7 +1557,7 @@ NOTICE:  adding not-null constraint to column "timecol"
  (26,public,continuous_agg_ts_max_t,t)
 (1 row)
 
-CREATE VIEW continuous_agg_ts_max_view
+CREATE MATERIALIZED VIEW continuous_agg_ts_max_view
     WITH (timescaledb.continuous, timescaledb.max_interval_per_job='365 days', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', timecol), COUNT(data) as value
         FROM continuous_agg_ts_max_t

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -24,13 +24,13 @@ INSERT INTO continuous_agg_test VALUES
     (15, -4, 22), (16, -4, 23);
 -- TEST for multiple continuous aggs 
 --- invalidations are picked up by both caggs
-CREATE VIEW cagg_1( timed, cnt ) 
+CREATE MATERIALIZED VIEW cagg_1( timed, cnt ) 
 WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.materialized_only=true )
 AS
     SELECT time_bucket( 2, timeval), COUNT(col1) 
     FROM continuous_agg_test
     GROUP BY 1;
-CREATE VIEW cagg_2( timed, grp, maxval) 
+CREATE MATERIALIZED VIEW cagg_2( timed, grp, maxval) 
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.materialized_only=true   )
 AS
     SELECT time_bucket(2, timeval), col1, max(col2) 
@@ -215,7 +215,7 @@ select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invali
 (1 row)
 
 --now drop cagg_1, should still have materialization_invalidation_log
-DROP VIEW cagg_1;
+DROP MATERIALIZED VIEW cagg_1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_5_chunk
 select count(*) from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
  count 
@@ -264,13 +264,13 @@ SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
 INSERT INTO continuous_agg_test VALUES
     (10, - 4, 1), (11, - 3, 5), (12, - 3, 7), (13, - 3, 9), (14,-4, 11),
     (15, -4, 22), (16, -4, 23);
-CREATE VIEW cagg_1( timed, cnt ) 
+CREATE MATERIALIZED VIEW cagg_1( timed, cnt ) 
 WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.materialized_only = true)
 AS
     SELECT time_bucket( 2, timeval), COUNT(col1) 
     FROM continuous_agg_test
     GROUP BY 1;
-CREATE VIEW cagg_2( timed, maxval) 
+CREATE MATERIALIZED VIEW cagg_2( timed, maxval) 
 WITH ( timescaledb.continuous , timescaledb.refresh_lag = '2', timescaledb.materialized_only = true)
 AS
     SELECT time_bucket(2, timeval), max(col2) 
@@ -386,9 +386,9 @@ select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   6 |                18 |                    18 |                      18
 (2 rows)
 
-DROP VIEW cagg_1;
+DROP MATERIALIZED VIEW cagg_1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_11_chunk
-DROP VIEW cagg_2;
+DROP MATERIALIZED VIEW cagg_2;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_6_12_chunk
 --TEST6 test the ignore_invalidation_older_than setting
 CREATE TABLE continuous_agg_test_ignore_invalidation_older_than(timeval integer, col1 integer, col2 integer);
@@ -408,19 +408,19 @@ SELECT set_integer_now_func('continuous_agg_test_ignore_invalidation_older_than'
 
 INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES
 (10, - 4, 1), (11, - 3, 5), (12, -3, 7);
-CREATE VIEW cagg_iia1( timed, cnt )
+CREATE MATERIALIZED VIEW cagg_iia1( timed, cnt )
         WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 5 , timescaledb.materialized_only=true)
 AS
 SELECT time_bucket( 2, timeval), COUNT(col1)
 FROM continuous_agg_test_ignore_invalidation_older_than
 GROUP BY 1;
-CREATE VIEW cagg_iia2( timed, maxval)
+CREATE MATERIALIZED VIEW cagg_iia2( timed, maxval)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 10, timescaledb.materialized_only=true)
 AS
 SELECT time_bucket(2, timeval), max(col2)
 FROM continuous_agg_test_ignore_invalidation_older_than
 GROUP BY 1;
-CREATE VIEW cagg_iia3( timed, maxval)
+CREATE MATERIALIZED VIEW cagg_iia3( timed, maxval)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 0, timescaledb.materialized_only=true)
 AS
 SELECT time_bucket(2, timeval), max(col2)
@@ -635,7 +635,7 @@ select * from cagg_iia3 order by 1;
 (5 rows)
 
 --change the parameter
-ALTER VIEW cagg_iia3 set (timescaledb.ignore_invalidation_older_than = 100);
+ALTER MATERIALIZED VIEW cagg_iia3 set (timescaledb.ignore_invalidation_older_than = 100);
 INSERT INTO continuous_agg_test_ignore_invalidation_older_than VALUES
  (10, -3, 20);
 --sees the change now
@@ -694,13 +694,13 @@ SELECT set_integer_now_func('foo', 'integer_now_foo');
  
 (1 row)
 
-CREATE OR REPLACE VIEW mat_m1( a, countb)
+CREATE MATERIALIZED VIEW mat_m1(a, countb)
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 10, timescaledb.max_interval_per_job=100)
 AS
 SELECT time_bucket(10, a), count(*)
 FROM foo
 GROUP BY time_bucket(10, a);
-CREATE OR REPLACE VIEW mat_m2( a, countb)
+CREATE MATERIALIZED VIEW mat_m2(a, countb)
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 0, timescaledb.max_interval_per_job=100)
 AS
 SELECT time_bucket(5, a), count(*)

--- a/tsl/test/expected/continuous_aggs_permissions.out
+++ b/tsl/test/expected/continuous_aggs_permissions.out
@@ -28,7 +28,7 @@ SELECT set_integer_now_func('conditions', 'integer_now_test1');
  
 (1 row)
 
-create or replace view mat_refresh_test
+CREATE MATERIALIZED VIEW mat_refresh_test
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -107,11 +107,11 @@ REVOKE EXECUTE ON FUNCTION get_constant() FROM PUBLIC;
 select from alter_job(:cagg_job_id, max_runtime => NULL);
 ERROR:  insufficient permissions to alter job 1000
 --make sure that commands fail
-ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
-ERROR:  must be owner of view mat_refresh_test
-ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
-ERROR:  must be owner of view mat_refresh_test
-DROP VIEW mat_refresh_test; 
+ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
+ERROR:  must be owner of continuous aggregate "mat_refresh_test"
+DROP MATERIALIZED VIEW mat_refresh_test; 
 ERROR:  must be owner of view mat_refresh_test
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 ERROR:  permission denied for table conditions
@@ -122,7 +122,7 @@ ERROR:  permission denied for table _materialized_hypertable_2
 SELECT * FROM :"mat_chunk_schema".:"mat_chunk_table";
 ERROR:  permission denied for table _hyper_2_2_chunk
 --cannot create a mat view without select and trigger grants
-create or replace view mat_perm_view_test
+CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -131,7 +131,7 @@ group by time_bucket(100, timec), location;
 NOTICE:  adding index _materialized_hypertable_5_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(location, time_partition_col)
 ERROR:  permission denied for table conditions_for_perm_check
 --cannot create mat view in a schema without create privileges
-create or replace view custom_schema.mat_perm_view_test
+CREATE MATERIALIZED VIEW custom_schema.mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -141,7 +141,7 @@ NOTICE:  adding index _materialized_hypertable_6_location_time_partition_col_idx
 ERROR:  permission denied for schema custom_schema
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
-create or replace view mat_perm_view_test
+CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity), get_constant()
@@ -152,9 +152,9 @@ NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 ERROR:  permission denied for function get_constant
-DROP VIEW mat_perm_view_test;
+DROP MATERIALIZED VIEW mat_perm_view_test;
 --can create a mat view on something with select and trigger grants
-create or replace view mat_perm_view_test
+CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)

--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -41,7 +41,7 @@ create table location_tab( locid integer, locname text );
 insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
 insert into location_tab values( 3, 'por');
-create or replace view mat_m1( location, timec, minl, sumt , sumh)
+create materialized view mat_m1( location, timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -60,7 +60,7 @@ FROM ( select max(timec)as timeval from conditions ) as q;
 REFRESH MATERIALIZED VIEW mat_m1;
 LOG:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to Sat Nov 03 17:00:00 2018 PDT
 --test first/last
-create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
+create materialized view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)

--- a/tsl/test/expected/continuous_aggs_query-12.out
+++ b/tsl/test/expected/continuous_aggs_query-12.out
@@ -41,7 +41,7 @@ create table location_tab( locid integer, locname text );
 insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
 insert into location_tab values( 3, 'por');
-create or replace view mat_m1( location, timec, minl, sumt , sumh)
+create materialized view mat_m1( location, timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -60,7 +60,7 @@ FROM ( select max(timec)as timeval from conditions ) as q;
 REFRESH MATERIALIZED VIEW mat_m1;
 LOG:  materializing continuous aggregate public.mat_m1: nothing to invalidate, new range up to Sat Nov 03 17:00:00 2018 PDT
 --test first/last
-create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
+create materialized view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -44,7 +44,7 @@ LIMIT 10;
  Mon May 04 22:30:00 2020 PDT |      0 |    8
 (10 rows)
 
-CREATE VIEW daily_temp
+CREATE MATERIALIZED VIEW daily_temp
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -190,7 +190,7 @@ SELECT create_hypertable('conditions_date', 'time');
  (3,public,conditions_date,t)
 (1 row)
 
-CREATE VIEW daily_temp_date
+CREATE MATERIALIZED VIEW daily_temp_date
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -222,7 +222,7 @@ SELECT set_integer_now_func('conditions_smallint', 'smallint_now');
  
 (1 row)
 
-CREATE VIEW cond_20_smallint
+CREATE MATERIALIZED VIEW cond_20_smallint
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -272,7 +272,7 @@ SELECT set_integer_now_func('conditions_int', 'int_now');
  
 (1 row)
 
-CREATE VIEW cond_20_int
+CREATE MATERIALIZED VIEW cond_20_int
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -322,7 +322,7 @@ SELECT set_integer_now_func('conditions_bigint', 'bigint_now');
  
 (1 row)
 
-CREATE VIEW cond_20_bigint
+CREATE MATERIALIZED VIEW cond_20_bigint
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -24,7 +24,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 -- test switching continuous agg view between different modes
 --
 -- check default view for new continuous aggregate
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -59,7 +59,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -82,7 +82,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (0 rows)
 
 -- upgrade view to union view again
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -113,7 +113,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- try upgrade view to union view that is already union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -153,7 +153,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -177,10 +177,10 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
  Fri Dec 31 16:00:00 1999 PST | 0.5
 (1 row)
 
-DROP VIEW metrics_summary;
+DROP MATERIALIZED VIEW metrics_summary;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 -- check default view for new continuous aggregate with materialized_only to true
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -206,7 +206,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (0 rows)
 
 -- upgrade view to union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -237,7 +237,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -259,11 +259,11 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -------------+-----
 (0 rows)
 
-DROP VIEW metrics_summary;
+DROP MATERIALIZED VIEW metrics_summary;
 --
 -- test queries on union view
 --
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -280,7 +280,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -------------+-----
 (0 rows)
 
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- after switch to union view all results should be returned
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
@@ -289,7 +289,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 REFRESH MATERIALIZED VIEW metrics_summary;
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- materialized only view should return data now too because refresh has happened
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
@@ -307,7 +307,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- but union view should
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
 ------------------------------+-----
@@ -318,7 +318,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- and after refresh non union view should have new data too
 REFRESH MATERIALIZED VIEW metrics_summary;
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
 ------------------------------+-----
@@ -346,7 +346,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
  
 (1 row)
 
-CREATE VIEW boundary_view
+CREATE MATERIALIZED VIEW boundary_view
   WITH (timescaledb.continuous)
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
@@ -461,7 +461,7 @@ SELECT set_integer_now_func('ht_intdata', 'integer_now_ht_intdata');
  
 (1 row)
 
-CREATE OR REPLACE VIEW mat_m1( a, countb, sumbc, spreadcb, avgc )
+CREATE MATERIALIZED VIEW mat_m1(a, countb, sumbc, spreadcb, avgc)
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 10)
 AS
 SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
@@ -498,7 +498,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 (2 rows)
 
 --verify that materialized only doesn't have rows with a> 20
-ALTER VIEW mat_m1 SET(timescaledb.materialized_only = true);
+ALTER MATERIALIZED VIEW mat_m1 SET(timescaledb.materialized_only = true);
 SELECT * FROM mat_m1 ORDER BY 1;
  a | countb | sumbc | spreadcb | avgc 
 ---+--------+-------+----------+------
@@ -506,7 +506,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 (1 row)
 
 --again revert the view to include real time aggregates
-ALTER VIEW mat_m1 SET(timescaledb.materialized_only = false);
+ALTER MATERIALIZED VIEW mat_m1 SET(timescaledb.materialized_only = false);
 INSERT into ht_intdata values( 31 , 15 , 30);
 INSERT into ht_intdata values( 31 , 14 , 70);
 --cagg was not refreshed, should include all rows
@@ -548,10 +548,10 @@ ORDER BY 1;
           31 |     2 | 129 |       56 |  50
 (3 rows)
 
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_12_chunk
 --- TEST union view with multiple WHERE and HAVING clauses
-CREATE VIEW mat_m1
+CREATE MATERIALIZED VIEW mat_m1
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 10,
       timescaledb.max_interval_per_job = 100)
 AS

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -24,7 +24,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 -- test switching continuous agg view between different modes
 --
 -- check default view for new continuous aggregate
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -59,7 +59,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -82,7 +82,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (0 rows)
 
 -- upgrade view to union view again
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -113,7 +113,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- try upgrade view to union view that is already union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -153,7 +153,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -177,10 +177,10 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
  Fri Dec 31 16:00:00 1999 PST | 0.5
 (1 row)
 
-DROP VIEW metrics_summary;
+DROP MATERIALIZED VIEW metrics_summary;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 -- check default view for new continuous aggregate with materialized_only to true
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -206,7 +206,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (0 rows)
 
 -- upgrade view to union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -237,7 +237,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -259,11 +259,11 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -------------+-----
 (0 rows)
 
-DROP VIEW metrics_summary;
+DROP MATERIALIZED VIEW metrics_summary;
 --
 -- test queries on union view
 --
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -280,7 +280,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -------------+-----
 (0 rows)
 
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- after switch to union view all results should be returned
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
@@ -289,7 +289,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 REFRESH MATERIALIZED VIEW metrics_summary;
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- materialized only view should return data now too because refresh has happened
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
@@ -307,7 +307,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 (1 row)
 
 -- but union view should
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
 ------------------------------+-----
@@ -318,7 +318,7 @@ SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 -- and after refresh non union view should have new data too
 REFRESH MATERIALIZED VIEW metrics_summary;
 WARNING:  REFRESH did not materialize the entire range since it was limited by the max_interval_per_job setting
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
          time_bucket          | avg 
 ------------------------------+-----
@@ -346,7 +346,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
  
 (1 row)
 
-CREATE VIEW boundary_view
+CREATE MATERIALIZED VIEW boundary_view
   WITH (timescaledb.continuous)
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
@@ -461,7 +461,7 @@ SELECT set_integer_now_func('ht_intdata', 'integer_now_ht_intdata');
  
 (1 row)
 
-CREATE OR REPLACE VIEW mat_m1( a, countb, sumbc, spreadcb, avgc )
+CREATE MATERIALIZED VIEW mat_m1(a, countb, sumbc, spreadcb, avgc)
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 10)
 AS
 SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
@@ -498,7 +498,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 (2 rows)
 
 --verify that materialized only doesn't have rows with a> 20
-ALTER VIEW mat_m1 SET(timescaledb.materialized_only = true);
+ALTER MATERIALIZED VIEW mat_m1 SET(timescaledb.materialized_only = true);
 SELECT * FROM mat_m1 ORDER BY 1;
  a | countb | sumbc | spreadcb | avgc 
 ---+--------+-------+----------+------
@@ -506,7 +506,7 @@ SELECT * FROM mat_m1 ORDER BY 1;
 (1 row)
 
 --again revert the view to include real time aggregates
-ALTER VIEW mat_m1 SET(timescaledb.materialized_only = false);
+ALTER MATERIALIZED VIEW mat_m1 SET(timescaledb.materialized_only = false);
 INSERT into ht_intdata values( 31 , 15 , 30);
 INSERT into ht_intdata values( 31 , 14 , 70);
 --cagg was not refreshed, should include all rows
@@ -548,10 +548,10 @@ ORDER BY 1;
           31 |     2 | 129 |       56 |  50
 (3 rows)
 
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_12_chunk
 --- TEST union view with multiple WHERE and HAVING clauses
-CREATE VIEW mat_m1
+CREATE MATERIALIZED VIEW mat_m1
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 10,
       timescaledb.max_interval_per_job = 100)
 AS

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -19,7 +19,7 @@ SELECT table_name FROM create_hypertable('device_readings', 'observation_time');
 (1 row)
 
 --Next, create your continuous aggregate view
-CREATE VIEW device_summary
+CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) --This flag is what makes the view continuous
 AS
 SELECT
@@ -44,7 +44,7 @@ SELECT * FROM device_summary;
 
 --Normally, the continuous view will be updated automatically on a schedule but, you can also do it manually.
 --We alter max_interval_per_job too since we are not using background workers
-ALTER VIEW device_summary SET (timescaledb.max_interval_per_job = '60 day');
+ALTER MATERIALIZED VIEW device_summary SET (timescaledb.max_interval_per_job = '60 day');
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW device_summary;
 LOG:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to Sun Dec 30 22:00:00 2018 PST
@@ -156,7 +156,7 @@ SELECT max(bucket) FROM device_summary;
 --Negative values create materialization where the bucket ends after the max of the raw data.
 --So to have you data always up-to-date make the refresh_lag (-bucket_width). Note this
 --will slow down your inserts because of invalidation.
-ALTER VIEW device_summary SET (timescaledb.refresh_lag = '-1 hour');
+ALTER MATERIALIZED VIEW device_summary SET (timescaledb.refresh_lag = '-1 hour');
 REFRESH MATERIALIZED VIEW device_summary;
 LOG:  materializing continuous aggregate public.device_summary: nothing to invalidate, new range up to Mon Dec 31 01:00:00 2018 PST
 SELECT max(observation_time) FROM device_readings;
@@ -208,9 +208,9 @@ SELECT * FROM device_summary WHERE device_id = 'device_1' and bucket = 'Sun Dec 
 -- For example you cannot cast to the local time. This is because
 -- a timezone setting can alter from user-to-user and thus
 -- cannot be materialized.
-DROP VIEW device_summary;
+DROP MATERIALIZED VIEW device_summary;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_6_chunk
-CREATE VIEW device_summary
+CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
@@ -226,9 +226,9 @@ ERROR:  only immutable functions are supported for continuous aggregate query
 --note the error.
 -- You have two options:
 -- Option 1: be explicit in your timezone:
-DROP VIEW device_summary;
-ERROR:  view "device_summary" does not exist
-CREATE VIEW device_summary
+DROP MATERIALIZED VIEW device_summary;
+ERROR:  materialized view "device_summary" does not exist
+CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
@@ -241,12 +241,12 @@ FROM
   device_readings
 GROUP BY bucket, device_id;
 NOTICE:  adding index _materialized_hypertable_3_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device_id, bucket)
-DROP VIEW device_summary;
+DROP MATERIALIZED VIEW device_summary;
 -- Option 2: Keep things as TIMESTAMPTZ in the view and convert to local time when
 -- querying from the view
-DROP VIEW device_summary;
-ERROR:  view "device_summary" does not exist
-CREATE VIEW device_summary
+DROP MATERIALIZED VIEW device_summary;
+ERROR:  materialized view "device_summary" does not exist
+CREATE MATERIALIZED VIEW device_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
 SELECT
@@ -292,11 +292,11 @@ SELECT set_integer_now_func('device_readings_int','device_readings_int_now');
  
 (1 row)
 
-CREATE VIEW device_readings_mat_only
+CREATE MATERIALIZED VIEW device_readings_mat_only
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1;
-CREATE VIEW device_readings_jit
+CREATE MATERIALIZED VIEW device_readings_jit
   WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
   SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1;
@@ -406,7 +406,7 @@ SELECT * FROM create_hypertable('whatever', 'time');
              8 | public      | whatever   | t
 (1 row)
 
-CREATE VIEW whatever_summary WITH (timescaledb.continuous) AS
+CREATE MATERIALIZED VIEW whatever_summary WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 hour', time) AS bucket, avg(metric)
   FROM whatever GROUP BY bucket;
 SELECT (SELECT format('%1$I.%2$I', schema_name, table_name)::regclass::oid
@@ -432,13 +432,13 @@ ERROR:  cannot drop table whatever because other objects depend on it
 -- object on it.
 CREATE VIEW whatever_summary_dependency AS SELECT * FROM whatever_summary;
 -- Should generate an error
-DROP VIEW whatever_summary;
+DROP MATERIALIZED VIEW whatever_summary;
 ERROR:  cannot drop view whatever_summary because other objects depend on it
 -- Dropping the dependent view so that we can do a proper drop below.
 DROP VIEW whatever_summary_dependency;
 ----------------------------------------------------------------
 -- Dropping the cagg should also remove the materialized table
-DROP VIEW whatever_summary;
+DROP MATERIALIZED VIEW whatever_summary;
 SELECT relname FROM pg_class WHERE oid = :mat_table;
  relname 
 ---------

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -227,7 +227,7 @@ SELECT set_integer_now_func('ca_inval_test', 'integer_now_test2');
  
 (1 row)
 
-CREATE VIEW cit_view
+CREATE MATERIALIZED VIEW cit_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(time)
         FROM ca_inval_test
@@ -323,7 +323,7 @@ SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test3');
 
 INSERT INTO ts_continuous_test SELECT i, i FROM
     (SELECT generate_series(0, 29) AS i) AS i;
-CREATE VIEW continuous_view
+CREATE MATERIALIZED VIEW continuous_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(location)
         FROM ts_continuous_test

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -1843,7 +1843,7 @@ INSERT INTO disttable VALUES
        ('2018-07-01 09:11', 90, 10303.12),
        ('2018-07-01 08:01', 29, 64);
 \set ON_ERROR_STOP 0
-CREATE VIEW disttable_cagg WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW disttable_cagg WITH (timescaledb.continuous)
 AS SELECT time_bucket('2 days', time), device, max(value)
     FROM disttable
     GROUP BY 1, 2;

--- a/tsl/test/expected/jit-11.out
+++ b/tsl/test/expected/jit-11.out
@@ -47,7 +47,7 @@ SELECT table_name FROM create_hypertable('jit_test_contagg', 'observation_time')
  jit_test_contagg
 (1 row)
 
-CREATE VIEW jit_device_summary
+CREATE MATERIALIZED VIEW jit_device_summary
 WITH (timescaledb.continuous)
 AS
 SELECT
@@ -63,7 +63,7 @@ INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_2', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
-ALTER VIEW jit_device_summary SET (timescaledb.max_interval_per_job = '60 day');
+ALTER MATERIALIZED VIEW jit_device_summary SET (timescaledb.max_interval_per_job = '60 day');
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW jit_device_summary;
 \set PREFIX 'EXPLAIN (VERBOSE, TIMING OFF, COSTS OFF, SUMMARY OFF)'

--- a/tsl/test/expected/jit-12.out
+++ b/tsl/test/expected/jit-12.out
@@ -47,7 +47,7 @@ SELECT table_name FROM create_hypertable('jit_test_contagg', 'observation_time')
  jit_test_contagg
 (1 row)
 
-CREATE VIEW jit_device_summary
+CREATE MATERIALIZED VIEW jit_device_summary
 WITH (timescaledb.continuous)
 AS
 SELECT
@@ -63,7 +63,7 @@ INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_2', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
-ALTER VIEW jit_device_summary SET (timescaledb.max_interval_per_job = '60 day');
+ALTER MATERIALIZED VIEW jit_device_summary SET (timescaledb.max_interval_per_job = '60 day');
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW jit_device_summary;
 \set PREFIX 'EXPLAIN (VERBOSE, TIMING OFF, COSTS OFF, SUMMARY OFF)'

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -265,7 +265,7 @@ SET default_transaction_read_only TO on;
 -- CREATE VIEW
 --
 \set ON_ERROR_STOP 0
-CREATE VIEW test_contagg_view
+CREATE MATERIALIZED VIEW test_contagg_view
 WITH (timescaledb.continuous)
 AS
 SELECT
@@ -276,7 +276,7 @@ SELECT
 FROM
   test_contagg
 GROUP BY bucket, device_id;
-ERROR:  cannot execute CREATE VIEW in a read-only transaction
+ERROR:  cannot execute CREATE MATERIALIZED VIEW in a read-only transaction
 -- policy API
 CALL _timescaledb_internal.policy_compression(1,'{}');
 ERROR:  cannot execute policy_compression() in a read-only transaction

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -2979,7 +2979,7 @@ EXECUTE param_prep (1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+CREATE MATERIALIZED VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket ('1d', time) AS time,
     device_id,
     avg(v1)
@@ -2998,7 +2998,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test;
+DROP MATERIALIZED VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
@@ -6766,7 +6766,7 @@ EXECUTE param_prep (1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+CREATE MATERIALIZED VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket ('1d', time) AS time,
     device_id,
     avg(v1)
@@ -6785,7 +6785,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test;
+DROP MATERIALIZED VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -2949,7 +2949,7 @@ EXECUTE param_prep (1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+CREATE MATERIALIZED VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket ('1d', time) AS time,
     device_id,
     avg(v1)
@@ -2968,7 +2968,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test;
+DROP MATERIALIZED VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan
@@ -6695,7 +6695,7 @@ EXECUTE param_prep (1);
 DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+CREATE MATERIALIZED VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket ('1d', time) AS time,
     device_id,
     avg(v1)
@@ -6714,7 +6714,7 @@ LIMIT 1;
  Fri Dec 31 16:00:00 1999 PST
 (1 row)
 
-DROP VIEW cagg_test;
+DROP MATERIALIZED VIEW cagg_test;
 RESET client_min_messages;
 --github issue 1558. nested loop with index scan needed
 --disables parallel scan

--- a/tsl/test/isolation/expected/continuous_aggs_multi.out
+++ b/tsl/test/isolation/expected/continuous_aggs_multi.out
@@ -2,12 +2,12 @@ Parsed test spec with 11 sessions
 
 starting permutation: Setup2 LockCompleted LockMat1 Refresh1 Refresh2 UnlockCompleted UnlockMat1
 step Setup2: 
-    CREATE VIEW continuous_view_1( bkt, cnt)
+    CREATE MATERIALIZED VIEW continuous_view_1( bkt, cnt)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
             GROUP BY 1;
-    CREATE VIEW continuous_view_2(bkt, maxl)
+    CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
@@ -33,12 +33,12 @@ step Refresh1: <... completed>
 
 starting permutation: Setup2 Refresh1 Refresh2 LockCompleted LockMat1 I1 Refresh1 Refresh2 UnlockCompleted UnlockMat1 Refresh1_sel Refresh2_sel
 step Setup2: 
-    CREATE VIEW continuous_view_1( bkt, cnt)
+    CREATE MATERIALIZED VIEW continuous_view_1( bkt, cnt)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
             GROUP BY 1;
-    CREATE VIEW continuous_view_2(bkt, maxl)
+    CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
@@ -79,12 +79,12 @@ bkt            maxl
 
 starting permutation: Setup2 AlterLag1 Refresh1 Refresh2 Refresh1_sel Refresh2_sel LockCompleted LockMat1 I2 Refresh1 Refresh2 UnlockCompleted UnlockMat1 Refresh1_sel Refresh2_sel
 step Setup2: 
-    CREATE VIEW continuous_view_1( bkt, cnt)
+    CREATE MATERIALIZED VIEW continuous_view_1( bkt, cnt)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
             GROUP BY 1;
-    CREATE VIEW continuous_view_2(bkt, maxl)
+    CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
@@ -93,7 +93,7 @@ step Setup2:
     BEGIN EXECUTE format( 'lock table %s', name);
     END; $$ LANGUAGE plpgsql;
 
-step AlterLag1: alter view continuous_view_1 set (timescaledb.refresh_lag = 10);
+step AlterLag1: alter materialized view continuous_view_1 set (timescaledb.refresh_lag = 10);
 R1: LOG:  materializing continuous aggregate public.continuous_view_1: nothing to invalidate, new range up to 15
 step Refresh1: REFRESH MATERIALIZED VIEW continuous_view_1;
 R2: LOG:  materializing continuous aggregate public.continuous_view_2: nothing to invalidate, new range up to 30
@@ -133,12 +133,12 @@ bkt            maxl
 
 starting permutation: Setup2 Refresh1 Refresh2 Refresh1_sel Refresh2_sel U1 U2 LInvRow Refresh1 Refresh2 UnlockInvRow Refresh1_sel Refresh2_sel
 step Setup2: 
-    CREATE VIEW continuous_view_1( bkt, cnt)
+    CREATE MATERIALIZED VIEW continuous_view_1( bkt, cnt)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
             GROUP BY 1;
-    CREATE VIEW continuous_view_2(bkt, maxl)
+    CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test

--- a/tsl/test/isolation/specs/continuous_aggs_concurrent_refresh.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_concurrent_refresh.spec
@@ -27,14 +27,14 @@ setup
       FROM conditions
     $$;
     SELECT set_integer_now_func('conditions', 'cond_now');
-    CREATE VIEW cond_10
+    CREATE MATERIALIZED VIEW cond_10
     WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
     AS
       SELECT time_bucket(10, time) AS bucket, avg(temp) AS avg_temp
       FROM conditions
       GROUP BY 1;
-    CREATE VIEW cond_20
+    CREATE MATERIALIZED VIEW cond_20
     WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
     AS

--- a/tsl/test/isolation/specs/continuous_aggs_insert.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_insert.spec
@@ -11,7 +11,7 @@ setup
     SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test');
     INSERT INTO ts_continuous_test SELECT i, i FROM
         (SELECT generate_series(0, 29) AS i) AS i;
-    CREATE VIEW continuous_view
+    CREATE MATERIALIZED VIEW continuous_view
         WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
         AS SELECT time_bucket('5', time), COUNT(location)
             FROM ts_continuous_test

--- a/tsl/test/isolation/specs/continuous_aggs_multi.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_multi.spec
@@ -22,12 +22,12 @@ teardown {
 session "SetupContinue"
 step "Setup2"
 {
-    CREATE VIEW continuous_view_1( bkt, cnt)
+    CREATE MATERIALIZED VIEW continuous_view_1( bkt, cnt)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
             GROUP BY 1;
-    CREATE VIEW continuous_view_2(bkt, maxl)
+    CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
@@ -70,7 +70,7 @@ step "UnlockMat1" { ROLLBACK; }
 
 #alter the refresh_lag for continuous_view_1
 session "CVddl"
-step "AlterLag1" { alter view continuous_view_1 set (timescaledb.refresh_lag = 10); }
+step "AlterLag1" { alter materialized view continuous_view_1 set (timescaledb.refresh_lag = 10); }
 
 #update the hypertable
 session "Upd"

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -283,7 +283,7 @@ SELECT * FROM timescaledb_information.policy_stats;
 -- continuous aggregate blocks drop_chunks
 INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '12 months', 0);
 
-CREATE VIEW tdc_view
+CREATE MATERIALIZED VIEW tdc_view
   WITH (timescaledb.continuous)
   AS SELECT time_bucket('1 hour', time), count(drop_order)
      FROM test_drop_chunks_table
@@ -306,4 +306,4 @@ SELECT job_id, time_bucket('1m',next_start) AS next_start, time_bucket('1m',last
 SELECT show_chunks('test_drop_chunks_table');
 
 --drop the view to allow drop chunks to work
-DROP VIEW tdc_view;
+DROP MATERIALIZED VIEW tdc_view;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -319,7 +319,7 @@ SELECT create_hypertable('metrics','time');
 INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
 
 -- check expressions in view definition
-CREATE VIEW cagg_expr WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW cagg_expr WITH (timescaledb.continuous)
 AS
 SELECT
   time_bucket('1d', time) AS time,

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -114,7 +114,7 @@ INSERT INTO conditions
 SELECT time, (random()*30)::int, random()*80 - 40
 FROM generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '10 min') AS time;
 
-CREATE VIEW conditions_summary
+CREATE MATERIALIZED VIEW conditions_summary
 WITH (timescaledb.continuous,
       timescaledb.max_interval_per_job = '60 days') AS
 SELECT device,
@@ -128,7 +128,7 @@ GROUP BY device, time_bucket(INTERVAL '1 hour', "time");
 REFRESH MATERIALIZED VIEW conditions_summary;
 
 ALTER TABLE conditions SET (timescaledb.compress);
-ALTER VIEW conditions_summary SET (
+ALTER MATERIALIZED VIEW conditions_summary SET (
       timescaledb.ignore_invalidation_older_than = '15 days'
 );
 

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -331,7 +331,7 @@ DROP VIEW dependent_1;
 
 --create a cont agg view on the ht as well then the drop should nuke everything
 SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
-CREATE VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+CREATE MATERIALIZED VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1
    GROUP BY 1;

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -38,7 +38,7 @@ CREATE OR REPLACE FUNCTION integer_now_foo() returns int LANGUAGE SQL STABLE as 
 SELECT set_integer_now_func('foo', 'integer_now_foo');
 
 
-create or replace view mat_m1( a, countb )
+CREATE MATERIALIZED VIEW mat_m1(a, countb)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select a, count(b)
@@ -75,7 +75,7 @@ order by tgname;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 -- TEST2 ---
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 
 SELECT * FROM _timescaledb_config.bgw_job;
 
@@ -96,7 +96,7 @@ insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 35);
 insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 35, 15);
 
 
-create or replace view mat_m1( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_m1( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -157,7 +157,7 @@ insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 35, 15);
 insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', 35, 25);
 
 
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+CREATE MATERIALIZED VIEW mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -201,8 +201,8 @@ order by time_bucket('1week', timec);
 --drop only the view.
 
 -- apply where clause on result of mat_m1 --
-DROP VIEW mat_m1;
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+DROP MATERIALIZED VIEW mat_m1;
+CREATE MATERIALIZED VIEW mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -247,8 +247,8 @@ order by time_bucket('1week', timec);
 
 -- TEST5 --
 ---------test with having clause ----------------------
-DROP VIEW mat_m1;
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+DROP MATERIALIZED VIEW mat_m1;
+create materialized view mat_m1( timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -313,7 +313,7 @@ insert into conditions
 select generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, 71, 28;
 
 --naming with AS clauses
-create or replace view mat_naming
+CREATE MATERIALIZED VIEW mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity), stddev(humidity)
@@ -336,10 +336,10 @@ where attnum > 0 and attrelid =
 (Select oid from pg_class where relname like :'MAT_TABLE_NAME')
 order by attnum, attname;
 
-DROP VIEW mat_naming;
+DROP MATERIALIZED VIEW mat_naming;
 
 --naming with default names
-create or replace view mat_naming
+CREATE MATERIALIZED VIEW mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
@@ -362,10 +362,10 @@ where attnum > 0 and attrelid =
 (Select oid from pg_class where relname like :'MAT_TABLE_NAME')
 order by attnum, attname;
 
-DROP VIEW mat_naming;
+DROP MATERIALIZED VIEW mat_naming;
 
 --naming with view col names
-create or replace view mat_naming (bucket, loc, sum_t_h, stdd)
+CREATE MATERIALIZED VIEW mat_naming(bucket, loc, sum_t_h, stdd)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
@@ -388,9 +388,9 @@ where attnum > 0 and attrelid =
 (Select oid from pg_class where relname like :'MAT_TABLE_NAME')
 order by attnum, attname;
 
-DROP VIEW mat_naming;
+DROP MATERIALIZED VIEW mat_naming;
 
-create or replace view mat_m1( timec, minl, sumth, stddevh)
+CREATE MATERIALIZED VIEW mat_m1(timec, minl, sumth, stddevh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1week', timec) ,
@@ -448,7 +448,7 @@ select * from :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 --lets drop the view and check
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 
 drop table conditions;
 CREATE TABLE conditions (
@@ -529,7 +529,7 @@ select count(*) from pg_class where relname = :'MAT_TABLE_NAME';
 select count(*) from pg_class where relname = :'DIR_VIEW_NAME';
 select count(*) from pg_class where relname = 'mat_test';
 
-DROP VIEW mat_test;
+DROP MATERIALIZED VIEW mat_test;
 
 --catalog entry should be gone
 SELECT count(*)
@@ -559,7 +559,7 @@ select table_name from create_hypertable( 'conditions', 'timec');
 
 --no data in hyper table on purpose so that CASCADE is not required because of chunks
 
-create or replace view mat_drop_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_drop_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -634,7 +634,7 @@ CREATE TABLE conditions (
 
 select table_name from create_hypertable( 'conditions', 'timec');
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -645,7 +645,7 @@ SELECT alter_job(id, schedule_interval => '1h') FROM _timescaledb_config.bgw_job
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
 SELECT _timescaledb_internal.to_interval(refresh_lag) FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_with_test';
 
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '6 h');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '6 h');
 SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job;
 SELECT _timescaledb_internal.to_interval(refresh_lag) FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_with_test';
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
@@ -657,9 +657,9 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_with_test')
 order by indexname;
 
-DROP VIEW mat_with_test;
+DROP MATERIALIZED VIEW mat_with_test;
 --no additional indexes
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '5 hours', timescaledb.create_group_indexes=false)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -690,7 +690,7 @@ select table_name from create_hypertable( 'conditions', 'timec', chunk_time_inte
 CREATE OR REPLACE FUNCTION integer_now_conditions() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0) FROM conditions $$;
 SELECT set_integer_now_func('conditions', 'integer_now_conditions');
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+CREATE MATERIALIZED VIEW mat_with_test(timec, minl, sumt , sumh)
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '500')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -701,11 +701,11 @@ SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
 SELECT refresh_lag FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_with_test';
 
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '100');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '100');
 SELECT refresh_lag FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_with_test';
 
 -- we can SET multiple options in one commad
-ALTER VIEW mat_with_test SET (timescaledb.refresh_lag = '100', timescaledb.max_interval_per_job='400');
+ALTER MATERIALIZED VIEW mat_with_test SET (timescaledb.refresh_lag = '100', timescaledb.max_interval_per_job='400');
 SELECT refresh_lag, max_interval_per_job FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_with_test';
 
 DROP TABLE conditions CASCADE;
@@ -728,7 +728,7 @@ SELECT create_hypertable(
 CREATE OR REPLACE FUNCTION integer_now_space_table() returns BIGINT LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), BIGINT '0') FROM space_table $$;
 SELECT set_integer_now_func('space_table', 'integer_now_space_table');
 
-CREATE VIEW space_view
+CREATE MATERIALIZED VIEW space_view
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-2')
 AS SELECT time_bucket('4', time), COUNT(data)
    FROM space_table
@@ -834,7 +834,7 @@ insert into conditions
 select generate_series(0, 200, 10), 'POR', 55, 75, 40, 70, NULL;
 
 
-create or replace view mat_ffunc_test
+CREATE MATERIALIZED VIEW mat_ffunc_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test'::text)
@@ -845,9 +845,9 @@ REFRESH MATERIALIZED VIEW mat_ffunc_test;
 
 SELECT * FROM mat_ffunc_test;
 
-DROP view mat_ffunc_test;
+DROP MATERIALIZED view mat_ffunc_test;
 
-create or replace view mat_ffunc_test
+CREATE MATERIALIZED VIEW mat_ffunc_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigint '123')
@@ -859,8 +859,8 @@ REFRESH MATERIALIZED VIEW mat_ffunc_test;
 SELECT * FROM mat_ffunc_test;
 
 --refresh mat view test when time_bucket is not projected --
-DROP VIEW mat_ffunc_test;
-create or replace view mat_refresh_test
+DROP MATERIALIZED VIEW mat_ffunc_test;
+CREATE MATERIALIZED VIEW mat_refresh_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -874,14 +874,14 @@ REFRESH MATERIALIZED VIEW mat_refresh_test;
 SELECT * FROM mat_refresh_test order by 1,2 ;
 
 -- test for bug when group by is not in project list
-create view conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
 select time_bucket(100, timec),  sum(humidity) 
 from conditions 
 group by time_bucket(100, timec), location;
 REFRESH MATERIALIZED VIEW conditions_grpby_view;
 select * from conditions_grpby_view order by 1, 2;
 
-create view conditions_grpby_view2 with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
+CREATE MATERIALIZED VIEW conditions_grpby_view2 with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
 select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location  
@@ -901,7 +901,7 @@ CREATE TABLE conditions (
 
 select table_name from create_hypertable( 'conditions', 'time');
 
-create or replace view mat_test5( timec, maxt)
+create materialized view mat_test5( timec, maxt)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='30 day', timescaledb.refresh_lag='-1day',
                timescaledb.max_interval_per_job='260 day')
 as

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -75,7 +75,7 @@ CREATE TABLE test_continuous_agg_table(time int, data int);
 SELECT create_hypertable('test_continuous_agg_table', 'time', chunk_time_interval => 10);
 CREATE OR REPLACE FUNCTION integer_now_test() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM test_continuous_agg_table $$;
 SELECT set_integer_now_func('test_continuous_agg_table', 'integer_now_test');
-CREATE VIEW test_continuous_agg_view
+CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
@@ -220,9 +220,9 @@ SELECT * FROM test_continuous_agg_view ORDER BY 1;
 -- fast restart test
 SELECT ts_bgw_params_reset_time();
 
-DROP VIEW test_continuous_agg_view;
+DROP MATERIALIZED VIEW test_continuous_agg_view;
 
-CREATE VIEW test_continuous_agg_view
+CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
         timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
@@ -285,10 +285,10 @@ select view_name, completed_threshold, invalidation_threshold, job_status, last_
 
 \x off
 
-DROP VIEW test_continuous_agg_view;
+DROP MATERIALIZED VIEW test_continuous_agg_view;
 
 --create a view with a function that it has no permission to execute
-CREATE VIEW test_continuous_agg_view
+CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous,
         timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',
@@ -322,7 +322,7 @@ INSERT INTO test_continuous_agg_table_w_grant
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER_2
 
 -- make sure view can be created
-CREATE VIEW test_continuous_agg_view_user_2
+CREATE MATERIALIZED VIEW test_continuous_agg_view_user_2
     WITH ( timescaledb.continuous,
         timescaledb.materialized_only=true,
         timescaledb.max_interval_per_job='2',

--- a/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
@@ -49,7 +49,7 @@ CREATE OR REPLACE FUNCTION integer_now_test2() returns bigint LANGUAGE SQL STABL
 
 SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
 
-CREATE VIEW drop_chunks_view1 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.max_interval_per_job=100)
+CREATE MATERIALIZED VIEW drop_chunks_view1 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.max_interval_per_job=100)
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
     GROUP BY 1;

--- a/tsl/test/sql/continuous_aggs_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_drop_chunks.sql
@@ -23,7 +23,7 @@ CREATE TABLE records (
 SELECT * FROM create_hypertable('records', 'time',
        chunk_time_interval => INTERVAL '1h');
 
-CREATE VIEW records_monthly 
+CREATE MATERIALIZED VIEW records_monthly 
     WITH (timescaledb.continuous)
     AS 
         SELECT time_bucket('1d', time) as bucket, 
@@ -41,7 +41,7 @@ SET timescaledb.current_timestamp_mock = '2000-04-01';
 
 SELECT * FROM records_monthly;
 
-ALTER VIEW records_monthly SET (
+ALTER MATERIALIZED VIEW records_monthly SET (
    timescaledb.ignore_invalidation_older_than = '15 days'
 );
 

--- a/tsl/test/sql/continuous_aggs_dump.sql
+++ b/tsl/test/sql/continuous_aggs_dump.sql
@@ -81,18 +81,18 @@ SELECT
 \gset
 
 
-DROP VIEW IF EXISTS mat_test;
+DROP MATERIALIZED VIEW IF EXISTS mat_test;
 
 --materialize this VIEW before dump this tests
 --that the partial state survives the dump intact
-CREATE VIEW mat_before
+CREATE MATERIALIZED VIEW mat_before
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_BEFORE;
 
 --materialize this VIEW after dump this tests
 --that the partialize VIEW and refresh mechanics
 --survives the dump intact
-CREATE VIEW mat_after
+CREATE MATERIALIZED VIEW mat_after
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
 AS :QUERY_AFTER;
 
@@ -159,5 +159,5 @@ SELECT count(*) FROM conditions_after;
 \ir include/cont_agg_test_equal.sql
 \set ECHO all
 
-DROP VIEW mat_after;
-DROP VIEW mat_before;
+DROP MATERIALIZED VIEW mat_after;
+DROP MATERIALIZED VIEW mat_before;

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -17,33 +17,33 @@ CREATE TABLE conditions (
     );
 select table_name from create_hypertable( 'conditions', 'timec');
 
-create  view mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location;
 
 --valid PG option
-create  view mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
 as
-select * from conditions , matt1;
+select * from conditions , mat_t1;
 
 -- join multiple tables
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
 group by location;
 
 -- join multiple tables WITH explicit JOIN
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions JOIN mat_t1 ON true
 where conditions.location = mat_t1.c
 group by location;
 
 -- LATERAL multiple tables
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions,
 LATERAL (Select * from mat_t1 where c = conditions.location) q
@@ -51,24 +51,24 @@ group by location;
 
 
 --non-hypertable
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select a, count(*) from mat_t1
 group by a;
 
 
 -- no group by
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select count(*) from conditions ;
 
 -- no time_bucket in group by
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select count(*) from conditions group by location;
 
 -- with valid query in a CTE
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 with m1 as (
 Select location, count(*) from conditions
@@ -76,26 +76,26 @@ Select location, count(*) from conditions
 select * from m1;
 
 --with DISTINCT ON
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec) ;
 
 --aggregate with DISTINCT
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  count(location) , sum(distinct temperature) from conditions
  group by time_bucket('1week', timec) , location;
 
 --aggregate with FILTER
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  sum(temperature) filter ( where humidity > 20 ) from conditions
  group by time_bucket('1week', timec) , location;
 
 -- aggregate with filter in having clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec), max(temperature)
 from conditions
@@ -103,63 +103,63 @@ from conditions
  having sum(temperature) filter ( where humidity > 20 ) > 50;
 
 -- time_bucket on non partitioning column of hypertable
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location;
 
 --time_bucket on expression
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location;
 
 --multiple time_bucket functions
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location;
 
 --time_bucket using additional args
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location;
 
 --time_bucket using non-const for first argument
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( timeinterval, timec) , location;
 
 -- ordered set aggr
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select mode() within group( order by humidity)
 from conditions
  group by time_bucket('1week', timec) ;
 
 --window function
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
 ;
 
 --aggregate without combine function
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select json_agg(location)
 from conditions
  group by time_bucket('1week', timec) , location;
 ;
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature), array_agg(location)
 from conditions
@@ -172,7 +172,7 @@ CREATE AGGREGATE newavg (
    finalfunc = int8_avg,
    initcond1 = '{0,0}'
 );
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), newavg(temperature::int4)
 from conditions
@@ -180,7 +180,7 @@ from conditions
 ;
 
 -- using subqueries
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
@@ -188,7 +188,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location ;
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
@@ -196,14 +196,14 @@ from conditions
  group by time_bucket('1week', timec) , location )  q;
 
 --using limit /limit offset
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 limit 10 ;
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -211,7 +211,7 @@ from conditions
 offset 10;
 
 --using ORDER BY in view defintion
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -219,7 +219,7 @@ from conditions
 ORDER BY 1;
 
 --using FETCH
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -228,14 +228,14 @@ fetch first 10 rows only;
 
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE;
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -243,14 +243,14 @@ from conditions
 FOR SHARE;
 
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE;
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -258,7 +258,7 @@ from conditions
 FOR NO KEY UPDATE;
 
 --tablesample clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
@@ -266,20 +266,20 @@ from conditions tablesample bernoulli(0.2)
 ;
 
 -- ONLY in from clause
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location ;
 
 --grouping sets and variants
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by grouping sets(time_bucket('1week', timec) , location ) ;
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -289,30 +289,36 @@ group by rollup(time_bucket('1week', timec) , location ) ;
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location  ;
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), min(location)
 from conditions
 group by time_bucket('1week', timec)
 having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08';
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec);
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec), test_stablefunc(humidity::int);
+
+-- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
+CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', timec)
+  FROM conditions
+GROUP BY time_bucket('1 week', timec);
 
 -- row security on table
 create table rowsec_tab( a bigint, b integer, c integer);
@@ -322,7 +328,7 @@ SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
 
-create  view mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( b), min(c)
 from rowsec_tab
@@ -344,7 +350,7 @@ CREATE TABLE conditions (
 select table_name from create_hypertable( 'conditions', 'timec');
 
 \set ON_ERROR_STOP 0
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 joules')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -352,14 +358,14 @@ from conditions
 group by time_bucket('1day', timec);
 \set ON_ERROR_STOP 1
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec);
 
-create or replace view mat_with_test_no_inval( timec, minl, sumt , sumh)
+create materialized view mat_with_test_no_inval( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours',
                timescaledb.ignore_invalidation_older_than='0')
 as
@@ -377,11 +383,11 @@ WHERE user_view_name = 'mat_with_test'
 \gset
 
 \set ON_ERROR_STOP 0
-ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
-ALTER VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1 joule');
-ALTER VIEW mat_with_test RESET(timescaledb.refresh_lag);
-ALTER VIEW mat_with_test ALTER timec DROP default;
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '1 joule');
+ALTER MATERIALIZED VIEW mat_with_test RESET(timescaledb.refresh_lag);
+ALTER MATERIALIZED VIEW mat_with_test ALTER timec DROP default;
 ALTER VIEW :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME" SET(timescaledb.refresh_lag = '1 hour');
 \set ON_ERROR_STOP 1
 
@@ -404,14 +410,14 @@ CREATE OR REPLACE FUNCTION integer_now_test_s() returns smallint LANGUAGE SQL ST
 SELECT set_integer_now_func('conditions', 'integer_now_test_s');
 
 \set ON_ERROR_STOP 0
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '32768')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -420,7 +426,7 @@ group by time_bucket(100, timec);
 
 ALTER TABLE conditions ALTER timec type int;
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483648')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -428,7 +434,7 @@ from conditions
 group by time_bucket(100, timec);
 
 -- max_interval_per_job must be at least time_bucket
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='10')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -436,14 +442,14 @@ from conditions
 group by time_bucket(100, timec);
 
 --ignore_invalidation_older_than must be positive
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='-10')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
@@ -452,22 +458,29 @@ group by time_bucket(100, timec);
 
 \set ON_ERROR_STOP 1
 
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
 
+-- Should print a useful error message, but not fail.
+CREATE MATERIALIZED VIEW IF NOT EXISTS mat_with_test
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
+  FROM conditions
+GROUP BY time_bucket(100, timec);
+
 \set ON_ERROR_STOP 0
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '1h');
-ALTER VIEW mat_with_test SET(timescaledb.refresh_lag = '2147483648');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '1h');
+ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '2147483648');
 ALTER TABLE conditions ALTER timec type bigint;
-\set ON_ERROR_STOP
-DROP VIEW mat_with_test;
+\set ON_ERROR_STOP 1
+DROP MATERIALIZED VIEW mat_with_test;
 
 ALTER TABLE conditions ALTER timec type bigint;
-create or replace view mat_with_test( timec, minl, sumt , sumh)
+create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
@@ -483,10 +496,22 @@ CREATE TABLE text_time(time TEXT);
     SELECT create_hypertable('text_time', 'time', chunk_time_interval => 10, time_partitioning_func => 'text_part_func');
 
 \set ON_ERROR_STOP 0
-CREATE VIEW text_view
-    WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW text_view
+    WITH (timescaledb.continuous)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
         GROUP BY 1;
 \set ON_ERROR_STOP 1
+
+-- Check that we get an error when mixing normal materialized views
+-- and continuous aggregates.
+CREATE MATERIALIZED VIEW normal_mat_view AS
+SELECT time_bucket('5', text_part_func(time)), COUNT(time)
+  FROM text_time
+GROUP BY 1;
+
+\set ON_ERROR_STOP 0
+DROP MATERIALIZED VIEW normal_mat_view, mat_with_test;
+\set ON_ERROR_STOP 1
+
 DROP TABLE text_time CASCADE;

--- a/tsl/test/sql/continuous_aggs_invalidation.sql
+++ b/tsl/test/sql/continuous_aggs_invalidation.sql
@@ -47,7 +47,7 @@ LIMIT 10;
 
 -- Create two continuous aggregates on the same hypertable to test
 -- that invalidations are handled correctly across both of them.
-CREATE VIEW cond_10
+CREATE MATERIALIZED VIEW cond_10
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -55,7 +55,7 @@ SELECT time_bucket(10, time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2;
 
-CREATE VIEW cond_20
+CREATE MATERIALIZED VIEW cond_20
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -63,7 +63,7 @@ SELECT time_bucket(20, time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2;
 
-CREATE VIEW measure_10
+CREATE MATERIALIZED VIEW measure_10
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS

--- a/tsl/test/sql/continuous_aggs_permissions.sql
+++ b/tsl/test/sql/continuous_aggs_permissions.sql
@@ -25,7 +25,7 @@ CREATE OR REPLACE FUNCTION integer_now_test1() returns int LANGUAGE SQL STABLE a
 SELECT set_integer_now_func('conditions', 'integer_now_test1');
 
 
-create or replace view mat_refresh_test
+CREATE MATERIALIZED VIEW mat_refresh_test
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -101,16 +101,16 @@ select from alter_job(:cagg_job_id, max_runtime => NULL);
 
 --make sure that commands fail
 
-ALTER VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
-ALTER VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
-DROP VIEW mat_refresh_test; 
+ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.refresh_lag = '6 h', timescaledb.refresh_interval = '2h');
+ALTER MATERIALIZED VIEW mat_refresh_test SET(timescaledb.materialized_only = true);
+DROP MATERIALIZED VIEW mat_refresh_test; 
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 SELECT * FROM mat_refresh_test;
 SELECT * FROM :materialization_hypertable;
 SELECT * FROM :"mat_chunk_schema".:"mat_chunk_table";
 
 --cannot create a mat view without select and trigger grants
-create or replace view mat_perm_view_test
+CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -118,7 +118,7 @@ from conditions_for_perm_check
 group by time_bucket(100, timec), location;
 
 --cannot create mat view in a schema without create privileges
-create or replace view custom_schema.mat_perm_view_test
+CREATE MATERIALIZED VIEW custom_schema.mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
@@ -127,7 +127,7 @@ group by time_bucket(100, timec), location;
 
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
-create or replace view mat_perm_view_test
+CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity), get_constant()
@@ -136,10 +136,10 @@ group by time_bucket(100, timec), location;
 
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
-DROP VIEW mat_perm_view_test;
+DROP MATERIALIZED VIEW mat_perm_view_test;
 
 --can create a mat view on something with select and trigger grants
-create or replace view mat_perm_view_test
+CREATE MATERIALIZED VIEW mat_perm_view_test
 WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)

--- a/tsl/test/sql/continuous_aggs_query.sql.in
+++ b/tsl/test/sql/continuous_aggs_query.sql.in
@@ -45,7 +45,7 @@ insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
 insert into location_tab values( 3, 'por');
 
-create or replace view mat_m1( location, timec, minl, sumt , sumh)
+create materialized view mat_m1( location, timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
@@ -59,7 +59,7 @@ FROM ( select max(timec)as timeval from conditions ) as q;
 REFRESH MATERIALIZED VIEW mat_m1;
 
 --test first/last
-create or replace view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
+create materialized view mat_m2(location, timec, firsth, lasth, maxtemp, mintemp)
 WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)

--- a/tsl/test/sql/continuous_aggs_refresh.sql
+++ b/tsl/test/sql/continuous_aggs_refresh.sql
@@ -21,7 +21,7 @@ SELECT * FROM conditions
 ORDER BY time DESC, device
 LIMIT 10;
 
-CREATE VIEW daily_temp
+CREATE MATERIALIZED VIEW daily_temp
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -92,7 +92,7 @@ CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
 CREATE TABLE conditions_date (time date NOT NULL, device int, temp float);
 SELECT create_hypertable('conditions_date', 'time');
 
-CREATE VIEW daily_temp_date
+CREATE MATERIALIZED VIEW daily_temp_date
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -119,7 +119,7 @@ $$;
 
 SELECT set_integer_now_func('conditions_smallint', 'smallint_now');
 
-CREATE VIEW cond_20_smallint
+CREATE MATERIALIZED VIEW cond_20_smallint
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -149,7 +149,7 @@ $$;
 
 SELECT set_integer_now_func('conditions_int', 'int_now');
 
-CREATE VIEW cond_20_int
+CREATE MATERIALIZED VIEW cond_20_int
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
@@ -179,7 +179,7 @@ $$;
 
 SELECT set_integer_now_func('conditions_bigint', 'bigint_now');
 
-CREATE VIEW cond_20_bigint
+CREATE MATERIALIZED VIEW cond_20_bigint
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -20,7 +20,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 --
 
 -- check default view for new continuous aggregate
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -33,21 +33,21 @@ SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- upgrade view to union view again
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- try upgrade view to union view that is already union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
@@ -59,17 +59,17 @@ REFRESH MATERIALIZED VIEW metrics_summary;
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 -- view should have results now after refresh
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
-DROP VIEW metrics_summary;
+DROP MATERIALIZED VIEW metrics_summary;
 
 -- check default view for new continuous aggregate with materialized_only to true
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -80,26 +80,26 @@ SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- upgrade view to union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- downgrade view to non-union view
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
 SELECT pg_get_viewdef('metrics_summary',true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
-DROP VIEW metrics_summary;
+DROP MATERIALIZED VIEW metrics_summary;
 
 --
 -- test queries on union view
 --
 
-CREATE VIEW metrics_summary
+CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
   SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
@@ -110,13 +110,13 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 -- query should not have results since cagg is materialized only and no refresh has happened yet
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 
 -- after switch to union view all results should be returned
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 REFRESH MATERIALIZED VIEW metrics_summary;
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 
 -- materialized only view should return data now too because refresh has happened
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -128,12 +128,12 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-02-01'::timestamptz, de
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- but union view should
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=false);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=false);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- and after refresh non union view should have new data too
 REFRESH MATERIALIZED VIEW metrics_summary;
-ALTER VIEW metrics_summary SET (timescaledb.materialized_only=true);
+ALTER MATERIALIZED VIEW metrics_summary SET (timescaledb.materialized_only=true);
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
 
 -- hardcoding now to 50 will lead to 30 watermark
@@ -149,7 +149,7 @@ SELECT create_hypertable('boundary_test','time',chunk_time_interval:=10);
 
 SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 
-CREATE VIEW boundary_view
+CREATE MATERIALIZED VIEW boundary_view
   WITH (timescaledb.continuous)
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
@@ -200,7 +200,7 @@ CREATE OR REPLACE FUNCTION integer_now_ht_intdata() returns int LANGUAGE SQL STA
 SELECT set_integer_now_func('ht_intdata', 'integer_now_ht_intdata');
 
 
-CREATE OR REPLACE VIEW mat_m1( a, countb, sumbc, spreadcb, avgc )
+CREATE MATERIALIZED VIEW mat_m1(a, countb, sumbc, spreadcb, avgc)
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 10)
 AS
 SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
@@ -224,11 +224,11 @@ ORDER BY 1;
 SELECT * FROM mat_m1 ORDER BY 1;
 
 --verify that materialized only doesn't have rows with a> 20
-ALTER VIEW mat_m1 SET(timescaledb.materialized_only = true);
+ALTER MATERIALIZED VIEW mat_m1 SET(timescaledb.materialized_only = true);
 SELECT * FROM mat_m1 ORDER BY 1;
 
 --again revert the view to include real time aggregates
-ALTER VIEW mat_m1 SET(timescaledb.materialized_only = false);
+ALTER MATERIALIZED VIEW mat_m1 SET(timescaledb.materialized_only = false);
 INSERT into ht_intdata values( 31 , 15 , 30);
 INSERT into ht_intdata values( 31 , 14 , 70);
 --cagg was not refreshed, should include all rows
@@ -245,10 +245,10 @@ GROUP BY time_bucket(1, a)
 HAVING sum(c) > 50
 ORDER BY 1;
 
-DROP VIEW mat_m1;
+DROP MATERIALIZED VIEW mat_m1;
 
 --- TEST union view with multiple WHERE and HAVING clauses
-CREATE VIEW mat_m1
+CREATE MATERIALIZED VIEW mat_m1
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 10,
       timescaledb.max_interval_per_job = 100)
 AS

--- a/tsl/test/sql/continuous_aggs_watermark.sql
+++ b/tsl/test/sql/continuous_aggs_watermark.sql
@@ -109,7 +109,7 @@ SELECT create_hypertable('ca_inval_test', 'time', chunk_time_interval=> 10);
 CREATE OR REPLACE FUNCTION integer_now_test2() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(time), 0) FROM ca_inval_test $$;
 SELECT set_integer_now_func('ca_inval_test', 'integer_now_test2');
 
-CREATE VIEW cit_view
+CREATE MATERIALIZED VIEW cit_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(time)
         FROM ca_inval_test
@@ -165,7 +165,7 @@ CREATE OR REPLACE FUNCTION integer_now_test3() returns int LANGUAGE SQL STABLE a
 SELECT set_integer_now_func('ts_continuous_test', 'integer_now_test3');
 INSERT INTO ts_continuous_test SELECT i, i FROM
     (SELECT generate_series(0, 29) AS i) AS i;
-CREATE VIEW continuous_view
+CREATE MATERIALIZED VIEW continuous_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(location)
         FROM ts_continuous_test

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -513,7 +513,7 @@ INSERT INTO disttable VALUES
        ('2018-07-01 08:01', 29, 64);
 
 \set ON_ERROR_STOP 0
-CREATE VIEW disttable_cagg WITH (timescaledb.continuous)
+CREATE MATERIALIZED VIEW disttable_cagg WITH (timescaledb.continuous)
 AS SELECT time_bucket('2 days', time), device, max(value)
     FROM disttable
     GROUP BY 1, 2;

--- a/tsl/test/sql/include/cont_agg_equal.sql
+++ b/tsl/test/sql/include/cont_agg_equal.sql
@@ -5,9 +5,9 @@
 --expects QUERY to be set
 \o /dev/null
 
-DROP VIEW IF EXISTS mat_test;
+DROP MATERIALIZED VIEW IF EXISTS mat_test;
 
-create view mat_test
+CREATE MATERIALIZED VIEW mat_test
 WITH ( timescaledb.continuous)
 as :QUERY
 ;

--- a/tsl/test/sql/include/jit_load.sql
+++ b/tsl/test/sql/include/jit_load.sql
@@ -17,7 +17,7 @@ CREATE TABLE jit_test_contagg (
 );
 SELECT table_name FROM create_hypertable('jit_test_contagg', 'observation_time');
 
-CREATE VIEW jit_device_summary
+CREATE MATERIALIZED VIEW jit_device_summary
 WITH (timescaledb.continuous)
 AS
 SELECT
@@ -34,6 +34,6 @@ SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_2', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
 
-ALTER VIEW jit_device_summary SET (timescaledb.max_interval_per_job = '60 day');
+ALTER MATERIALIZED VIEW jit_device_summary SET (timescaledb.max_interval_per_job = '60 day');
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 REFRESH MATERIALIZED VIEW jit_device_summary;

--- a/tsl/test/sql/include/transparent_decompression_query.sql
+++ b/tsl/test/sql/include/transparent_decompression_query.sql
@@ -809,7 +809,7 @@ DEALLOCATE param_prep;
 -- test continuous aggs
 SET client_min_messages TO error;
 
-CREATE VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+CREATE MATERIALIZED VIEW cagg_test WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
 SELECT time_bucket ('1d', time) AS time,
     device_id,
     avg(v1)
@@ -827,7 +827,7 @@ FROM cagg_test
 ORDER BY time
 LIMIT 1;
 
-DROP VIEW cagg_test;
+DROP MATERIALIZED VIEW cagg_test;
 
 RESET client_min_messages;
 

--- a/tsl/test/sql/read_only.sql
+++ b/tsl/test/sql/read_only.sql
@@ -229,7 +229,7 @@ SET default_transaction_read_only TO on;
 --
 \set ON_ERROR_STOP 0
 
-CREATE VIEW test_contagg_view
+CREATE MATERIALIZED VIEW test_contagg_view
 WITH (timescaledb.continuous)
 AS
 SELECT


### PR DESCRIPTION
We change the syntax for defining continuous aggregates to use `CREATE
MATERIALIZED VIEW` rather than `CREATE VIEW`. The command still creates
a view, while `CREATE MATERIALIZED VIEW` creates a table.  Raise an
error if `CREATE VIEW` is used to create a continuous aggregate and
redirect to `CREATE MATERIALIZED VIEW`.

In a similar vein, `DROP MATERIALIZED VIEW` is used for continuous
aggregates and continuous aggregates cannot be dropped with `DROP
VIEW`.

Continuous aggregates are altered using `ALTER MATERIALIZED VIEW`
rather than `ALTER VIEW`, so we ensure that it works for `ALTER
MATERIALIZED VIEW` and gives an error if you try to use `ALTER VIEW` to
change a continuous aggregate.

Note that we allow `ALTER VIEW ... SET SCHEMA` to be used with the
partial view as well as with the direct view, so this is handled as a
special case.

Fixes #2233
