### PR TITLE
Fix assertion failure in job_stat error handling

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: Cache suffix
       if: runner.os == 'macOS'
       run: |
-        echo "::set-env name=CACHE_SUFFIX::-$(pwd | sed -e 's!^[^0-9]\{1,\}/\([0-9.]\{1,\}\)/[^0-9]\{1,\}!\1!')"
+        echo "::set-env name=CACHE_SUFFIX::-${ImageVersion}"
 
     # we cache the build directory instead of the install directory here
     # because extension installation will write files to install directory
@@ -65,7 +65,12 @@ jobs:
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
         cd ~/$PG_SRC_DIR
-        ./configure --prefix=$HOME/$PG_INSTALL_DIR ${{ matrix.pg_build_args }} --with-llvm LLVM_CONFIG=${{ matrix.llvm_config }} --with-openssl --without-readline --without-zlib
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          ./configure --prefix=$HOME/$PG_INSTALL_DIR ${{ matrix.pg_build_args }} --with-llvm LLVM_CONFIG=${{ matrix.llvm_config }} --with-openssl --without-readline --without-zlib --without-libxml ${{ matrix.pg_extra_args }}
+        else
+          # the current github macos image has a buggy llvm installation so we build without llvm on mac
+          ./configure --prefix=$HOME/$PG_INSTALL_DIR ${{ matrix.pg_build_args }} --with-openssl --without-readline --without-zlib --without-libxml ${{ matrix.pg_extra_args }}
+        fi
         make -j $MAKE_JOBS
         make -j $MAKE_JOBS -C src/test/isolation
         make -j $MAKE_JOBS -C contrib/postgres_fdw

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -25,9 +25,6 @@ PG11_LATEST = "11.9"
 PG12_EARLIEST = "12.0"
 PG12_LATEST = "12.4"
 
-PG_DEBUG = "--enable-debug --enable-cassert"
-PG_MAC_PATH = "--with-libraries=/usr/local/opt/openssl/lib --with-includes=/usr/local/opt/openssl/include"
-
 m = {"include": [],}
 
 # helper functions to generate matrix entries
@@ -40,7 +37,7 @@ def build_debug_config(overrides):
   base_config = dict({
     "name": "Debug",
     "build_type": "Debug",
-    "pg_build_args": PG_DEBUG,
+    "pg_build_args": "--enable-debug --enable-cassert",
     "tsdb_build_args": "-DCODECOVERAGE=ON",
     "installcheck_args": "IGNORES='bgw_db_scheduler'",
     "coverage": True,
@@ -86,7 +83,7 @@ def macos_config(overrides):
     "cc": "clang",
     "cxx": "clang++",
     "clang": "clang",
-    "pg_build_args": PG_MAC_PATH,
+    "pg_extra_args": "--with-libraries=/usr/local/opt/openssl/lib --with-includes=/usr/local/opt/openssl/include",
     "tsdb_build_args": "-DASSERTIONS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl",
     "llvm_config": "/usr/local/opt/llvm/bin/llvm-config",
     "coverage": False,
@@ -99,7 +96,7 @@ def macos_config(overrides):
 m["include"].append(build_debug_config({"pg":PG11_LATEST}))
 m["include"].append(build_debug_config({"pg":PG12_LATEST}))
 
-m["include"].append(build_release_config(macos_config({"pg_build_args":PG_MAC_PATH})))
+m["include"].append(build_release_config(macos_config({})))
 
 # if this is not a pull request e.g. a scheduled run or a push
 # to a specific branch like prerelease_test we add additional
@@ -122,7 +119,7 @@ if event_type != "pull_request":
   m["include"].append(build_debug_config({"pg":PG12_EARLIEST}))
 
   # add debug test for MacOS
-  m["include"].append(build_debug_config(macos_config({"pg_build_args":PG_DEBUG+" "+PG_MAC_PATH})))
+  m["include"].append(build_debug_config(macos_config({})))
 
   # add release test for latest pg11 and latest pg12
   m["include"].append(build_release_config({"pg":PG11_LATEST}))

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -238,6 +238,7 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 	}
 	PG_CATCH();
 	{
+		MemoryContextSwitchTo(oldctx);
 		ErrorData *errdata = CopyErrorData();
 		ereport(LOG,
 				(errcode(ERRCODE_INTERNAL_ERROR),
@@ -247,7 +248,7 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 		RollbackAndReleaseCurrentSubTransaction();
 	}
 	PG_END_TRY();
-	MemoryContextSwitchTo(oldctx);
+	Assert(CurrentMemoryContext == oldctx);
 	if (!res_set)
 	{
 		TimestampTz nowt;


### PR DESCRIPTION
Since CopyErrorData asserts that the current MemoryContext is not
ErrorContext we need to make sure to switch context before copying
ErrorData.