### PR TITLE
Fix segfault when executing jobs with NULL config

### DIFF
--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -479,7 +479,11 @@ job_execute(BgwJob *job)
 	 */
 	MemoryContextSwitchTo(parent_ctx);
 	arg1 = makeConst(INT4OID, -1, InvalidOid, 4, Int32GetDatum(job->fd.id), false, true);
-	arg2 = makeConst(JSONBOID, -1, InvalidOid, -1, JsonbPGetDatum(job->fd.config), false, false);
+	if (job->fd.config == NULL)
+		arg2 = makeNullConst(JSONBOID, -1, InvalidOid);
+	else
+		arg2 =
+			makeConst(JSONBOID, -1, InvalidOid, -1, JsonbPGetDatum(job->fd.config), false, false);
 
 	funcexpr = makeFuncExpr(proc,
 							VOIDOID,


### PR DESCRIPTION
This patch adds check for NULL config as makeConst will segfault
when trying to detoast datum when passed a NULL config.