### PR TITLE
Ignore build and IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ typedef.list
 
 /CMakeSettings.json
 /out/*
+/debug/
+/cmake-build-debug/
+/.idea/


### PR DESCRIPTION
Updating gitignore to exclude default build folders and CLion folder.