### PR TITLE
Fix segfault in chunk_append with space partitioning

### DIFF
--- a/src/chunk_append/chunk_append.c
+++ b/src/chunk_append/chunk_append.c
@@ -193,6 +193,9 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 			List *merge_childs = NIL;
 			MergeAppendPath *append;
 
+			if (flat == NULL)
+				break;
+
 			foreach (lc_oid, current_oids)
 			{
 				/* postgres may have pruned away some children already */
@@ -207,6 +210,8 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 				{
 					merge_childs = lappend(merge_childs, child);
 					flat = lnext(flat);
+					if (flat == NULL)
+						break;
 				}
 			}
 


### PR DESCRIPTION
When postgres prunes children before we create the ChunkAppend
path there might be a mismatch between the children of the path
and the ordered list of children in a space partitioned hypertable.

Fixes #1841