### PR TITLE
Make hypertable_approximate_row_count return row count only

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,15 +1,16 @@
 --Drop functions in size_utils and dependencies, ordering matters.
 -- Do not reorder
-DROP VIEW timescaledb_information.hypertable;
-DROP FUNCTION hypertable_relation_size_pretty;
-DROP FUNCTION  hypertable_relation_size;
-DROP FUNCTION chunk_relation_size_pretty;
-DROP FUNCTION  chunk_relation_size;
-DROP FUNCTION indexes_relation_size_pretty;
-DROP FUNCTION  indexes_relation_size;
-DROP FUNCTION _timescaledb_internal.partitioning_column_to_pretty;
-DROP FUNCTION _timescaledb_internal.range_value_to_pretty;
+DROP VIEW IF EXISTS timescaledb_information.hypertable;
+DROP FUNCTION IF EXISTS hypertable_relation_size_pretty;
+DROP FUNCTION IF EXISTS hypertable_relation_size;
+DROP FUNCTION IF EXISTS chunk_relation_size_pretty;
+DROP FUNCTION IF EXISTS chunk_relation_size;
+DROP FUNCTION IF EXISTS indexes_relation_size_pretty;
+DROP FUNCTION IF EXISTS indexes_relation_size;
+DROP FUNCTION IF EXISTS _timescaledb_internal.partitioning_column_to_pretty;
+DROP FUNCTION IF EXISTS _timescaledb_internal.range_value_to_pretty;
 -- end of do not reorder
+DROP FUNCTION IF EXISTS hypertable_approximate_row_count;
 DROP VIEW IF EXISTS timescaledb_information.compressed_chunk_stats;
 DROP VIEW IF EXISTS timescaledb_information.compressed_hypertable_stats;
 

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -28,6 +28,7 @@ WHERE oid IN (
  add_retention_policy
  allow_new_chunks
  alter_job
+ approximate_row_count
  attach_data_node
  attach_tablespace
  block_new_chunks
@@ -47,7 +48,6 @@ WHERE oid IN (
  first
  get_telemetry_report
  histogram
- hypertable_approximate_row_count
  hypertable_compression_stats
  hypertable_detailed_size
  hypertable_index_size

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -153,6 +153,217 @@ SELECT * FROM chunks_detailed_size('toast_test');
  _timescaledb_internal | _hyper_4_9_chunk |       24576 |       16384 |        8192 |       49152 | 
 (1 row)
 
+-- Tests for approximate_row_count()
+--
+-- Regular table
+--
+CREATE TABLE approx_count(time TIMESTAMP, value int);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:01', 1);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:02', 2);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:03', 3);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:04', 4);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:05', 5);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:06', 6);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:07', 7);
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
+ANALYZE approx_count;
+SELECT count(*) FROM approx_count;
+ count 
+-------
+     7
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     7
+(1 row)
+
+DROP TABLE approx_count;
+-- Regular table with basic inheritance
+--
+CREATE TABLE approx_count(id int);
+CREATE TABLE approx_count_child(id2 int) INHERITS (approx_count);
+INSERT INTO approx_count_child VALUES(0);
+INSERT INTO approx_count VALUES(1);
+SELECT count(*) FROM approx_count;
+ count 
+-------
+     2
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
+ANALYZE approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     1
+(1 row)
+
+ANALYZE approx_count_child;
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     2
+(1 row)
+
+DROP TABLE approx_count CASCADE;
+NOTICE:  drop cascades to table approx_count_child
+-- Regular table with nested inheritance
+--
+CREATE TABLE approx_count(id int);
+CREATE TABLE approx_count_a(id2 int) INHERITS (approx_count);
+CREATE TABLE approx_count_b(id3 int) INHERITS (approx_count_a);
+CREATE TABLE approx_count_c(id4 int) INHERITS (approx_count_b);
+INSERT INTO approx_count_a VALUES(0);
+INSERT INTO approx_count_b VALUES(1);
+INSERT INTO approx_count_c VALUES(2);
+INSERT INTO approx_count VALUES(3);
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
+ANALYZE approx_count_a;
+ANALYZE approx_count_b;
+ANALYZE approx_count_c;
+ANALYZE approx_count;
+SELECT count(*) FROM approx_count;
+ count 
+-------
+     4
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     4
+(1 row)
+
+SELECT count(*) FROM approx_count_a;
+ count 
+-------
+     3
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count_a');
+ approximate_row_count 
+-----------------------
+                     3
+(1 row)
+
+SELECT count(*) FROM approx_count_b;
+ count 
+-------
+     2
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count_b');
+ approximate_row_count 
+-----------------------
+                     2
+(1 row)
+
+SELECT count(*) FROM approx_count_c;
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count_c');
+ approximate_row_count 
+-----------------------
+                     1
+(1 row)
+
+DROP TABLE approx_count CASCADE;
+NOTICE:  drop cascades to 3 other objects
+-- Regular table with declarative partitioning
+--
+CREATE TABLE approx_count_dp(time TIMESTAMP, value int) PARTITION BY RANGE(time);
+CREATE TABLE approx_count_dp0 PARTITION OF approx_count_dp
+FOR VALUES FROM ('2004-01-01 00:00:00') TO ('2005-01-01 00:00:00');
+CREATE TABLE approx_count_dp1 PARTITION OF approx_count_dp
+FOR VALUES FROM ('2005-01-01 00:00:00') TO ('2006-01-01 00:00:00');
+CREATE TABLE approx_count_dp2 PARTITION OF approx_count_dp
+FOR VALUES FROM ('2006-01-01 00:00:00') TO ('2007-01-01 00:00:00');
+INSERT INTO approx_count_dp VALUES('2004-01-01 10:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2004-01-01 11:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2004-01-01 12:00:01', 1);
+INSERT INTO approx_count_dp VALUES('2005-01-01 10:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2005-01-01 11:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2005-01-01 12:00:01', 1);
+INSERT INTO approx_count_dp VALUES('2006-01-01 10:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2006-01-01 11:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2006-01-01 12:00:01', 1);
+SELECT count(*) FROM approx_count_dp;
+ count 
+-------
+     9
+(1 row)
+
+SELECT count(*) FROM approx_count_dp0;
+ count 
+-------
+     3
+(1 row)
+
+SELECT count(*) FROM approx_count_dp1;
+ count 
+-------
+     3
+(1 row)
+
+SELECT count(*) FROM approx_count_dp2;
+ count 
+-------
+     3
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count_dp');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
+ANALYZE approx_count_dp;
+SELECT * FROM approximate_row_count('approx_count_dp');
+ approximate_row_count 
+-----------------------
+                     9
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count_dp0');
+ approximate_row_count 
+-----------------------
+                     3
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count_dp1');
+ approximate_row_count 
+-----------------------
+                     3
+(1 row)
+
+SELECT * FROM approximate_row_count('approx_count_dp2');
+ approximate_row_count 
+-----------------------
+                     3
+(1 row)
+
+-- Hypertable
+--
 CREATE TABLE approx_count(time TIMESTAMP, value int);
 SELECT * FROM create_hypertable('approx_count', 'time');
 NOTICE:  adding not-null constraint to column "time"
@@ -171,34 +382,37 @@ INSERT INTO approx_count VALUES('2004-01-01 10:00:07', 7);
 INSERT INTO approx_count VALUES('2004-01-01 10:00:08', 8);
 INSERT INTO approx_count VALUES('2004-01-01 10:00:09', 9);
 INSERT INTO approx_count VALUES('2004-01-01 10:00:10', 10);
-ANALYZE approx_count;
-SELECT * FROM hypertable_approximate_row_count('approx_count');
- schema_name |  table_name  | row_estimate 
--------------+--------------+--------------
- public      | approx_count |           10
+SELECT count(*) FROM approx_count;
+ count 
+-------
+    10
 (1 row)
 
--- all hypertables
-SELECT * FROM hypertable_approximate_row_count();
- schema_name |       table_name        | row_estimate 
--------------+-------------------------+--------------
- public      | approx_count            |           10
- public      | timestamp_partitioned   |            0
- public      | timestamp_partitioned_2 |            0
- public      | toast_test              |            0
- public      | two_Partitions          |            0
-(5 rows)
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
 
-SELECT * FROM hypertable_approximate_row_count(NULL);
- schema_name |       table_name        | row_estimate 
--------------+-------------------------+--------------
- public      | approx_count            |           10
- public      | timestamp_partitioned   |            0
- public      | timestamp_partitioned_2 |            0
- public      | toast_test              |            0
- public      | two_Partitions          |            0
-(5 rows)
+ANALYZE approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                    10
+(1 row)
 
+\set ON_ERROR_STOP 0
+SELECT * FROM approximate_row_count('unexisting');
+ERROR:  relation "unexisting" does not exist at character 37
+SELECT * FROM approximate_row_count();
+ERROR:  function approximate_row_count() does not exist at character 15
+SELECT * FROM approximate_row_count(NULL);
+ approximate_row_count 
+-----------------------
+                      
+(1 row)
+
+\set ON_ERROR_STOP 1
 SELECT * FROM chunks_detailed_size(NULL);
  chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 --------------+------------+-------------+-------------+-------------+-------------+-----------

--- a/test/sql/size_utils.sql
+++ b/test/sql/size_utils.sql
@@ -40,6 +40,107 @@ this must be over 2k. this must be over 2k. this must be over 2k. this must be o
 $$);
 SELECT * FROM chunks_detailed_size('toast_test');
 
+-- Tests for approximate_row_count()
+--
+
+-- Regular table
+--
+CREATE TABLE approx_count(time TIMESTAMP, value int);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:01', 1);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:02', 2);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:03', 3);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:04', 4);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:05', 5);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:06', 6);
+INSERT INTO approx_count VALUES('2004-01-01 10:00:07', 7);
+SELECT * FROM approximate_row_count('approx_count');
+ANALYZE approx_count;
+SELECT count(*) FROM approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+DROP TABLE approx_count;
+
+-- Regular table with basic inheritance
+--
+CREATE TABLE approx_count(id int);
+CREATE TABLE approx_count_child(id2 int) INHERITS (approx_count);
+INSERT INTO approx_count_child VALUES(0);
+INSERT INTO approx_count VALUES(1);
+SELECT count(*) FROM approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+ANALYZE approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+ANALYZE approx_count_child;
+SELECT * FROM approximate_row_count('approx_count');
+DROP TABLE approx_count CASCADE;
+
+-- Regular table with nested inheritance
+--
+CREATE TABLE approx_count(id int);
+CREATE TABLE approx_count_a(id2 int) INHERITS (approx_count);
+CREATE TABLE approx_count_b(id3 int) INHERITS (approx_count_a);
+CREATE TABLE approx_count_c(id4 int) INHERITS (approx_count_b);
+
+INSERT INTO approx_count_a VALUES(0);
+INSERT INTO approx_count_b VALUES(1);
+INSERT INTO approx_count_c VALUES(2);
+INSERT INTO approx_count VALUES(3);
+
+SELECT * FROM approximate_row_count('approx_count');
+
+ANALYZE approx_count_a;
+ANALYZE approx_count_b;
+ANALYZE approx_count_c;
+ANALYZE approx_count;
+
+SELECT count(*) FROM approx_count;
+SELECT * FROM approximate_row_count('approx_count');
+SELECT count(*) FROM approx_count_a;
+SELECT * FROM approximate_row_count('approx_count_a');
+SELECT count(*) FROM approx_count_b;
+SELECT * FROM approximate_row_count('approx_count_b');
+SELECT count(*) FROM approx_count_c;
+SELECT * FROM approximate_row_count('approx_count_c');
+
+DROP TABLE approx_count CASCADE;
+
+-- Regular table with declarative partitioning
+--
+
+CREATE TABLE approx_count_dp(time TIMESTAMP, value int) PARTITION BY RANGE(time);
+
+CREATE TABLE approx_count_dp0 PARTITION OF approx_count_dp
+FOR VALUES FROM ('2004-01-01 00:00:00') TO ('2005-01-01 00:00:00');
+CREATE TABLE approx_count_dp1 PARTITION OF approx_count_dp
+FOR VALUES FROM ('2005-01-01 00:00:00') TO ('2006-01-01 00:00:00');
+CREATE TABLE approx_count_dp2 PARTITION OF approx_count_dp
+FOR VALUES FROM ('2006-01-01 00:00:00') TO ('2007-01-01 00:00:00');
+
+INSERT INTO approx_count_dp VALUES('2004-01-01 10:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2004-01-01 11:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2004-01-01 12:00:01', 1);
+
+INSERT INTO approx_count_dp VALUES('2005-01-01 10:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2005-01-01 11:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2005-01-01 12:00:01', 1);
+
+INSERT INTO approx_count_dp VALUES('2006-01-01 10:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2006-01-01 11:00:00', 1);
+INSERT INTO approx_count_dp VALUES('2006-01-01 12:00:01', 1);
+
+SELECT count(*) FROM approx_count_dp;
+SELECT count(*) FROM approx_count_dp0;
+SELECT count(*) FROM approx_count_dp1;
+SELECT count(*) FROM approx_count_dp2;
+
+SELECT * FROM approximate_row_count('approx_count_dp');
+ANALYZE approx_count_dp;
+SELECT * FROM approximate_row_count('approx_count_dp');
+SELECT * FROM approximate_row_count('approx_count_dp0');
+SELECT * FROM approximate_row_count('approx_count_dp1');
+SELECT * FROM approximate_row_count('approx_count_dp2');
+
+-- Hypertable
+--
 CREATE TABLE approx_count(time TIMESTAMP, value int);
 SELECT * FROM create_hypertable('approx_count', 'time');
 INSERT INTO approx_count VALUES('2004-01-01 10:00:01', 1);
@@ -52,13 +153,16 @@ INSERT INTO approx_count VALUES('2004-01-01 10:00:07', 7);
 INSERT INTO approx_count VALUES('2004-01-01 10:00:08', 8);
 INSERT INTO approx_count VALUES('2004-01-01 10:00:09', 9);
 INSERT INTO approx_count VALUES('2004-01-01 10:00:10', 10);
+SELECT count(*) FROM approx_count;
+SELECT * FROM approximate_row_count('approx_count');
 ANALYZE approx_count;
+SELECT * FROM approximate_row_count('approx_count');
 
-SELECT * FROM hypertable_approximate_row_count('approx_count');
-
--- all hypertables
-SELECT * FROM hypertable_approximate_row_count();
-SELECT * FROM hypertable_approximate_row_count(NULL);
+\set ON_ERROR_STOP 0
+SELECT * FROM approximate_row_count('unexisting');
+SELECT * FROM approximate_row_count();
+SELECT * FROM approximate_row_count(NULL);
+\set ON_ERROR_STOP 1
 
 SELECT * FROM chunks_detailed_size(NULL);
 SELECT * FROM hypertable_detailed_size(NULL);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1346,3 +1346,36 @@ SELECT reloptions FROM pg_class WHERE relname = :statchunk;
 (1 row)
 
 DROP TABLE stattest;
+-- Test approximate_row_count() with compressed hypertable
+--
+CREATE TABLE approx_count(time timestamptz not null, device int, temp float);
+SELECT create_hypertable('approx_count', 'time');
+     create_hypertable      
+----------------------------
+ (29,public,approx_count,t)
+(1 row)
+
+INSERT INTO approx_count SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, random()*80
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-04 1:00', '1 hour') t;
+SELECT count(*) FROM approx_count;
+ count 
+-------
+    49
+(1 row)
+
+ALTER TABLE approx_count SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
+NOTICE:  adding index _compressed_hypertable_30_device__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_30 USING BTREE(device, _ts_meta_sequence_num)
+SELECT approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
+ANALYZE approx_count;
+SELECT approximate_row_count('approx_count');
+ approximate_row_count 
+-----------------------
+                    49
+(1 row)
+
+DROP TABLE approx_count;

--- a/tsl/test/expected/dist_api_calls.out
+++ b/tsl/test/expected/dist_api_calls.out
@@ -231,7 +231,7 @@ SELECT reorder_chunk('_timescaledb_internal._dist_hyper_1_4_chunk', verbose => T
 ERROR:  move_chunk() and reorder_chunk() cannot be used with distributed hypertables
 \set ON_ERROR_STOP 1
 DROP TABLESPACE tablespace1;
--- Ensure hypertable_approximate_row_count() works with distributed hypertable
+-- Ensure approximate_row_count() works with distributed hypertable
 --
 SELECT * FROM disttable ORDER BY time;
              time             | device |  value   
@@ -253,34 +253,34 @@ SELECT count(*) FROM disttable;
      8
 (1 row)
 
-SELECT hypertable_approximate_row_count('disttable');
- hypertable_approximate_row_count 
-----------------------------------
- (public,disttable,8)
+SELECT approximate_row_count('disttable');
+ approximate_row_count 
+-----------------------
+                     8
 (1 row)
 
-SELECT * FROM test.remote_exec(NULL, $$ SELECT hypertable_approximate_row_count('disttable'); $$);
-NOTICE:  [data_node_1]:  SELECT hypertable_approximate_row_count('disttable')
+SELECT * FROM test.remote_exec(NULL, $$ SELECT approximate_row_count('disttable'); $$);
+NOTICE:  [data_node_1]:  SELECT approximate_row_count('disttable')
 NOTICE:  [data_node_1]:
-hypertable_approximate_row_count
---------------------------------
-(public,disttable,3)            
+approximate_row_count
+---------------------
+                    3
 (1 row)
 
 
-NOTICE:  [data_node_2]:  SELECT hypertable_approximate_row_count('disttable')
+NOTICE:  [data_node_2]:  SELECT approximate_row_count('disttable')
 NOTICE:  [data_node_2]:
-hypertable_approximate_row_count
---------------------------------
-(public,disttable,2)            
+approximate_row_count
+---------------------
+                    2
 (1 row)
 
 
-NOTICE:  [data_node_3]:  SELECT hypertable_approximate_row_count('disttable')
+NOTICE:  [data_node_3]:  SELECT approximate_row_count('disttable')
 NOTICE:  [data_node_3]:
-hypertable_approximate_row_count
---------------------------------
-(public,disttable,3)            
+approximate_row_count
+---------------------
+                    3
 (1 row)
 
 
@@ -380,17 +380,17 @@ SELECT count(*) FROM disttable_repl;
      8
 (1 row)
 
-SELECT hypertable_approximate_row_count('disttable_repl');
- hypertable_approximate_row_count 
-----------------------------------
- (public,disttable_repl,0)
+SELECT approximate_row_count('disttable_repl');
+ approximate_row_count 
+-----------------------
+                     0
 (1 row)
 
 ANALYZE disttable_repl;
-SELECT hypertable_approximate_row_count('disttable_repl');
- hypertable_approximate_row_count 
-----------------------------------
- (public,disttable_repl,8)
+SELECT approximate_row_count('disttable_repl');
+ approximate_row_count 
+-----------------------
+                     8
 (1 row)
 
 DROP TABLE disttable_repl;

--- a/tsl/test/sql/dist_api_calls.sql
+++ b/tsl/test/sql/dist_api_calls.sql
@@ -82,15 +82,15 @@ SELECT reorder_chunk('_timescaledb_internal._dist_hyper_1_4_chunk', verbose => T
 
 DROP TABLESPACE tablespace1;
 
--- Ensure hypertable_approximate_row_count() works with distributed hypertable
+-- Ensure approximate_row_count() works with distributed hypertable
 --
 SELECT * FROM disttable ORDER BY time;
 
 ANALYZE disttable;
 
 SELECT count(*) FROM disttable;
-SELECT hypertable_approximate_row_count('disttable');
-SELECT * FROM test.remote_exec(NULL, $$ SELECT hypertable_approximate_row_count('disttable'); $$);
+SELECT approximate_row_count('disttable');
+SELECT * FROM test.remote_exec(NULL, $$ SELECT approximate_row_count('disttable'); $$);
 
 -- Test with native replication
 --
@@ -115,9 +115,9 @@ SELECT * FROM show_chunks('disttable_repl');
 SELECT * FROM test.remote_exec(NULL, $$ SELECT show_chunks('disttable_repl'); $$);
 
 SELECT count(*) FROM disttable_repl;
-SELECT hypertable_approximate_row_count('disttable_repl');
+SELECT approximate_row_count('disttable_repl');
 
 ANALYZE disttable_repl;
-SELECT hypertable_approximate_row_count('disttable_repl');
+SELECT approximate_row_count('disttable_repl');
 
 DROP TABLE disttable_repl;


### PR DESCRIPTION
This change renames function to `approximate_row_count()` and adds support for regular tables. Return a row count estimate for a table instead of a table list. Add test for compression.

Issue: https://github.com/timescale/timescaledb/issues/2252 and https://github.com/timescale/timescaledb/issues/1741