### PR TITLE
Handle AT_CookedColumnDefault in process_utility

### DIFF
--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -37,6 +37,15 @@ if(APACHE_ONLY)
   add_definitions(-DAPACHE_ONLY)
 endif()
 
+# AT_CookedColumnDefault was backported to PG12 but is not yet in a released version.
+# To be able to build against snapshots and REL_12_STABLE branch we check header file
+# for existance. Once PG 12.5 is out this can safely be turned into a version check.
+file(READ ${PG_INCLUDEDIR_SERVER}/nodes/parsenodes.h PG_PARSENODES_H)
+string(REGEX MATCH "AT_CookedColumnDefault" PG_HAS_COOKEDCOLUMNDEFAULT ${PG_CONFIG_H})
+if (PG_HAS_COOKEDCOLUMNDEFAULT)
+  add_definitions(-DPG_HAS_COOKEDCOLUMNDEFAULT)
+endif()
+
 include_directories(${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
 include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER})
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2948,6 +2948,9 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_SetLogged:
 		case AT_SetStorage:
 		case AT_ColumnDefault:
+#ifdef PG_HAS_COOKEDCOLUMNDEFAULT
+		case AT_CookedColumnDefault:
+#endif
 		case AT_SetNotNull:
 #if PG12_GE
 		case AT_CheckNotNull:


### PR DESCRIPTION
Postgres added a new alter table subcommand in a bugfix for
CREATE TABLE LIKE with inheritance which got backported to previous
versions. We check for presence of the subcommand with cmake so
we can support building on snapshot versions which also fixes the
ABI breakage test.

https://github.com/postgres/postgres/commit/50289819230d8ddad510879ee4793b04a05cf13b