### PR TITLE
Use end of last bucket as cagg watermark

### DIFF
--- a/sql/util_time.sql
+++ b/sql/util_time.sql
@@ -69,19 +69,5 @@ $BODY$;
 CREATE OR REPLACE FUNCTION _timescaledb_internal.time_to_internal(time_val ANYELEMENT)
 RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_time_to_internal' LANGUAGE C VOLATILE STRICT;
 
--- return the materialization watermark for a continuous aggregate materialization hypertable
--- returns NULL when no materialization has happened yet
 CREATE OR REPLACE FUNCTION _timescaledb_internal.cagg_watermark(hypertable_id INTEGER)
-RETURNS INT8 LANGUAGE SQL AS
-$BODY$
-
-  SELECT
-    watermark
-  FROM
-    _timescaledb_catalog.continuous_agg cagg
-    LEFT JOIN _timescaledb_catalog.continuous_aggs_completed_threshold completed ON completed.materialization_id = cagg.mat_hypertable_id
-  WHERE
-    cagg.mat_hypertable_id = $1;
-
-$BODY$ STABLE STRICT;
-
+RETURNS INT8 AS '@MODULE_PATHNAME@', 'ts_continuous_agg_watermark' LANGUAGE C STABLE STRICT;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -40,6 +40,7 @@ extern TSDLLEXPORT WithClauseResult *ts_continuous_agg_with_clause_parse(const L
 typedef struct ContinuousAgg
 {
 	FormData_continuous_agg data;
+	Oid relid;
 } ContinuousAgg;
 
 typedef enum ContinuousAggHypertableStatus

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -267,6 +267,15 @@ ts_time_datum_get_nobegin(Oid timetype)
 }
 
 Datum
+ts_time_datum_get_nobegin_or_min(Oid timetype)
+{
+	if (TS_TIME_IS_INTEGER_TIME(timetype))
+		return ts_time_datum_get_min(timetype);
+
+	return ts_time_datum_get_nobegin(timetype);
+}
+
+Datum
 ts_time_datum_get_noend(Oid timetype)
 {
 	switch (timetype)

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -18,6 +18,7 @@
  * and thus add the difference between the two epochs. This will constrain the
  * max supported timestamp by the same amount. */
 #define TS_TIMESTAMP_MIN MIN_TIMESTAMP
+#define TS_TIMESTAMP_MAX (TS_TIMESTAMP_END - 1)
 #define TS_TIMESTAMP_END (END_TIMESTAMP - TS_EPOCH_DIFF_MICROSECONDS)
 #define TS_TIMESTAMP_INTERNAL_MIN (TS_TIMESTAMP_MIN + TS_EPOCH_DIFF_MICROSECONDS)
 #define TS_TIMESTAMP_INTERNAL_MAX (TS_TIMESTAMP_INTERNAL_END - 1)
@@ -67,6 +68,7 @@ extern TSDLLEXPORT Datum ts_time_datum_get_min(Oid timetype);
 extern TSDLLEXPORT Datum ts_time_datum_get_max(Oid timetype);
 extern TSDLLEXPORT Datum ts_time_datum_get_end(Oid timetype);
 extern TSDLLEXPORT Datum ts_time_datum_get_nobegin(Oid timetype);
+extern TSDLLEXPORT Datum ts_time_datum_get_nobegin_or_min(Oid timetype);
 extern TSDLLEXPORT Datum ts_time_datum_get_noend(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_min(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_max(Oid timetype);

--- a/test/src/test_time_utils.c
+++ b/test/src/test_time_utils.c
@@ -182,6 +182,7 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 	TestEnsureError(ts_time_get_end(INT8OID));
 	TestEnsureError(ts_time_get_nobegin(INT8OID));
 	TestEnsureError(ts_time_get_noend(INT8OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_nobegin_or_min(INT8OID)), PG_INT64_MIN);
 	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_min(INT8OID)), PG_INT64_MIN);
 	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_max(INT8OID)), PG_INT64_MAX);
 	TestEnsureError(ts_time_datum_get_end(INT8OID));
@@ -194,6 +195,7 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 	TestEnsureError(ts_time_get_end(INT4OID));
 	TestEnsureError(ts_time_get_nobegin(INT4OID));
 	TestEnsureError(ts_time_get_noend(INT4OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_nobegin_or_min(INT4OID)), PG_INT32_MIN);
 	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_min(INT4OID)), PG_INT32_MIN);
 	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_max(INT4OID)), PG_INT32_MAX);
 	TestEnsureError(ts_time_datum_get_end(INT4OID));
@@ -206,6 +208,7 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 	TestEnsureError(ts_time_get_end(INT2OID));
 	TestEnsureError(ts_time_get_nobegin(INT2OID));
 	TestEnsureError(ts_time_get_noend(INT2OID));
+	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_nobegin_or_min(INT2OID)), PG_INT16_MIN);
 	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_min(INT2OID)), PG_INT16_MIN);
 	TestAssertInt64Eq(DatumGetInt64(ts_time_datum_get_max(INT2OID)), PG_INT16_MAX);
 	TestEnsureError(ts_time_datum_get_end(INT2OID));
@@ -218,7 +221,10 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 	TestAssertInt64Eq(ts_time_get_end_or_max(TIMESTAMPOID), TS_TIMESTAMP_INTERNAL_END);
 	TestAssertInt64Eq(ts_time_get_nobegin(TIMESTAMPOID), TS_TIME_NOBEGIN);
 	TestAssertInt64Eq(ts_time_get_noend(TIMESTAMPOID), TS_TIME_NOEND);
+	TestAssertInt64Eq(DatumGetTimestamp(ts_time_datum_get_nobegin_or_min(TIMESTAMPOID)),
+					  DT_NOBEGIN);
 	TestAssertInt64Eq(DatumGetTimestamp(ts_time_datum_get_min(TIMESTAMPOID)), TS_TIMESTAMP_MIN);
+	TestAssertInt64Eq(DatumGetTimestamp(ts_time_datum_get_max(TIMESTAMPOID)), TS_TIMESTAMP_MAX);
 	TestAssertInt64Eq(DatumGetTimestamp(ts_time_datum_get_end(TIMESTAMPOID)), TS_TIMESTAMP_END);
 	TestAssertInt64Eq(DatumGetTimestamp(ts_time_datum_get_nobegin(TIMESTAMPOID)), DT_NOBEGIN);
 	TestAssertInt64Eq(DatumGetTimestamp(ts_time_datum_get_noend(TIMESTAMPOID)), DT_NOEND);
@@ -229,7 +235,10 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 	TestAssertInt64Eq(ts_time_get_end_or_max(TIMESTAMPTZOID), TS_TIMESTAMP_INTERNAL_END);
 	TestAssertInt64Eq(ts_time_get_nobegin(TIMESTAMPTZOID), TS_TIME_NOBEGIN);
 	TestAssertInt64Eq(ts_time_get_noend(TIMESTAMPTZOID), TS_TIME_NOEND);
+	TestAssertInt64Eq(DatumGetTimestampTz(ts_time_datum_get_nobegin_or_min(TIMESTAMPTZOID)),
+					  DT_NOBEGIN);
 	TestAssertInt64Eq(DatumGetTimestampTz(ts_time_datum_get_min(TIMESTAMPTZOID)), TS_TIMESTAMP_MIN);
+	TestAssertInt64Eq(DatumGetTimestampTz(ts_time_datum_get_max(TIMESTAMPTZOID)), TS_TIMESTAMP_MAX);
 	TestAssertInt64Eq(DatumGetTimestampTz(ts_time_datum_get_end(TIMESTAMPTZOID)), TS_TIMESTAMP_END);
 	TestAssertInt64Eq(DatumGetTimestampTz(ts_time_datum_get_nobegin(TIMESTAMPTZOID)), DT_NOBEGIN);
 	TestAssertInt64Eq(DatumGetTimestampTz(ts_time_datum_get_noend(TIMESTAMPTZOID)), DT_NOEND);
@@ -240,7 +249,9 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 	TestAssertInt64Eq(ts_time_get_end_or_max(DATEOID), TS_DATE_INTERNAL_END);
 	TestAssertInt64Eq(ts_time_get_nobegin(DATEOID), TS_TIME_NOBEGIN);
 	TestAssertInt64Eq(ts_time_get_noend(DATEOID), TS_TIME_NOEND);
+	TestAssertInt64Eq(DatumGetDateADT(ts_time_datum_get_nobegin_or_min(DATEOID)), DATEVAL_NOBEGIN);
 	TestAssertInt64Eq(DatumGetDateADT(ts_time_datum_get_min(DATEOID)), TS_DATE_MIN);
+	TestAssertInt64Eq(DatumGetDateADT(ts_time_datum_get_max(DATEOID)), TS_DATE_MAX);
 	TestAssertInt64Eq(DatumGetDateADT(ts_time_datum_get_end(DATEOID)), TS_DATE_END);
 	TestAssertInt64Eq(DatumGetDateADT(ts_time_datum_get_nobegin(DATEOID)), DATEVAL_NOBEGIN);
 	TestAssertInt64Eq(DatumGetDateADT(ts_time_datum_get_noend(DATEOID)), DATEVAL_NOEND);
@@ -251,7 +262,9 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 	TestEnsureError(ts_time_get_end(NUMERICOID));
 	TestEnsureError(ts_time_get_nobegin(NUMERICOID));
 	TestEnsureError(ts_time_get_noend(NUMERICOID));
+	TestEnsureError(ts_time_datum_get_nobegin_or_min(NUMERICOID));
 	TestEnsureError(ts_time_datum_get_min(NUMERICOID));
+	TestEnsureError(ts_time_datum_get_max(NUMERICOID));
 	TestEnsureError(ts_time_datum_get_end(NUMERICOID));
 	TestEnsureError(ts_time_datum_get_nobegin(NUMERICOID));
 	TestEnsureError(ts_time_datum_get_noend(NUMERICOID));

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1912,29 +1912,8 @@ cagg_boundary_make_lower_bound(Oid type)
 	bool typbyval;
 
 	get_typlenbyval(type, &typlen, &typbyval);
+	value = ts_time_datum_get_nobegin_or_min(type);
 
-	switch (type)
-	{
-		case INT2OID:
-			value = Int16GetDatum(PG_INT16_MIN);
-			break;
-		case DATEOID:
-		case INT4OID:
-			value = Int32GetDatum(PG_INT32_MIN);
-			break;
-		case INT8OID:
-		case TIMESTAMPTZOID:
-		case TIMESTAMPOID:
-			value = Int64GetDatum(PG_INT64_MIN);
-			break;
-		default:
-			/* validation at earlier stages should prevent ever reaching this */
-			ereport(ERROR,
-					(errcode(ERRCODE_TS_INTERNAL_ERROR),
-					 errmsg("unsupported datatype \"%s\" for continuous aggregate",
-							format_type_be(type))));
-			pg_unreachable();
-	}
 	return makeConst(type, -1, InvalidOid, typlen, value, false, typbyval);
 }
 

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -112,6 +112,7 @@ compute_bucketed_refresh_window(const InternalTimeRange *refresh_window, int64 b
 			exclusive_end = ts_time_saturating_sub(result.end, 1, result.type);
 
 		bucketed_end = ts_time_bucket_by_type(bucket_width, exclusive_end, result.type);
+
 		/* We get the time value for the start of the bucket, so need to add
 		 * bucket_width to get the end of it */
 		result.end = ts_time_saturating_add(bucketed_end, bucket_width, refresh_window->type);
@@ -228,6 +229,7 @@ continuous_agg_refresh_with_window(const ContinuousAgg *cagg,
 			 * aren't, so add one to the end of the invalidated region */
 			.end = ts_time_saturating_add(DatumGetInt64(end), 1, refresh_window->type),
 		};
+
 		InternalTimeRange bucketed_refresh_window =
 			compute_bucketed_refresh_window(&invalidation, cagg->data.bucket_width);
 

--- a/tsl/test/expected/continuous_aggs_permissions.out
+++ b/tsl/test/expected/continuous_aggs_permissions.out
@@ -122,7 +122,7 @@ ERROR:  must be owner of view mat_refresh_test
 REFRESH MATERIALIZED VIEW mat_refresh_test;
 ERROR:  permission denied for table conditions
 SELECT * FROM mat_refresh_test;
-ERROR:  permission denied for view mat_refresh_test
+ERROR:  permission denied for materialized view mat_refresh_test
 SELECT * FROM :materialization_hypertable;
 ERROR:  permission denied for table _materialized_hypertable_2
 SELECT * FROM :"mat_chunk_schema".:"mat_chunk_table";

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -351,11 +351,14 @@ CREATE MATERIALIZED VIEW boundary_view
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
+SELECT mat_hypertable_id AS boundary_view_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'boundary_view' \gset
 -- watermark should be NULL
-SELECT _timescaledb_internal.cagg_watermark(6);
+SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
  cagg_watermark 
 ----------------
-               
+    -2147483648
 (1 row)
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
@@ -393,7 +396,7 @@ SELECT * FROM boundary_view ORDER BY time_bucket;
 
 REFRESH MATERIALIZED VIEW boundary_view;
 -- watermark should be 30
-SELECT _timescaledb_internal.cagg_watermark(6);
+SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
  cagg_watermark 
 ----------------
              30
@@ -564,8 +567,22 @@ INSERT into ht_intdata values( 42 , 15 , 80);
 INSERT into ht_intdata values( 42 , 15 , 18);
 INSERT into ht_intdata values( 41 , 18 , 21);
 REFRESH MATERIALIZED VIEW mat_m1;
-SELECT view_name, completed_threshold from timescaledb_information.continuous_aggregate_stats
-WHERE view_name::text like 'mat_m1';
+SELECT mat_hypertable_id AS mat_m1_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'mat_m1' \gset
+-- Show the new watermark
+SELECT _timescaledb_internal.cagg_watermark(:mat_m1_id);
+ cagg_watermark 
+----------------
+             25
+(1 row)
+
+-- Data inserted after refresh and after cagg_watermark should be
+-- reflected in the real-time aggregation
+INSERT into ht_intdata VALUES (34, 13, 65), (26, 12, 78), (28, 9, 32);
+SELECT view_name, completed_threshold
+FROM timescaledb_information.continuous_aggregate_stats
+WHERE view_name::text LIKE 'mat_m1';
  view_name | completed_threshold 
 -----------+---------------------
  mat_m1    | 30
@@ -576,7 +593,7 @@ SELECT * from mat_m1 ORDER BY 1;
  time_bucket | sum 
 -------------+-----
           20 | 135
-          30 | 129
+          30 | 207
           40 |  95
 (3 rows)
 
@@ -585,11 +602,11 @@ FROM ht_intdata
 WHERE b < 16 and c > 20
 GROUP BY time_bucket(5, a)
 HAVING sum(c) > 50 and avg(b)::int > 12
-ORDER by 1; 
+ORDER by 1;
  time_bucket | sum 
 -------------+-----
           20 | 135
-          30 | 129
+          30 | 207
           40 |  95
 (3 rows)
 
@@ -611,14 +628,304 @@ ORDER by 1;
          ->  HashAggregate (actual rows=2 loops=1)
                Group Key: time_bucket(5, ht_intdata.a)
                Filter: ((sum(ht_intdata.c) > 50) AND ((avg(ht_intdata.b))::integer > 12))
-               ->  Custom Scan (ChunkAppend) on ht_intdata (actual rows=3 loops=1)
-                     Chunks excluded during startup: 2
-                     ->  Index Scan Backward using _hyper_7_13_chunk_ht_intdata_a_idx on _hyper_7_13_chunk (actual rows=2 loops=1)
+               Rows Removed by Filter: 1
+               ->  Custom Scan (ChunkAppend) on ht_intdata (actual rows=6 loops=1)
+                     Chunks excluded during startup: 1
+                     ->  Index Scan Backward using _hyper_7_11_chunk_ht_intdata_a_idx on _hyper_7_11_chunk (actual rows=2 loops=1)
+                           Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
+                           Filter: ((b < 16) AND (c > 20))
+                     ->  Index Scan Backward using _hyper_7_13_chunk_ht_intdata_a_idx on _hyper_7_13_chunk (actual rows=3 loops=1)
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                      ->  Index Scan Backward using _hyper_7_14_chunk_ht_intdata_a_idx on _hyper_7_14_chunk (actual rows=1 loops=1)
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                            Rows Removed by Filter: 2
-(23 rows)
+(27 rows)
 
+-- Test caggs with different time types
+CREATE TABLE smallint_table (time smallint, value int);
+CREATE TABLE int_table (time int, value int);
+CREATE TABLE bigint_table (time bigint, value int);
+CREATE TABLE date_table (time date, value int);
+CREATE TABLE timestamp_table (time timestamp, value int);
+CREATE TABLE timestamptz_table (time timestamptz, value int);
+SELECT create_hypertable('smallint_table', 'time', chunk_time_interval=>20);
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable       
+------------------------------
+ (10,public,smallint_table,t)
+(1 row)
+
+SELECT create_hypertable('int_table', 'time', chunk_time_interval=>20);
+NOTICE:  adding not-null constraint to column "time"
+    create_hypertable    
+-------------------------
+ (11,public,int_table,t)
+(1 row)
+
+SELECT create_hypertable('bigint_table', 'time', chunk_time_interval=>20);
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (12,public,bigint_table,t)
+(1 row)
+
+SELECT create_hypertable('date_table', 'time');
+NOTICE:  adding not-null constraint to column "time"
+    create_hypertable     
+--------------------------
+ (13,public,date_table,t)
+(1 row)
+
+SELECT create_hypertable('timestamp_table', 'time');
+NOTICE:  adding not-null constraint to column "time"
+       create_hypertable       
+-------------------------------
+ (14,public,timestamp_table,t)
+(1 row)
+
+SELECT create_hypertable('timestamptz_table', 'time');
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (15,public,timestamptz_table,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION smallint_now()
+RETURNS smallint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)::smallint
+    FROM smallint_table
+$$;
+CREATE OR REPLACE FUNCTION int_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM int_table
+$$;
+CREATE OR REPLACE FUNCTION bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)::bigint
+    FROM bigint_table
+$$;
+SELECT set_integer_now_func('smallint_table', 'smallint_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT set_integer_now_func('int_table', 'int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT set_integer_now_func('bigint_table', 'bigint_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW smallint_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
+FROM smallint_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW int_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(5, time) AS bucket, avg(value)
+FROM int_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW bigint_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
+FROM bigint_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW date_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM date_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW timestamp_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM timestamp_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW timestamptz_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM timestamptz_table
+GROUP BY 1;
+-- Refresh first without data
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+-- Watermarks at min for the above caggs:
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+ user_view_name  |    cagg_watermark    
+-----------------+----------------------
+ bigint_agg      | -9223372036854775808
+ boundary_view   |                   30
+ date_agg        |  -210866803200000000
+ int_agg         |          -2147483648
+ mat_m1          |                   25
+ metrics_summary |      946771200000000
+ smallint_agg    |               -32768
+ timestamp_agg   |  -210866803200000000
+ timestamptz_agg |  -210866803200000000
+(9 rows)
+
+INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO int_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO bigint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO date_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+INSERT INTO timestamp_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+INSERT INTO timestamptz_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+-- Refresh to move the watermarks
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+-- Watermarks should reflect the new materializations
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+ user_view_name  |  cagg_watermark  
+-----------------+------------------
+ bigint_agg      |               20
+ boundary_view   |               30
+ date_agg        | 1578614400000000
+ int_agg         |               20
+ mat_m1          |               25
+ metrics_summary |  946771200000000
+ smallint_agg    |               20
+ timestamp_agg   | 1578614400000000
+ timestamptz_agg | 1578614400000000
+(9 rows)
+
+-- Test overflow of valid ranges by inserting values close to the max
+-- supported time values. Adding one bucket to these values overflow
+-- the valid time ranges so the watermark should end up at the end of
+-- valid range for the type.
+INSERT INTO smallint_table VALUES (32765, 1);
+INSERT INTO int_table VALUES (2147483645, 1);
+INSERT INTO bigint_table VALUES (9223372036854775804, 1);
+INSERT INTO date_table VALUES ('294247-01-01', 1);
+INSERT INTO timestamp_table VALUES ('294247-01-01 00:00:00-00', 1);
+INSERT INTO timestamptz_table VALUES ('294247-01-01 00:00:00-00', 1);
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+-- Watermarks after refresh hould be at the end of the valid range for
+-- the time type
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+ user_view_name  |   cagg_watermark    
+-----------------+---------------------
+ bigint_agg      | 9223372036854775807
+ boundary_view   |                  30
+ date_agg        | 9223372036854775807
+ int_agg         |          2147483647
+ mat_m1          |                  25
+ metrics_summary |     946771200000000
+ smallint_agg    |               32767
+ timestamp_agg   | 9223372036854775807
+ timestamptz_agg | 9223372036854775807
+(9 rows)
+
+-- Querying the aggs should work even when fully materialized
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ bucket |          avg           
+--------+------------------------
+      0 |     4.2500000000000000
+     10 |    19.0000000000000000
+  32760 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+   bucket   |          avg           
+------------+------------------------
+          0 |     1.5000000000000000
+          5 |     7.0000000000000000
+         15 |    19.0000000000000000
+ 2147483645 | 1.00000000000000000000
+(4 rows)
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+       bucket        |          avg           
+---------------------+------------------------
+                   0 |     4.2500000000000000
+                  10 |    19.0000000000000000
+ 9223372036854775800 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+    bucket    |          avg           
+--------------+------------------------
+ 12-31-2019   | 1.00000000000000000000
+ 01-02-2020   |     2.0000000000000000
+ 01-06-2020   |     6.0000000000000000
+ 01-08-2020   |     8.0000000000000000
+ 12-31-294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+           bucket           |          avg           
+----------------------------+------------------------
+ Tue Dec 31 00:00:00 2019   | 1.00000000000000000000
+ Thu Jan 02 00:00:00 2020   |     2.0000000000000000
+ Mon Jan 06 00:00:00 2020   |     6.0000000000000000
+ Wed Jan 08 00:00:00 2020   |     8.0000000000000000
+ Thu Dec 31 00:00:00 294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+             bucket             |          avg           
+--------------------------------+------------------------
+ Mon Dec 30 16:00:00 2019 PST   | 1.00000000000000000000
+ Wed Jan 01 16:00:00 2020 PST   |     2.0000000000000000
+ Sun Jan 05 16:00:00 2020 PST   |     6.0000000000000000
+ Tue Jan 07 16:00:00 2020 PST   |     8.0000000000000000
+ Wed Dec 30 16:00:00 294246 PST | 1.00000000000000000000
+(5 rows)
+
+\set ON_ERROR_STOP 0
+-------------------------------------
+-- Test invalid inputs for cagg_watermark
+-------------------------------------
+-- Non-existing materialized hypertable
+SELECT _timescaledb_internal.cagg_watermark(100);
+ERROR:  100 is not a materialized hypertable
+-- NULL hypertable ID. Function is STRICT, so does nothing:
+SELECT _timescaledb_internal.cagg_watermark(NULL);
+ cagg_watermark 
+----------------
+               
+(1 row)
+
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -351,11 +351,14 @@ CREATE MATERIALIZED VIEW boundary_view
 AS
   SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
+SELECT mat_hypertable_id AS boundary_view_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'boundary_view' \gset
 -- watermark should be NULL
-SELECT _timescaledb_internal.cagg_watermark(6);
+SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
  cagg_watermark 
 ----------------
-               
+    -2147483648
 (1 row)
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
@@ -393,7 +396,7 @@ SELECT * FROM boundary_view ORDER BY time_bucket;
 
 REFRESH MATERIALIZED VIEW boundary_view;
 -- watermark should be 30
-SELECT _timescaledb_internal.cagg_watermark(6);
+SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
  cagg_watermark 
 ----------------
              30
@@ -564,8 +567,22 @@ INSERT into ht_intdata values( 42 , 15 , 80);
 INSERT into ht_intdata values( 42 , 15 , 18);
 INSERT into ht_intdata values( 41 , 18 , 21);
 REFRESH MATERIALIZED VIEW mat_m1;
-SELECT view_name, completed_threshold from timescaledb_information.continuous_aggregate_stats
-WHERE view_name::text like 'mat_m1';
+SELECT mat_hypertable_id AS mat_m1_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'mat_m1' \gset
+-- Show the new watermark
+SELECT _timescaledb_internal.cagg_watermark(:mat_m1_id);
+ cagg_watermark 
+----------------
+             25
+(1 row)
+
+-- Data inserted after refresh and after cagg_watermark should be
+-- reflected in the real-time aggregation
+INSERT into ht_intdata VALUES (34, 13, 65), (26, 12, 78), (28, 9, 32);
+SELECT view_name, completed_threshold
+FROM timescaledb_information.continuous_aggregate_stats
+WHERE view_name::text LIKE 'mat_m1';
  view_name | completed_threshold 
 -----------+---------------------
  mat_m1    | 30
@@ -576,7 +593,7 @@ SELECT * from mat_m1 ORDER BY 1;
  time_bucket | sum 
 -------------+-----
           20 | 135
-          30 | 129
+          30 | 207
           40 |  95
 (3 rows)
 
@@ -585,11 +602,11 @@ FROM ht_intdata
 WHERE b < 16 and c > 20
 GROUP BY time_bucket(5, a)
 HAVING sum(c) > 50 and avg(b)::int > 12
-ORDER by 1; 
+ORDER by 1;
  time_bucket | sum 
 -------------+-----
           20 | 135
-          30 | 129
+          30 | 207
           40 |  95
 (3 rows)
 
@@ -614,14 +631,304 @@ ORDER by 1;
          ->  HashAggregate (actual rows=2 loops=1)
                Group Key: time_bucket(5, ht_intdata.a)
                Filter: ((sum(ht_intdata.c) > 50) AND ((avg(ht_intdata.b))::integer > 12))
-               ->  Custom Scan (ChunkAppend) on ht_intdata (actual rows=3 loops=1)
-                     Chunks excluded during startup: 2
-                     ->  Index Scan Backward using _hyper_7_13_chunk_ht_intdata_a_idx on _hyper_7_13_chunk (actual rows=2 loops=1)
+               Rows Removed by Filter: 1
+               ->  Custom Scan (ChunkAppend) on ht_intdata (actual rows=6 loops=1)
+                     Chunks excluded during startup: 1
+                     ->  Index Scan Backward using _hyper_7_11_chunk_ht_intdata_a_idx on _hyper_7_11_chunk (actual rows=2 loops=1)
+                           Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
+                           Filter: ((b < 16) AND (c > 20))
+                     ->  Index Scan Backward using _hyper_7_13_chunk_ht_intdata_a_idx on _hyper_7_13_chunk (actual rows=3 loops=1)
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                      ->  Index Scan Backward using _hyper_7_14_chunk_ht_intdata_a_idx on _hyper_7_14_chunk (actual rows=1 loops=1)
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                            Rows Removed by Filter: 2
-(26 rows)
+(30 rows)
 
+-- Test caggs with different time types
+CREATE TABLE smallint_table (time smallint, value int);
+CREATE TABLE int_table (time int, value int);
+CREATE TABLE bigint_table (time bigint, value int);
+CREATE TABLE date_table (time date, value int);
+CREATE TABLE timestamp_table (time timestamp, value int);
+CREATE TABLE timestamptz_table (time timestamptz, value int);
+SELECT create_hypertable('smallint_table', 'time', chunk_time_interval=>20);
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable       
+------------------------------
+ (10,public,smallint_table,t)
+(1 row)
+
+SELECT create_hypertable('int_table', 'time', chunk_time_interval=>20);
+NOTICE:  adding not-null constraint to column "time"
+    create_hypertable    
+-------------------------
+ (11,public,int_table,t)
+(1 row)
+
+SELECT create_hypertable('bigint_table', 'time', chunk_time_interval=>20);
+NOTICE:  adding not-null constraint to column "time"
+     create_hypertable      
+----------------------------
+ (12,public,bigint_table,t)
+(1 row)
+
+SELECT create_hypertable('date_table', 'time');
+NOTICE:  adding not-null constraint to column "time"
+    create_hypertable     
+--------------------------
+ (13,public,date_table,t)
+(1 row)
+
+SELECT create_hypertable('timestamp_table', 'time');
+NOTICE:  adding not-null constraint to column "time"
+       create_hypertable       
+-------------------------------
+ (14,public,timestamp_table,t)
+(1 row)
+
+SELECT create_hypertable('timestamptz_table', 'time');
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (15,public,timestamptz_table,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION smallint_now()
+RETURNS smallint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)::smallint
+    FROM smallint_table
+$$;
+CREATE OR REPLACE FUNCTION int_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM int_table
+$$;
+CREATE OR REPLACE FUNCTION bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)::bigint
+    FROM bigint_table
+$$;
+SELECT set_integer_now_func('smallint_table', 'smallint_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT set_integer_now_func('int_table', 'int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT set_integer_now_func('bigint_table', 'bigint_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW smallint_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
+FROM smallint_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW int_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(5, time) AS bucket, avg(value)
+FROM int_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW bigint_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
+FROM bigint_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW date_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM date_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW timestamp_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM timestamp_table
+GROUP BY 1;
+CREATE MATERIALIZED VIEW timestamptz_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM timestamptz_table
+GROUP BY 1;
+-- Refresh first without data
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+-- Watermarks at min for the above caggs:
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+ user_view_name  |    cagg_watermark    
+-----------------+----------------------
+ bigint_agg      | -9223372036854775808
+ boundary_view   |                   30
+ date_agg        |  -210866803200000000
+ int_agg         |          -2147483648
+ mat_m1          |                   25
+ metrics_summary |      946771200000000
+ smallint_agg    |               -32768
+ timestamp_agg   |  -210866803200000000
+ timestamptz_agg |  -210866803200000000
+(9 rows)
+
+INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO int_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO bigint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO date_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+INSERT INTO timestamp_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+INSERT INTO timestamptz_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+-- Refresh to move the watermarks
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+-- Watermarks should reflect the new materializations
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+ user_view_name  |  cagg_watermark  
+-----------------+------------------
+ bigint_agg      |               20
+ boundary_view   |               30
+ date_agg        | 1578614400000000
+ int_agg         |               20
+ mat_m1          |               25
+ metrics_summary |  946771200000000
+ smallint_agg    |               20
+ timestamp_agg   | 1578614400000000
+ timestamptz_agg | 1578614400000000
+(9 rows)
+
+-- Test overflow of valid ranges by inserting values close to the max
+-- supported time values. Adding one bucket to these values overflow
+-- the valid time ranges so the watermark should end up at the end of
+-- valid range for the type.
+INSERT INTO smallint_table VALUES (32765, 1);
+INSERT INTO int_table VALUES (2147483645, 1);
+INSERT INTO bigint_table VALUES (9223372036854775804, 1);
+INSERT INTO date_table VALUES ('294247-01-01', 1);
+INSERT INTO timestamp_table VALUES ('294247-01-01 00:00:00-00', 1);
+INSERT INTO timestamptz_table VALUES ('294247-01-01 00:00:00-00', 1);
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+-- Watermarks after refresh hould be at the end of the valid range for
+-- the time type
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+ user_view_name  |   cagg_watermark    
+-----------------+---------------------
+ bigint_agg      | 9223372036854775807
+ boundary_view   |                  30
+ date_agg        | 9223372036854775807
+ int_agg         |          2147483647
+ mat_m1          |                  25
+ metrics_summary |     946771200000000
+ smallint_agg    |               32767
+ timestamp_agg   | 9223372036854775807
+ timestamptz_agg | 9223372036854775807
+(9 rows)
+
+-- Querying the aggs should work even when fully materialized
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ bucket |          avg           
+--------+------------------------
+      0 |     4.2500000000000000
+     10 |    19.0000000000000000
+  32760 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+   bucket   |          avg           
+------------+------------------------
+          0 |     1.5000000000000000
+          5 |     7.0000000000000000
+         15 |    19.0000000000000000
+ 2147483645 | 1.00000000000000000000
+(4 rows)
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+       bucket        |          avg           
+---------------------+------------------------
+                   0 |     4.2500000000000000
+                  10 |    19.0000000000000000
+ 9223372036854775800 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+    bucket    |          avg           
+--------------+------------------------
+ 12-31-2019   | 1.00000000000000000000
+ 01-02-2020   |     2.0000000000000000
+ 01-06-2020   |     6.0000000000000000
+ 01-08-2020   |     8.0000000000000000
+ 12-31-294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+           bucket           |          avg           
+----------------------------+------------------------
+ Tue Dec 31 00:00:00 2019   | 1.00000000000000000000
+ Thu Jan 02 00:00:00 2020   |     2.0000000000000000
+ Mon Jan 06 00:00:00 2020   |     6.0000000000000000
+ Wed Jan 08 00:00:00 2020   |     8.0000000000000000
+ Thu Dec 31 00:00:00 294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+             bucket             |          avg           
+--------------------------------+------------------------
+ Mon Dec 30 16:00:00 2019 PST   | 1.00000000000000000000
+ Wed Jan 01 16:00:00 2020 PST   |     2.0000000000000000
+ Sun Jan 05 16:00:00 2020 PST   |     6.0000000000000000
+ Tue Jan 07 16:00:00 2020 PST   |     8.0000000000000000
+ Wed Dec 30 16:00:00 294246 PST | 1.00000000000000000000
+(5 rows)
+
+\set ON_ERROR_STOP 0
+-------------------------------------
+-- Test invalid inputs for cagg_watermark
+-------------------------------------
+-- Non-existing materialized hypertable
+SELECT _timescaledb_internal.cagg_watermark(100);
+ERROR:  100 is not a materialized hypertable
+-- NULL hypertable ID. Function is STRICT, so does nothing:
+SELECT _timescaledb_internal.cagg_watermark(NULL);
+ cagg_watermark 
+----------------
+               
+(1 row)
+
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -156,8 +156,12 @@ AS
 
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
 
+SELECT mat_hypertable_id AS boundary_view_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'boundary_view' \gset
+
 -- watermark should be NULL
-SELECT _timescaledb_internal.cagg_watermark(6);
+SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
 :PREFIX SELECT * FROM boundary_view;
@@ -168,7 +172,7 @@ SELECT * FROM boundary_view ORDER BY time_bucket;
 REFRESH MATERIALIZED VIEW boundary_view;
 
 -- watermark should be 30
-SELECT _timescaledb_internal.cagg_watermark(6);
+SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- both sides of the UNION should return 2 rows
 :PREFIX SELECT * FROM boundary_view;
@@ -264,8 +268,20 @@ INSERT into ht_intdata values( 41 , 18 , 21);
 
 REFRESH MATERIALIZED VIEW mat_m1;
 
-SELECT view_name, completed_threshold from timescaledb_information.continuous_aggregate_stats
-WHERE view_name::text like 'mat_m1';
+SELECT mat_hypertable_id AS mat_m1_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'mat_m1' \gset
+
+-- Show the new watermark
+SELECT _timescaledb_internal.cagg_watermark(:mat_m1_id);
+
+-- Data inserted after refresh and after cagg_watermark should be
+-- reflected in the real-time aggregation
+INSERT into ht_intdata VALUES (34, 13, 65), (26, 12, 78), (28, 9, 32);
+
+SELECT view_name, completed_threshold
+FROM timescaledb_information.continuous_aggregate_stats
+WHERE view_name::text LIKE 'mat_m1';
 
 --view and direct query should return same results
 SELECT * from mat_m1 ORDER BY 1;
@@ -274,7 +290,174 @@ FROM ht_intdata
 WHERE b < 16 and c > 20
 GROUP BY time_bucket(5, a)
 HAVING sum(c) > 50 and avg(b)::int > 12
-ORDER by 1; 
+ORDER by 1;
 
 -- plan output
 :PREFIX SELECT * FROM mat_m1 ORDER BY 1;
+
+-- Test caggs with different time types
+CREATE TABLE smallint_table (time smallint, value int);
+CREATE TABLE int_table (time int, value int);
+CREATE TABLE bigint_table (time bigint, value int);
+CREATE TABLE date_table (time date, value int);
+CREATE TABLE timestamp_table (time timestamp, value int);
+CREATE TABLE timestamptz_table (time timestamptz, value int);
+
+SELECT create_hypertable('smallint_table', 'time', chunk_time_interval=>20);
+SELECT create_hypertable('int_table', 'time', chunk_time_interval=>20);
+SELECT create_hypertable('bigint_table', 'time', chunk_time_interval=>20);
+SELECT create_hypertable('date_table', 'time');
+SELECT create_hypertable('timestamp_table', 'time');
+SELECT create_hypertable('timestamptz_table', 'time');
+
+CREATE OR REPLACE FUNCTION smallint_now()
+RETURNS smallint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)::smallint
+    FROM smallint_table
+$$;
+CREATE OR REPLACE FUNCTION int_now()
+RETURNS int LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)
+    FROM int_table
+$$;
+CREATE OR REPLACE FUNCTION bigint_now()
+RETURNS bigint LANGUAGE SQL STABLE AS
+$$
+    SELECT coalesce(max(time), 0)::bigint
+    FROM bigint_table
+$$;
+
+SELECT set_integer_now_func('smallint_table', 'smallint_now');
+SELECT set_integer_now_func('int_table', 'int_now');
+SELECT set_integer_now_func('bigint_table', 'bigint_now');
+
+CREATE MATERIALIZED VIEW smallint_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
+FROM smallint_table
+GROUP BY 1;
+
+CREATE MATERIALIZED VIEW int_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(5, time) AS bucket, avg(value)
+FROM int_table
+GROUP BY 1;
+
+CREATE MATERIALIZED VIEW bigint_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
+FROM bigint_table
+GROUP BY 1;
+
+CREATE MATERIALIZED VIEW date_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM date_table
+GROUP BY 1;
+
+CREATE MATERIALIZED VIEW timestamp_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM timestamp_table
+GROUP BY 1;
+
+CREATE MATERIALIZED VIEW timestamptz_agg
+WITH (timescaledb.continuous)
+AS
+SELECT time_bucket('2 days', time) AS bucket, avg(value)
+FROM timestamptz_table
+GROUP BY 1;
+
+-- Refresh first without data
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+
+-- Watermarks at min for the above caggs:
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+
+INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO int_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO bigint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
+INSERT INTO date_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+INSERT INTO timestamp_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+INSERT INTO timestamptz_table VALUES ('2020-01-01', 1), ('2020-01-02', 2), ('2020-01-06', 6), ('2020-01-08', 8);
+
+-- Refresh to move the watermarks
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+
+
+-- Watermarks should reflect the new materializations
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+
+-- Test overflow of valid ranges by inserting values close to the max
+-- supported time values. Adding one bucket to these values overflow
+-- the valid time ranges so the watermark should end up at the end of
+-- valid range for the type.
+INSERT INTO smallint_table VALUES (32765, 1);
+INSERT INTO int_table VALUES (2147483645, 1);
+INSERT INTO bigint_table VALUES (9223372036854775804, 1);
+INSERT INTO date_table VALUES ('294247-01-01', 1);
+INSERT INTO timestamp_table VALUES ('294247-01-01 00:00:00-00', 1);
+INSERT INTO timestamptz_table VALUES ('294247-01-01 00:00:00-00', 1);
+
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+
+-- Watermarks after refresh hould be at the end of the valid range for
+-- the time type
+SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg
+ORDER BY 1,2;
+
+-- Querying the aggs should work even when fully materialized
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+
+\set ON_ERROR_STOP 0
+-------------------------------------
+-- Test invalid inputs for cagg_watermark
+-------------------------------------
+-- Non-existing materialized hypertable
+SELECT _timescaledb_internal.cagg_watermark(100);
+-- NULL hypertable ID. Function is STRICT, so does nothing:
+SELECT _timescaledb_internal.cagg_watermark(NULL);
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
The function `cagg_watermark` returns the time threshold at which
materialized data ends and raw query data begins in a real-time
aggregation query (union view).

The watermark is simply the completed threshold of the continuous
aggregate materializer. However, since the completed threshold will no
longer exist with the new continuous aggregates, the watermark
function has been changed to return the end of the last bucket in the
materialized hypertable.

In most cases, the completed threshold is the same as the end of the
last materialized bucket. However, there are situations when it is
not; for example, when there is a filter in the view query some
buckets might not be materialized because no data matched the
filter. The completed threshold would move ahead regardless. For
instance, if there is only data from "device_2" in the raw hypertable
and the aggregate has a filter `device=1`, there will be no buckets
materialized although the completed threshold moves forward. Therefore
the new watermark function might sometimes return a lower watermark
than the old function. A similar situation explains the different
output in one of the union view tests.