### PR TITLE
Remove Ubuntu 19.10 from APT package test

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # Debian images:  9 (stretch), or 10 (buster)
         # Ubuntu images:  18.04 LTS (bionic), 19.10 (eoan), 20.04 LTS (focal)
-        image: [ "debian:9-slim", "debian:10-slim", "ubuntu:bionic", "ubuntu:eoan", "ubuntu:focal"]
+        image: [ "debian:9-slim", "debian:10-slim", "ubuntu:bionic", "ubuntu:focal"]
         pg: [ 9.6, 10, 11, 12 ]
         exclude:
           - image: "ubuntu:focal"


### PR DESCRIPTION
This patch removes Ubuntu 19.10 from APT package test because
19.10 is no longer supported by Ubuntu so we don't build packages
for it anymore.