### PR TITLE
Fix issues relate to non-inclusive refresh window

### DIFF
--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -253,6 +253,9 @@ set_remainder_after_cut(Invalidation *remainder, int32 hyper_id, int64 modificat
  * The part(s) of the invalidation that are outside the refresh window after
  * the cut will remain in the log. The part of the invalidation that fits
  * within the window is returned as the "remainder".
+ *
+ * Note that the refresh window is exclusive in the end while invalidations
+ * are inclusive.
  */
 static InvalidationResult
 cut_invalidation_along_refresh_window(const CaggInvalidationState *state,
@@ -308,7 +311,8 @@ cut_invalidation_along_refresh_window(const CaggInvalidationState *state,
 									cagg_hyper_id,
 									invalidation->modification_time,
 									refresh_window->start,
-									MIN(refresh_window->end,
+									/* Refresh window not exclusive at end */
+									MIN(refresh_window->end - 1,
 										invalidation->greatest_modified_value));
 			result = INVAL_CUT;
 		}
@@ -333,7 +337,8 @@ cut_invalidation_along_refresh_window(const CaggInvalidationState *state,
 									cagg_hyper_id,
 									invalidation->modification_time,
 									MAX(invalidation->lowest_modified_value, refresh_window->start),
-									refresh_window->end);
+									/* Refresh window exclusive at end */
+									refresh_window->end - 1);
 			result = INVAL_CUT;
 		}
 	}

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -80,26 +80,26 @@ CREATE MATERIALIZED VIEW cond_10
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
-SELECT time_bucket(BIGINT '10', time) AS day, device, avg(temp) AS avg_temp
+SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2;
-NOTICE:  adding index _materialized_hypertable_3_device_day_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device, day)
+NOTICE:  adding index _materialized_hypertable_3_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device, bucket)
 CREATE MATERIALIZED VIEW cond_20
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
-SELECT time_bucket(BIGINT '20', time) AS day, device, avg(temp) AS avg_temp
+SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2;
-NOTICE:  adding index _materialized_hypertable_4_device_day_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, day)
+NOTICE:  adding index _materialized_hypertable_4_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, bucket)
 CREATE MATERIALIZED VIEW measure_10
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
 AS
-SELECT time_bucket(10, time) AS day, device, avg(temp) AS avg_temp
+SELECT time_bucket(10, time) AS bucket, device, avg(temp) AS avg_temp
 FROM measurements
 GROUP BY 1,2;
-NOTICE:  adding index _materialized_hypertable_5_device_day_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(device, day)
+NOTICE:  adding index _materialized_hypertable_5_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(device, bucket)
 -- There should be three continuous aggregates, two on one hypertable
 -- and one on the other:
 SELECT mat_hypertable_id, raw_hypertable_id, user_view_name
@@ -113,21 +113,21 @@ FROM _timescaledb_catalog.continuous_agg;
 
 -- The continuous aggregates should be empty
 SELECT * FROM cond_10
-ORDER BY day DESC, device;
- day | device | avg_temp 
------+--------+----------
+ORDER BY bucket DESC, device;
+ bucket | device | avg_temp 
+--------+--------+----------
 (0 rows)
 
 SELECT * FROM cond_20
-ORDER BY day DESC, device;
- day | device | avg_temp 
------+--------+----------
+ORDER BY bucket DESC, device;
+ bucket | device | avg_temp 
+--------+--------+----------
 (0 rows)
 
 SELECT * FROM measure_10
-ORDER BY day DESC, device;
- day | device | avg_temp 
------+--------+----------
+ORDER BY bucket DESC, device;
+ bucket | device | avg_temp 
+--------+--------+----------
 (0 rows)
 
 -- Must refresh to move the invalidation threshold, or no
@@ -536,4 +536,230 @@ SELECT materialization_id AS cagg_id,
        5 | -9223372036854775808 |                   -1
        5 |                   30 |  9223372036854775807
 (9 rows)
+
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        2 |    20 |  20
+(1 row)
+
+-- Clear the table and aggregate
+DELETE FROM conditions;
+SELECT * FROM conditions;
+ time | device | temp 
+------+--------+------
+(0 rows)
+
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        1 |     1 | 100
+        2 |    20 |  20
+(2 rows)
+
+CALL refresh_continuous_aggregate('cond_10', NULL, NULL);
+SELECT * FROM cond_10
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+(0 rows)
+
+-------------------------------------------------------
+-- Test corner cases against a minimal bucket aggregate
+-------------------------------------------------------
+CREATE MATERIALIZED VIEW cond_1
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(BIGINT '1', time) AS bucket, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2;
+NOTICE:  adding index _materialized_hypertable_6_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, bucket)
+SELECT mat_hypertable_id AS cond_1_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond_1' \gset
+-- Test invalidations with bucket size 1
+INSERT INTO conditions VALUES (0, 1, 1.0);
+SELECT hypertable_id AS hyper_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+       ORDER BY 1,2,3;
+ hyper_id | start | end 
+----------+-------+-----
+        1 |     0 |   0
+        2 |    20 |  20
+(2 rows)
+
+-- Refreshing around the bucket should not update the aggregate
+CALL refresh_continuous_aggregate('cond_1', -1, 0);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+(0 rows)
+
+CALL refresh_continuous_aggregate('cond_1', 1, 2);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+(0 rows)
+
+-- Refresh only the invalidated bucket
+CALL refresh_continuous_aggregate('cond_1', 0, 1);
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       WHERE materialization_id = :cond_1_id
+       ORDER BY 1,2,3;
+ cagg_id |        start         |         end         
+---------+----------------------+---------------------
+       6 | -9223372036854775808 |                  -2
+       6 |                    2 | 9223372036854775807
+(2 rows)
+
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        1
+(1 row)
+
+-- Refresh 1 extra bucket on the left
+INSERT INTO conditions VALUES (0, 1, 2.0);
+CALL refresh_continuous_aggregate('cond_1', -1, 1);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |      1.5
+(1 row)
+
+-- Refresh 1 extra bucket on the right
+INSERT INTO conditions VALUES (0, 1, 3.0);
+CALL refresh_continuous_aggregate('cond_1', 0, 2);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        2
+(1 row)
+
+-- Refresh 1 extra bucket on each side
+INSERT INTO conditions VALUES (0, 1, 4.0);
+CALL refresh_continuous_aggregate('cond_1', -1, 2);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |      2.5
+(1 row)
+
+-- Clear to reset aggregate
+DELETE FROM conditions;
+CALL refresh_continuous_aggregate('cond_1', NULL, NULL);
+-- Test invalidation of size 2
+INSERT INTO conditions VALUES (0, 1, 1.0), (1, 1, 2.0);
+-- Refresh one bucket at a time
+CALL refresh_continuous_aggregate('cond_1', 0, 1);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        1
+(1 row)
+
+CALL refresh_continuous_aggregate('cond_1', 1, 2);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        1
+      1 |      1 |        2
+(2 rows)
+
+-- Repeat the same thing but refresh the whole invalidation at once
+DELETE FROM conditions;
+CALL refresh_continuous_aggregate('cond_1', NULL, NULL);
+INSERT INTO conditions VALUES (0, 1, 1.0), (1, 1, 2.0);
+CALL refresh_continuous_aggregate('cond_1', 0, 2);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        1
+      1 |      1 |        2
+(2 rows)
+
+-- Test invalidation of size 3
+DELETE FROM conditions;
+CALL refresh_continuous_aggregate('cond_1', NULL, NULL);
+INSERT INTO conditions VALUES (0, 1, 1.0), (1, 1, 2.0), (2, 1, 3.0);
+-- Invalidation extends beyond the refresh window on both ends
+CALL refresh_continuous_aggregate('cond_1', 1, 2);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      1 |      1 |        2
+(1 row)
+
+-- Should leave one invalidation on each side of the refresh window
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       WHERE materialization_id = :cond_1_id
+       ORDER BY 1,2,3;
+ cagg_id |        start        |         end         
+---------+---------------------+---------------------
+       6 |                   0 |                   0
+       6 |                   2 |                   2
+       6 | 9223372036854775807 | 9223372036854775807
+(3 rows)
+
+-- Refresh the two remaining invalidations
+CALL refresh_continuous_aggregate('cond_1', 0, 1);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        1
+      1 |      1 |        2
+(2 rows)
+
+CALL refresh_continuous_aggregate('cond_1', 2, 3);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        1
+      1 |      1 |        2
+      2 |      1 |        3
+(3 rows)
+
+-- Clear and repeat but instead refresh the whole range in one go. The
+-- result should be the same as the three partial refreshes
+DELETE FROM conditions;
+CALL refresh_continuous_aggregate('cond_1', NULL, NULL);
+INSERT INTO conditions VALUES (0, 1, 1.0), (1, 1, 2.0), (2, 1, 3.0);
+CALL refresh_continuous_aggregate('cond_1', 0, 3);
+SELECT * FROM cond_1
+ORDER BY 1,2;
+ bucket | device | avg_temp 
+--------+--------+----------
+      0 |      1 |        1
+      1 |      1 |        2
+      2 |      1 |        3
+(3 rows)
 


### PR DESCRIPTION
This change fixes some corner-case issues that could lead to a refresh
not actually refreshing when it should.

The issues arise because invalidations are inclusive in both ends
while the refresh window is exclusive in the end. In some case, this
wasn't correctly accounted for.

To fix the issues, the remainder after cutting invalidations has been
adjusted and we always add 1 to the end of the refresh window when it
is set from an invalidation. In addition, we add an extra check for
this case when computing the bucketed refresh window and the end of
the refresh window is at the start of the bucket (i.e., the window
size is 1).

The test suite has also been expanded to test for some of these corner
cases.