### PR TITLE
Migrate ignore_invalidation_older_than for continuous aggregates

### DIFF
--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -14,3 +14,4 @@ SELECT * FROM cagg.realtime_mat ORDER BY bucket, location;
 
 SELECT view_name, refresh_interval, materialized_only, materialization_hypertable FROM timescaledb_information.continuous_aggregates ORDER BY view_name::text;
 
+SELECT maxtemp FROM mat_ignoreinval ORDER BY 1;


### PR DESCRIPTION
When the extension is updated to 2.0, we need to migrate
existing ignore_invalidation_older_than settings to the new
continuous aggregate policy framework.

ignore_invalidation_older_than setting is mapped to start_interval
of the refresh policy.If the default value is used, it is mapped
to NULL start_interval, otherwise it is converted to an
interval value.