### PR TITLE
Overflow handling for refresh policy with integer based time

### DIFF
--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -84,5 +84,6 @@ extern TSDLLEXPORT int64 ts_time_get_noend(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_noend_or_max(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_saturating_add(int64 timeval, int64 interval, Oid timetype);
 extern TSDLLEXPORT int64 ts_time_saturating_sub(int64 timeval, int64 interval, Oid timetype);
-
+extern TSDLLEXPORT int64 ts_subtract_integer_from_now_saturating(Oid now_func, int64 interval,
+																 Oid timetype);
 #endif /* TIMESCALEDB_TIME_UTILS_H */

--- a/tsl/src/bgw_policy/continuous_aggregate_api.h
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.h
@@ -16,8 +16,6 @@ extern Datum policy_refresh_cagg_proc(PG_FUNCTION_ARGS);
 extern Datum policy_refresh_cagg_remove(PG_FUNCTION_ARGS);
 
 int32 policy_continuous_aggregate_get_mat_hypertable_id(const Jsonb *config);
-int64 policy_refresh_cagg_get_refresh_start(const Dimension *dim, const Jsonb *config,
-											bool *start_isnull);
-int64 policy_refresh_cagg_get_refresh_end(const Dimension *dim, const Jsonb *config,
-										  bool *end_isnull);
+int64 policy_refresh_cagg_get_refresh_start(const Dimension *dim, const Jsonb *config);
+int64 policy_refresh_cagg_get_refresh_end(const Dimension *dim, const Jsonb *config);
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_CAGG_API_H */

--- a/tsl/src/bgw_policy/policy_utils.h
+++ b/tsl/src/bgw_policy/policy_utils.h
@@ -11,5 +11,7 @@
 bool policy_config_check_hypertable_lag_equality(Jsonb *config, const char *json_label,
 												 Oid dim_type, Oid lag_type, Datum lag_datum);
 int64 subtract_integer_from_now(int64 interval, Oid time_dim_type, Oid now_func);
+int64 subtract_integer_from_now_internal(int64 interval, Oid time_dim_type, Oid now_func,
+										 bool *overflow);
 Datum subtract_interval_from_now(Interval *interval, Oid time_dim_type);
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_UTILS_H */

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -138,11 +138,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                     msg                     
---------+-----------+--------------------------------------------+---------------------------------------------
+ msg_no | mock_time |              application_name              |                        msg                         
+--------+-----------+--------------------------------------------+----------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until 25000, started at 0
-      0 |         0 | Refresh Continuous Aggregate Policy [1000] | refresh continuous aggregate range NULL , 6
+      0 |         0 | Refresh Continuous Aggregate Policy [1000] | refresh continuous aggregate range -2147483648 , 6
 (3 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:job_id;
@@ -371,11 +371,11 @@ SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(25);
 (1 row)
 
 SELECT * FROM sorted_bgw_log;
- msg_no | mock_time |              application_name              |                     msg                      
---------+-----------+--------------------------------------------+----------------------------------------------
+ msg_no | mock_time |              application_name              |                         msg                         
+--------+-----------+--------------------------------------------+-----------------------------------------------------
       0 |         0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |         0 | DB Scheduler                               | [TESTING] Wait until 25000, started at 0
-      0 |         0 | Refresh Continuous Aggregate Policy [1001] | refresh continuous aggregate range NULL , 12
+      0 |         0 | Refresh Continuous Aggregate Policy [1001] | refresh continuous aggregate range -2147483648 , 12
 (3 rows)
 
 -- job ran once, successfully
@@ -420,10 +420,10 @@ SELECT * FROM sorted_bgw_log;
 --------+-------------+--------------------------------------------+----------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until 25000, started at 0
-      0 |           0 | Refresh Continuous Aggregate Policy [1001] | refresh continuous aggregate range NULL , 12
+      0 |           0 | Refresh Continuous Aggregate Policy [1001] | refresh continuous aggregate range -2147483648 , 12
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until 43200025000, started at 43200000000
-      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | refresh continuous aggregate range NULL , 12
+      0 | 43200000000 | Refresh Continuous Aggregate Policy [1001] | refresh continuous aggregate range -2147483648 , 12
 (6 rows)
 
 SELECT job_id, next_start - last_finish as until_next, last_run_success, total_runs, total_successes, total_failures, total_crashes
@@ -639,7 +639,7 @@ SELECT * from sorted_bgw_log;
 --------+-------------+--------------------------------------------+---------------------------------------------------------------
       0 |           0 | DB Scheduler                               | [TESTING] Registered new background worker
       1 |           0 | DB Scheduler                               | [TESTING] Wait until 25000, started at 0
-      0 |           0 | Refresh Continuous Aggregate Policy [1003] | refresh continuous aggregate range NULL , 3
+      0 |           0 | Refresh Continuous Aggregate Policy [1003] | refresh continuous aggregate range -2147483648 , 3
       0 | 43200000000 | DB Scheduler                               | [TESTING] Registered new background worker
       1 | 43200000000 | DB Scheduler                               | [TESTING] Wait until 43200025000, started at 43200000000
       0 | 43200000000 | Refresh Continuous Aggregate Policy [1003] | job 1003 threw an error

--- a/tsl/test/expected/continuous_aggs_policy.out
+++ b/tsl/test/expected/continuous_aggs_policy.out
@@ -230,7 +230,7 @@ NOTICE:  adding not-null constraint to column "a"
  smallint_tab
 (1 row)
 
-CREATE OR REPLACE FUNCTION integer_now_smallint_tab() returns smallint LANGUAGE SQL STABLE as $$ SELECT 20::smallint $$;
+CREATE OR REPLACE FUNCTION integer_now_smallint_tab() returns smallint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(a)::smallint, 0::smallint) FROM smallint_tab ; $$;
 SELECT set_integer_now_func('smallint_tab', 'integer_now_smallint_tab');
  set_integer_now_func 
 ----------------------
@@ -256,22 +256,117 @@ INSERT INTO smallint_tab VALUES(5);
 INSERT INTO smallint_tab VALUES(10);
 INSERT INTO smallint_tab VALUES(20);
 CALL run_job(:job_id);
-SELECT * FROM mat_smallint;
+SELECT * FROM mat_smallint ORDER BY 1;
  a  | countb 
 ----+--------
   5 |      1
  10 |      1
 (2 rows)
 
-\set ON_ERROR_STOP 0
-SELECT add_continuous_aggregate_policy('mat_smallint', 15::smallint, 10::smallint, '1h'::interval, if_not_exists=>true);
-WARNING:  could not add refresh policy due to existing policy on continuous aggregate with different arguments
- add_continuous_aggregate_policy 
----------------------------------
-                              -1
+--remove all the data--
+TRUNCATE table smallint_tab;
+CALL refresh_continuous_aggregate('mat_smallint', NULL, NULL);
+SELECT * FROM mat_smallint ORDER BY 1;
+ a | countb 
+---+--------
+(0 rows)
+
+-- Case 1: overflow by subtracting from PG_INT16_MIN
+--overflow start_interval, end_interval [-32768, -32768)
+SELECT remove_continuous_aggregate_policy('mat_smallint');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
 (1 row)
 
+INSERT INTO smallint_tab VALUES( -32768 );
+SELECT integer_now_smallint_tab();
+ integer_now_smallint_tab 
+--------------------------
+                   -32768
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_smallint', 10::smallint, 5::smallint , '1 h'::interval) as job_id \gset
+\set ON_ERROR_STOP 0
+CALL run_job(:job_id);
+ERROR:  invalid refresh window
 \set ON_ERROR_STOP 1
+SELECT * FROM mat_smallint ORDER BY 1;
+ a | countb 
+---+--------
+(0 rows)
+
+-- overflow start_interval. now this runs as range is capped [-32768, -32765) 
+INSERT INTO smallint_tab VALUES( -32760 );
+SELECT maxval, maxval - 10, maxval -5 FROM integer_now_smallint_tab() as maxval;
+ maxval | ?column? | ?column? 
+--------+----------+----------
+ -32760 |   -32770 |   -32765
+(1 row)
+
+CALL run_job(:job_id);
+SELECT * FROM mat_smallint ORDER BY 1;
+   a    | countb 
+--------+--------
+ -32768 |      1
+(1 row)
+
+--remove all the data--
+TRUNCATE table smallint_tab;
+CALL refresh_continuous_aggregate('mat_smallint', NULL, NULL);
+SELECT * FROM mat_smallint ORDER BY 1;
+ a | countb 
+---+--------
+(0 rows)
+
+-- Case 2: overflow by subtracting from PG_INT16_MAX
+--overflow start and end . will fail as range is [32767, 32767] 
+SELECT remove_continuous_aggregate_policy('mat_smallint');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+INSERT INTO smallint_tab VALUES( 32766 );
+INSERT INTO smallint_tab VALUES( 32767 );
+SELECT maxval, maxval - (-1), maxval - (-2) FROM integer_now_smallint_tab() as maxval;
+ maxval | ?column? | ?column? 
+--------+----------+----------
+  32767 |    32768 |    32769
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_smallint', -1::smallint, -2::smallint , '1 h'::interval) as job_id \gset
+\set ON_ERROR_STOP 0
+CALL run_job(:job_id);
+ERROR:  invalid refresh window
+\set ON_ERROR_STOP 1
+SELECT * FROM mat_smallint ORDER BY 1;
+ a | countb 
+---+--------
+(0 rows)
+
+SELECT remove_continuous_aggregate_policy('mat_smallint');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+--overflow end . will work range is [32765, 32767)  
+SELECT maxval, maxval - (1), maxval - (-2) FROM integer_now_smallint_tab() as maxval;
+ maxval | ?column? | ?column? 
+--------+----------+----------
+  32767 |    32766 |    32769
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_smallint', 1::smallint, -2::smallint , '1 h'::interval) as job_id \gset
+\set ON_ERROR_STOP 0
+CALL run_job(:job_id);
+SELECT * FROM mat_smallint ORDER BY 1;
+   a   | countb 
+-------+--------
+ 32766 |      1
+(1 row)
+
 -- tests for interval argument conversions
 --
 \set ON_ERROR_STOP 0
@@ -288,7 +383,7 @@ WARNING:  could not add refresh policy due to existing policy on continuous aggr
 
 \set ON_ERROR_STOP 1
 DROP MATERIALIZED VIEW mat_smallint;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_8_7_chunk
+NOTICE:  drop cascades to 3 other objects
 DROP TABLE smallint_tab CASCADE;
 --bigint table
 CREATE TABLE bigint_tab (a bigint);
@@ -327,5 +422,21 @@ SELECT * FROM mat_bigint;
   5 |      1
  10 |      1
 (2 rows)
+
+-- test NULL for end
+SELECT remove_continuous_aggregate_policy('mat_bigint');
+ remove_continuous_aggregate_policy 
+------------------------------------
+ 
+(1 row)
+
+SELECT add_continuous_aggregate_policy('mat_bigint', 1::smallint, NULL , '1 h'::interval) as job_id \gset
+INSERT INTO bigint_tab VALUES(500);
+CALL run_job(:job_id);
+SELECT * FROM mat_bigint WHERE a>100 ORDER BY 1;
+  a  | countb 
+-----+--------
+ 500 |      1
+(1 row)
 
 -- end of coverage tests


### PR DESCRIPTION
When we compute the start and end intervals for the
refresh job execution, there is a potential to
run into overflow with integer computations. Handle 
overflow condition by setting the start/end boundaries to 
PG_INT64_MIN or PG_INT64_MAX.