### PR TITLE
Disable gapfill on distributed hypertable

### DIFF
--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -486,6 +486,11 @@ data_node_scan_add_node_paths(PlannerInfo *root, RelOptInfo *hyper_rel)
 	ts_cache_release(hcache);
 }
 
+/*
+ * Creates CustomScanPath for the data node and adds to output_rel. No custom_path is added,
+ * i.e., it is encapsulated by the CustomScanPath, so it doesn't inflate continuation of the
+ * planning and will be planned locally on the data node.
+ */
 void
 data_node_scan_create_upper_paths(PlannerInfo *root, UpperRelationKind stage, RelOptInfo *input_rel,
 								  RelOptInfo *output_rel, void *extra)

--- a/tsl/src/nodes/gapfill/planner.h
+++ b/tsl/src/nodes/gapfill/planner.h
@@ -8,7 +8,7 @@
 
 #include <postgres.h>
 
-void plan_add_gapfill(PlannerInfo *, RelOptInfo *);
+void plan_add_gapfill(PlannerInfo *root, RelOptInfo *group_rel, bool dist_ht);
 void gapfill_adjust_window_targetlist(PlannerInfo *root, RelOptInfo *input_rel,
 									  RelOptInfo *output_rel);
 

--- a/tsl/test/expected/dist_api_calls.out
+++ b/tsl/test/expected/dist_api_calls.out
@@ -216,6 +216,44 @@ _timescaledb_internal._dist_hyper_1_8_chunk
  
 (1 row)
 
+-- Simple test of time_bucket_gapfill, which is disabled for now.
+\set ON_ERROR_STOP 0
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-02 18:00'),
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 1;
+ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
+       device,
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 1,2;
+ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+SELECT
+  time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
+  lag(min(time)) OVER ()
+FROM disttable
+GROUP BY 1;
+ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+-- Test the same queries with enabled partitionwise aggregate
+SET enable_partitionwise_aggregate = 'on';
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-02 18:00'),
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 1;
+ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
+       device,
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 1,2;
+ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+SET enable_partitionwise_aggregate = 'off';
+\set ON_ERROR_STOP 1
 -- Ensure that move_chunk() and reorder_chunk() functions cannot be used
 -- with distributed hypertable
 SET ROLE TO DEFAULT;


### PR DESCRIPTION
There are number of issues when time_bucket_gapfill is run on
distributed hypertable. Thus a non-supported error is returned in this
case until the issues are fixed.

PR note: The issues are described in https://github.com/timescale/timescaledb-private/issues/838