### PR TITLE
Make tests with tablespaces solo tests

### DIFF
--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -65,11 +65,14 @@ endif()
 # tests that fail or are unreliable when run in parallel
 # bgw tests need to run first otherwise they are flaky
 set(SOLO_TESTS
+  alter
+  alternate_users
   bgw_db_scheduler
   bgw_launcher
-  alternate_users
+  index
   net
   pg_dump_unprivileged
+  tablespace
   telemetry
 )
 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -112,6 +112,7 @@ set(SOLO_TESTS
   bgw_reorder_drop_chunks
   chunk_api
   compress_bgw_reorder_drop_chunks
+  compression_ddl
   continuous_aggs_bgw
   continuous_aggs_dump
   data_fetcher
@@ -126,6 +127,8 @@ set(SOLO_TESTS
   dist_hypertable_with_oids
   dist_partial_agg
   issues
+  move-11
+  move-12
   read_only
   remote_connection_cache
   remote_copy


### PR DESCRIPTION
Tablespaces are created cluster-wide, which means that tests that
create tablespaces cannot run together with other tests that create the
same tablespaces. This commit make those tests into solo tests to avoid
collisions with other tablespace-creating tests and also fix a test
that could trigger error if it was not executed after a test that
created the tablespaces.