### PR TITLE
Fix invalidation log initialization

### DIFF
--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -473,30 +473,37 @@ select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
 ERROR:  parameter timescaledb.ignore_invalidation_older_than must be an integer for hypertables with integer time values
-\set ON_ERROR_STOP 1
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec);
--- Should print a useful error message, but not fail.
-CREATE MATERIALIZED VIEW IF NOT EXISTS mat_with_test
-WITH (timescaledb.continuous) AS
-SELECT time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
-  FROM conditions
-GROUP BY time_bucket(100, timec);
-NOTICE:  continuous aggregate "mat_with_test" already exists, skipping
+ERROR:  invalid integer_now function
 \set ON_ERROR_STOP 0
-ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '1h');
-ERROR:  parameter timescaledb.refresh_lag must be an integer for hypertables with integer time values
-ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.refresh_lag = '2147483648');
-ERROR:  timescaledb.refresh_lag out of range
-ALTER TABLE conditions ALTER timec type bigint;
-ERROR:  cannot alter type of a column used by a view or rule
-\set ON_ERROR_STOP 1
-DROP MATERIALIZED VIEW mat_with_test;
-ALTER TABLE conditions ALTER timec type bigint;
+DROP TABLE conditions cascade;
+CREATE TABLE conditions (
+      timec       BIGINT       NOT NULL,
+      location    TEXT              NOT NULL,
+      temperature DOUBLE PRECISION  NULL,
+      humidity    DOUBLE PRECISION  NULL,
+      lowp        double precision NULL,
+      highp       double precision null,
+      allnull     double precision null
+    );
+select table_name from create_hypertable( 'conditions', 'timec', chunk_time_interval=> 100);
+ table_name 
+------------
+ conditions
+(1 row)
+
+CREATE OR REPLACE FUNCTION integer_now_test_b() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0)::bigint FROM conditions $$;
+SELECT set_integer_now_func('conditions', 'integer_now_test_b');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
@@ -510,9 +517,9 @@ CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
 CREATE TABLE text_time(time TEXT);
     SELECT create_hypertable('text_time', 'time', chunk_time_interval => 10, time_partitioning_func => 'text_part_func');
 NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (9,public,text_time,t)
+    create_hypertable    
+-------------------------
+ (10,public,text_time,t)
 (1 row)
 
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
The invalidation log initialization did not adjust
the timestamp to internal format. Use ts_get_now_internal
in all places that write entries to the invlaidation log.