### PR TITLE
Add common patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+\#*#
+.#*
 *~
 **/CMakeFiles/
 **/CMakeCache.txt
@@ -22,6 +24,7 @@ typedef.list
 /.vs
 /compile_commands.json
 /.DS_Store
+/.clangd
 
 /CMakeSettings.json
 /out/*


### PR DESCRIPTION
Patterns `#*#` and `.#*` are for auto-genereated files from Emacs and
can end up in source directories.

Pattern `.clangd` is the working directory for `clangd` and handles
source code indexing.