### PR TITLE
Fix check for refresh window

### DIFF
--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -304,11 +304,11 @@ continuous_agg_refresh_internal(ContinuousAgg *cagg, InternalTimeRange *refresh_
 	 * prevent transaction blocks.  */
 	PreventInTransactionBlock(true, REFRESH_FUNCTION_NAME);
 
-	if (refresh_window_arg->start >= refresh_window_arg->end)
+	if (refresh_window_arg->start > refresh_window_arg->end)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid refresh window"),
-				 errhint("The start of the window must be before the end.")));
+				 errhint("The start of the window must be before or the same as the end.")));
 
 	refresh_window = compute_bucketed_refresh_window(refresh_window_arg, cagg->data.bucket_width);
 

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -177,8 +177,6 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
 ERROR:  invalid input syntax for type timestamp with time zone: "xyz"
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
 ERROR:  invalid refresh window
-CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-03');
-ERROR:  invalid refresh window
 -- Bad time input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
 ERROR:  invalid type of time argument

--- a/tsl/test/sql/continuous_aggs_refresh.sql
+++ b/tsl/test/sql/continuous_aggs_refresh.sql
@@ -80,7 +80,6 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-05-03');
 CALL refresh_continuous_aggregate('daily_temp', 'xyz', '2020-05-05');
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', 'xyz');
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
-CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-03');
 -- Bad time input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
 CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');


### PR DESCRIPTION
Refresh window endpoints are inclusive, not exclusive, so the check
should be to generate an error if the start point is strictly larger
than the endpoint.