### PR TITLE
Fix rename constraint/rename index

### DIFF
--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -69,6 +69,8 @@ extern int ts_chunk_constraint_delete_by_constraint_name(int32 chunk_id,
 extern void ts_chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
 extern int ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname,
 															const char *newname);
+extern int ts_chunk_constraint_adjust_meta(int32 chunk_id, const char *ht_constraint_name,
+										   const char *oldname, const char *newname);
 
 extern char *
 ts_chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid,

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -45,6 +45,8 @@ extern void ts_chunk_index_delete_by_name(const char *schema, const char *index_
 extern int ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname);
 extern int ts_chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid,
 										const char *newname);
+extern int ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name,
+									  const char *old_name, const char *new_name);
 extern int ts_chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid,
 										 const char *tablespace);
 extern void ts_chunk_index_create_from_constraint(int32 hypertable_id, Oid hypertable_constraint,

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -686,3 +686,51 @@ SELECT * from _timescaledb_catalog.chunk;
 (2 rows)
 
 DROP TABLE my_table;
+-- test renaming unique constraints/indexes
+CREATE TABLE t_hypertable ( id INTEGER NOT NULL, time TIMESTAMPTZ NOT NULL, value FLOAT NOT NULL CHECK (value > 0), UNIQUE(id, time));
+SELECT create_hypertable('t_hypertable', 'time');
+     create_hypertable      
+----------------------------
+ (13,public,t_hypertable,t)
+(1 row)
+
+INSERT INTO t_hypertable AS h VALUES ( 1, '2020-01-01 00:00:00', 3.2) ON CONFLICT (id, time) DO UPDATE SET value = h.value + EXCLUDED.value;
+INSERT INTO t_hypertable AS h VALUES ( 1, '2021-01-01 00:00:00', 3.2) ON CONFLICT (id, time) DO UPDATE SET value = h.value + EXCLUDED.value;
+BEGIN;
+ALTER INDEX t_hypertable_id_time_key RENAME TO t_new_constraint;
+-- chunk_index and chunk_constraint should both have updated constraint names
+SELECT hypertable_index_name, index_name from _timescaledb_catalog.chunk_index WHERE hypertable_index_name = 't_new_constraint' ORDER BY 1,2;
+ hypertable_index_name |             index_name              
+-----------------------+-------------------------------------
+ t_new_constraint      | _hyper_13_26_chunk_t_new_constraint
+ t_new_constraint      | _hyper_13_27_chunk_t_new_constraint
+(2 rows)
+
+SELECT hypertable_constraint_name, constraint_name from _timescaledb_catalog.chunk_constraint WHERE hypertable_constraint_name = 't_new_constraint' ORDER BY 1,2;
+ hypertable_constraint_name |           constraint_name           
+----------------------------+-------------------------------------
+ t_new_constraint           | _hyper_13_26_chunk_t_new_constraint
+ t_new_constraint           | _hyper_13_27_chunk_t_new_constraint
+(2 rows)
+
+INSERT INTO t_hypertable AS h VALUES ( 1, '2020-01-01 00:01:00', 3.2) ON CONFLICT (id, time) DO UPDATE SET value = h.value + EXCLUDED.value;
+ROLLBACK;
+BEGIN;
+ALTER TABLE t_hypertable RENAME CONSTRAINT t_hypertable_id_time_key TO t_new_constraint;
+-- chunk_index and chunk_constraint should both have updated constraint names
+SELECT hypertable_index_name, index_name from _timescaledb_catalog.chunk_index WHERE hypertable_index_name = 't_new_constraint' ORDER BY 1,2;
+ hypertable_index_name |      index_name       
+-----------------------+-----------------------
+ t_new_constraint      | 26_5_t_new_constraint
+ t_new_constraint      | 27_6_t_new_constraint
+(2 rows)
+
+SELECT hypertable_constraint_name, constraint_name from _timescaledb_catalog.chunk_constraint WHERE hypertable_constraint_name = 't_new_constraint' ORDER BY 1,2;
+ hypertable_constraint_name |    constraint_name    
+----------------------------+-----------------------
+ t_new_constraint           | 26_5_t_new_constraint
+ t_new_constraint           | 27_6_t_new_constraint
+(2 rows)
+
+INSERT INTO t_hypertable AS h VALUES ( 1, '2020-01-01 00:01:00', 3.2) ON CONFLICT (id, time) DO UPDATE SET value = h.value + EXCLUDED.value;
+ROLLBACK;


### PR DESCRIPTION
When a constraint is backed by an index like a unique constraint
or a primary key constraint the constraint can be renamed by either
ALTER TABLE RENAME CONSTRAINT or by ALTER INDEX RENAME. Depending
on the command used to rename different internal metadata tables
would be adjusted leading to corrupt metadata. This patch makes
ALTER TABLE RENAME CONSTRAINT and ALTER INDEX RENAME adjust the
same metadata tables.

Fixes #2101 