### PR TITLE
Bump appveyor docker image to postgres 12.4 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -157,9 +157,9 @@ build_script:
 
     docker-switch-linux
 
-    docker run -d --name pgregress --env POSTGRES_HOST_AUTH_METHOD=trust postgres:12.2-alpine
+    docker run -d --name pgregress --env POSTGRES_HOST_AUTH_METHOD=trust postgres:12.4-alpine
 
-    docker exec -it pgregress /bin/bash -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev findutils gcc libc-dev make util-linux-dev diffutils cmake bison flex curl git openssl-dev openssl postgresql-dev~=12.2"
+    docker exec -it pgregress /bin/bash -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev findutils gcc libc-dev make util-linux-dev diffutils cmake bison flex curl git openssl-dev openssl postgresql-dev~=12.4"
 
     docker exec -it pgregress /bin/bash -c "ln -s /usr/lib/postgresql/pgxs/src/test/regress/pg_regress /usr/local/bin/pg_regress"
 


### PR DESCRIPTION
Due to a version conflict between the 12.2 and the 12.4 postgres
packages in alpine the 12.2 package was not installable on recent
alpine images. This patch bumps the involved packages to the latest
postgres version and also uses the most recent postgres image for
running appveyor tests.