### PR TITLE
Release 1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## 1.7.4 (2020-09-07)
+
+This maintenance release contains bugfixes since the 1.7.3 release. We deem it
+high priority for upgrading if TimescaleDB is deployed with replicas (synchronous
+or asynchronous).
+
+In particular the fixes contained in this maintenance release address an issue with
+running queries on compressed hypertables on standby nodes.
+
+**Bugfixes**
+* #2340 Remove tuple lock on select path
+
 ## 1.7.3 (2020-07-27)
 
 This maintenance release contains bugfixes since the 1.7.2 release. We deem it high

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -94,6 +94,7 @@ set(MOD_FILES
   updates/1.7.0--1.7.1.sql
   updates/1.7.1--1.7.2.sql
   updates/1.7.2--1.7.3.sql
+  updates/1.7.3--1.7.4.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
 version = 2.0.0-dev
-update_from_version = 1.7.3
+update_from_version = 1.7.4


### PR DESCRIPTION
This maintenance release contains bugfixes since the 1.7.3 release. We deem it high
priority for upgrading.

In particular the fixes contained in this maintenance release address an issue with
running queries on compressed hypertables on standby nodes.

**Bugfixes**
* #2336 Remove tuple lock on select path