### PR TITLE
Cap invalidation threshold at last data bucket

### DIFF
--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -156,6 +156,8 @@ extern TSDLLEXPORT void ts_hypertable_func_call_on_data_nodes(Hypertable *ht,
 															  FunctionCallInfo fcinfo);
 extern TSDLLEXPORT int16 ts_validate_replication_factor(int32 replication_factor, bool is_null,
 														bool is_dist_call);
+extern TSDLLEXPORT Datum ts_hypertable_get_open_dim_max_value(const Hypertable *ht,
+															  int dimension_index, bool *isnull);
 
 #define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock)                       \
 	ts_hypertable_scan_with_memory_context(schema,                                                 \

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -436,6 +436,15 @@ ts_time_get_noend(Oid timetype)
 	return ts_time_get_noend(coerce_to_time_type(timetype));
 }
 
+int64
+ts_time_get_noend_or_max(Oid timetype)
+{
+	if (TS_TIME_IS_INTEGER_TIME(timetype))
+		return ts_time_get_max(timetype);
+
+	return ts_time_get_noend(timetype);
+}
+
 /*
  * Add an interval to a time value in a saturating way.
  *

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -54,6 +54,10 @@
 	(TS_TIME_IS_INTEGER_TIME(type) || TS_TIME_DATUM_IS_NOBEGIN(timeval, type) ||                   \
 	 TS_TIME_DATUM_IS_NOEND(timeval, type))
 
+#define TS_TIME_IS_MIN(timeval, type) (timeval == ts_time_get_min(type))
+#define TS_TIME_IS_MAX(timeval, type) (timeval == ts_time_get_max(type))
+#define TS_TIME_IS_END(timeval, type)                                                              \
+	(!TS_TIME_IS_INTEGER_TIME(type) && timeval == ts_time_get_end(type))
 #define TS_TIME_IS_NOBEGIN(timeval, type)                                                          \
 	(!TS_TIME_IS_INTEGER_TIME(type) && timeval == ts_time_get_nobegin(type))
 #define TS_TIME_IS_NOEND(timeval, type)                                                            \
@@ -76,6 +80,7 @@ extern TSDLLEXPORT int64 ts_time_get_end(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_end_or_max(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_nobegin(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_noend(Oid timetype);
+extern TSDLLEXPORT int64 ts_time_get_noend_or_max(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_saturating_add(int64 timeval, int64 interval, Oid timetype);
 extern TSDLLEXPORT int64 ts_time_saturating_sub(int64 timeval, int64 interval, Oid timetype);
 

--- a/tsl/src/continuous_aggs/invalidation_threshold.h
+++ b/tsl/src/continuous_aggs/invalidation_threshold.h
@@ -8,9 +8,14 @@
 
 #include <postgres.h>
 
-extern int64 continuous_agg_invalidation_threshold_get(int32 hypertable_id);
-extern bool continuous_agg_invalidation_threshold_set(int32 raw_hypertable_id,
-													  int64 invalidation_threshold);
-extern void continuous_agg_invalidation_threshold_lock(int32 raw_hypertable_id);
+typedef struct InternalTimeRange InternalTimeRange;
+typedef struct ContinuousAgg ContinuousAgg;
+
+extern int64 invalidation_threshold_get(int32 hypertable_id);
+extern int64 invalidation_threshold_set_or_get(int32 raw_hypertable_id,
+											   int64 invalidation_threshold);
+extern void invalidation_threshold_lock(int32 raw_hypertable_id);
+extern int64 invalidation_threshold_compute(const ContinuousAgg *cagg,
+											const InternalTimeRange *refresh_window);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_THRESHOLD_H */

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -222,7 +222,7 @@ continuous_agg_materialize(int32 materialization_id, ContinuousAggMatOptions *op
 	 * (github issue 1940)
 	 * Prevent this by serializing on the raw hypertable row
 	 */
-	continuous_agg_invalidation_threshold_lock(cagg_data.raw_hypertable_id);
+	invalidation_threshold_lock(cagg_data.raw_hypertable_id);
 	drain_invalidation_log(cagg_data.raw_hypertable_id, &invalidations);
 	materialization_invalidation_log_table_relation =
 		table_open(catalog_get_table_id(catalog, CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG),
@@ -292,8 +292,8 @@ continuous_agg_materialize(int32 materialization_id, ContinuousAggMatOptions *op
 	{
 		LockRelationOid(catalog_get_table_id(catalog, CONTINUOUS_AGGS_INVALIDATION_THRESHOLD),
 						AccessExclusiveLock);
-		continuous_agg_invalidation_threshold_set(cagg_data.raw_hypertable_id,
-												  materialization_invalidation_threshold);
+		invalidation_threshold_set_or_get(cagg_data.raw_hypertable_id,
+										  materialization_invalidation_threshold);
 	}
 
 	table_close(materialization_invalidation_log_table_relation, NoLock);

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -26,25 +26,25 @@ SELECT create_hypertable('measurements', 'time', chunk_time_interval => 10);
  (2,public,measurements,t)
 (1 row)
 
-CREATE OR REPLACE FUNCTION cond_now()
+CREATE OR REPLACE FUNCTION bigint_now()
 RETURNS bigint LANGUAGE SQL STABLE AS
 $$
     SELECT coalesce(max(time), 0)
     FROM conditions
 $$;
-CREATE OR REPLACE FUNCTION measure_now()
+CREATE OR REPLACE FUNCTION int_now()
 RETURNS int LANGUAGE SQL STABLE AS
 $$
     SELECT coalesce(max(time), 0)
     FROM measurements
 $$;
-SELECT set_integer_now_func('conditions', 'cond_now');
+SELECT set_integer_now_func('conditions', 'bigint_now');
  set_integer_now_func 
 ----------------------
  
 (1 row)
 
-SELECT set_integer_now_func('measurements', 'measure_now');
+SELECT set_integer_now_func('measurements', 'int_now');
  set_integer_now_func 
 ----------------------
  
@@ -527,7 +527,7 @@ SELECT materialization_id AS cagg_id,
  cagg_id |        start         |         end          
 ---------+----------------------+----------------------
        3 | -9223372036854775808 | -9223372036854775801
-       3 |  9223372036854775807 |  9223372036854775807
+       3 |                  110 |  9223372036854775807
        4 | -9223372036854775808 |                   19
        4 |                   15 |                   42
        4 |                   20 |                   25
@@ -851,11 +851,11 @@ SELECT materialization_id AS cagg_id,
        FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
        WHERE materialization_id = :cond_1_id
        ORDER BY 1,2,3;
- cagg_id |        start        |         end         
----------+---------------------+---------------------
-       6 |                   0 |                   0
-       6 |                   2 |                   2
-       6 | 9223372036854775807 | 9223372036854775807
+ cagg_id | start |         end         
+---------+-------+---------------------
+       6 |     0 |                   0
+       6 |     2 |                   2
+       6 |   110 | 9223372036854775807
 (3 rows)
 
 -- Refresh the two remaining invalidations
@@ -893,4 +893,211 @@ ORDER BY 1,2;
       1 |      1 |        2
       2 |      1 |        3
 (3 rows)
+
+----------------------------------------------
+-- Test that invalidation threshold is capped
+----------------------------------------------
+CREATE table threshold_test (time int, value int);
+SELECT create_hypertable('threshold_test', 'time', chunk_time_interval => 4);
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable      
+-----------------------------
+ (7,public,threshold_test,t)
+(1 row)
+
+SELECT set_integer_now_func('threshold_test', 'int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW thresh_2
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket(2, time) AS bucket, max(value) AS max
+FROM threshold_test
+GROUP BY 1;
+SELECT raw_hypertable_id AS thresh_hyper_id, mat_hypertable_id AS thresh_cagg_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'thresh_2' \gset
+-- There's no invalidation threshold initially
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :thresh_hyper_id
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+(0 rows)
+
+-- Test that threshold is initilized to min value when there's no data
+-- and we specify an infinite end. Note that the min value may differ
+-- depending on time type.
+CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
+NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :thresh_hyper_id
+ORDER BY 1,2;
+ hypertable_id |  watermark  
+---------------+-------------
+             7 | -2147483648
+(1 row)
+
+INSERT INTO threshold_test
+SELECT v, v FROM generate_series(1, 10) v;
+CALL refresh_continuous_aggregate('thresh_2', 0, 5);
+-- Threshold should move to end of refresh window (note that window
+-- expands to end of bucket).
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :thresh_hyper_id
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             7 |         6
+(1 row)
+
+-- Refresh where both the start and end of the window is above the
+-- max data value
+CALL refresh_continuous_aggregate('thresh_2', 14, NULL);
+NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+SELECT watermark AS thresh_hyper_id_watermark
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :thresh_hyper_id \gset
+-- Refresh where we start from the current watermark to infinity
+CALL refresh_continuous_aggregate('thresh_2', :thresh_hyper_id_watermark, NULL);
+NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+-- Now refresh with max end of the window to test that the
+-- invalidation threshold is capped at the last bucket of data
+CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :thresh_hyper_id
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             7 |        12
+(1 row)
+
+-- Should not have processed invalidations beyond the invalidation
+-- threshold.
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       WHERE materialization_id = :thresh_cagg_id
+       ORDER BY 1,2,3;
+ cagg_id |        start         |         end         
+---------+----------------------+---------------------
+       8 | -9223372036854775808 |                  -1
+       8 |                   12 | 9223372036854775807
+(2 rows)
+
+-- Check that things are properly materialized
+SELECT * FROM thresh_2
+ORDER BY 1;
+ bucket | max 
+--------+-----
+      0 |   1
+      2 |   3
+      4 |   5
+      6 |   7
+      8 |   9
+     10 |  10
+(6 rows)
+
+-- Delete the last data
+SELECT show_chunks AS chunk_to_drop
+FROM show_chunks('threshold_test')
+ORDER BY 1 DESC
+LIMIT 1 \gset
+DELETE FROM threshold_test
+WHERE time > 6;
+-- The last data in the hypertable is gone
+SELECT time_bucket(2, time) AS bucket, max(value) AS max
+FROM threshold_test
+GROUP BY 1
+ORDER BY 1;
+ bucket | max 
+--------+-----
+      0 |   1
+      2 |   3
+      4 |   5
+      6 |   6
+(4 rows)
+
+-- The aggregate still holds data
+SELECT * FROM thresh_2
+ORDER BY 1;
+ bucket | max 
+--------+-----
+      0 |   1
+      2 |   3
+      4 |   5
+      6 |   7
+      8 |   9
+     10 |  10
+(6 rows)
+
+-- Refresh the aggregate to bring it up-to-date
+CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
+-- Data also gone from the aggregate
+SELECT * FROM thresh_2
+ORDER BY 1;
+ bucket | max 
+--------+-----
+      0 |   1
+      2 |   3
+      4 |   5
+      6 |   6
+(4 rows)
+
+-- The invalidation threshold remains the same
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :thresh_hyper_id
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             7 |        12
+(1 row)
+
+-- Insert new data beyond the invalidation threshold to move it
+-- forward
+INSERT INTO threshold_test
+SELECT v, v FROM generate_series(7, 15) v;
+CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
+-- Aggregate now updated to reflect newly aggregated data
+SELECT * FROM thresh_2
+ORDER BY 1;
+ bucket | max 
+--------+-----
+      0 |   1
+      2 |   3
+      4 |   5
+      6 |   7
+      8 |   9
+     10 |  11
+     12 |  13
+     14 |  15
+(8 rows)
+
+-- The invalidation threshold should have moved forward to the end of
+-- the new data
+SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :thresh_hyper_id
+ORDER BY 1,2;
+ hypertable_id | watermark 
+---------------+-----------
+             7 |        16
+(1 row)
+
+-- The aggregate remains invalid beyond the invalidation threshold
+SELECT materialization_id AS cagg_id,
+       lowest_modified_value AS start,
+       greatest_modified_value AS end
+       FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+       WHERE materialization_id = :thresh_cagg_id
+       ORDER BY 1,2,3;
+ cagg_id |        start         |         end         
+---------+----------------------+---------------------
+       8 | -9223372036854775808 |                  -1
+       8 |                   16 | 9223372036854775807
+(2 rows)
 

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -83,7 +83,7 @@ ORDER BY day DESC, device;
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01', '2020-05-03');
 DEBUG:  refreshing continuous aggregate "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sun May 03 17:00:00 2020 PDT ]
-DEBUG:  hypertable 1 existing  watermark >= new invalidation threshold 1588723200000000 1588550400000000
+DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 1588723200000000 1588550400000000
 DEBUG:  invalidation refresh on "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sat May 02 17:00:00 2020 PDT ]
 RESET client_min_messages;
 -- Compare the aggregate to the equivalent query on the source table
@@ -148,6 +148,7 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::date, '2020-05-03'
 NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 -- Unbounded window forward in time
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', NULL);
+NOTICE:  continuous aggregate "daily_temp" is already up-to-date
 CALL refresh_continuous_aggregate('daily_temp', NULL, NULL);
 -- Unbounded window back in time
 CALL refresh_continuous_aggregate('daily_temp', NULL, '2020-05-01');

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -766,11 +766,17 @@ FROM timestamptz_table
 GROUP BY 1;
 -- Refresh first without data
 CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+NOTICE:  continuous aggregate "int_agg" is already up-to-date
 CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+NOTICE:  continuous aggregate "smallint_agg" is already up-to-date
 CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+NOTICE:  continuous aggregate "bigint_agg" is already up-to-date
 CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
 -- Watermarks at min for the above caggs:
 SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
 FROM _timescaledb_catalog.continuous_agg

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -769,11 +769,17 @@ FROM timestamptz_table
 GROUP BY 1;
 -- Refresh first without data
 CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+NOTICE:  continuous aggregate "int_agg" is already up-to-date
 CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+NOTICE:  continuous aggregate "smallint_agg" is already up-to-date
 CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+NOTICE:  continuous aggregate "bigint_agg" is already up-to-date
 CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
 -- Watermarks at min for the above caggs:
 SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
 FROM _timescaledb_catalog.continuous_agg

--- a/tsl/test/src/test_continuous_aggs.c
+++ b/tsl/test/src/test_continuous_aggs.c
@@ -55,7 +55,7 @@ ts_run_continuous_agg_materialization(PG_FUNCTION_ARGS)
 
 	if (partial_view.name == NULL)
 		elog(ERROR, "view cannot be NULL");
-	invalidation_threshold = continuous_agg_invalidation_threshold_get(hypertable_id);
+	invalidation_threshold = invalidation_threshold_get(hypertable_id);
 	completed_threshold = ts_continuous_agg_get_completed_threshold(materialization_id);
 
 	if (lmv > completed_threshold)


### PR DESCRIPTION
When refreshing with an "infinite" refresh window going forward in
time, the invalidation threshold is also moved forward to the end of
the valid time range. This effectively renders the invalidation
threshold useless, leading to unnecessary write amplification.

To handle infinite refreshes better, this change caps the refresh
window at the end of the last bucket of data in the underlying
hypertable, as to not move the invalidation threshold further than
necessary. For instance, if the max time value in the hypertable is
11, a refresh command such as:

```
CALL refresh_continuous_aggregate(NULL, NULL);
```
would be turned into
```
CALL refresh_continuous_aggregate(NULL, 20);
```

assuming that a bucket starts at 10 and ends at 20 (exclusive). Thus
the invalidation threshold would at most move to 20, allowing the
threshold to still do its work once time again moves forward and
beyond it.

Note that one must never process invalidations beyond the invalidation
threshold without also moving it, as that would clear that area from
invalidations and thus prohibit refreshing that region once the
invalidation threshold is moved forward. Therefore, if we do not move
the threshold further than a certain point, we cannot refresh beyond
it either. An alternative, and perhaps safer, approach would be to
always invalidate the region over which the invalidation threshold is
moved (i.e., new_threshold - old_threshold). However, that is left for
a future change.

It would be possible to also cap non-infinite refreshes, e.g.,
refreshes that end at a higher time value than the max time value in
the hypertable. However, when an explicit end is specified, it might
be on purpose so optimizing this case is also left for the future.

Closes #2333