### PR TITLE
Remove tuple lock on select path

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -254,12 +254,6 @@
 #define TUPLE_DESC_HAS_OIDS(desc) false
 #endif
 
-#if defined(__GNUC__)
-#define TS_ATTRIBUTE_NONNULL(X) __attribute__((nonnull X))
-#else
-#define TS_ATTRIBUTE_NONNULL(X)
-#endif
-
 /* Compatibility functions for table access method API introduced in PG12 */
 #if PG11
 #include "compat/tupconvert.h"

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -53,8 +53,7 @@ extern DimensionVec *ts_dimension_slice_collision_scan_limit(int32 dimension_id,
 extern bool ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
 extern DimensionSlice *ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id,
 															  ScanTupLock *tuplock,
-															  MemoryContext mctx)
-	TS_ATTRIBUTE_NONNULL((2));
+															  MemoryContext mctx);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension_before_point(int32 dimension_id,
 																	   int64 point, int limit,


### PR DESCRIPTION
When executing a SELECT on a hypertable, it is not possible to acquire
tuple locks on hot standbys since they require a transaction id and
transaction ids cannot be created when running as a standby running in
ephemeral recovery mode.

This commit removes the tuple lock from the SELECT code path if running
in recovery mode.