### PR TITLE
Support continuous aggregates table access method

### DIFF
--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -899,12 +899,12 @@ SELECT set_integer_now_func('whatever', 'integer_now_test');
 
 CREATE MATERIALIZED VIEW whatever_view_1
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-SELECT time_bucket('2', time), COUNT(data)
+SELECT time_bucket('5', time), COUNT(data)
   FROM whatever GROUP BY 1;
 CREATE MATERIALIZED VIEW whatever_view_2
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 TABLESPACE tablespace1 AS
-SELECT time_bucket('2', time), COUNT(data)
+SELECT time_bucket('5', time), COUNT(data)
   FROM whatever GROUP BY 1;
 INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;
 CALL refresh_continuous_aggregate('whatever_view_1', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs_tableam.out
+++ b/tsl/test/expected/continuous_aggs_tableam.out
@@ -1,0 +1,94 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE ACCESS METHOD heap2 TYPE TABLE HANDLER heap_tableam_handler;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+CREATE VIEW cagg_info AS
+WITH
+  caggs AS (
+    SELECT format('%s.%s', user_view_schema, user_view_name)::regclass AS user_view,
+           format('%s.%s', ht.schema_name, ht.table_name)::regclass AS mat_relid
+      FROM _timescaledb_catalog.hypertable ht,
+           _timescaledb_catalog.continuous_agg cagg
+     WHERE ht.id = cagg.mat_hypertable_id
+  )
+SELECT user_view,
+       relname AS mat_table,
+       (SELECT spcname FROM pg_tablespace WHERE oid = reltablespace) AS tablespace
+  FROM pg_class JOIN caggs ON pg_class.oid = caggs.mat_relid;
+CREATE TABLE whatever(time BIGINT NOT NULL, data INTEGER);
+SELECT hypertable_id AS whatever_nid
+  FROM create_hypertable('whatever', 'time', chunk_time_interval => 10)
+\gset
+CREATE OR REPLACE FUNCTION integer_now_test() RETURNS bigint
+LANGUAGE SQL STABLE AS $$
+	SELECT coalesce(max(time), bigint '0') FROM whatever
+$$;
+SELECT set_integer_now_func('whatever', 'integer_now_test');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;
+-- Checking that the access method for the materialized hypertable is
+-- set to the correct access method.
+CREATE MATERIALIZED VIEW tableam_view USING heap2
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket('5', time), COUNT(data)
+  FROM whatever GROUP BY 1;
+CREATE MATERIALIZED VIEW notableam_view
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket('5', time), COUNT(data)
+  FROM whatever GROUP BY 1;
+SELECT user_view, mat_table, amname
+FROM cagg_info,
+     LATERAL (SELECT relam FROM pg_class WHERE relname = mat_table) AS cls,
+     LATERAL (SELECT amname FROM pg_am WHERE oid = relam) AS am
+WHERE user_view::text IN ('tableam_view', 'notableam_view');
+   user_view    |         mat_table          | amname 
+----------------+----------------------------+--------
+ tableam_view   | _materialized_hypertable_2 | heap2
+ notableam_view | _materialized_hypertable_3 | heap
+(2 rows)
+
+-- Check that the view with the other access method actually works.
+SELECT * FROM notableam_view ORDER BY 1;
+ time_bucket | count 
+-------------+-------
+(0 rows)
+
+SELECT * FROM tableam_view ORDER BY 1;
+ time_bucket | count 
+-------------+-------
+(0 rows)
+
+CALL refresh_continuous_aggregate('notableam_view', NULL, NULL);
+CALL refresh_continuous_aggregate('tableam_view', NULL, NULL);
+SELECT * FROM notableam_view ORDER BY 1;
+ time_bucket | count 
+-------------+-------
+           0 |     5
+           5 |     5
+          10 |     5
+          15 |     5
+          20 |     5
+          25 |     5
+(6 rows)
+
+SELECT * FROM tableam_view ORDER BY 1;
+ time_bucket | count 
+-------------+-------
+           0 |     5
+           5 |     5
+          10 |     5
+          15 |     5
+          20 |     5
+          25 |     5
+(6 rows)
+
+DROP MATERIALIZED VIEW notableam_view;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_3_4_chunk
+DROP MATERIALIZED VIEW tableam_view;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_5_chunk

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -101,6 +101,7 @@ endif()
 if (${PG_VERSION_MAJOR} GREATER_EQUAL "12")
   list(APPEND TEST_FILES_DEBUG
     dist_hypertable_am.sql
+    continuous_aggs_tableam.sql
   )
 endif()
 

--- a/tsl/test/sql/continuous_aggs_ddl.sql
+++ b/tsl/test/sql/continuous_aggs_ddl.sql
@@ -540,13 +540,13 @@ SELECT set_integer_now_func('whatever', 'integer_now_test');
 
 CREATE MATERIALIZED VIEW whatever_view_1
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
-SELECT time_bucket('2', time), COUNT(data)
+SELECT time_bucket('5', time), COUNT(data)
   FROM whatever GROUP BY 1;
 
 CREATE MATERIALIZED VIEW whatever_view_2
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 TABLESPACE tablespace1 AS
-SELECT time_bucket('2', time), COUNT(data)
+SELECT time_bucket('5', time), COUNT(data)
   FROM whatever GROUP BY 1;
 
 INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;

--- a/tsl/test/sql/continuous_aggs_tableam.sql
+++ b/tsl/test/sql/continuous_aggs_tableam.sql
@@ -1,0 +1,66 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE ACCESS METHOD heap2 TYPE TABLE HANDLER heap_tableam_handler;
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+CREATE VIEW cagg_info AS
+WITH
+  caggs AS (
+    SELECT format('%s.%s', user_view_schema, user_view_name)::regclass AS user_view,
+           format('%s.%s', ht.schema_name, ht.table_name)::regclass AS mat_relid
+      FROM _timescaledb_catalog.hypertable ht,
+           _timescaledb_catalog.continuous_agg cagg
+     WHERE ht.id = cagg.mat_hypertable_id
+  )
+SELECT user_view,
+       relname AS mat_table,
+       (SELECT spcname FROM pg_tablespace WHERE oid = reltablespace) AS tablespace
+  FROM pg_class JOIN caggs ON pg_class.oid = caggs.mat_relid;
+
+CREATE TABLE whatever(time BIGINT NOT NULL, data INTEGER);
+
+SELECT hypertable_id AS whatever_nid
+  FROM create_hypertable('whatever', 'time', chunk_time_interval => 10)
+\gset
+
+CREATE OR REPLACE FUNCTION integer_now_test() RETURNS bigint
+LANGUAGE SQL STABLE AS $$
+	SELECT coalesce(max(time), bigint '0') FROM whatever
+$$;
+
+SELECT set_integer_now_func('whatever', 'integer_now_test');
+
+INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;
+
+-- Checking that the access method for the materialized hypertable is
+-- set to the correct access method.
+CREATE MATERIALIZED VIEW tableam_view USING heap2
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket('5', time), COUNT(data)
+  FROM whatever GROUP BY 1;
+
+CREATE MATERIALIZED VIEW notableam_view
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket('5', time), COUNT(data)
+  FROM whatever GROUP BY 1;
+
+SELECT user_view, mat_table, amname
+FROM cagg_info,
+     LATERAL (SELECT relam FROM pg_class WHERE relname = mat_table) AS cls,
+     LATERAL (SELECT amname FROM pg_am WHERE oid = relam) AS am
+WHERE user_view::text IN ('tableam_view', 'notableam_view');
+
+-- Check that the view with the other access method actually works.
+SELECT * FROM notableam_view ORDER BY 1;
+SELECT * FROM tableam_view ORDER BY 1;
+CALL refresh_continuous_aggregate('notableam_view', NULL, NULL);
+CALL refresh_continuous_aggregate('tableam_view', NULL, NULL);
+SELECT * FROM notableam_view ORDER BY 1;
+SELECT * FROM tableam_view ORDER BY 1;
+
+DROP MATERIALIZED VIEW notableam_view;
+DROP MATERIALIZED VIEW tableam_view;


### PR DESCRIPTION
If a table access method is provided when creating a continuous
aggregate using `CREATE MATERIALIZED VIEW` it will be used to set the
table access method for the materialized hypertable.

Closes #2123