### PR TITLE
Continuous aggregate view changes

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -57,39 +57,7 @@ CREATE OR REPLACE VIEW timescaledb_information.policy_stats as
 CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregates as
   SELECT format('%1$I.%2$I', cagg.user_view_schema, cagg.user_view_name)::regclass as view_name,
     viewinfo.viewowner as view_owner,
-    CASE _timescaledb_internal.get_time_type(cagg.raw_hypertable_id)
-      WHEN 'TIMESTAMP'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.refresh_lag)::TEXT
-      WHEN 'TIMESTAMPTZ'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.refresh_lag)::TEXT
-      WHEN 'DATE'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.refresh_lag)::TEXT
-      ELSE cagg.refresh_lag::TEXT
-    END AS refresh_lag,
     bgwjob.schedule_interval as refresh_interval,
-    CASE _timescaledb_internal.get_time_type(cagg.raw_hypertable_id)
-      WHEN 'TIMESTAMP'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.max_interval_per_job)::TEXT
-      WHEN 'TIMESTAMPTZ'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.max_interval_per_job)::TEXT
-      WHEN 'DATE'::regtype
-        THEN _timescaledb_internal.to_interval(cagg.max_interval_per_job)::TEXT
-      ELSE cagg.max_interval_per_job::TEXT
-    END AS max_interval_per_job,
-    CASE
-      WHEN cagg.ignore_invalidation_older_than = BIGINT '9223372036854775807'
-        THEN NULL
-      ELSE
-    CASE _timescaledb_internal.get_time_type(cagg.raw_hypertable_id)
-          WHEN 'TIMESTAMP'::regtype
-            THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
-          WHEN 'TIMESTAMPTZ'::regtype
-            THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
-          WHEN 'DATE'::regtype
-            THEN _timescaledb_internal.to_interval(cagg.ignore_invalidation_older_than)::TEXT
-          ELSE cagg.ignore_invalidation_older_than::TEXT
-        END
-    END AS ignore_invalidation_older_than,
     cagg.materialized_only,
     format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as materialization_hypertable,
     directview.viewdefinition as view_definition

--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -12,5 +12,5 @@ REFRESH MATERIALIZED VIEW cagg.realtime_mat;
 
 SELECT * FROM cagg.realtime_mat ORDER BY bucket, location;
 
-SELECT view_name, refresh_lag, refresh_interval, max_interval_per_job, ignore_invalidation_older_than, materialized_only, materialization_hypertable FROM timescaledb_information.continuous_aggregates ORDER BY view_name::text;
+SELECT view_name, refresh_interval, materialized_only, materialization_hypertable FROM timescaledb_information.continuous_aggregates ORDER BY view_name::text;
 

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -457,14 +457,12 @@ SELECT * FROM test_continuous_agg_view ORDER BY 1;
 
 \x on
 --check the information views --
-select view_name, view_owner, refresh_lag, max_interval_per_job, materialization_hypertable
+select view_name, view_owner, materialization_hypertable
 from timescaledb_information.continuous_aggregates
 where view_name::text like '%test_continuous_agg_view';
 -[ RECORD 1 ]--------------+-------------------------------------------------
 view_name                  | test_continuous_agg_view
 view_owner                 | default_perm_user
-refresh_lag                | -2
-max_interval_per_job       | 2
 materialization_hypertable | _timescaledb_internal._materialized_hypertable_3
 
 select view_name, view_definition from timescaledb_information.continuous_aggregates

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -1403,16 +1403,6 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_statu
  max_mat_view_date      | 2019-09-16             | 2019-09-16             |        |            | 
 (4 rows)
 
-SELECT view_name, refresh_lag, max_interval_per_job
-    FROM timescaledb_information.continuous_aggregates ORDER BY 1;
-       view_name        |  refresh_lag  | max_interval_per_job 
-------------------------+---------------+----------------------
- max_mat_view           | -2            | 4
- max_mat_view_t         | @ 2 hours ago | @ 4 hours
- max_mat_view_timestamp | @ 2 hours ago | @ 1 day 16 hours
- max_mat_view_date      | @ 7 days ago  | @ 140 days
-(4 rows)
-
 SET SESSION timezone TO 'EST';
 SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_status, last_run_duration
     FROM timescaledb_information.continuous_aggregate_stats ORDER BY 1;
@@ -1422,16 +1412,6 @@ SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_statu
  max_mat_view_t         | 2019-09-09 07:00:00-05 | 2019-09-09 07:00:00-05 |        |            | 
  max_mat_view_timestamp | 2019-09-09 12:00:00    | 2019-09-09 12:00:00    |        |            | 
  max_mat_view_date      | 2019-09-16             | 2019-09-16             |        |            | 
-(4 rows)
-
-SELECT view_name, refresh_lag, max_interval_per_job
-    FROM timescaledb_information.continuous_aggregates ORDER BY 1;
-       view_name        |  refresh_lag  | max_interval_per_job 
-------------------------+---------------+----------------------
- max_mat_view           | -2            | 4
- max_mat_view_t         | @ 2 hours ago | @ 4 hours
- max_mat_view_timestamp | @ 2 hours ago | @ 1 day 16 hours
- max_mat_view_date      | @ 7 days ago  | @ 140 days
 (4 rows)
 
 -- test timezone is respected when materializing cagg with TIMESTAMP time column

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -37,12 +37,12 @@ AS
     FROM continuous_agg_test
     GROUP BY 1, 2;
 NOTICE:  adding index _materialized_hypertable_3_grp_timed_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(grp, timed)
-select view_name, view_owner, refresh_lag, max_interval_per_job , materialization_hypertable 
-from timescaledb_information.continuous_aggregates;
- view_name |    view_owner     | refresh_lag | max_interval_per_job |            materialization_hypertable            
------------+-------------------+-------------+----------------------+--------------------------------------------------
- cagg_1    | default_perm_user | -2          | 40                   | _timescaledb_internal._materialized_hypertable_2
- cagg_2    | default_perm_user | -2          | 40                   | _timescaledb_internal._materialized_hypertable_3
+select view_name, view_owner, materialization_hypertable 
+from timescaledb_information.continuous_aggregates ORDER BY 1;
+ view_name |    view_owner     |            materialization_hypertable            
+-----------+-------------------+--------------------------------------------------
+ cagg_1    | default_perm_user | _timescaledb_internal._materialized_hypertable_2
+ cagg_2    | default_perm_user | _timescaledb_internal._materialized_hypertable_3
 (2 rows)
 
 --TEST1: cagg_1 is materialized, not cagg_2.

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -73,21 +73,18 @@ SELECT * FROM device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, de
 --You can view informaton about your continuous aggregates. The meaning of these fields will be explained further down.
 \x
 SELECT * FROM timescaledb_information.continuous_aggregates;
--[ RECORD 1 ]------------------+-------------------------------------------------------------------------------------------------------------
-view_name                      | device_summary
-view_owner                     | default_perm_user
-refresh_lag                    | @ 2 hours
-refresh_interval               | @ 2 hours
-max_interval_per_job           | @ 60 days
-ignore_invalidation_older_than | 
-materialized_only              | t
-materialization_hypertable     | _timescaledb_internal._materialized_hypertable_2
-view_definition                |  SELECT time_bucket('@ 1 hour'::interval, device_readings.observation_time) AS bucket,                      +
-                               |     device_readings.device_id,                                                                              +
-                               |     avg(device_readings.metric) AS metric_avg,                                                              +
-                               |     (max(device_readings.metric) - min(device_readings.metric)) AS metric_spread                            +
-                               |    FROM device_readings                                                                                     +
-                               |   GROUP BY (time_bucket('@ 1 hour'::interval, device_readings.observation_time)), device_readings.device_id;
+-[ RECORD 1 ]--------------+-------------------------------------------------------------------------------------------------------------
+view_name                  | device_summary
+view_owner                 | default_perm_user
+refresh_interval           | @ 2 hours
+materialized_only          | t
+materialization_hypertable | _timescaledb_internal._materialized_hypertable_2
+view_definition            |  SELECT time_bucket('@ 1 hour'::interval, device_readings.observation_time) AS bucket,                      +
+                           |     device_readings.device_id,                                                                              +
+                           |     avg(device_readings.metric) AS metric_avg,                                                              +
+                           |     (max(device_readings.metric) - min(device_readings.metric)) AS metric_spread                            +
+                           |    FROM device_readings                                                                                     +
+                           |   GROUP BY (time_bucket('@ 1 hour'::interval, device_readings.observation_time)), device_readings.device_id;
 
 --You can also view information about your background workers.
 --Note: (some fields are empty because there are no background workers used in tests)
@@ -139,12 +136,6 @@ SELECT schedule_interval FROM _timescaledb_config.bgw_job WHERE id = 1000;
 -- the most up-to-date data.
 -- Namely, it will only contain data where: bucket end < (max(time)-refresh_lag)
 --By default refresh_lag is 2 x bucket_width
-SELECT refresh_lag FROM timescaledb_information.continuous_aggregates;
- refresh_lag 
--------------
- @ 2 hours
-(1 row)
-
 SELECT max(observation_time) FROM device_readings;
              max              
 ------------------------------

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -268,7 +268,7 @@ SELECT * FROM test_continuous_agg_view ORDER BY 1;
 
 \x on
 --check the information views --
-select view_name, view_owner, refresh_lag, max_interval_per_job, materialization_hypertable
+select view_name, view_owner, materialization_hypertable
 from timescaledb_information.continuous_aggregates
 where view_name::text like '%test_continuous_agg_view';
 

--- a/tsl/test/sql/continuous_aggs_materialize.sql
+++ b/tsl/test/sql/continuous_aggs_materialize.sql
@@ -640,16 +640,10 @@ SELECT * FROM max_mat_view_date ORDER BY 1;
 SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_status, last_run_duration
     FROM timescaledb_information.continuous_aggregate_stats ORDER BY 1;
 
-SELECT view_name, refresh_lag, max_interval_per_job
-    FROM timescaledb_information.continuous_aggregates ORDER BY 1;
-
 SET SESSION timezone TO 'EST';
 
 SELECT view_name, completed_threshold, invalidation_threshold, job_id, job_status, last_run_duration
     FROM timescaledb_information.continuous_aggregate_stats ORDER BY 1;
-
-SELECT view_name, refresh_lag, max_interval_per_job
-    FROM timescaledb_information.continuous_aggregates ORDER BY 1;
 
 -- test timezone is respected when materializing cagg with TIMESTAMP time column
 RESET client_min_messages;

--- a/tsl/test/sql/continuous_aggs_multi.sql
+++ b/tsl/test/sql/continuous_aggs_multi.sql
@@ -31,8 +31,8 @@ AS
     FROM continuous_agg_test
     GROUP BY 1, 2;
 
-select view_name, view_owner, refresh_lag, max_interval_per_job , materialization_hypertable 
-from timescaledb_information.continuous_aggregates;
+select view_name, view_owner, materialization_hypertable 
+from timescaledb_information.continuous_aggregates ORDER BY 1;
 
 --TEST1: cagg_1 is materialized, not cagg_2.
 refresh materialized view cagg_1;

--- a/tsl/test/sql/continuous_aggs_usage.sql
+++ b/tsl/test/sql/continuous_aggs_usage.sql
@@ -78,7 +78,6 @@ SELECT schedule_interval FROM _timescaledb_config.bgw_job WHERE id = 1000;
 -- Namely, it will only contain data where: bucket end < (max(time)-refresh_lag)
 
 --By default refresh_lag is 2 x bucket_width
-SELECT refresh_lag FROM timescaledb_information.continuous_aggregates;
 SELECT max(observation_time) FROM device_readings;
 SELECT max(bucket) FROM device_summary;
 


### PR DESCRIPTION
With the new continuous aggregate API, some of
the parameters used to create a continuous agg are
now obsolete. Remove obsolete settings information from
timescaledb_information.continuous_aggregates.