### PR TITLE
Continuous aggregates support WITH NO DATA

### DIFF
--- a/test/expected/telemetry_community.out
+++ b/test/expected/telemetry_community.out
@@ -46,6 +46,7 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket;
+NOTICE:  continuous aggregate "device_summary" is already up-to-date
 SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs');
  json_object_field 
 -------------------

--- a/test/sql/updates/setup.continuous_aggs.sql
+++ b/test/sql/updates/setup.continuous_aggs.sql
@@ -118,7 +118,7 @@ BEGIN
 	histogram(temperature, 0, 100, 5)
       FROM conditions_before
       GROUP BY bucket, location
-      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
     PERFORM add_refresh_continuous_aggregate_policy('mat_before', NULL, '-30 days'::interval, '336 h');
 
   END IF;

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -119,7 +119,7 @@ BEGIN
 	histogram(temperature, 0, 100, 5)
       FROM conditions_before
       GROUP BY bucket, location
-      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
     PERFORM add_refresh_continuous_aggregate_policy('mat_before', NULL, '-30 days'::interval, '336 h'); 
   END IF;
 END $$;
@@ -224,7 +224,7 @@ BEGIN
 	histogram(temperature, 0, 100, 5)
       FROM conditions_before
       GROUP BY bucket, location
-      HAVING min(location) >= 'NYC' and avg(temperature) > 2;
+      HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
     PERFORM add_refresh_continuous_aggregate_policy('cagg.realtime_mat', NULL, '-30 days'::interval, '336 h'); 
   END IF;
 END $$;

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -283,7 +283,7 @@ policy_refresh_cagg_execute(int32 job_id, Jsonb *config)
 	refresh_window = (InternalTimeRange){ .type = dim_type,
 										  .start = (start_isnull ? PG_INT64_MIN : refresh_start),
 										  .end = (end_isnull ? PG_INT64_MAX : refresh_end) };
-	continuous_agg_refresh_internal(cagg, &refresh_window);
+	continuous_agg_refresh_internal(cagg, &refresh_window, false);
 	elog(LOG,
 		 "refresh continuous aggregate range %s , %s",
 		 ts_internal_to_time_string(refresh_start, dim_type),

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -14,7 +14,7 @@
 
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
-											const InternalTimeRange *refresh_window);
+											const InternalTimeRange *refresh_window, bool verbose);
 extern void continuous_agg_refresh_all(const Hypertable *ht, int64 start, int64 end);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_REFRESH_H */

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -943,7 +943,7 @@ SELECT
   avg(v1) + avg(v2) AS avg1,
   avg(v1+v2) AS avg2
 FROM metrics
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_14_const_time_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(const, time)
 NOTICE:  adding index _materialized_hypertable_14_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(numeric, time)
 NOTICE:  adding index _materialized_hypertable_14_case_time_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(case, time)

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -193,7 +193,7 @@ SELECT device,
        MAX(temperature) AS max_temperature,
        MIN(temperature) AS min_temperature
 FROM conditions
-GROUP BY device, time_bucket(INTERVAL '1 hour', "time");
+GROUP BY device, time_bucket(INTERVAL '1 hour', "time") WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_8_device_day_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, day)
 CALL refresh_continuous_aggregate('conditions_summary', NULL, NULL);
 ALTER TABLE conditions SET (timescaledb.compress);

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -508,7 +508,7 @@ SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
 CREATE MATERIALIZED VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1
-   GROUP BY 1;
+   GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test1_cont_view', NULL, '1 hour'::interval, '1 day'::interval);
  add_refresh_continuous_aggregate_policy 
 -----------------------------------------

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -47,7 +47,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select a, count(b)
 from foo
-group by time_bucket(1, a), a;
+group by time_bucket(1, a), a WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_2_a_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(a, time_partition_col)
 SELECT add_refresh_continuous_aggregate_policy('mat_m1', NULL, 2::integer, '12 h'::interval); 
  add_refresh_continuous_aggregate_policy 
@@ -127,7 +127,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -201,7 +201,7 @@ as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
-group by time_bucket('1week', timec) ;
+group by time_bucket('1week', timec)  WITH NO DATA;
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -257,7 +257,7 @@ min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 where location = 'NYC'
 group by time_bucket('1week', timec)
-;
+ WITH NO DATA;
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -310,7 +310,7 @@ select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by time_bucket('1week', timec)
-having stddev(humidity) is not null;
+having stddev(humidity) is not null WITH NO DATA;
 ;
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -383,7 +383,7 @@ as
 select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by bucket, loc
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_10_loc_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(loc, bucket)
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -418,7 +418,7 @@ as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by 1,2
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_11_location_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_11 USING BTREE(location, time_bucket)
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -453,7 +453,7 @@ as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by 1,2
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_12_loc_bucket_idx ON _timescaledb_internal._materialized_hypertable_12 USING BTREE(loc, bucket)
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -488,7 +488,7 @@ select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by  time_bucket('1week', timec)
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -735,7 +735,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 \set ON_ERROR_STOP 0
 DROP TABLE conditions;
 ERROR:  cannot drop table conditions because other objects depend on it
@@ -864,7 +864,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec), location, humidity, temperature;
+group by time_bucket('1day', timec), location, humidity, temperature WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_20_grp_5_5_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING BTREE(grp_5_5, timec)
 NOTICE:  adding index _materialized_hypertable_20_grp_6_6_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING BTREE(grp_6_6, timec)
 NOTICE:  adding index _materialized_hypertable_20_grp_7_7_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING BTREE(grp_7_7, timec)
@@ -932,7 +932,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec), location, humidity, temperature;
+group by time_bucket('1day', timec), location, humidity, temperature WITH NO DATA;
 select indexname, indexdef from pg_indexes where tablename =
 (SELECT h.table_name
 FROM _timescaledb_catalog.continuous_agg ca
@@ -973,7 +973,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('mat_with_test', NULL, 500::integer, '12 h'::interval); 
  add_refresh_continuous_aggregate_policy 
 -----------------------------------------
@@ -1044,7 +1044,7 @@ CREATE MATERIALIZED VIEW space_view
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-2')
 AS SELECT time_bucket('4', time), COUNT(data)
    FROM space_table
-   GROUP BY 1;
+   GROUP BY 1 WITH NO DATA;
 INSERT INTO space_table VALUES
   (0, 1, 1), (0, 2, 1), (1, 1, 1), (1, 2, 1),
   (10, 1, 1), (10, 2, 1), (11, 1, 1), (11, 2, 1);
@@ -1185,7 +1185,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test'::text)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 LOG:  materializing continuous aggregate public.mat_ffunc_test: nothing to invalidate, new range up to 300
 SELECT * FROM mat_ffunc_test;
@@ -1206,7 +1206,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigint '123')
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 LOG:  materializing continuous aggregate public.mat_ffunc_test: nothing to invalidate, new range up to 300
 SELECT * FROM mat_ffunc_test;
@@ -1228,7 +1228,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select location, max(humidity)
 from conditions
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_29_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_29 USING BTREE(location, time_partition_col)
 insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
@@ -1247,7 +1247,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
 select time_bucket(100, timec),  sum(humidity) 
 from conditions 
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_30_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_30 USING BTREE(grp_3_3, time_bucket)
 REFRESH MATERIALIZED VIEW conditions_grpby_view;
 LOG:  materializing continuous aggregate public.conditions_grpby_view: nothing to invalidate, new range up to 300
@@ -1265,7 +1265,7 @@ select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location  
 having avg(temperature) > 0
-;
+ WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_31_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_31 USING BTREE(grp_3_3, time_bucket)
 REFRESH MATERIALIZED VIEW conditions_grpby_view2;
 LOG:  materializing continuous aggregate public.conditions_grpby_view2: nothing to invalidate, new range up to 300
@@ -1300,7 +1300,7 @@ create materialized view mat_test5( timec, maxt)
 as
 select time_bucket('1day', time), max(temperature)
 from conditions
-group by time_bucket('1day', time);
+group by time_bucket('1day', time) WITH NO DATA;
 SET timescaledb.current_timestamp_mock = '2001-03-11';
 insert into conditions values('2001-03-10', '1');
 insert into conditions values('2001-03-10', '2');

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -87,7 +87,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view', NULL, 4::integer, '12 h'::interval);
  add_refresh_continuous_aggregate_policy 
 -----------------------------------------
@@ -364,7 +364,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view', NULL, -2::integer, '12 h'::interval);
  add_refresh_continuous_aggregate_policy 
 -----------------------------------------
@@ -493,7 +493,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value, get_constant_no_perms()
         FROM test_continuous_agg_table
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_4_get_constant_no_perms_time_bucke_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(get_constant_no_perms, time_bucket)
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view', NULL, -2::integer, '12 h'::interval);
  add_refresh_continuous_aggregate_policy 
@@ -575,7 +575,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view_user_2
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table_w_grant
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view_user_2', NULL, -2::integer, '12 h'::interval);
  add_refresh_continuous_aggregate_policy 
 -----------------------------------------

--- a/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
@@ -53,7 +53,7 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
 CREATE MATERIALIZED VIEW drop_chunks_view1 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.max_interval_per_job=100)
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 --raw hypertable will have 40 chunks and the mat. hypertable will have 2 and 4
 -- chunks respectively
 SELECT set_chunk_time_interval('_timescaledb_internal._materialized_hypertable_2', 10);

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -39,7 +39,7 @@ CREATE MATERIALIZED VIEW rename_test
   WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1week', time), COUNT(data)
     FROM foo
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name |  partial_view_schema  | partial_view_name 
@@ -226,7 +226,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
   )
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
@@ -309,7 +309,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
   )
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_u_name
@@ -437,7 +437,7 @@ CREATE MATERIALIZED VIEW new_name_view
   )
 AS SELECT time_bucket('6', time_bucket), COUNT(agg_2_2)
     FROM new_name
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 ERROR:  hypertable is a continuous aggregate materialization table
 -- cannot create a continuous aggregate on a continuous aggregate view
 CREATE MATERIALIZED VIEW drop_chunks_view_view
@@ -447,7 +447,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view_view
   )
 AS SELECT time_bucket('6', time_bucket), SUM(count)
     FROM drop_chunks_view
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 \set ON_ERROR_STOP 1
 DROP INDEX new_name_idx;
@@ -474,7 +474,7 @@ SELECT
   avg(v1) + avg(v2) AS avg1,
   avg(v1+v2) AS avg2
 FROM metrics
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_9_const_time_idx ON _timescaledb_internal._materialized_hypertable_9 USING BTREE(const, time)
 NOTICE:  adding index _materialized_hypertable_9_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_9 USING BTREE(numeric, time)
 NOTICE:  adding index _materialized_hypertable_9_case_time_idx ON _timescaledb_internal._materialized_hypertable_9 USING BTREE(case, time)
@@ -515,7 +515,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
   )
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 --dropping chunks will process the invalidations
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
@@ -900,12 +900,12 @@ SELECT set_integer_now_func('whatever', 'integer_now_test');
 CREATE MATERIALIZED VIEW whatever_view_1
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW whatever_view_2
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 TABLESPACE tablespace1 AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;
 CALL refresh_continuous_aggregate('whatever_view_1', NULL, NULL);
 CALL refresh_continuous_aggregate('whatever_view_2', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -30,7 +30,7 @@ CREATE MATERIALIZED VIEW records_monthly
             clientId,
             avg(value) as value_avg,
             max(value)-min(value) as value_spread
-        FROM records GROUP BY bucket, clientId;
+        FROM records GROUP BY bucket, clientId WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_2_clientid_bucket_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(clientid, bucket)
 INSERT INTO clients(name) VALUES ('test-client');
 INSERT INTO records

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -88,14 +88,14 @@ NOTICE:  materialized view "mat_test" does not exist, skipping
 --that the partial state survives the dump intact
 CREATE MATERIALIZED VIEW mat_before
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
-AS :QUERY_BEFORE;
+AS :QUERY_BEFORE WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_3_location_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, bucket)
 --materialize this VIEW after dump this tests
 --that the partialize VIEW and refresh mechanics
 --survives the dump intact
 CREATE MATERIALIZED VIEW mat_after
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
-AS :QUERY_AFTER;
+AS :QUERY_AFTER WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_4_location_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(location, bucket)
 --materialize mat_before
 SET client_min_messages TO LOG;

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -22,49 +22,49 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfil
 as
 select location , min(temperature)
 from conditions
-group by time_bucket('1d', timec), location;
+group by time_bucket('1d', timec), location WITH NO DATA;
 ERROR:  unrecognized parameter "timescaledb.myfill"
 --valid PG option
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
 as
-select * from conditions , mat_t1;
+select * from conditions , mat_t1 WITH NO DATA;
 ERROR:  unsupported combination of storage parameters
 -- join multiple tables
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
-group by location;
+group by location WITH NO DATA;
 ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 -- join multiple tables WITH explicit JOIN
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions JOIN mat_t1 ON true
 where conditions.location = mat_t1.c
-group by location;
+group by location WITH NO DATA;
 ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 -- LATERAL multiple tables
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions,
 LATERAL (Select * from mat_t1 where c = conditions.location) q
-group by location;
+group by location WITH NO DATA;
 ERROR:  only 1 hypertable is permitted in SELECT query for continuous aggregate
 --non-hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select a, count(*) from mat_t1
-group by a;
+group by a WITH NO DATA;
 ERROR:  table "mat_t1" is not a hypertable
 -- no group by
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
-select count(*) from conditions ;
+select count(*) from conditions  WITH NO DATA;
 ERROR:  SELECT query for continuous aggregate should have at least 1 aggregate function and a GROUP BY clause with time_bucket
 -- no time_bucket in group by
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
-select count(*) from conditions group by location;
+select count(*) from conditions group by location WITH NO DATA;
 ERROR:  no valid bucketing function found for continuous aggregate query
 -- with valid query in a CTE
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -72,26 +72,26 @@ AS
 with m1 as (
 Select location, count(*) from conditions
  group by time_bucket('1week', timec) , location)
-select * from m1;
+select * from m1 WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --with DISTINCT ON
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
- select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec) ;
+ select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --aggregate with DISTINCT
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  count(location) , sum(distinct temperature) from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 --aggregate with FILTER
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  sum(temperature) filter ( where humidity > 20 ) from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 -- aggregate with filter in having clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -99,70 +99,70 @@ AS
 Select time_bucket('1week', timec), max(temperature)
 from conditions
  group by time_bucket('1week', timec) , location
- having sum(temperature) filter ( where humidity > 20 ) > 50;
+ having sum(temperature) filter ( where humidity > 20 ) > 50 WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 -- time_bucket on non partitioning column of hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket('1week', timemeasure) , location;
+ group by time_bucket('1week', timemeasure) , location WITH NO DATA;
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
 --time_bucket on expression
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket('1week', timec+ '10 minutes'::interval) , location;
+ group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
 --multiple time_bucket functions
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket('1week', timec) , time_bucket('1month', timec), location;
+ group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
 ERROR:  multiple time_bucket functions not permitted in continuous aggregate query
 --time_bucket using additional args
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location;
+ group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
 ERROR:  no valid bucketing function found for continuous aggregate query
 --time_bucket using non-const for first argument
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket( timeinterval, timec) , location;
+ group by time_bucket( timeinterval, timec) , location WITH NO DATA;
 ERROR:  first argument to time_bucket function should be a constant for continuous aggregate query
 -- ordered set aggr
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select mode() within group( order by humidity)
 from conditions
- group by time_bucket('1week', timec) ;
+ group by time_bucket('1week', timec)  WITH NO DATA;
 ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported for continuous aggregate query
 --window function
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
-;
+ WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --aggregate without combine function
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select json_agg(location)
 from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates which are not parallelizable are not supported by continuous aggregate query
 ;
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature), array_agg(location)
 from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates which are not parallelizable are not supported by continuous aggregate query
 ;
 -- userdefined aggregate without combine function
@@ -175,7 +175,7 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), newavg(temperature::int4)
 from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ERROR:  aggregates which are not parallelizable are not supported by continuous aggregate query
 ;
 -- using subqueries
@@ -185,14 +185,14 @@ Select sum(humidity), avg(temperature::int4)
 from
 ( select humidity, temperature, location, timec
 from conditions ) q
- group by time_bucket('1week', timec) , location ;
+ group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
 from conditions
- group by time_bucket('1week', timec) , location )  q;
+ group by time_bucket('1week', timec) , location )  q WITH NO DATA;
 ERROR:  SELECT query for continuous aggregate should have at least 1 aggregate function and a GROUP BY clause with time_bucket
 --using limit /limit offset
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -200,14 +200,14 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-limit 10 ;
+limit 10  WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-offset 10;
+offset 10 WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --using ORDER BY in view defintion
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -215,7 +215,7 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-ORDER BY 1;
+ORDER BY 1 WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --using FETCH
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -223,7 +223,7 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-fetch first 10 rows only;
+fetch first 10 rows only WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
@@ -232,28 +232,28 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR KEY SHARE;
+FOR KEY SHARE WITH NO DATA;
 ERROR:  FOR KEY SHARE is not allowed with GROUP BY clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR SHARE;
+FOR SHARE WITH NO DATA;
 ERROR:  FOR SHARE is not allowed with GROUP BY clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR UPDATE;
+FOR UPDATE WITH NO DATA;
 ERROR:  FOR UPDATE is not allowed with GROUP BY clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR NO KEY UPDATE;
+FOR NO KEY UPDATE WITH NO DATA;
 ERROR:  FOR NO KEY UPDATE is not allowed with GROUP BY clause
 --tablesample clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -261,27 +261,27 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
  group by time_bucket('1week', timec) , location
-;
+ WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 -- ONLY in from clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
- group by time_bucket('1week', timec) , location ;
+ group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --grouping sets and variants
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
- group by grouping sets(time_bucket('1week', timec) , location ) ;
+ group by grouping sets(time_bucket('1week', timec) , location )  WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
-group by rollup(time_bucket('1week', timec) , location ) ;
+group by rollup(time_bucket('1week', timec) , location )  WITH NO DATA;
 ERROR:  invalid SELECT query for continuous aggregate
 --NO immutable functions -- check all clauses
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
@@ -290,26 +290,26 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
-group by time_bucket('1week', timec) , location  ;
+group by time_bucket('1week', timec) , location   WITH NO DATA;
 ERROR:  only immutable functions are supported for continuous aggregate query
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), min(location)
 from conditions
 group by time_bucket('1week', timec)
-having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08';
+having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08' WITH NO DATA;
 ERROR:  only immutable functions are supported for continuous aggregate query
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
-group by time_bucket('1week', timec);
+group by time_bucket('1week', timec) WITH NO DATA;
 ERROR:  only immutable functions are supported for continuous aggregate query
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)
 from conditions
-group by time_bucket('1week', timec), test_stablefunc(humidity::int);
+group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DATA;
 ERROR:  only immutable functions are supported for continuous aggregate query
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
 CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous) AS
@@ -339,7 +339,7 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( b), min(c)
 from rowsec_tab
-group by time_bucket('1', a);
+group by time_bucket('1', a) WITH NO DATA;
 ERROR:  continuous aggregate query cannot be created on table with row security
 drop table conditions cascade;
 --negative tests for WITH options
@@ -364,7 +364,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 joules')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 ERROR:  invalid input syntax for type interval: "5 joules"
 \set ON_ERROR_STOP 1
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -372,14 +372,14 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 create materialized view mat_with_test_no_inval( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours',
                timescaledb.ignore_invalidation_older_than='0')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 SELECT  h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
        partial_view_name as "PART_VIEW_NAME",
@@ -433,14 +433,14 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '32768')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  time_bucket function for continuous aggregate query should be called on the dimension column of the hypertable 
 ALTER TABLE conditions ALTER timec type int;
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -448,7 +448,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483648')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  timescaledb.refresh_lag out of range
 -- max_interval_per_job must be at least time_bucket
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -456,7 +456,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='10')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  parameter timescaledb.max_interval_per_job must be at least the size of the time_bucket width
 --ignore_invalidation_older_than must be positive
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -464,21 +464,21 @@ create materialized view mat_with_test( timec, minl, sumt , sumh)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  parameter timescaledb.ignore_invalidation_older_than must not be negative
 create materialized view mat_with_test( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  parameter timescaledb.ignore_invalidation_older_than must be an integer for hypertables with integer time values
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 ERROR:  invalid integer_now function
 \set ON_ERROR_STOP 0
 DROP TABLE conditions cascade;
@@ -509,7 +509,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by 1;
+group by 1 WITH NO DATA;
 -- custom time partition functions are not supported with invalidations
 CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
     AS $$ SELECT length($1)::BIGINT $$
@@ -527,7 +527,7 @@ CREATE MATERIALIZED VIEW text_view
     WITH (timescaledb.continuous)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 ERROR:  continuous aggregate do not support custom partitioning functions
 \set ON_ERROR_STOP 1
 -- Check that we get an error when mixing normal materialized views
@@ -535,7 +535,7 @@ ERROR:  continuous aggregate do not support custom partitioning functions
 CREATE MATERIALIZED VIEW normal_mat_view AS
 SELECT time_bucket('5', text_part_func(time)), COUNT(time)
   FROM text_time
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 0
 DROP MATERIALIZED VIEW normal_mat_view, mat_with_test;
 ERROR:  mixing continuous aggregates and other objects not allowed

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -82,7 +82,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_3_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device, bucket)
 CREATE MATERIALIZED VIEW cond_20
 WITH (timescaledb.continuous,
@@ -90,7 +90,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_4_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, bucket)
 CREATE MATERIALIZED VIEW measure_10
 WITH (timescaledb.continuous,
@@ -98,7 +98,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(10, time) AS bucket, device, avg(temp) AS avg_temp
 FROM measurements
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_5_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(device, bucket)
 -- There should be three continuous aggregates, two on one hypertable
 -- and one on the other:
@@ -711,7 +711,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(BIGINT '1', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_6_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, bucket)
 SELECT mat_hypertable_id AS cond_1_id
 FROM _timescaledb_catalog.continuous_agg
@@ -917,7 +917,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(2, time) AS bucket, max(value) AS max
 FROM threshold_test
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 SELECT raw_hypertable_id AS thresh_hyper_id, mat_hypertable_id AS thresh_cagg_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'thresh_2' \gset

--- a/tsl/test/expected/continuous_aggs_materialize.out
+++ b/tsl/test/expected/continuous_aggs_materialize.out
@@ -617,7 +617,7 @@ CREATE MATERIALIZED VIEW test_t_mat_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_test_t
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT mat_hypertable_id, raw_hypertable_id, user_view_schema, user_view_name,
        partial_view_schema, partial_view_name,
        _timescaledb_internal.to_timestamp(bucket_width), _timescaledb_internal.to_interval(refresh_lag)
@@ -834,7 +834,7 @@ CREATE MATERIALIZED VIEW extreme_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('1', time), SUM(data) as value
         FROM continuous_agg_extreme
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT id as raw_table_id FROM _timescaledb_catalog.hypertable WHERE table_name='continuous_agg_extreme' \gset
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE raw_hypertable_id=:raw_table_id \gset
 -- EMPTY table should be a nop
@@ -978,7 +978,7 @@ CREATE MATERIALIZED VIEW negative_view_5
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('5', time), COUNT(data) as value
         FROM continuous_agg_negative
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 -- two chunks, 4 buckets
 INSERT INTO continuous_agg_negative
     SELECT i, i FROM generate_series(0, 11) AS i;
@@ -1038,7 +1038,7 @@ CREATE MATERIALIZED VIEW negative_view_5
             WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
 AS SELECT time_bucket('5', time), COUNT(data) as value
    FROM continuous_agg_negative
-   GROUP BY 1;
+   GROUP BY 1 WITH NO DATA;
 -- we can handle values near max
 INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
 SET client_min_messages TO error;
@@ -1085,7 +1085,7 @@ CREATE MATERIALIZED VIEW max_mat_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4', timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), COUNT(data) as value
         FROM continuous_agg_max_mat
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 10) AS i;
 SET client_min_messages TO LOG;
 -- first run create two materializations
@@ -1275,7 +1275,7 @@ CREATE MATERIALIZED VIEW max_mat_view_t
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4 hours', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_max_mat_t
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 INSERT INTO continuous_agg_max_mat_t
     SELECT i, i FROM
         generate_series('2019-09-09 1:00'::TIMESTAMPTZ, '2019-09-09 10:00', '1 hour') AS i;
@@ -1347,7 +1347,7 @@ CREATE MATERIALIZED VIEW max_mat_view_timestamp
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time)
         FROM continuous_agg_max_mat_timestamp
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 INSERT INTO continuous_agg_max_mat_timestamp
     SELECT generate_series('2019-09-09 1:00'::TIMESTAMPTZ, '2019-09-09 10:00', '1 hour');
 -- first materializes everything
@@ -1377,7 +1377,7 @@ CREATE MATERIALIZED VIEW max_mat_view_date
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-7 days')
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 INSERT INTO continuous_agg_max_mat_date
     SELECT generate_series('2019-09-01'::DATE, '2019-09-010 10:00', '1 day');
 SET timescaledb.current_timestamp_mock = '2019-09-09 01:00 UTC';
@@ -1433,7 +1433,7 @@ CREATE MATERIALIZED VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 REFRESH MATERIALIZED VIEW timezone_test_summary;
 -- this must return 1 as only 1 row is in the materialization interval
 SELECT count(*) FROM timezone_test_summary;
@@ -1462,7 +1462,7 @@ CREATE MATERIALIZED VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 REFRESH MATERIALIZED VIEW timezone_test_summary;
 -- this must return 1 as only 1 row is in the materialization interval
 SELECT count(*) FROM timezone_test_summary;
@@ -1496,7 +1496,7 @@ CREATE MATERIALIZED VIEW continuous_agg_int_max
     WITH (timescaledb.continuous, timescaledb.refresh_lag='0')
     AS SELECT time_bucket('10', time), COUNT(data) as value
         FROM continuous_agg_int
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 INSERT INTO continuous_agg_int values (-10, 100), (1,100), (10, 100);
 select chunk_name, range_start_integer, range_end_integer 
 FROM timescaledb_information.chunks 
@@ -1541,7 +1541,7 @@ CREATE MATERIALIZED VIEW continuous_agg_ts_max_view
     WITH (timescaledb.continuous, timescaledb.max_interval_per_job='365 days', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', timecol), COUNT(data) as value
         FROM continuous_agg_ts_max_t
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 INSERT INTO continuous_agg_ts_max_t
     values ('1969-01-01 1:00'::timestamptz, 10);
 REFRESH MATERIALIZED VIEW continuous_agg_ts_max_view;

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -29,13 +29,13 @@ WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.mate
 AS
     SELECT time_bucket( 2, timeval), COUNT(col1) 
     FROM continuous_agg_test
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW cagg_2( timed, grp, maxval) 
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.materialized_only=true   )
 AS
     SELECT time_bucket(2, timeval), col1, max(col2) 
     FROM continuous_agg_test
-    GROUP BY 1, 2;
+    GROUP BY 1, 2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_3_grp_timed_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(grp, timed)
 select view_name, view_owner, materialization_hypertable 
 from timescaledb_information.continuous_aggregates ORDER BY 1;
@@ -269,13 +269,13 @@ WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.mate
 AS
     SELECT time_bucket( 2, timeval), COUNT(col1) 
     FROM continuous_agg_test
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW cagg_2( timed, maxval) 
 WITH ( timescaledb.continuous , timescaledb.refresh_lag = '2', timescaledb.materialized_only = true)
 AS
     SELECT time_bucket(2, timeval), max(col2) 
     FROM continuous_agg_test
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 refresh materialized view cagg_1;
 LOG:  materializing continuous aggregate public.cagg_1: nothing to invalidate, new range up to 18
 select * from cagg_1 order by 1;
@@ -413,19 +413,19 @@ CREATE MATERIALIZED VIEW cagg_iia1( timed, cnt )
 AS
 SELECT time_bucket( 2, timeval), COUNT(col1)
 FROM continuous_agg_test_ignore_invalidation_older_than
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW cagg_iia2( timed, maxval)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 10, timescaledb.materialized_only=true)
 AS
 SELECT time_bucket(2, timeval), max(col2)
 FROM continuous_agg_test_ignore_invalidation_older_than
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW cagg_iia3( timed, maxval)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 0, timescaledb.materialized_only=true)
 AS
 SELECT time_bucket(2, timeval), max(col2)
 FROM continuous_agg_test_ignore_invalidation_older_than
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 refresh materialized view cagg_iia1;
 LOG:  materializing continuous aggregate public.cagg_iia1: nothing to invalidate, new range up to 14
 select * from cagg_iia1 order by 1;
@@ -699,13 +699,13 @@ WITH (timescaledb.continuous, timescaledb.refresh_lag = 10, timescaledb.max_inte
 AS
 SELECT time_bucket(10, a), count(*)
 FROM foo
-GROUP BY time_bucket(10, a);
+GROUP BY time_bucket(10, a) WITH NO DATA;
 CREATE MATERIALIZED VIEW mat_m2(a, countb)
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 0, timescaledb.max_interval_per_job=100)
 AS
 SELECT time_bucket(5, a), count(*)
 FROM foo
-GROUP BY time_bucket(5, a);
+GROUP BY time_bucket(5, a) WITH NO DATA;
 select view_name, materialized_only from timescaledb_information.continuous_aggregates
 WHERE view_name::text like 'mat_m%'
 order by view_name;

--- a/tsl/test/expected/continuous_aggs_permissions.out
+++ b/tsl/test/expected/continuous_aggs_permissions.out
@@ -33,7 +33,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_2_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, time_partition_col)
 SELECT add_refresh_continuous_aggregate_policy('mat_refresh_test', NULL, -200::integer, '12 h'::interval);
  add_refresh_continuous_aggregate_policy 
@@ -133,7 +133,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity)
 from conditions_for_perm_check
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_5_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(location, time_partition_col)
 ERROR:  permission denied for table conditions_for_perm_check
 --cannot create mat view in a schema without create privileges
@@ -142,7 +142,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_6_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(location, time_partition_col)
 ERROR:  permission denied for schema custom_schema
 --cannot use a function without EXECUTE privileges
@@ -152,7 +152,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity), get_constant()
 from conditions_for_perm_check_w_grant
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_7_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_7 USING BTREE(location, time_partition_col)
 NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_7 USING BTREE(get_constant, time_partition_col)
 --this should fail
@@ -165,7 +165,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 SELECT * FROM mat_perm_view_test;

--- a/tsl/test/expected/continuous_aggs_policy.out
+++ b/tsl/test/expected/continuous_aggs_policy.out
@@ -34,7 +34,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 SELECT a, count(b)
 FROM int_tab
-GROUP BY time_bucket(1, a), a;
+GROUP BY time_bucket(1, a), a WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_2_a_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(a, time_partition_col)
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
@@ -131,7 +131,7 @@ CREATE MATERIALIZED VIEW max_mat_view_date
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 0
 SELECT add_refresh_continuous_aggregate_policy('max_mat_view_date', '2 days'::interval, 10 , '1 day'::interval); 
 ERROR:  invalid parameter value for end_interval
@@ -160,7 +160,7 @@ CREATE MATERIALIZED VIEW max_mat_view_timestamp
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_timestamp
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('max_mat_view_timestamp', '10 day'::interval, '1 h'::interval , '1 h'::interval) as job_id \gset
 CALL run_job(:job_id);
 SELECT config FROM _timescaledb_config.bgw_job 
@@ -207,7 +207,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 SELECT time_bucket( SMALLINT '1', a) , count(*)
 FROM smallint_tab
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 0
 SELECT add_refresh_continuous_aggregate_policy('mat_smallint', 15, 0 , '1 h'::interval);
 ERROR:  invalid parameter value for start_interval

--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -46,7 +46,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec), location;
+group by time_bucket('1day', timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 --compute time_bucketted max+bucket_width for the materialized view
@@ -65,7 +65,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions
-group by time_bucket('1day', timec), location;
+group by time_bucket('1day', timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, timec)
 --time that refresh assumes as now() for repeatability
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';

--- a/tsl/test/expected/continuous_aggs_query-12.out
+++ b/tsl/test/expected/continuous_aggs_query-12.out
@@ -46,7 +46,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec), location;
+group by time_bucket('1day', timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 --compute time_bucketted max+bucket_width for the materialized view
@@ -65,7 +65,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions
-group by time_bucket('1day', timec), location;
+group by time_bucket('1day', timec), location WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, timec)
 --time that refresh assumes as now() for repeatability
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -50,7 +50,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_2_device_day_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(device, day)
 -- The continuous aggregate should be empty
 SELECT * FROM daily_temp
@@ -198,7 +198,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions_date
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_4_device_day_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, day)
 CALL refresh_continuous_aggregate('daily_temp_date', '2020-05-01', '2020-05-03');
 -- Try max refresh window size
@@ -229,7 +229,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 ERROR:  missing integer-now function on hypertable "conditions_smallint"
 \set ON_ERROR_STOP 1
 SELECT set_integer_now_func('conditions_smallint', 'smallint_now');
@@ -244,7 +244,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_6_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, bucket)
 CALL refresh_continuous_aggregate('cond_20_smallint', 5::smallint, 50::smallint);
 SELECT * FROM cond_20_smallint
@@ -296,7 +296,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(INT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_int
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_8_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, bucket)
 CALL refresh_continuous_aggregate('cond_20_int', 5, 50);
 SELECT * FROM cond_20_int
@@ -348,7 +348,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_bigint
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_10_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(device, bucket)
 CALL refresh_continuous_aggregate('cond_20_bigint', 5, 50);
 SELECT * FROM cond_20_bigint
@@ -371,3 +371,55 @@ ORDER BY 1,2;
 
 -- Try max refresh window size
 CALL refresh_continuous_aggregate('cond_20_bigint', NULL, NULL);
+-- Test that WITH NO DATA and WITH DATA works (we use whatever is the
+-- default for Postgres, so we do not need to have test for the
+-- default).
+CREATE MATERIALIZED VIEW weekly_temp_without_data
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH NO DATA;
+NOTICE:  adding index _materialized_hypertable_11_device_day_idx ON _timescaledb_internal._materialized_hypertable_11 USING BTREE(device, day)
+CREATE MATERIALIZED VIEW weekly_temp_with_data
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH DATA;
+NOTICE:  adding index _materialized_hypertable_12_device_day_idx ON _timescaledb_internal._materialized_hypertable_12 USING BTREE(device, day)
+NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
+SELECT * FROM weekly_temp_without_data;
+ day | device | avg_temp 
+-----+--------+----------
+(0 rows)
+
+SELECT * FROM weekly_temp_with_data;
+             day              | device |     avg_temp     
+------------------------------+--------+------------------
+ Sun Apr 26 17:00:00 2020 PDT |      3 | 21.5631067961165
+ Sun Apr 26 17:00:00 2020 PDT |      1 | 17.2474226804124
+ Sun May 03 17:00:00 2020 PDT |      0 | 16.7659574468085
+ Sun May 03 17:00:00 2020 PDT |      1 | 22.7272727272727
+ Sun Apr 26 17:00:00 2020 PDT |      0 | 17.8181818181818
+ Sun Apr 26 17:00:00 2020 PDT |      2 | 18.9803921568627
+ Sun May 03 17:00:00 2020 PDT |      2 |  15.811320754717
+ Sun May 03 17:00:00 2020 PDT |      3 |               19
+(8 rows)
+
+CALL refresh_continuous_aggregate('weekly_temp_without_data', NULL, NULL);
+SELECT * FROM weekly_temp_without_data;
+             day              | device |     avg_temp     
+------------------------------+--------+------------------
+ Sun Apr 26 17:00:00 2020 PDT |      3 | 21.5631067961165
+ Sun Apr 26 17:00:00 2020 PDT |      1 | 17.2474226804124
+ Sun May 03 17:00:00 2020 PDT |      0 | 16.7659574468085
+ Sun May 03 17:00:00 2020 PDT |      1 | 22.7272727272727
+ Sun Apr 26 17:00:00 2020 PDT |      0 | 17.8181818181818
+ Sun Apr 26 17:00:00 2020 PDT |      2 | 18.9803921568627
+ Sun May 03 17:00:00 2020 PDT |      2 |  15.811320754717
+ Sun May 03 17:00:00 2020 PDT |      3 |               19
+(8 rows)
+

--- a/tsl/test/expected/continuous_aggs_tableam.out
+++ b/tsl/test/expected/continuous_aggs_tableam.out
@@ -37,11 +37,11 @@ INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;
 CREATE MATERIALIZED VIEW tableam_view USING heap2
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW notableam_view
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 SELECT user_view, mat_table, amname
 FROM cagg_info,
      LATERAL (SELECT relam FROM pg_class WHERE relname = mat_table) AS cls,

--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -27,7 +27,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 ALTER TABLE metrics DROP COLUMN f2;
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
@@ -183,7 +183,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -266,7 +266,7 @@ DROP MATERIALIZED VIEW metrics_summary;
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 -- should be marked as materialized_only in catalog
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -349,7 +349,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 CREATE MATERIALIZED VIEW boundary_view
   WITH (timescaledb.continuous)
 AS
-  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
+  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1 WITH NO DATA;
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
 SELECT mat_hypertable_id AS boundary_view_id
 FROM _timescaledb_catalog.continuous_agg
@@ -471,7 +471,7 @@ SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
 FROM ht_intdata
 WHERE b < 16
 GROUP BY time_bucket(1, a)
-HAVING sum(c) > 50;
+HAVING sum(c) > 50 WITH NO DATA;
 REFRESH MATERIALIZED VIEW mat_m1;
 SELECT view_name, completed_threshold from timescaledb_information.continuous_aggregate_stats
 WHERE view_name::text like 'mat_m1';
@@ -562,7 +562,7 @@ SELECT time_bucket(5, a), sum(b+c)
 FROM ht_intdata
 WHERE b < 16 and c > 20
 GROUP BY time_bucket(5, a)
-HAVING sum(c) > 50 and avg(b)::int > 12 ;
+HAVING sum(c) > 50 and avg(b)::int > 12  WITH NO DATA;
 INSERT into ht_intdata values( 42 , 15 , 80);
 INSERT into ht_intdata values( 42 , 15 , 18);
 INSERT into ht_intdata values( 41 , 18 , 21);
@@ -733,37 +733,37 @@ WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
 FROM smallint_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW int_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(5, time) AS bucket, avg(value)
 FROM int_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW bigint_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
 FROM bigint_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW date_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM date_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamp_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamp_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamptz_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamptz_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 -- Refresh first without data
 CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
 NOTICE:  continuous aggregate "int_agg" is already up-to-date

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -27,7 +27,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 ALTER TABLE metrics DROP COLUMN f2;
 -- this should be union view
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
@@ -183,7 +183,7 @@ NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -266,7 +266,7 @@ DROP MATERIALIZED VIEW metrics_summary;
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 -- should be marked as materialized_only in catalog
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
  user_view_name  | materialized_only 
@@ -349,7 +349,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 CREATE MATERIALIZED VIEW boundary_view
   WITH (timescaledb.continuous)
 AS
-  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
+  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1 WITH NO DATA;
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
 SELECT mat_hypertable_id AS boundary_view_id
 FROM _timescaledb_catalog.continuous_agg
@@ -471,7 +471,7 @@ SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
 FROM ht_intdata
 WHERE b < 16
 GROUP BY time_bucket(1, a)
-HAVING sum(c) > 50;
+HAVING sum(c) > 50 WITH NO DATA;
 REFRESH MATERIALIZED VIEW mat_m1;
 SELECT view_name, completed_threshold from timescaledb_information.continuous_aggregate_stats
 WHERE view_name::text like 'mat_m1';
@@ -562,7 +562,7 @@ SELECT time_bucket(5, a), sum(b+c)
 FROM ht_intdata
 WHERE b < 16 and c > 20
 GROUP BY time_bucket(5, a)
-HAVING sum(c) > 50 and avg(b)::int > 12 ;
+HAVING sum(c) > 50 and avg(b)::int > 12  WITH NO DATA;
 INSERT into ht_intdata values( 42 , 15 , 80);
 INSERT into ht_intdata values( 42 , 15 , 18);
 INSERT into ht_intdata values( 41 , 18 , 21);
@@ -736,37 +736,37 @@ WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
 FROM smallint_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW int_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(5, time) AS bucket, avg(value)
 FROM int_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW bigint_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
 FROM bigint_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW date_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM date_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamp_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamp_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW timestamptz_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamptz_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 -- Refresh first without data
 CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
 NOTICE:  continuous aggregate "int_agg" is already up-to-date

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -29,7 +29,7 @@ SELECT
   max(metric)-min(metric) as metric_spread --We can also use expressions on aggregates and constants
 FROM
   device_readings
-GROUP BY bucket, device_id; --We have to group by the bucket column, but can also add other group-by columns
+GROUP BY bucket, device_id WITH NO DATA; --We have to group by the bucket column, but can also add other group-by columns
 NOTICE:  adding index _materialized_hypertable_2_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(device_id, bucket)
 SELECT add_refresh_continuous_aggregate_policy('device_summary', NULL, '2 h'::interval, '2 h'::interval);
  add_refresh_continuous_aggregate_policy 
@@ -217,7 +217,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   device_readings
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 ERROR:  only immutable functions are supported for continuous aggregate query
 --note the error.
 -- You have two options:
@@ -235,7 +235,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   device_readings
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_3_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device_id, bucket)
 DROP MATERIALIZED VIEW device_summary;
 -- Option 2: Keep things as TIMESTAMPTZ in the view and convert to local time when
@@ -253,7 +253,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   device_readings
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 REFRESH MATERIALIZED VIEW device_summary;
 LOG:  new materialization range for public.device_readings (time column observation_time) larger than allowed in one run, truncating Sun Dec 30 11:00:00 2018 PST to Sat Dec 01 20:00:00 2018 PST
@@ -291,11 +291,11 @@ SELECT set_integer_now_func('device_readings_int','device_readings_int_now');
 CREATE MATERIALIZED VIEW device_readings_mat_only
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
-  SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1;
+  SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW device_readings_jit
   WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS
-  SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1;
+  SELECT time_bucket(10,time), avg(value) FROM device_readings_int GROUP BY 1 WITH NO DATA;
 INSERT INTO device_readings_int SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
 -- materialization only should have 0 rows
 SELECT * FROM device_readings_mat_only ORDER BY time_bucket;
@@ -404,7 +404,7 @@ SELECT * FROM create_hypertable('whatever', 'time');
 
 CREATE MATERIALIZED VIEW whatever_summary WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 hour', time) AS bucket, avg(metric)
-  FROM whatever GROUP BY bucket;
+  FROM whatever GROUP BY bucket WITH NO DATA;
 SELECT (SELECT format('%1$I.%2$I', schema_name, table_name)::regclass::oid
           FROM _timescaledb_catalog.hypertable
 	 WHERE id = raw_hypertable_id) AS raw_table

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -230,7 +230,7 @@ CREATE MATERIALIZED VIEW cit_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(time)
         FROM ca_inval_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 INSERT INTO ca_inval_test SELECT generate_series(0, 5);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
@@ -326,7 +326,7 @@ CREATE MATERIALIZED VIEW continuous_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(location)
         FROM ts_continuous_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
  hypertable_id | watermark 
 ---------------+-----------

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -1846,7 +1846,7 @@ INSERT INTO disttable VALUES
 CREATE MATERIALIZED VIEW disttable_cagg WITH (timescaledb.continuous)
 AS SELECT time_bucket('2 days', time), device, max(value)
     FROM disttable
-    GROUP BY 1, 2;
+    GROUP BY 1, 2 WITH NO DATA;
 ERROR:  continuous aggregates are not supported on distributed hypertables
 \set ON_ERROR_STOP 1
 DROP TABLE disttable;

--- a/tsl/test/expected/jit-11.out
+++ b/tsl/test/expected/jit-11.out
@@ -57,7 +57,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   jit_test_contagg
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 psql:include/jit_load.sql:30: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;

--- a/tsl/test/expected/jit-12.out
+++ b/tsl/test/expected/jit-12.out
@@ -57,7 +57,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   jit_test_contagg
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 psql:include/jit_load.sql:30: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -275,7 +275,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   test_contagg
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 ERROR:  cannot execute CREATE MATERIALIZED VIEW in a read-only transaction
 -- policy API
 CALL _timescaledb_internal.policy_compression(1,'{}');

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -2986,7 +2986,7 @@ SELECT time_bucket ('1d', time) AS time,
 FROM :TEST_TABLE
 WHERE device_id = 1
 GROUP BY 1,
-    2;
+    2 WITH NO DATA;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time
@@ -6773,7 +6773,7 @@ SELECT time_bucket ('1d', time) AS time,
 FROM :TEST_TABLE
 WHERE device_id = 1
 GROUP BY 1,
-    2;
+    2 WITH NO DATA;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -2956,7 +2956,7 @@ SELECT time_bucket ('1d', time) AS time,
 FROM :TEST_TABLE
 WHERE device_id = 1
 GROUP BY 1,
-    2;
+    2 WITH NO DATA;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time
@@ -6702,7 +6702,7 @@ SELECT time_bucket ('1d', time) AS time,
 FROM :TEST_TABLE
 WHERE device_id = 1
 GROUP BY 1,
-    2;
+    2 WITH NO DATA;
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 REFRESH MATERIALIZED VIEW cagg_test;
 SELECT time

--- a/tsl/test/isolation/expected/continuous_aggs_multi.out
+++ b/tsl/test/isolation/expected/continuous_aggs_multi.out
@@ -6,12 +6,12 @@ step Setup2:
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE FUNCTION lock_mattable( name text) RETURNS void AS $$
     BEGIN EXECUTE format( 'lock table %s', name);
     END; $$ LANGUAGE plpgsql;
@@ -37,12 +37,12 @@ step Setup2:
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE FUNCTION lock_mattable( name text) RETURNS void AS $$
     BEGIN EXECUTE format( 'lock table %s', name);
     END; $$ LANGUAGE plpgsql;
@@ -83,12 +83,12 @@ step Setup2:
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE FUNCTION lock_mattable( name text) RETURNS void AS $$
     BEGIN EXECUTE format( 'lock table %s', name);
     END; $$ LANGUAGE plpgsql;
@@ -137,12 +137,12 @@ step Setup2:
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE FUNCTION lock_mattable( name text) RETURNS void AS $$
     BEGIN EXECUTE format( 'lock table %s', name);
     END; $$ LANGUAGE plpgsql;

--- a/tsl/test/isolation/specs/continuous_aggs_concurrent_refresh.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_concurrent_refresh.spec
@@ -33,14 +33,14 @@ setup
     AS
       SELECT time_bucket(10, time) AS bucket, avg(temp) AS avg_temp
       FROM conditions
-      GROUP BY 1;
+      GROUP BY 1 WITH NO DATA;
     CREATE MATERIALIZED VIEW cond_20
     WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
     AS
       SELECT time_bucket(20, time) AS bucket, avg(temp) AS avg_temp
       FROM conditions
-      GROUP BY 1;
+      GROUP BY 1 WITH NO DATA;
 
     CREATE OR REPLACE FUNCTION cagg_bucket_count(cagg regclass)
     RETURNS int AS

--- a/tsl/test/isolation/specs/continuous_aggs_insert.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_insert.spec
@@ -15,7 +15,7 @@ setup
         WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
         AS SELECT time_bucket('5', time), COUNT(location)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
 }
 
 teardown {

--- a/tsl/test/isolation/specs/continuous_aggs_multi.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_multi.spec
@@ -26,12 +26,12 @@ step "Setup2"
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), COUNT(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE MATERIALIZED VIEW continuous_view_2(bkt, maxl)
         WITH ( timescaledb.continuous,timescaledb.refresh_lag='-10', timescaledb.materialized_only = true)
         AS SELECT time_bucket('5', time), max(val)
             FROM ts_continuous_test
-            GROUP BY 1;
+            GROUP BY 1 WITH NO DATA;
     CREATE FUNCTION lock_mattable( name text) RETURNS void AS $$
     BEGIN EXECUTE format( 'lock table %s', name);
     END; $$ LANGUAGE plpgsql;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -331,7 +331,7 @@ SELECT
   avg(v1) + avg(v2) AS avg1,
   avg(v1+v2) AS avg2
 FROM metrics
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 REFRESH MATERIALIZED VIEW cagg_expr;

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -123,7 +123,7 @@ SELECT device,
        MAX(temperature) AS max_temperature,
        MIN(temperature) AS min_temperature
 FROM conditions
-GROUP BY device, time_bucket(INTERVAL '1 hour', "time");
+GROUP BY device, time_bucket(INTERVAL '1 hour', "time") WITH NO DATA;
 
 CALL refresh_continuous_aggregate('conditions_summary', NULL, NULL);
 

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -334,7 +334,7 @@ SET timescaledb.current_timestamp_mock = '2018-03-28 1:00';
 CREATE MATERIALIZED VIEW test1_cont_view WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1 hour', "Time"), SUM(i)
    FROM test1
-   GROUP BY 1;
+   GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test1_cont_view', NULL, '1 hour'::interval, '1 day'::interval);
 REFRESH MATERIALIZED VIEW test1_cont_view;
 

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -43,7 +43,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select a, count(b)
 from foo
-group by time_bucket(1, a), a;
+group by time_bucket(1, a), a WITH NO DATA;
 
 SELECT add_refresh_continuous_aggregate_policy('mat_m1', NULL, 2::integer, '12 h'::interval); 
 SELECT * FROM _timescaledb_config.bgw_job;
@@ -102,7 +102,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -164,7 +164,7 @@ as
 select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
-group by time_bucket('1week', timec) ;
+group by time_bucket('1week', timec)  WITH NO DATA;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -211,7 +211,7 @@ min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 where location = 'NYC'
 group by time_bucket('1week', timec)
-;
+ WITH NO DATA;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -256,7 +256,7 @@ select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by time_bucket('1week', timec)
-having stddev(humidity) is not null;
+having stddev(humidity) is not null WITH NO DATA;
 ;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
@@ -320,7 +320,7 @@ as
 select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by bucket, loc
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -346,7 +346,7 @@ as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by 1,2
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -372,7 +372,7 @@ as
 select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by 1,2
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -398,7 +398,7 @@ select time_bucket('1week', timec) ,
 min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by  time_bucket('1week', timec)
-having min(location) >= 'NYC' and avg(temperature) > 20;
+having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
@@ -565,7 +565,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 
 \set ON_ERROR_STOP 0
 DROP TABLE conditions;
@@ -640,7 +640,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec), location, humidity, temperature;
+group by time_bucket('1day', timec), location, humidity, temperature WITH NO DATA;
 
 SELECT add_refresh_continuous_aggregate_policy('mat_with_test', NULL, '5 h'::interval, '12 h'::interval); 
 SELECT alter_job(id, schedule_interval => '1h') FROM _timescaledb_config.bgw_job;
@@ -666,7 +666,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec), location, humidity, temperature;
+group by time_bucket('1day', timec), location, humidity, temperature WITH NO DATA;
 
 select indexname, indexdef from pg_indexes where tablename =
 (SELECT h.table_name
@@ -697,7 +697,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 SELECT add_refresh_continuous_aggregate_policy('mat_with_test', NULL, 500::integer, '12 h'::interval); 
 SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job;
@@ -736,7 +736,7 @@ CREATE MATERIALIZED VIEW space_view
 WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag = '-2')
 AS SELECT time_bucket('4', time), COUNT(data)
    FROM space_table
-   GROUP BY 1;
+   GROUP BY 1 WITH NO DATA;
 
 INSERT INTO space_table VALUES
   (0, 1, 1), (0, 2, 1), (1, 1, 1), (1, 2, 1),
@@ -843,7 +843,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test'::text)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 
@@ -856,7 +856,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigint '123')
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 REFRESH MATERIALIZED VIEW mat_ffunc_test;
 
@@ -869,7 +869,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.re
 as
 select location, max(humidity)
 from conditions
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 
 insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
@@ -881,7 +881,7 @@ SELECT * FROM mat_refresh_test order by 1,2 ;
 CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous, timescaledb.refresh_lag = '-200') as 
 select time_bucket(100, timec),  sum(humidity) 
 from conditions 
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 REFRESH MATERIALIZED VIEW conditions_grpby_view;
 select * from conditions_grpby_view order by 1, 2;
 
@@ -890,7 +890,7 @@ select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location  
 having avg(temperature) > 0
-;
+ WITH NO DATA;
 REFRESH MATERIALIZED VIEW conditions_grpby_view2;
 select * from conditions_grpby_view2 order by 1, 2;
 
@@ -911,7 +911,7 @@ create materialized view mat_test5( timec, maxt)
 as
 select time_bucket('1day', time), max(temperature)
 from conditions
-group by time_bucket('1day', time);
+group by time_bucket('1day', time) WITH NO DATA;
 
 SET timescaledb.current_timestamp_mock = '2001-03-11';
 insert into conditions values('2001-03-10', '1');

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -79,7 +79,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view', NULL, 4::integer, '12 h'::interval);
 
 -- even before running, stats shows something
@@ -229,7 +229,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view', NULL, -2::integer, '12 h'::interval);
 
@@ -289,7 +289,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value, get_constant_no_perms()
         FROM test_continuous_agg_table
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view', NULL, -2::integer, '12 h'::interval);
 
 
@@ -333,7 +333,7 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view_user_2
         timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), SUM(data) as value
         FROM test_continuous_agg_table_w_grant
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT add_refresh_continuous_aggregate_policy('test_continuous_agg_view_user_2', NULL, -2::integer, '12 h'::interval);
 
 SELECT id AS job_id FROM _timescaledb_config.bgw_job ORDER BY id desc limit 1 \gset

--- a/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
@@ -52,7 +52,7 @@ SELECT set_integer_now_func('drop_chunks_table', 'integer_now_test2');
 CREATE MATERIALIZED VIEW drop_chunks_view1 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-5', timescaledb.max_interval_per_job=100)
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 
 --raw hypertable will have 40 chunks and the mat. hypertable will have 2 and 4
 -- chunks respectively

--- a/tsl/test/sql/continuous_aggs_ddl.sql
+++ b/tsl/test/sql/continuous_aggs_ddl.sql
@@ -39,7 +39,7 @@ CREATE MATERIALIZED VIEW rename_test
   WITH ( timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1week', time), COUNT(data)
     FROM foo
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
@@ -156,7 +156,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
   )
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
         schema_name AS drop_chunks_mat_schema,
@@ -206,7 +206,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
   )
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 
 SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
         schema_name AS drop_chunks_mat_schema,
@@ -286,7 +286,7 @@ CREATE MATERIALIZED VIEW new_name_view
   )
 AS SELECT time_bucket('6', time_bucket), COUNT(agg_2_2)
     FROM new_name
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 
 -- cannot create a continuous aggregate on a continuous aggregate view
 CREATE MATERIALIZED VIEW drop_chunks_view_view
@@ -296,7 +296,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view_view
   )
 AS SELECT time_bucket('6', time_bucket), SUM(count)
     FROM drop_chunks_view
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 1
 
 DROP INDEX new_name_idx;
@@ -320,7 +320,7 @@ SELECT
   avg(v1) + avg(v2) AS avg1,
   avg(v1+v2) AS avg2
 FROM metrics
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 SET timescaledb.current_timestamp_mock = '2000-01-10';
 CALL refresh_continuous_aggregate('cagg_expr', NULL, NULL);
@@ -343,7 +343,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
   )
 AS SELECT time_bucket('5', time), max(data)
     FROM drop_chunks_table
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 
 INSERT INTO drop_chunks_table SELECT i, i FROM generate_series(0, 20) AS i;
 --dropping chunks will process the invalidations
@@ -541,13 +541,13 @@ SELECT set_integer_now_func('whatever', 'integer_now_test');
 CREATE MATERIALIZED VIEW whatever_view_1
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW whatever_view_2
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 TABLESPACE tablespace1 AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 
 INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;
 CALL refresh_continuous_aggregate('whatever_view_1', NULL, NULL);

--- a/tsl/test/sql/continuous_aggs_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_drop_chunks.sql
@@ -30,7 +30,7 @@ CREATE MATERIALIZED VIEW records_monthly
             clientId,
             avg(value) as value_avg,
             max(value)-min(value) as value_spread
-        FROM records GROUP BY bucket, clientId;
+        FROM records GROUP BY bucket, clientId WITH NO DATA;
 
 INSERT INTO clients(name) VALUES ('test-client');
 

--- a/tsl/test/sql/continuous_aggs_dump.sql
+++ b/tsl/test/sql/continuous_aggs_dump.sql
@@ -87,14 +87,14 @@ DROP MATERIALIZED VIEW IF EXISTS mat_test;
 --that the partial state survives the dump intact
 CREATE MATERIALIZED VIEW mat_before
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
-AS :QUERY_BEFORE;
+AS :QUERY_BEFORE WITH NO DATA;
 
 --materialize this VIEW after dump this tests
 --that the partialize VIEW and refresh mechanics
 --survives the dump intact
 CREATE MATERIALIZED VIEW mat_after
 WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day')
-AS :QUERY_AFTER;
+AS :QUERY_AFTER WITH NO DATA;
 
 --materialize mat_before
 

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -21,51 +21,51 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfil
 as
 select location , min(temperature)
 from conditions
-group by time_bucket('1d', timec), location;
+group by time_bucket('1d', timec), location WITH NO DATA;
 
 --valid PG option
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
 as
-select * from conditions , mat_t1;
+select * from conditions , mat_t1 WITH NO DATA;
 
 -- join multiple tables
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
-group by location;
+group by location WITH NO DATA;
 
 -- join multiple tables WITH explicit JOIN
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions JOIN mat_t1 ON true
 where conditions.location = mat_t1.c
-group by location;
+group by location WITH NO DATA;
 
 -- LATERAL multiple tables
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select location, count(*) from conditions,
 LATERAL (Select * from mat_t1 where c = conditions.location) q
-group by location;
+group by location WITH NO DATA;
 
 
 --non-hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
 select a, count(*) from mat_t1
-group by a;
+group by a WITH NO DATA;
 
 
 -- no group by
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
-select count(*) from conditions ;
+select count(*) from conditions  WITH NO DATA;
 
 -- no time_bucket in group by
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
-select count(*) from conditions group by location;
+select count(*) from conditions group by location WITH NO DATA;
 
 -- with valid query in a CTE
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -73,26 +73,26 @@ AS
 with m1 as (
 Select location, count(*) from conditions
  group by time_bucket('1week', timec) , location)
-select * from m1;
+select * from m1 WITH NO DATA;
 
 --with DISTINCT ON
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as
- select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec) ;
+ select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
 
 --aggregate with DISTINCT
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  count(location) , sum(distinct temperature) from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 
 --aggregate with FILTER
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select time_bucket('1week', timec),
  sum(temperature) filter ( where humidity > 20 ) from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 
 -- aggregate with filter in having clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -100,70 +100,70 @@ AS
 Select time_bucket('1week', timec), max(temperature)
 from conditions
  group by time_bucket('1week', timec) , location
- having sum(temperature) filter ( where humidity > 20 ) > 50;
+ having sum(temperature) filter ( where humidity > 20 ) > 50 WITH NO DATA;
 
 -- time_bucket on non partitioning column of hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket('1week', timemeasure) , location;
+ group by time_bucket('1week', timemeasure) , location WITH NO DATA;
 
 --time_bucket on expression
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket('1week', timec+ '10 minutes'::interval) , location;
+ group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
 
 --multiple time_bucket functions
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket('1week', timec) , time_bucket('1month', timec), location;
+ group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
 
 --time_bucket using additional args
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location;
+ group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
 
 --time_bucket using non-const for first argument
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select max(temperature)
 from conditions
- group by time_bucket( timeinterval, timec) , location;
+ group by time_bucket( timeinterval, timec) , location WITH NO DATA;
 
 -- ordered set aggr
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select mode() within group( order by humidity)
 from conditions
- group by time_bucket('1week', timec) ;
+ group by time_bucket('1week', timec)  WITH NO DATA;
 
 --window function
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
-;
+ WITH NO DATA;
 
 --aggregate without combine function
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select json_agg(location)
 from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature), array_agg(location)
 from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ;
 
 -- userdefined aggregate without combine function
@@ -176,7 +176,7 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), newavg(temperature::int4)
 from conditions
- group by time_bucket('1week', timec) , location;
+ group by time_bucket('1week', timec) , location WITH NO DATA;
 ;
 
 -- using subqueries
@@ -186,14 +186,14 @@ Select sum(humidity), avg(temperature::int4)
 from
 ( select humidity, temperature, location, timec
 from conditions ) q
- group by time_bucket('1week', timec) , location ;
+ group by time_bucket('1week', timec) , location  WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
 from conditions
- group by time_bucket('1week', timec) , location )  q;
+ group by time_bucket('1week', timec) , location )  q WITH NO DATA;
 
 --using limit /limit offset
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -201,14 +201,14 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-limit 10 ;
+limit 10  WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-offset 10;
+offset 10 WITH NO DATA;
 
 --using ORDER BY in view defintion
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -216,7 +216,7 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-ORDER BY 1;
+ORDER BY 1 WITH NO DATA;
 
 --using FETCH
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -224,7 +224,7 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-fetch first 10 rows only;
+fetch first 10 rows only WITH NO DATA;
 
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
@@ -233,14 +233,14 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR KEY SHARE;
+FOR KEY SHARE WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR SHARE;
+FOR SHARE WITH NO DATA;
 
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -248,14 +248,14 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR UPDATE;
+FOR UPDATE WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
-FOR NO KEY UPDATE;
+FOR NO KEY UPDATE WITH NO DATA;
 
 --tablesample clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
@@ -263,27 +263,27 @@ AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
  group by time_bucket('1week', timec) , location
-;
+ WITH NO DATA;
 
 -- ONLY in from clause
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
- group by time_bucket('1week', timec) , location ;
+ group by time_bucket('1week', timec) , location  WITH NO DATA;
 
 --grouping sets and variants
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
- group by grouping sets(time_bucket('1week', timec) , location ) ;
+ group by grouping sets(time_bucket('1week', timec) , location )  WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
-group by rollup(time_bucket('1week', timec) , location ) ;
+group by rollup(time_bucket('1week', timec) , location )  WITH NO DATA;
 
 --NO immutable functions -- check all clauses
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
@@ -293,26 +293,26 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
-group by time_bucket('1week', timec) , location  ;
+group by time_bucket('1week', timec) , location   WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum(humidity), min(location)
 from conditions
 group by time_bucket('1week', timec)
-having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08';
+having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08' WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
-group by time_bucket('1week', timec);
+group by time_bucket('1week', timec) WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( temperature ), min(location)
 from conditions
-group by time_bucket('1week', timec), test_stablefunc(humidity::int);
+group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DATA;
 
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
 CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous) AS
@@ -332,7 +332,7 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS
 Select sum( b), min(c)
 from rowsec_tab
-group by time_bucket('1', a);
+group by time_bucket('1', a) WITH NO DATA;
 
 drop table conditions cascade;
 
@@ -355,7 +355,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 joules')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 \set ON_ERROR_STOP 1
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -363,7 +363,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours')
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 
 create materialized view mat_with_test_no_inval( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '5 hours',
@@ -371,7 +371,7 @@ create materialized view mat_with_test_no_inval( timec, minl, sumt , sumh)
 as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec);
+group by time_bucket('1day', timec) WITH NO DATA;
 
 SELECT  h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -415,14 +415,14 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '32768')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 ALTER TABLE conditions ALTER timec type int;
 
@@ -431,7 +431,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483648')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 -- max_interval_per_job must be at least time_bucket
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -439,7 +439,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='10')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 --ignore_invalidation_older_than must be positive
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -447,21 +447,21 @@ create materialized view mat_with_test( timec, minl, sumt , sumh)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
         WITH ( timescaledb.continuous, timescaledb.ignore_invalidation_older_than='1 hour')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket(100, timec);
+group by time_bucket(100, timec) WITH NO DATA;
 
 \set ON_ERROR_STOP 0
 DROP TABLE conditions cascade;
@@ -485,7 +485,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '2147483647')
 as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by 1;
+group by 1 WITH NO DATA;
 
 -- custom time partition functions are not supported with invalidations
 CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
@@ -500,7 +500,7 @@ CREATE MATERIALIZED VIEW text_view
     WITH (timescaledb.continuous)
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 1
 
 -- Check that we get an error when mixing normal materialized views
@@ -508,7 +508,7 @@ CREATE MATERIALIZED VIEW text_view
 CREATE MATERIALIZED VIEW normal_mat_view AS
 SELECT time_bucket('5', text_part_func(time)), COUNT(time)
   FROM text_time
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 \set ON_ERROR_STOP 0
 DROP MATERIALIZED VIEW normal_mat_view, mat_with_test;

--- a/tsl/test/sql/continuous_aggs_invalidation.sql
+++ b/tsl/test/sql/continuous_aggs_invalidation.sql
@@ -53,7 +53,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW cond_20
 WITH (timescaledb.continuous,
@@ -61,7 +61,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW measure_10
 WITH (timescaledb.continuous,
@@ -69,7 +69,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(10, time) AS bucket, device, avg(temp) AS avg_temp
 FROM measurements
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 
 -- There should be three continuous aggregates, two on one hypertable
 -- and one on the other:
@@ -398,7 +398,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(BIGINT '1', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
-GROUP BY 1,2;
+GROUP BY 1,2 WITH NO DATA;
 
 SELECT mat_hypertable_id AS cond_1_id
 FROM _timescaledb_catalog.continuous_agg
@@ -529,7 +529,7 @@ WITH (timescaledb.continuous,
 AS
 SELECT time_bucket(2, time) AS bucket, max(value) AS max
 FROM threshold_test
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 SELECT raw_hypertable_id AS thresh_hyper_id, mat_hypertable_id AS thresh_cagg_id
 FROM _timescaledb_catalog.continuous_agg

--- a/tsl/test/sql/continuous_aggs_materialize.sql
+++ b/tsl/test/sql/continuous_aggs_materialize.sql
@@ -274,7 +274,7 @@ CREATE MATERIALIZED VIEW test_t_mat_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_test_t
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 SELECT mat_hypertable_id, raw_hypertable_id, user_view_schema, user_view_name,
        partial_view_schema, partial_view_name,
@@ -372,7 +372,7 @@ CREATE MATERIALIZED VIEW extreme_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('1', time), SUM(data) as value
         FROM continuous_agg_extreme
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 SELECT id as raw_table_id FROM _timescaledb_catalog.hypertable WHERE table_name='continuous_agg_extreme' \gset
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE raw_hypertable_id=:raw_table_id \gset
 
@@ -447,7 +447,7 @@ CREATE MATERIALIZED VIEW negative_view_5
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('5', time), COUNT(data) as value
         FROM continuous_agg_negative
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 -- two chunks, 4 buckets
 INSERT INTO continuous_agg_negative
@@ -478,7 +478,7 @@ CREATE MATERIALIZED VIEW negative_view_5
             WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2')
 AS SELECT time_bucket('5', time), COUNT(data) as value
    FROM continuous_agg_negative
-   GROUP BY 1;
+   GROUP BY 1 WITH NO DATA;
 
 -- we can handle values near max
 INSERT INTO continuous_agg_negative VALUES (:big_int_max-3, 201);
@@ -509,7 +509,7 @@ CREATE MATERIALIZED VIEW max_mat_view
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4', timescaledb.refresh_lag='-2')
     AS SELECT time_bucket('2', time), COUNT(data) as value
         FROM continuous_agg_max_mat
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 INSERT INTO continuous_agg_max_mat SELECT i, i FROM generate_series(0, 10) AS i;
 SET client_min_messages TO LOG;
@@ -580,7 +580,7 @@ CREATE MATERIALIZED VIEW max_mat_view_t
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.max_interval_per_job='4 hours', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time), COUNT(data) as value
         FROM continuous_agg_max_mat_t
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 INSERT INTO continuous_agg_max_mat_t
     SELECT i, i FROM
@@ -609,7 +609,7 @@ CREATE MATERIALIZED VIEW max_mat_view_timestamp
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', time)
         FROM continuous_agg_max_mat_timestamp
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 INSERT INTO continuous_agg_max_mat_timestamp
     SELECT generate_series('2019-09-09 1:00'::TIMESTAMPTZ, '2019-09-09 10:00', '1 hour');
@@ -626,7 +626,7 @@ CREATE MATERIALIZED VIEW max_mat_view_date
     WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.refresh_lag='-7 days')
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 INSERT INTO continuous_agg_max_mat_date
     SELECT generate_series('2019-09-01'::DATE, '2019-09-010 10:00', '1 day');
@@ -662,7 +662,7 @@ CREATE MATERIALIZED VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 REFRESH MATERIALIZED VIEW timezone_test_summary;
 
@@ -684,7 +684,7 @@ CREATE MATERIALIZED VIEW timezone_test_summary
     WITH (timescaledb.continuous,timescaledb.materialized_only=true)
     AS SELECT time_bucket('5m', time)
         FROM timezone_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 REFRESH MATERIALIZED VIEW timezone_test_summary;
 
@@ -706,7 +706,7 @@ CREATE MATERIALIZED VIEW continuous_agg_int_max
     WITH (timescaledb.continuous, timescaledb.refresh_lag='0')
     AS SELECT time_bucket('10', time), COUNT(data) as value
         FROM continuous_agg_int
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 INSERT INTO continuous_agg_int values (-10, 100), (1,100), (10, 100);
 select chunk_name, range_start_integer, range_end_integer 
@@ -728,7 +728,7 @@ CREATE MATERIALIZED VIEW continuous_agg_ts_max_view
     WITH (timescaledb.continuous, timescaledb.max_interval_per_job='365 days', timescaledb.refresh_lag='-2 hours')
     AS SELECT time_bucket('2 hours', timecol), COUNT(data) as value
         FROM continuous_agg_ts_max_t
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 INSERT INTO continuous_agg_ts_max_t
     values ('1969-01-01 1:00'::timestamptz, 10);

--- a/tsl/test/sql/continuous_aggs_multi.sql
+++ b/tsl/test/sql/continuous_aggs_multi.sql
@@ -22,14 +22,14 @@ WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.mate
 AS
     SELECT time_bucket( 2, timeval), COUNT(col1) 
     FROM continuous_agg_test
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW cagg_2( timed, grp, maxval) 
 WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.materialized_only=true   )
 AS
     SELECT time_bucket(2, timeval), col1, max(col2) 
     FROM continuous_agg_test
-    GROUP BY 1, 2;
+    GROUP BY 1, 2 WITH NO DATA;
 
 select view_name, view_owner, materialization_hypertable 
 from timescaledb_information.continuous_aggregates ORDER BY 1;
@@ -108,13 +108,13 @@ WITH ( timescaledb.continuous , timescaledb.refresh_lag = '-2', timescaledb.mate
 AS
     SELECT time_bucket( 2, timeval), COUNT(col1) 
     FROM continuous_agg_test
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 CREATE MATERIALIZED VIEW cagg_2( timed, maxval) 
 WITH ( timescaledb.continuous , timescaledb.refresh_lag = '2', timescaledb.materialized_only = true)
 AS
     SELECT time_bucket(2, timeval), max(col2) 
     FROM continuous_agg_test
-    GROUP BY 1;
+    GROUP BY 1 WITH NO DATA;
 refresh materialized view cagg_1;
 select * from cagg_1 order by 1;
 refresh materialized view cagg_2;
@@ -163,21 +163,21 @@ CREATE MATERIALIZED VIEW cagg_iia1( timed, cnt )
 AS
 SELECT time_bucket( 2, timeval), COUNT(col1)
 FROM continuous_agg_test_ignore_invalidation_older_than
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW cagg_iia2( timed, maxval)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 10, timescaledb.materialized_only=true)
 AS
 SELECT time_bucket(2, timeval), max(col2)
 FROM continuous_agg_test_ignore_invalidation_older_than
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW cagg_iia3( timed, maxval)
         WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-2', timescaledb.ignore_invalidation_older_than = 0, timescaledb.materialized_only=true)
 AS
 SELECT time_bucket(2, timeval), max(col2)
 FROM continuous_agg_test_ignore_invalidation_older_than
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 refresh materialized view cagg_iia1;
 select * from cagg_iia1 order by 1;
@@ -278,14 +278,14 @@ WITH (timescaledb.continuous, timescaledb.refresh_lag = 10, timescaledb.max_inte
 AS
 SELECT time_bucket(10, a), count(*)
 FROM foo
-GROUP BY time_bucket(10, a);
+GROUP BY time_bucket(10, a) WITH NO DATA;
 
 CREATE MATERIALIZED VIEW mat_m2(a, countb)
 WITH (timescaledb.continuous, timescaledb.refresh_lag = 0, timescaledb.max_interval_per_job=100)
 AS
 SELECT time_bucket(5, a), count(*)
 FROM foo
-GROUP BY time_bucket(5, a);
+GROUP BY time_bucket(5, a) WITH NO DATA;
 
 select view_name, materialized_only from timescaledb_information.continuous_aggregates
 WHERE view_name::text like 'mat_m%'

--- a/tsl/test/sql/continuous_aggs_permissions.sql
+++ b/tsl/test/sql/continuous_aggs_permissions.sql
@@ -30,7 +30,7 @@ WITH ( timescaledb.continuous, timescaledb.refresh_lag = '-200')
 as
 select location, max(humidity)
 from conditions
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 
 SELECT add_refresh_continuous_aggregate_policy('mat_refresh_test', NULL, -200::integer, '12 h'::interval);
 
@@ -117,7 +117,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity)
 from conditions_for_perm_check
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 
 --cannot create mat view in a schema without create privileges
 CREATE MATERIALIZED VIEW custom_schema.mat_perm_view_test
@@ -125,7 +125,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
@@ -134,7 +134,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity), get_constant()
 from conditions_for_perm_check_w_grant
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 
 --this should fail
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
@@ -146,7 +146,7 @@ WITH ( timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.r
 as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
-group by time_bucket(100, timec), location;
+group by time_bucket(100, timec), location WITH NO DATA;
 
 REFRESH MATERIALIZED VIEW mat_perm_view_test;
 SELECT * FROM mat_perm_view_test;

--- a/tsl/test/sql/continuous_aggs_policy.sql
+++ b/tsl/test/sql/continuous_aggs_policy.sql
@@ -31,7 +31,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 SELECT a, count(b)
 FROM int_tab
-GROUP BY time_bucket(1, a), a;
+GROUP BY time_bucket(1, a), a WITH NO DATA;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
@@ -83,7 +83,7 @@ CREATE MATERIALIZED VIEW max_mat_view_date
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_max_mat_date
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 \set ON_ERROR_STOP 0
 SELECT add_refresh_continuous_aggregate_policy('max_mat_view_date', '2 days'::interval, 10 , '1 day'::interval); 
@@ -104,7 +104,7 @@ CREATE MATERIALIZED VIEW max_mat_view_timestamp
     WITH (timescaledb.continuous, timescaledb.materialized_only=true)
     AS SELECT time_bucket('7 days', time)
         FROM continuous_agg_timestamp
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 SELECT add_refresh_continuous_aggregate_policy('max_mat_view_timestamp', '10 day'::interval, '1 h'::interval , '1 h'::interval) as job_id \gset
 CALL run_job(:job_id);
@@ -136,7 +136,7 @@ WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
 SELECT time_bucket( SMALLINT '1', a) , count(*)
 FROM smallint_tab
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 0
 SELECT add_refresh_continuous_aggregate_policy('mat_smallint', 15, 0 , '1 h'::interval);
 SELECT add_refresh_continuous_aggregate_policy('mat_smallint', 98898::smallint , 0::smallint, '1 h'::interval);

--- a/tsl/test/sql/continuous_aggs_query.sql.in
+++ b/tsl/test/sql/continuous_aggs_query.sql.in
@@ -50,7 +50,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
-group by time_bucket('1day', timec), location;
+group by time_bucket('1day', timec), location WITH NO DATA;
 
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 --compute time_bucketted max+bucket_width for the materialized view
@@ -64,7 +64,7 @@ WITH ( timescaledb.continuous, timescaledb.max_interval_per_job='365 days')
 as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions
-group by time_bucket('1day', timec), location;
+group by time_bucket('1day', timec), location WITH NO DATA;
 --time that refresh assumes as now() for repeatability
 SET timescaledb.current_timestamp_mock = '2018-12-31 00:00';
 SELECT time_bucket('1day' , q.timeval+ '1day'::interval)

--- a/tsl/test/sql/continuous_aggs_tableam.sql
+++ b/tsl/test/sql/continuous_aggs_tableam.sql
@@ -41,12 +41,12 @@ INSERT INTO whatever SELECT i, i FROM generate_series(0, 29) AS i;
 CREATE MATERIALIZED VIEW tableam_view USING heap2
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW notableam_view
 WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
 SELECT time_bucket('5', time), COUNT(data)
-  FROM whatever GROUP BY 1;
+  FROM whatever GROUP BY 1 WITH NO DATA;
 
 SELECT user_view, mat_table, amname
 FROM cagg_info,

--- a/tsl/test/sql/continuous_aggs_union_view.sql.in
+++ b/tsl/test/sql/continuous_aggs_union_view.sql.in
@@ -23,7 +23,7 @@ INSERT INTO metrics(time, device_id, value) SELECT '2000-01-01'::timestamptz, de
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 
 ALTER TABLE metrics DROP COLUMN f2;
 
@@ -72,7 +72,7 @@ DROP MATERIALIZED VIEW metrics_summary;
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 
 -- this should be view without union
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
@@ -102,7 +102,7 @@ DROP MATERIALIZED VIEW metrics_summary;
 CREATE MATERIALIZED VIEW metrics_summary
   WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS
-  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1;
+  SELECT time_bucket('1d',time), avg(value) FROM metrics GROUP BY 1 WITH NO DATA;
 
 -- should be marked as materialized_only in catalog
 SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_agg WHERE user_view_name='metrics_summary';
@@ -152,7 +152,7 @@ SELECT set_integer_now_func('boundary_test','boundary_test_int_now');
 CREATE MATERIALIZED VIEW boundary_view
   WITH (timescaledb.continuous)
 AS
-  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1;
+  SELECT time_bucket(10,time), avg(value) FROM boundary_test GROUP BY 1 WITH NO DATA;
 
 INSERT INTO boundary_test SELECT i, i*10 FROM generate_series(10,40,10) AS g(i);
 
@@ -211,7 +211,7 @@ SELECT time_bucket(1, a), count(*), sum(b+c), max(c)-min(b), avg(c)::int
 FROM ht_intdata
 WHERE b < 16
 GROUP BY time_bucket(1, a)
-HAVING sum(c) > 50;
+HAVING sum(c) > 50 WITH NO DATA;
 
 REFRESH MATERIALIZED VIEW mat_m1;
 SELECT view_name, completed_threshold from timescaledb_information.continuous_aggregate_stats
@@ -260,7 +260,7 @@ SELECT time_bucket(5, a), sum(b+c)
 FROM ht_intdata
 WHERE b < 16 and c > 20
 GROUP BY time_bucket(5, a)
-HAVING sum(c) > 50 and avg(b)::int > 12 ;
+HAVING sum(c) > 50 and avg(b)::int > 12  WITH NO DATA;
 
 INSERT into ht_intdata values( 42 , 15 , 80);
 INSERT into ht_intdata values( 42 , 15 , 18);
@@ -338,42 +338,42 @@ WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(SMALLINT '10', time) AS bucket, avg(value)
 FROM smallint_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW int_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(5, time) AS bucket, avg(value)
 FROM int_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW bigint_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, avg(value)
 FROM bigint_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW date_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM date_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW timestamp_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamp_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 CREATE MATERIALIZED VIEW timestamptz_agg
 WITH (timescaledb.continuous)
 AS
 SELECT time_bucket('2 days', time) AS bucket, avg(value)
 FROM timestamptz_table
-GROUP BY 1;
+GROUP BY 1 WITH NO DATA;
 
 -- Refresh first without data
 CALL refresh_continuous_aggregate('int_agg', NULL, NULL);

--- a/tsl/test/sql/continuous_aggs_watermark.sql
+++ b/tsl/test/sql/continuous_aggs_watermark.sql
@@ -112,7 +112,7 @@ CREATE MATERIALIZED VIEW cit_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(time)
         FROM ca_inval_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 INSERT INTO ca_inval_test SELECT generate_series(0, 5);
 
@@ -168,7 +168,7 @@ CREATE MATERIALIZED VIEW continuous_view
     WITH ( timescaledb.continuous)
     AS SELECT time_bucket('5', time), COUNT(location)
         FROM ts_continuous_test
-        GROUP BY 1;
+        GROUP BY 1 WITH NO DATA;
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -516,7 +516,7 @@ INSERT INTO disttable VALUES
 CREATE MATERIALIZED VIEW disttable_cagg WITH (timescaledb.continuous)
 AS SELECT time_bucket('2 days', time), device, max(value)
     FROM disttable
-    GROUP BY 1, 2;
+    GROUP BY 1, 2 WITH NO DATA;
 \set ON_ERROR_STOP 1
 
 DROP TABLE disttable;

--- a/tsl/test/sql/include/cont_agg_equal.sql
+++ b/tsl/test/sql/include/cont_agg_equal.sql
@@ -10,7 +10,7 @@ DROP MATERIALIZED VIEW IF EXISTS mat_test;
 CREATE MATERIALIZED VIEW mat_test
 WITH ( timescaledb.continuous)
 as :QUERY
-;
+ WITH NO DATA;
 
 select h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",

--- a/tsl/test/sql/include/jit_load.sql
+++ b/tsl/test/sql/include/jit_load.sql
@@ -27,7 +27,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   jit_test_contagg
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;

--- a/tsl/test/sql/include/transparent_decompression_query.sql
+++ b/tsl/test/sql/include/transparent_decompression_query.sql
@@ -816,7 +816,7 @@ SELECT time_bucket ('1d', time) AS time,
 FROM :TEST_TABLE
 WHERE device_id = 1
 GROUP BY 1,
-    2;
+    2 WITH NO DATA;
 
 SET timescaledb.current_timestamp_mock = 'Wed Jan 19 15:55:00 2000 PST';
 

--- a/tsl/test/sql/read_only.sql
+++ b/tsl/test/sql/read_only.sql
@@ -239,7 +239,7 @@ SELECT
   max(metric)-min(metric) as metric_spread
 FROM
   test_contagg
-GROUP BY bucket, device_id;
+GROUP BY bucket, device_id WITH NO DATA;
 
 -- policy API
 CALL _timescaledb_internal.policy_compression(1,'{}');


### PR DESCRIPTION
This commit will add support for `WITH NO DATA` when creating a
continuous aggregate and will refresh the continuous aggregate when
creating it unless `WITH NO DATA` is provided.
    
All test cases are also updated.
    
Closes #2341