### PR TITLE
Fix caggs width expression handling on int based hypertables

### DIFF
--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -940,5 +940,126 @@ DROP MATERIALIZED VIEW whatever_view_1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_24_chunk
 DROP MATERIALIZED VIEW whatever_view_2;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_14_25_chunk
+-- test bucket width expressions on integer hypertables
+CREATE TABLE metrics_int2 (
+  time int2 NOT NULL,
+  device_id int,
+  v1 float,
+  v2 float
+);
+CREATE TABLE metrics_int4 (
+  time int4 NOT NULL,
+  device_id int,
+  v1 float,
+  v2 float
+);
+CREATE TABLE metrics_int8 (
+  time int8 NOT NULL,
+  device_id int,
+  v1 float,
+  v2 float
+);
+SELECT create_hypertable (('metrics_' || dt)::regclass, 'time', chunk_time_interval => 10)
+FROM (
+  VALUES ('int2'),
+    ('int4'),
+    ('int8')) v (dt);
+     create_hypertable      
+----------------------------
+ (15,public,metrics_int2,t)
+ (16,public,metrics_int4,t)
+ (17,public,metrics_int8,t)
+(3 rows)
+
+CREATE OR REPLACE FUNCTION int2_now ()
+  RETURNS int2
+  LANGUAGE SQL
+  STABLE
+  AS $$
+  SELECT 10::int2
+$$;
+CREATE OR REPLACE FUNCTION int4_now ()
+  RETURNS int4
+  LANGUAGE SQL
+  STABLE
+  AS $$
+  SELECT 10::int4
+$$;
+CREATE OR REPLACE FUNCTION int8_now ()
+  RETURNS int8
+  LANGUAGE SQL
+  STABLE
+  AS $$
+  SELECT 10::int8
+$$;
+SELECT set_integer_now_func (('metrics_' || dt)::regclass, (dt || '_now')::regproc)
+FROM (
+  VALUES ('int2'),
+    ('int4'),
+    ('int8')) v (dt);
+ set_integer_now_func 
+----------------------
+ 
+ 
+ 
+(3 rows)
+
+-- width expression for int2 hypertables
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(1::smallint, time)
+FROM metrics_int2
+GROUP BY 1;
+NOTICE:  continuous aggregate "width_expr" is already up-to-date
+DROP MATERIALIZED VIEW width_expr;
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(1::smallint + 2::smallint, time)
+FROM metrics_int2
+GROUP BY 1;
+NOTICE:  continuous aggregate "width_expr" is already up-to-date
+DROP MATERIALIZED VIEW width_expr;
+-- width expression for int4 hypertables
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(1, time)
+FROM metrics_int4
+GROUP BY 1;
+NOTICE:  continuous aggregate "width_expr" is already up-to-date
+DROP MATERIALIZED VIEW width_expr;
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(1 + 2, time)
+FROM metrics_int4
+GROUP BY 1;
+NOTICE:  continuous aggregate "width_expr" is already up-to-date
+DROP MATERIALIZED VIEW width_expr;
+-- width expression for int8 hypertables
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(1, time)
+FROM metrics_int8
+GROUP BY 1;
+NOTICE:  continuous aggregate "width_expr" is already up-to-date
+DROP MATERIALIZED VIEW width_expr;
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(1 + 2, time)
+FROM metrics_int8
+GROUP BY 1;
+NOTICE:  continuous aggregate "width_expr" is already up-to-date
+DROP MATERIALIZED VIEW width_expr;
+\set ON_ERROR_STOP 0
+-- non-immutable expresions should be rejected
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(extract(year FROM now())::smallint, time)
+FROM metrics_int2
+GROUP BY 1;
+ERROR:  first argument to time_bucket function should be an immutable expression for continuous aggregate query
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(extract(year FROM now())::int, time)
+FROM metrics_int4
+GROUP BY 1;
+ERROR:  first argument to time_bucket function should be an immutable expression for continuous aggregate query
+CREATE MATERIALIZED VIEW width_expr WITH (timescaledb.continuous) AS
+SELECT time_bucket(extract(year FROM now())::int, time)
+FROM metrics_int8
+GROUP BY 1;
+ERROR:  first argument to time_bucket function should be an immutable expression for continuous aggregate query
+\set ON_ERROR_STOP 1
 DROP TABLESPACE tablespace1;
 DROP TABLESPACE tablespace2;

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -135,7 +135,7 @@ AS
 Select max(temperature)
 from conditions
  group by time_bucket( timeinterval, timec) , location WITH NO DATA;
-ERROR:  first argument to time_bucket function should be a constant for continuous aggregate query
+ERROR:  first argument to time_bucket function should be an immutable expression for continuous aggregate query
 -- ordered set aggr
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 AS


### PR DESCRIPTION
This patch changes the time_bucket validation to constify the width
argument so any immutable expression will be allowed. This change
allows continuous aggregates on hypertables with int8 time dimension
without requiring a workaround from a user to get the time_bucket
call accepted.

Fixes #1597 