### PR TITLE
Run postgres regression test suite as part of our CI

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -106,6 +106,9 @@ jobs:
         set -o pipefail
         make -k -C build installcheck ${{ matrix.installcheck_args }} | tee installcheck.log
 
+    - name: pginstallcheck
+      run: make -C build pginstallcheck
+
     - name: coverage
       if: matrix.coverage
       run: make -j $MAKE_JOBS -k -C build coverage


### PR DESCRIPTION
During migration of CI from travis to github actions running
postgres regression test suite was missed. This patch changes
our regression workflow to run postgres regression test suite
as well.