### PR TITLE
Make block chunks API internal

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -184,16 +184,6 @@ CREATE OR REPLACE FUNCTION detach_data_node(
 ) RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_data_node_detach' LANGUAGE C VOLATILE;
 
--- Block new chunk creation on a data node for a distributed hypertable. NULL hypertable means it will block
--- chunks for all distributed hypertables
-CREATE OR REPLACE FUNCTION block_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL, force BOOLEAN = FALSE) RETURNS INTEGER
-AS '@MODULE_PATHNAME@', 'ts_data_node_block_new_chunks' LANGUAGE C VOLATILE;
-
--- Reallow chunk creations on a blocked data node for a distributed hypertable. NULL hypertable means it will
--- allow chunks for all distributed hypertables
-CREATE OR REPLACE FUNCTION allow_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL) RETURNS INTEGER
-AS '@MODULE_PATHNAME@', 'ts_data_node_allow_new_chunks' LANGUAGE C VOLATILE;
-
 -- Execute query on a specified list of data nodes. By default node_list is NULL, which means
 -- to execute the query on every data node
 CREATE OR REPLACE FUNCTION distributed_exec(query TEXT, node_list name[] = NULL) RETURNS VOID

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -8,3 +8,15 @@ AS '@MODULE_PATHNAME@', 'ts_chunk_index_clone' LANGUAGE C VOLATILE STRICT;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_index_replace(chunk_index_oid_old OID, chunk_index_oid_new OID) RETURNS VOID
 AS '@MODULE_PATHNAME@', 'ts_chunk_index_replace' LANGUAGE C VOLATILE STRICT;
+
+-- Block new chunk creation on a data node for a distributed
+-- hypertable. NULL hypertable means it will block chunks for all
+-- distributed hypertables
+CREATE OR REPLACE FUNCTION _timescaledb_internal.block_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL, force BOOLEAN = FALSE) RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_data_node_block_new_chunks' LANGUAGE C VOLATILE;
+
+-- Allow chunk creation on a blocked data node for a distributed
+-- hypertable. NULL hypertable means it will allow chunks for all
+-- distributed hypertables
+CREATE OR REPLACE FUNCTION _timescaledb_internal.allow_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL) RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_data_node_allow_new_chunks' LANGUAGE C VOLATILE;

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -26,12 +26,10 @@ WHERE oid IN (
  add_job
  add_reorder_policy
  add_retention_policy
- allow_new_chunks
  alter_job
  approximate_row_count
  attach_data_node
  attach_tablespace
- block_new_chunks
  chunk_compression_stats
  chunks_detailed_size
  compress_chunk
@@ -76,5 +74,5 @@ WHERE oid IN (
  timescaledb_fdw_validator
  timescaledb_post_restore
  timescaledb_pre_restore
-(57 rows)
+(55 rows)
 

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -860,14 +860,14 @@ SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 (6 rows)
 
 -- Block one data node for specific hypertable
-SELECT * FROM block_new_chunks('data_node_1', 'disttable');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'disttable');
  block_new_chunks 
 ------------------
                 1
 (1 row)
 
 -- Block one data node for all hypertables
-SELECT * FROM block_new_chunks('data_node_1');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1');
 NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "disttable"
  block_new_chunks 
 ------------------
@@ -911,26 +911,26 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 -- some ERROR cases
 \set ON_ERROR_STOP 0
 -- Will error due to under-replication
-SELECT * FROM block_new_chunks('data_node_2');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2');
 ERROR:  blocking new chunks on data node "data_node_2" risks making new data for hypertable "disttable" under-replicated
 -- can't block/allow non-existing data node
-SELECT * FROM block_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_12345', 'disttable');
 ERROR:  server "data_node_12345" does not exist
-SELECT * FROM allow_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_12345', 'disttable');
 ERROR:  server "data_node_12345" does not exist
 -- NULL data node
-SELECT * FROM block_new_chunks(NULL, 'disttable');
+SELECT * FROM _timescaledb_internal.block_new_chunks(NULL, 'disttable');
 ERROR:  invalid node_name: cannot be NULL
-SELECT * FROM allow_new_chunks(NULL, 'disttable');
+SELECT * FROM _timescaledb_internal.allow_new_chunks(NULL, 'disttable');
 ERROR:  invalid node_name: cannot be NULL
 -- can't block/allow on non hypertable
-SELECT * FROM block_new_chunks('data_node_1', 'devices');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'devices');
 ERROR:  table "devices" is not a hypertable
-SELECT * FROM allow_new_chunks('data_node_1', 'devices');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1', 'devices');
 ERROR:  table "devices" is not a hypertable
 \set ON_ERROR_STOP 1
 -- Force block all data nodes
-SELECT * FROM block_new_chunks('data_node_2', force => true);
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2', force => true);
 WARNING:  new data for hypertable "disttable" will be under-replicated due to blocking new chunks on data node "data_node_2"
 WARNING:  new data for hypertable "disttable_2" will be under-replicated due to blocking new chunks on data node "data_node_2"
  block_new_chunks 
@@ -938,7 +938,7 @@ WARNING:  new data for hypertable "disttable_2" will be under-replicated due to 
                 2
 (1 row)
 
-SELECT * FROM block_new_chunks('data_node_1', force => true);
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', force => true);
 NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "disttable"
 NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "disttable_2"
  block_new_chunks 
@@ -946,7 +946,7 @@ NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "d
                 0
 (1 row)
 
-SELECT * FROM block_new_chunks('data_node_3', force => true);
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_3', force => true);
 WARNING:  new data for hypertable "disttable" will be under-replicated due to blocking new chunks on data node "data_node_3"
 WARNING:  new data for hypertable "disttable_2" will be under-replicated due to blocking new chunks on data node "data_node_3"
  block_new_chunks 
@@ -972,19 +972,19 @@ INSERT INTO disttable VALUES ('2019-11-02 02:45', 1, 13.3);
 ERROR:  no available data nodes (detached or blocked for new chunks) for hypertable "disttable"
 \set ON_ERROR_STOP 1
 -- unblock data nodes for all hypertables
-SELECT * FROM allow_new_chunks('data_node_1');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1');
  allow_new_chunks 
 ------------------
                 2
 (1 row)
 
-SELECT * FROM allow_new_chunks('data_node_2');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_2');
  allow_new_chunks 
 ------------------
                 2
 (1 row)
 
-SELECT * FROM allow_new_chunks('data_node_3');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_3');
  allow_new_chunks 
 ------------------
                 2
@@ -1173,9 +1173,9 @@ NOTICE:  adding not-null constraint to column "time"
 -- error due to missing permissions
 SELECT * FROM detach_data_node('data_node_4', 'disttable_3');
 ERROR:  must be owner of hypertable "disttable_3"
-SELECT * FROM block_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_4', 'disttable_3');
 ERROR:  must be owner of hypertable "disttable_3"
-SELECT * FROM allow_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_4', 'disttable_3');
 ERROR:  must be owner of hypertable "disttable_3"
 \set ON_ERROR_STOP 1
 -- detach table(s) where user has permissions, otherwise show NOTICE

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -440,10 +440,10 @@ CREATE TABLE devices(device int, name text);
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 
 -- Block one data node for specific hypertable
-SELECT * FROM block_new_chunks('data_node_1', 'disttable');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'disttable');
 
 -- Block one data node for all hypertables
-SELECT * FROM block_new_chunks('data_node_1');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1');
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 
@@ -459,22 +459,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 -- some ERROR cases
 \set ON_ERROR_STOP 0
 -- Will error due to under-replication
-SELECT * FROM block_new_chunks('data_node_2');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2');
 -- can't block/allow non-existing data node
-SELECT * FROM block_new_chunks('data_node_12345', 'disttable');
-SELECT * FROM allow_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_12345', 'disttable');
 -- NULL data node
-SELECT * FROM block_new_chunks(NULL, 'disttable');
-SELECT * FROM allow_new_chunks(NULL, 'disttable');
+SELECT * FROM _timescaledb_internal.block_new_chunks(NULL, 'disttable');
+SELECT * FROM _timescaledb_internal.allow_new_chunks(NULL, 'disttable');
 -- can't block/allow on non hypertable
-SELECT * FROM block_new_chunks('data_node_1', 'devices');
-SELECT * FROM allow_new_chunks('data_node_1', 'devices');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'devices');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1', 'devices');
 \set ON_ERROR_STOP 1
 
 -- Force block all data nodes
-SELECT * FROM block_new_chunks('data_node_2', force => true);
-SELECT * FROM block_new_chunks('data_node_1', force => true);
-SELECT * FROM block_new_chunks('data_node_3', force => true);
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2', force => true);
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', force => true);
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_3', force => true);
 
 -- All data nodes are blocked
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
@@ -485,9 +485,9 @@ INSERT INTO disttable VALUES ('2019-11-02 02:45', 1, 13.3);
 \set ON_ERROR_STOP 1
 
 -- unblock data nodes for all hypertables
-SELECT * FROM allow_new_chunks('data_node_1');
-SELECT * FROM allow_new_chunks('data_node_2');
-SELECT * FROM allow_new_chunks('data_node_3');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_2');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_3');
 
 SELECT table_name, node_name, block_chunks
 FROM _timescaledb_catalog.hypertable_data_node dn,
@@ -566,8 +566,8 @@ SELECT * FROM create_distributed_hypertable('disttable_4', 'time', replication_f
 \set ON_ERROR_STOP 0
 -- error due to missing permissions
 SELECT * FROM detach_data_node('data_node_4', 'disttable_3');
-SELECT * FROM block_new_chunks('data_node_4', 'disttable_3');
-SELECT * FROM allow_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_4', 'disttable_3');
 \set ON_ERROR_STOP 1
 
 -- detach table(s) where user has permissions, otherwise show NOTICE


### PR DESCRIPTION
This change moves the block chunks functionality to the internal
namespace since it won't be part of the public API for the 2.0
release.

Fixes #2236