### PR TITLE
Filter materialized hypertables in view

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -25,6 +25,8 @@ CREATE OR REPLACE VIEW timescaledb_information.hypertables AS
         INNER JOIN pg_tables t
         ON ht.table_name=t.tablename
            AND ht.schema_name=t.schemaname
+        LEFT OUTER JOIN _timescaledb_catalog.continuous_agg ca
+        ON ca.mat_hypertable_id=ht.id
         LEFT OUTER JOIN (
             SELECT hypertable_id,
             array_agg(tablespace_name ORDER BY id) as tablespace_list
@@ -38,7 +40,7 @@ CREATE OR REPLACE VIEW timescaledb_information.hypertables AS
                       GROUP BY hypertable_id) dn
     ON ht.id = dn.hypertable_id
     WHERE ht.compressed is false --> no internal compression tables
-;
+    AND ca.mat_hypertable_id IS NULL;
 
 CREATE OR REPLACE VIEW timescaledb_information.license AS
   SELECT _timescaledb_internal.license_edition() as edition,

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -137,6 +137,16 @@ FROM _timescaledb_catalog.continuous_agg ca
 INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_m1'
 \gset
+-- Materialized hypertable for mat_m1 should not be visible in the
+-- hypertables view:
+SELECT table_schema, table_name
+FROM timescaledb_information.hypertables;
+ table_schema | table_name 
+--------------+------------
+ public       | foo
+ public       | conditions
+(2 rows)
+
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -114,6 +114,11 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_m1'
 \gset
 
+-- Materialized hypertable for mat_m1 should not be visible in the
+-- hypertables view:
+SELECT table_schema, table_name
+FROM timescaledb_information.hypertables;
+
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select


### PR DESCRIPTION
This change filters materialized hypertables from the hypertables
view, similar to how internal compression hypertables are
filtered.

Materialized hypertables are internal objects created as a side effect
of creating a continuous aggregate, and these internal hypertables are
still listed in the continuous_aggregates view.

Fixes #2383