### PR TITLE
Error on create continuous aggregate with data

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3307,6 +3307,11 @@ process_create_table_as(ProcessUtilityArgs *args)
 							   "parameters."),
 					 errhint("Use only parameters with the \"timescaledb.\" prefix when "
 							 "creating a continuous aggregate.")));
+
+		if (!stmt->into->skipData)
+			PreventInTransactionBlock(args->context == PROCESS_UTILITY_TOPLEVEL,
+									  "CREATE MATERIALIZED VIEW ... WITH DATA");
+
 		return ts_cm_functions->process_cagg_viewstmt(args->parsetree,
 													  args->query_string,
 													  args->pstmt,

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -423,3 +423,49 @@ SELECT * FROM weekly_temp_without_data;
  Sun May 03 17:00:00 2020 PDT |      3 |               19
 (8 rows)
 
+-- These should fail since we do not allow refreshing inside a
+-- transaction, not even as part of CREATE MATERIALIZED VIEW.
+\set ON_ERROR_STOP 0
+DO LANGUAGE PLPGSQL $$ BEGIN
+CREATE MATERIALIZED VIEW weekly_conditions
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH DATA;
+END $$;
+ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot be executed from a function
+BEGIN;
+CREATE MATERIALIZED VIEW weekly_conditions
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH DATA;
+ERROR:  CREATE MATERIALIZED VIEW ... WITH DATA cannot run inside a transaction block
+COMMIT;
+\set ON_ERROR_STOP 1
+-- This should not fail since we do not refresh the continuous
+-- aggregate.
+DO LANGUAGE PLPGSQL $$ BEGIN
+CREATE MATERIALIZED VIEW weekly_conditions_1
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH NO DATA;
+END $$;
+NOTICE:  adding index _materialized_hypertable_13_device_day_idx ON _timescaledb_internal._materialized_hypertable_13 USING BTREE(device, day)
+BEGIN;
+CREATE MATERIALIZED VIEW weekly_conditions_2
+WITH (timescaledb.continuous,
+      timescaledb.materialized_only=true)
+AS
+SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
+FROM conditions
+GROUP BY 1,2 WITH NO DATA;
+NOTICE:  adding index _materialized_hypertable_14_device_day_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(device, day)
+COMMIT;


### PR DESCRIPTION
If a continuous aggregate is created using `CREATE MATERIALIZED VIEW`
using the `WITH DATA` option, it will fail with a segmentation fault if
executed inside a transaction or block. This is because starting a new
transaction in the middle of the statement will reset the SPI stack.

This commit fixes this by raising an error if `CREATE MATERIALIZED
VIEW` is not executed on top-level and `WITH DATA` is used either
directly or indirectly.

Closes #2371