### PR TITLE
Allow REFRESH MATERIALIZED VIEW to refresh caggs

### DIFF
--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -409,7 +409,9 @@ SELECT * FROM weekly_temp_with_data;
  Sun May 03 17:00:00 2020 PDT |      3 |               19
 (8 rows)
 
-CALL refresh_continuous_aggregate('weekly_temp_without_data', NULL, NULL);
+-- Test that REFRESH MATERIALIZED VIEW works as an alternative to
+-- refresh_continuous_aggregate()
+REFRESH MATERIALIZED VIEW weekly_temp_without_data;
 SELECT * FROM weekly_temp_without_data;
              day              | device |     avg_temp     
 ------------------------------+--------+------------------

--- a/tsl/test/sql/continuous_aggs_refresh.sql
+++ b/tsl/test/sql/continuous_aggs_refresh.sql
@@ -237,7 +237,9 @@ GROUP BY 1,2 WITH DATA;
 SELECT * FROM weekly_temp_without_data;
 SELECT * FROM weekly_temp_with_data;
 
-CALL refresh_continuous_aggregate('weekly_temp_without_data', NULL, NULL);
+-- Test that REFRESH MATERIALIZED VIEW works as an alternative to
+-- refresh_continuous_aggregate()
+REFRESH MATERIALIZED VIEW weekly_temp_without_data;
 
 SELECT * FROM weekly_temp_without_data;
 


### PR DESCRIPTION
It is now possible to use `REFRESH MATERIALIZED VIEW` as an
alternative to `refresh_continuous_aggregate` when doing "infinite"
refreshes.