### PR TITLE
Fix failing isolation test on PG11.0

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -111,7 +111,7 @@ if event_type != "pull_request":
     "llvm_config": "/usr/bin/llvm-config-8",
     "clang": "clang-8",
     "extra_packages": "llvm-8 llvm-8-dev llvm-8-tools",
-    "installcheck_args": "IGNORES='continuous_aggs_insert continuous_aggs_multi'"
+    "installcheck_args": "IGNORES='continuous_aggs_insert continuous_aggs_multi continuous_aggs_concurrent_refresh'"
   }
   m["include"].append(build_debug_config(pg11_debug_earliest))
 


### PR DESCRIPTION
Early version of PG11 produces slightly different output for isolation
tests. Thus the affected tests are ignored.
continuous_aggs_concurrent_refresh is one of them and this commit adds
it to the ignored test list.

PR comment:
[Link](https://github.com/timescale/timescaledb/runs/1114025453?check_suite_focus=true) to the failed test