### PR TITLE
Fix typo in chunks view

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -150,8 +150,8 @@ SELECT
         THEN NULL
         ELSE dimsl.range_end
     END as integer_range_end,
-    CASE WHEN srcch.compressed_chunk_id is not null THEN 'true'
-         ELSE 'false'
+    CASE WHEN srcch.compressed_chunk_id is not null THEN true
+         ELSE false
     END as is_compressed,
     pgtab.spcname as chunk_table_space,
     chdn.node_list

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -162,7 +162,7 @@ range_start            | Wed Jan 18 16:00:00 2017 PST
 range_end              | Wed Jan 25 16:00:00 2017 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | false
+is_compressed          | f
 chunk_tablespace       | tablespace1
 data_nodes             | 
 -[ RECORD 2 ]----------+-----------------------------
@@ -176,7 +176,7 @@ range_start            | Wed Jan 18 16:00:00 2017 PST
 range_end              | Wed Jan 25 16:00:00 2017 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | false
+is_compressed          | f
 chunk_tablespace       | tablespace2
 data_nodes             | 
 

--- a/test/expected/views.out
+++ b/test/expected/views.out
@@ -187,15 +187,15 @@ INSERT into test_table_int SELECT generate_series( 1, 20), 100;
  SELECT * FROM timescaledb_information.chunks WHERE hypertable_name = 'ht1' ORDER BY chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |    chunk_name    | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace | data_nodes 
 -------------------+-----------------+-----------------------+------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+------------
- public            | ht1             | _timescaledb_internal | _hyper_1_1_chunk | time              | timestamp with time zone | Wed Dec 29 16:00:00 1999 PST | Wed Jan 05 16:00:00 2000 PST |                     |                   | false         |                  | 
+ public            | ht1             | _timescaledb_internal | _hyper_1_1_chunk | time              | timestamp with time zone | Wed Dec 29 16:00:00 1999 PST | Wed Jan 05 16:00:00 2000 PST |                     |                   | f             |                  | 
 (1 row)
 
  SELECT * FROM timescaledb_information.chunks WHERE hypertable_name = 'test_table_int' ORDER BY chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |    chunk_name    | primary_dimension | primary_dimension_type | range_start | range_end | range_start_integer | range_end_integer | is_compressed | chunk_tablespace | data_nodes 
 -------------------+-----------------+-----------------------+------------------+-------------------+------------------------+-------------+-----------+---------------------+-------------------+---------------+------------------+------------
- public            | test_table_int  | _timescaledb_internal | _hyper_5_7_chunk | time              | bigint                 |             |           |                   0 |                10 | false         |                  | 
- public            | test_table_int  | _timescaledb_internal | _hyper_5_8_chunk | time              | bigint                 |             |           |                  10 |                20 | false         |                  | 
- public            | test_table_int  | _timescaledb_internal | _hyper_5_9_chunk | time              | bigint                 |             |           |                  20 |                30 | false         |                  | 
+ public            | test_table_int  | _timescaledb_internal | _hyper_5_7_chunk | time              | bigint                 |             |           |                   0 |                10 | f             |                  | 
+ public            | test_table_int  | _timescaledb_internal | _hyper_5_8_chunk | time              | bigint                 |             |           |                  10 |                20 | f             |                  | 
+ public            | test_table_int  | _timescaledb_internal | _hyper_5_9_chunk | time              | bigint                 |             |           |                  20 |                30 | f             |                  | 
 (3 rows)
 
 \x 

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -241,7 +241,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | false
+is_compressed          | f
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_1,db_dist_compression_2}
 -[ RECORD 2 ]----------+----------------------------------------------
@@ -255,7 +255,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | false
+is_compressed          | f
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_2,db_dist_compression_3}
 -[ RECORD 3 ]----------+----------------------------------------------
@@ -269,7 +269,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | false
+is_compressed          | f
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_1,db_dist_compression_3}
 

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -72,9 +72,9 @@ SELECT * from timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |      chunk_name       | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace |        data_nodes         
 -------------------+-----------------+-----------------------+-----------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+---------------------------
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_1_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | false         |                  | {view_node_1,view_node_2}
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_2_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | false         |                  | {view_node_2,view_node_3}
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_3_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | false         |                  | {view_node_1,view_node_3}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_1_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_1,view_node_2}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_2_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_2,view_node_3}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_3_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_1,view_node_3}
 (3 rows)
 
 SELECT * from timescaledb_information.dimensions 


### PR DESCRIPTION
The is_compressed column for timescaledb_information.chunks
view is defined as TEXT instead of BOOLEAN
as true and false were specified using string literals.