### PR TITLE
Fix field name in continuous_aggregate view

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -73,7 +73,7 @@ CREATE OR REPLACE VIEW timescaledb_information.policy_stats as
 CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregates as
   SELECT format('%1$I.%2$I', cagg.user_view_schema, cagg.user_view_name)::regclass as view_name,
     viewinfo.viewowner as view_owner,
-    bgwjob.schedule_interval as refresh_interval,
+    bgwjob.schedule_interval,
     cagg.materialized_only,
     format('%1$I.%2$I', ht.schema_name, ht.table_name)::regclass as materialization_hypertable,
     directview.viewdefinition as view_definition

--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -12,6 +12,6 @@ REFRESH MATERIALIZED VIEW cagg.realtime_mat;
 
 SELECT * FROM cagg.realtime_mat ORDER BY bucket, location;
 
-SELECT view_name, refresh_interval, materialized_only, materialization_hypertable FROM timescaledb_information.continuous_aggregates ORDER BY view_name::text;
+SELECT view_name, schedule_interval, materialized_only, materialization_hypertable FROM timescaledb_information.continuous_aggregates ORDER BY view_name::text;
 
 SELECT maxtemp FROM mat_ignoreinval ORDER BY 1;

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -73,7 +73,7 @@ SELECT * FROM timescaledb_information.continuous_aggregates;
 -[ RECORD 1 ]--------------+-------------------------------------------------------------------------------------------------------------
 view_name                  | device_summary
 view_owner                 | default_perm_user
-refresh_interval           | @ 2 hours
+schedule_interval          | @ 2 hours
 materialized_only          | t
 materialization_hypertable | _timescaledb_internal._materialized_hypertable_2
 view_definition            |  SELECT time_bucket('@ 1 hour'::interval, device_readings.observation_time) AS bucket,                      +


### PR DESCRIPTION
Rename the `refresh_interval` field in
`timescaledb_information.continuous_aggregate` view to match the
parameter name in `add_continuous_aggregate_policy`.