### PR TITLE
Check owner when refreshing a continuous aggregate

### DIFF
--- a/tsl/test/expected/continuous_aggs_permissions.out
+++ b/tsl/test/expected/continuous_aggs_permissions.out
@@ -118,7 +118,7 @@ ERROR:  must be owner of continuous aggregate "mat_refresh_test"
 DROP MATERIALIZED VIEW mat_refresh_test;
 ERROR:  must be owner of view mat_refresh_test
 CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
-ERROR:  permission denied for table conditions
+ERROR:  must be owner of view mat_refresh_test
 SELECT * FROM mat_refresh_test;
 ERROR:  permission denied for materialized view mat_refresh_test
 SELECT * FROM :materialization_hypertable;


### PR DESCRIPTION
This change checks for ownership of the user view when refreshing a
continuous aggregate (it's assumed the other objects have the same
owner). This mimics the checks done when refreshing a regular
materialized view.

Fixes #2408