### PR TITLE
Remove duplicate find_em_expr_for_rel function

### DIFF
--- a/src/catalog.h
+++ b/src/catalog.h
@@ -136,10 +136,6 @@ typedef struct FormData_hypertable
 
 typedef FormData_hypertable *Form_hypertable;
 
-/* replication_factor can be NULL, thus it should not be used through the struct from the tuple */
-#define HYPERTABLE_TUPLE_SIZE(isnull)                                                              \
-	(offsetof(FormData_hypertable, replication_factor) + (isnull ? 0 : sizeof(int16)))
-
 /* Hypertable primary index attribute numbers */
 enum Anum_hypertable_pkey_idx
 {

--- a/src/chunk_data_node.h
+++ b/src/chunk_data_node.h
@@ -31,11 +31,5 @@ extern int ts_chunk_data_node_delete_by_node_name(const char *node_name);
 extern TSDLLEXPORT List *
 ts_chunk_data_node_scan_by_node_name_and_hypertable_id(const char *node_name, int32 hypertable_id,
 													   MemoryContext mctx);
-extern TSDLLEXPORT bool ts_chunk_data_node_contains_non_replicated_chunks(List *chunk_data_nodes);
-
-extern TSDLLEXPORT void ts_chunk_data_node_update_foreign_table_server(Oid relid,
-																	   Oid new_server_id);
-extern TSDLLEXPORT void
-ts_chunk_data_node_update_foreign_table_server_if_needed(int32 chunk_id, Oid existing_server_id);
 
 #endif /* TIMESCALEDB_CHUNK_DATA_NODE_H */

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -404,15 +404,6 @@ ts_chunk_index_create_from_adjusted_index_info(int32 hypertable_id, Relation hyp
 					   get_rel_name(RelationGetRelid(hypertable_idxrel)));
 }
 
-static inline Oid
-chunk_index_get_schemaid(Form_chunk_index chunk_index, bool missing_ok)
-{
-	return ts_chunk_get_schema_id(chunk_index->chunk_id, missing_ok);
-}
-
-#define chunk_index_tuple_get_schema(tuple)                                                        \
-	chunk_index_get_schema((FormData_chunk_index *) GETSTRUCT(tuple));
-
 /*
  * Create all indexes on a chunk, given the indexes that exists on the chunk's
  * hypertable.
@@ -626,7 +617,7 @@ chunk_index_tuple_delete(TupleInfo *ti, void *data)
 	bool should_free;
 	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
 	FormData_chunk_index *chunk_index = (FormData_chunk_index *) GETSTRUCT(tuple);
-	Oid schemaid = chunk_index_get_schemaid(chunk_index, true);
+	Oid schemaid = ts_chunk_get_schema_id(chunk_index->chunk_id, true);
 	ChunkIndexDeleteData *cid = data;
 
 	ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
@@ -1041,7 +1032,7 @@ chunk_index_tuple_set_tablespace(TupleInfo *ti, void *data)
 	bool should_free;
 	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
 	FormData_chunk_index *chunk_index = (FormData_chunk_index *) GETSTRUCT(tuple);
-	Oid schemaoid = chunk_index_get_schemaid(chunk_index, false);
+	Oid schemaoid = ts_chunk_get_schema_id(chunk_index->chunk_id, false);
 	Oid indexrelid = get_relname_relid(NameStr(chunk_index->index_name), schemaoid);
 	AlterTableCmd *cmd = makeNode(AlterTableCmd);
 	List *cmds = NIL;

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -29,7 +29,6 @@ typedef struct ChunkIndexMapping
 extern void ts_chunk_index_create(Relation hypertable_rel, int32 hypertable_id,
 								  Relation hypertable_idxrel, int32 chunk_id, Relation chunkrel);
 
-extern List *ts_get_expr_index_attnames(IndexInfo *ii, Relation htrel);
 void ts_adjust_indexinfo_attnos(IndexInfo *indexinfo, Oid ht_relid, Relation template_indexrel,
 								Relation chunkrel);
 extern void ts_chunk_index_create_from_adjusted_index_info(int32 hypertable_id,

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -31,6 +31,19 @@
 #include "utils.h"
 #include "errors.h"
 
+/* add_dimension record attribute numbers */
+enum Anum_add_dimension
+{
+	Anum_add_dimension_id = 1,
+	Anum_add_dimension_schema_name,
+	Anum_add_dimension_table_name,
+	Anum_add_dimension_column_name,
+	Anum_add_dimension_created,
+	_Anum_add_dimension_max,
+};
+
+#define Natts_add_dimension (_Anum_add_dimension_max - 1)
+
 static int
 cmp_dimension_id(const void *left, const void *right)
 {

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -109,19 +109,6 @@ typedef struct DimensionInfo
 #define DIMENSION_INFO_IS_SET(di)                                                                  \
 	(di != NULL && OidIsValid((di)->table_relid) && (di)->colname != NULL)
 
-/* add_dimension record attribute numbers */
-enum Anum_add_dimension
-{
-	Anum_add_dimension_id = 1,
-	Anum_add_dimension_schema_name,
-	Anum_add_dimension_table_name,
-	Anum_add_dimension_column_name,
-	Anum_add_dimension_created,
-	_Anum_add_dimension_max,
-};
-
-#define Natts_add_dimension (_Anum_add_dimension_max - 1)
-
 extern Hyperspace *ts_dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension,
 									 MemoryContext mctx);
 extern DimensionSlice *ts_dimension_calculate_default_slice(Dimension *dim, int64 value);
@@ -146,17 +133,6 @@ extern int ts_dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete
 extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_open(Oid table_relid, Name column_name,
 																Datum interval, Oid interval_type,
 																regproc partitioning_func);
-
-static inline DimensionInfo *
-ts_dimension_info_create_open_interval_usec(Oid table_relid, Name column_name, int64 interval_usec,
-											regproc partitioning_func)
-{
-	return ts_dimension_info_create_open(table_relid,
-										 column_name,
-										 Int64GetDatum(interval_usec),
-										 INT8OID,
-										 partitioning_func);
-}
 
 extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_closed(Oid table_relid, Name column_name,
 																  int32 num_slices,

--- a/src/net/conn.h
+++ b/src/net/conn.h
@@ -40,8 +40,4 @@ extern void ts_connection_destroy(Connection *conn);
 extern int ts_connection_set_timeout_millis(Connection *conn, unsigned long millis);
 extern const char *ts_connection_get_and_clear_error(Connection *conn);
 
-/*  Called in init.c */
-extern void ts_connection_init(void);
-extern void ts_connection_fini(void);
-
 #endif /* TIMESCALEDB_NET_CONN_H */

--- a/src/plan_add_hashagg.h
+++ b/src/plan_add_hashagg.h
@@ -19,10 +19,5 @@
  * */
 
 extern void ts_plan_add_hashagg(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *output_rel);
-extern double ts_custom_group_estimate_time_bucket(PlannerInfo *root, FuncExpr *expr,
-												   double path_rows);
-extern double ts_custom_group_estimate_date_trunc(PlannerInfo *root, FuncExpr *expr,
-												  double path_rows);
-extern double ts_custom_group_estimate_expr(PlannerInfo *root, Node *expr, double path_rows);
 
 #endif /* TIMESCALEDB_PLAN_ADD_HASHAGG_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -700,6 +700,13 @@ ts_get_appendrelinfo(PlannerInfo *root, Index rti, bool missing_ok)
 	return NULL;
 }
 
+/*
+ * Find an equivalence class member expression, all of whose Vars, come from
+ * the indicated relation.
+ *
+ * This function has been copied from find_em_expr_for_rel in
+ * contrib/postgres_fdw/postgres_fdw.c in postgres source.
+ */
 Expr *
 ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -110,8 +110,6 @@ extern TSDLLEXPORT List *ts_get_reloptions(Oid relid);
 
 #define is_inheritance_table(relid) (is_inheritance_child(relid) || is_inheritance_parent(relid))
 
-#define DATUM_GET(values, attno) values[attno - 1]
-
 static inline int64
 int64_min(int64 a, int64 b)
 {

--- a/tsl/src/continuous_aggs/options.h
+++ b/tsl/src/continuous_aggs/options.h
@@ -6,22 +6,11 @@
 #ifndef TIMESCALEDB_TSL_CONTINUOUS_AGGS_OPTIONS_H
 #define TIMESCALEDB_TSL_CONTINUOUS_AGGS_OPTIONS_H
 #include <postgres.h>
-#include <c.h>
 
 #include "with_clause_parser.h"
 #include "continuous_agg.h"
 
-extern int64 continuous_agg_parse_refresh_lag(Oid column_type,
-											  WithClauseResult *with_clause_options);
-extern int64
-continuous_agg_parse_ignore_invalidation_older_than(Oid column_type,
-													WithClauseResult *with_clause_options);
-
-extern int64 continuous_agg_parse_max_interval_per_job(Oid column_type,
-													   WithClauseResult *with_clause_options,
-													   int64 bucket_width);
-
 extern void continuous_agg_update_options(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);
 
-#endif
+#endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_OPTIONS_H */

--- a/tsl/src/data_node.h
+++ b/tsl/src/data_node.h
@@ -38,7 +38,6 @@ extern List *data_node_array_to_node_name_list(ArrayType *nodearr);
 extern List *data_node_oids_to_node_name_list(List *data_node_oids, AclMode mode);
 extern void data_node_name_list_check_acl(List *data_node_names, AclMode mode);
 extern Datum data_node_ping(PG_FUNCTION_ARGS);
-extern Datum data_node_set_chunk_default_data_node(PG_FUNCTION_ARGS);
 
 /* This should only be used for testing */
 extern Datum data_node_add_without_dist_id(PG_FUNCTION_ARGS);

--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -213,34 +213,6 @@ static void get_relation_column_alias_ids(Var *node, RelOptInfo *foreignrel, int
 										  int *colno);
 
 /*
- * Find an equivalence class member expression, all of whose Vars, come from
- * the indicated relation.
- */
-extern Expr *
-find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
-{
-	ListCell *lc_em;
-
-	foreach (lc_em, ec->ec_members)
-	{
-		EquivalenceMember *em = lfirst(lc_em);
-
-		if (bms_is_subset(em->em_relids, rel->relids))
-		{
-			/*
-			 * If there is more than one equivalence member whose Vars are
-			 * taken entirely from this relation, we'll be content to choose
-			 * any one of those.
-			 */
-			return em->em_expr;
-		}
-	}
-
-	/* We didn't find any suitable equivalence class expression */
-	return NULL;
-}
-
-/*
  * Examine each qual clause in input_conds, and classify them into two groups,
  * which are returned as two lists:
  *	- remote_conds contains expressions that can be evaluated remotely
@@ -2799,7 +2771,7 @@ appendOrderByClause(List *pathkeys, deparse_expr_cxt *context)
 		PathKey *pathkey = lfirst(lcell);
 		Expr *em_expr;
 
-		em_expr = find_em_expr_for_rel(pathkey->pk_eclass, baserel);
+		em_expr = ts_find_em_expr_for_rel(pathkey->pk_eclass, baserel);
 		Assert(em_expr != NULL);
 
 		appendStringInfoString(buf, delim);

--- a/tsl/src/fdw/deparse.h
+++ b/tsl/src/fdw/deparse.h
@@ -19,7 +19,6 @@ typedef struct DeparsedInsertStmt
 	List *retrieved_attrs;
 } DeparsedInsertStmt;
 
-extern Expr *find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel);
 extern void deparse_insert_stmt(DeparsedInsertStmt *stmt, RangeTblEntry *rte, Index rtindex,
 								Relation rel, List *target_attrs, bool do_nothing,
 								List *returning_list);

--- a/tsl/src/fdw/scan_plan.c
+++ b/tsl/src/fdw/scan_plan.c
@@ -70,7 +70,8 @@ get_useful_pathkeys_for_relation(PlannerInfo *root, RelOptInfo *rel)
 			 * is_foreign_expr would detect volatile expressions as well, but
 			 * checking ec_has_volatile here saves some cycles.
 			 */
-			if (pathkey_ec->ec_has_volatile || !(em_expr = find_em_expr_for_rel(pathkey_ec, rel)) ||
+			if (pathkey_ec->ec_has_volatile ||
+				!(em_expr = ts_find_em_expr_for_rel(pathkey_ec, rel)) ||
 				!is_foreign_expr(root, rel, em_expr))
 			{
 				query_pathkeys_ok = false;

--- a/tsl/src/remote/txn_store.h
+++ b/tsl/src/remote/txn_store.h
@@ -34,6 +34,4 @@ extern void remote_txn_store_destroy(RemoteTxnStore *store);
 	for (hash_seq_init(&store->scan, store->hashtable);                                            \
 		 NULL != (remote_txn = (RemoteTxn *) hash_seq_search(&store->scan));)
 
-#define remote_txn_store_foreach_break(store) (hash_seq_term(&ums->scan); break)
-
 #endif /* TIMESCALEDB_TSL_REMOTE_TXN_STORE_H */


### PR DESCRIPTION
The functions find_em_expr_for_rel and ts_find_em_expr_for_rel are
identical. This patch removes find_em_expr_for_rel and changes all
call-sites to use ts_find_em_expr_for_rel.