### PR TITLE
Remove catalog options for continuous aggregates

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -251,11 +251,8 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_agg (
     partial_view_schema NAME NOT NULL,
     partial_view_name NAME NOT NULL,
     bucket_width  BIGINT NOT NULL,
-    refresh_lag BIGINT NOT NULL,
     direct_view_schema NAME NOT NULL,
     direct_view_name NAME NOT NULL,
-    max_interval_per_job BIGINT NOT NULL,
-    ignore_invalidation_older_than BIGINT NOT NULL DEFAULT BIGINT '9223372036854775807',
     materialized_only BOOL NOT NULL DEFAULT false,
     UNIQUE(user_view_schema, user_view_name),
     UNIQUE(partial_view_schema, partial_view_name)

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -323,11 +323,8 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_agg (
     partial_view_schema NAME NOT NULL,
     partial_view_name NAME NOT NULL,
     bucket_width  BIGINT NOT NULL,
-    refresh_lag BIGINT NOT NULL,
     direct_view_schema NAME NOT NULL,
     direct_view_name NAME NOT NULL,
-    max_interval_per_job BIGINT NOT NULL,
-    ignore_invalidation_older_than BIGINT NOT NULL DEFAULT BIGINT '9223372036854775807',
     materialized_only BOOL NOT NULL DEFAULT false,
     UNIQUE(user_view_schema, user_view_name),
     UNIQUE(partial_view_schema, partial_view_name)
@@ -339,7 +336,7 @@ CREATE INDEX IF NOT EXISTS continuous_agg_raw_hypertable_id_idx
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_agg', '');
 GRANT SELECT ON _timescaledb_catalog.continuous_agg TO PUBLIC;
 
-INSERT INTO _timescaledb_catalog.continuous_agg SELECT mat_hypertable_id,raw_hypertable_id,user_view_schema,user_view_name,partial_view_schema,partial_view_name,bucket_width,refresh_lag,direct_view_schema,direct_view_name,max_interval_per_job,ignore_invalidation_older_than,materialized_only FROM _timescaledb_catalog.continuous_agg_tmp;
+INSERT INTO _timescaledb_catalog.continuous_agg SELECT mat_hypertable_id,raw_hypertable_id,user_view_schema,user_view_name,partial_view_schema,partial_view_name,bucket_width,direct_view_schema,direct_view_name,materialized_only FROM _timescaledb_catalog.continuous_agg_tmp;
 DROP TABLE _timescaledb_catalog.continuous_agg_tmp;
 
 ALTER TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log ADD CONSTRAINT continuous_aggs_materialization_invalid_materialization_id_fkey FOREIGN KEY(materialization_id) REFERENCES _timescaledb_catalog.continuous_agg(mat_hypertable_id);

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -854,11 +854,8 @@ typedef enum Anum_continuous_agg
 	Anum_continuous_agg_partial_view_schema,
 	Anum_continuous_agg_partial_view_name,
 	Anum_continuous_agg_bucket_width,
-	Anum_continuous_agg_refresh_lag,
 	Anum_continuous_agg_direct_view_schema,
 	Anum_continuous_agg_direct_view_name,
-	Anum_continuous_agg_max_interval_per_job,
-	Anum_continuous_agg_ignore_invalidation_older_than,
 	Anum_continuous_agg_materialize_only,
 	_Anum_continuous_agg_max,
 } Anum_continuous_agg;
@@ -874,11 +871,8 @@ typedef struct FormData_continuous_agg
 	NameData partial_view_schema;
 	NameData partial_view_name;
 	int64 bucket_width;
-	int64 refresh_lag;
 	NameData direct_view_schema;
 	NameData direct_view_name;
-	int64 max_interval_per_job;
-	int64 ignore_invalidation_older_than;
 } FormData_continuous_agg;
 
 typedef FormData_continuous_agg *Form_continuous_agg;

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -64,7 +64,6 @@ typedef struct ContinuousAggsCacheInvalEntry
 	int64 modification_time;
 	Oid previous_chunk_relid;
 	AttrNumber previous_chunk_open_dimension;
-
 	bool value_is_set;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -63,8 +63,8 @@ SELECT * FROM timescaledb_information.policy_stats;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_agg;
- mat_hypertable_id | raw_hypertable_id | user_view_schema | user_view_name | partial_view_schema | partial_view_name | bucket_width | refresh_lag | direct_view_schema | direct_view_name | max_interval_per_job | ignore_invalidation_older_than | materialized_only 
--------------------+-------------------+------------------+----------------+---------------------+-------------------+--------------+-------------+--------------------+------------------+----------------------+--------------------------------+-------------------
+ mat_hypertable_id | raw_hypertable_id | user_view_schema | user_view_name | partial_view_schema | partial_view_name | bucket_width | direct_view_schema | direct_view_name | materialized_only 
+-------------------+-------------------+------------------+----------------+---------------------+-------------------+--------------+--------------------+------------------+-------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -48,7 +48,7 @@ NOTICE:  adding not-null constraint to column "time"
  (2,public,continuous_agg_test_mat,t)
 (1 row)
 
-INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,0,'','',0, bigint '10000000');
+INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,'','');
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- create the trigger
 CREATE TRIGGER continuous_agg_insert_trigger

--- a/tsl/test/sql/continuous_aggs_watermark.sql
+++ b/tsl/test/sql/continuous_aggs_watermark.sql
@@ -20,7 +20,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 CREATE TABLE continuous_agg_test_mat(time int);
 select create_hypertable('continuous_agg_test_mat', 'time', chunk_time_interval=> 10);
-INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,0,'','',0, bigint '10000000');
+INSERT INTO _timescaledb_catalog.continuous_agg VALUES (2, 1, '','','','',0,'','');
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 -- create the trigger


### PR DESCRIPTION
This change removes the catalog options `refresh_lag`,
`max_interval_per_job` and `ignore_invalidation_older_than`, which are
no longer used.

Closes #2396