### PR TITLE
Fix format strings used in tests

### DIFF
--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -7,7 +7,7 @@ CREATE VIEW hypertable_tablespaces AS
 SELECT cls.relname AS hypertable,
        (SELECT spcname FROM pg_tablespace WHERE oid = reltablespace) AS tablespace
   FROM _timescaledb_catalog.hypertable,
-  LATERAL (SELECT * FROM pg_class WHERE oid = format('%s.%s', schema_name, table_name)::regclass) AS cls
+  LATERAL (SELECT * FROM pg_class WHERE oid = format('%I.%I', schema_name, table_name)::regclass) AS cls
   ORDER BY hypertable, tablespace;
 GRANT SELECT ON hypertable_tablespaces TO PUBLIC;
 --Test hypertable with tablespace. Tablespaces are cluster-wide, so we

--- a/test/sql/tablespace.sql
+++ b/test/sql/tablespace.sql
@@ -9,7 +9,7 @@ CREATE VIEW hypertable_tablespaces AS
 SELECT cls.relname AS hypertable,
        (SELECT spcname FROM pg_tablespace WHERE oid = reltablespace) AS tablespace
   FROM _timescaledb_catalog.hypertable,
-  LATERAL (SELECT * FROM pg_class WHERE oid = format('%s.%s', schema_name, table_name)::regclass) AS cls
+  LATERAL (SELECT * FROM pg_class WHERE oid = format('%I.%I', schema_name, table_name)::regclass) AS cls
   ORDER BY hypertable, tablespace;
 GRANT SELECT ON hypertable_tablespaces TO PUBLIC;
 

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -227,7 +227,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
 AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
     GROUP BY 1 WITH NO DATA;
-SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
+SELECT format('%I.%I', schema_name, table_name) AS drop_chunks_mat_table,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
@@ -309,7 +309,7 @@ CREATE MATERIALIZED VIEW drop_chunks_view
 AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
     GROUP BY 1 WITH NO DATA;
-SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
+SELECT format('%I.%I', schema_name, table_name) AS drop_chunks_mat_table_u,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_u_name
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
@@ -678,7 +678,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
            0 |   4
 (8 rows)
 
-SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_tablen,
+SELECT format('%I.%I', schema_name, table_name) AS drop_chunks_mat_tablen,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
@@ -868,10 +868,10 @@ ORDER BY 1;
 CREATE VIEW cagg_info AS
 WITH
   caggs AS (
-    SELECT format('%s.%s', user_view_schema, user_view_name)::regclass AS user_view,
-           format('%s.%s', direct_view_schema, direct_view_name)::regclass AS direct_view,
-           format('%s.%s', partial_view_schema, partial_view_name)::regclass AS partial_view,
-           format('%s.%s', ht.schema_name, ht.table_name)::regclass AS mat_relid
+    SELECT format('%I.%I', user_view_schema, user_view_name)::regclass AS user_view,
+           format('%I.%I', direct_view_schema, direct_view_name)::regclass AS direct_view,
+           format('%I.%I', partial_view_schema, partial_view_name)::regclass AS partial_view,
+           format('%I.%I', ht.schema_name, ht.table_name)::regclass AS mat_relid
       FROM _timescaledb_catalog.hypertable ht,
            _timescaledb_catalog.continuous_agg cagg
      WHERE ht.id = cagg.mat_hypertable_id

--- a/tsl/test/expected/continuous_aggs_tableam.out
+++ b/tsl/test/expected/continuous_aggs_tableam.out
@@ -7,8 +7,8 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE VIEW cagg_info AS
 WITH
   caggs AS (
-    SELECT format('%s.%s', user_view_schema, user_view_name)::regclass AS user_view,
-           format('%s.%s', ht.schema_name, ht.table_name)::regclass AS mat_relid
+    SELECT format('%I.%I', user_view_schema, user_view_name)::regclass AS user_view,
+           format('%I.%I', ht.schema_name, ht.table_name)::regclass AS mat_relid
       FROM _timescaledb_catalog.hypertable ht,
            _timescaledb_catalog.continuous_agg cagg
      WHERE ht.id = cagg.mat_hypertable_id

--- a/tsl/test/sql/continuous_aggs_ddl.sql
+++ b/tsl/test/sql/continuous_aggs_ddl.sql
@@ -158,7 +158,7 @@ AS SELECT time_bucket('5', time), COUNT(data)
     FROM drop_chunks_table
     GROUP BY 1 WITH NO DATA;
 
-SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table,
+SELECT format('%I.%I', schema_name, table_name) AS drop_chunks_mat_table,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
@@ -207,7 +207,7 @@ AS SELECT time_bucket('3', time), COUNT(data)
     FROM drop_chunks_table_u
     GROUP BY 1 WITH NO DATA;
 
-SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_table_u,
+SELECT format('%I.%I', schema_name, table_name) AS drop_chunks_mat_table_u,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_u_name
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
@@ -401,7 +401,7 @@ CALL refresh_continuous_aggregate('drop_chunks_view', 30, 40);
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 
 
-SELECT format('%s.%s', schema_name, table_name) AS drop_chunks_mat_tablen,
+SELECT format('%I.%I', schema_name, table_name) AS drop_chunks_mat_tablen,
         schema_name AS drop_chunks_mat_schema,
         table_name AS drop_chunks_mat_table_name
     FROM _timescaledb_catalog.hypertable, _timescaledb_catalog.continuous_agg
@@ -511,10 +511,10 @@ ORDER BY 1;
 CREATE VIEW cagg_info AS
 WITH
   caggs AS (
-    SELECT format('%s.%s', user_view_schema, user_view_name)::regclass AS user_view,
-           format('%s.%s', direct_view_schema, direct_view_name)::regclass AS direct_view,
-           format('%s.%s', partial_view_schema, partial_view_name)::regclass AS partial_view,
-           format('%s.%s', ht.schema_name, ht.table_name)::regclass AS mat_relid
+    SELECT format('%I.%I', user_view_schema, user_view_name)::regclass AS user_view,
+           format('%I.%I', direct_view_schema, direct_view_name)::regclass AS direct_view,
+           format('%I.%I', partial_view_schema, partial_view_name)::regclass AS partial_view,
+           format('%I.%I', ht.schema_name, ht.table_name)::regclass AS mat_relid
       FROM _timescaledb_catalog.hypertable ht,
            _timescaledb_catalog.continuous_agg cagg
      WHERE ht.id = cagg.mat_hypertable_id

--- a/tsl/test/sql/continuous_aggs_tableam.sql
+++ b/tsl/test/sql/continuous_aggs_tableam.sql
@@ -10,8 +10,8 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE VIEW cagg_info AS
 WITH
   caggs AS (
-    SELECT format('%s.%s', user_view_schema, user_view_name)::regclass AS user_view,
-           format('%s.%s', ht.schema_name, ht.table_name)::regclass AS mat_relid
+    SELECT format('%I.%I', user_view_schema, user_view_name)::regclass AS user_view,
+           format('%I.%I', ht.schema_name, ht.table_name)::regclass AS mat_relid
       FROM _timescaledb_catalog.hypertable ht,
            _timescaledb_catalog.continuous_agg cagg
      WHERE ht.id = cagg.mat_hypertable_id


### PR DESCRIPTION
This patch fixes the format strings used to construct object names
in tests. The format strings used in those tests would break when
object names are involved that require quoting.