### PR TITLE
Remove unused refresh arguments from invalidation

### DIFF
--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -41,8 +41,7 @@ extern void invalidation_hyper_log_add_entry(int32 hyper_id, int64 modtime, int6
 extern void invalidation_add_entry(const Hypertable *ht, int64 start, int64 end);
 extern void invalidation_entry_set_from_hyper_invalidation(Invalidation *entry, const TupleInfo *ti,
 														   int32 hyper_id);
-extern void invalidation_process_hypertable_log(const ContinuousAgg *cagg,
-												const InternalTimeRange *refresh_window);
+extern void invalidation_process_hypertable_log(const ContinuousAgg *cagg);
 extern InvalidationStore *invalidation_process_cagg_log(const ContinuousAgg *cagg,
 														const InternalTimeRange *refresh_window);
 extern void invalidation_store_free(InvalidationStore *store);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -433,7 +433,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	}
 
 	/* Process invalidations in the hypertable invalidation log */
-	invalidation_process_hypertable_log(cagg, &refresh_window);
+	invalidation_process_hypertable_log(cagg);
 
 	/* Start a new transaction. Note that this invalidates previous memory
 	 * allocations (and locks). */
@@ -481,8 +481,8 @@ continuous_agg_refresh_all(const Hypertable *ht, int64 start, int64 end)
 	invalidation_threshold_set_or_get(ht->fd.id, refresh_window.end);
 
 	/* It is enough to process the hypertable invalidation log once,
-	 * so do it only for the first continuous aggregate */
-	invalidation_process_hypertable_log(linitial(caggs), &refresh_window);
+	 * so do it only for the first continuous aggregate. */
+	invalidation_process_hypertable_log(linitial(caggs));
 	/* Must make invalidation processing visible */
 	CommandCounterIncrement();
 


### PR DESCRIPTION
After recent refactoring the refresh window arguments are not used in
many invalidation functions. This fixes the code and removes unused
arguments to avoid future confusions.