### PR TITLE
Turn debug messages into DEBUG1

### DIFF
--- a/test/expected/chunk_utils_compression.out
+++ b/test/expected/chunk_utils_compression.out
@@ -29,7 +29,6 @@ SELECT create_hypertable('public.table_to_compress', 'time', chunk_time_interval
 (1 row)
 
 ALTER TABLE public.table_to_compress SET (timescaledb.compress, timescaledb.compress_segmentby = 'acq_id');
-NOTICE:  adding index _compressed_hypertable_3_acq_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_3 USING BTREE(acq_id, _ts_meta_sequence_num)
 INSERT INTO public.table_to_compress VALUES ('2020-01-01', 1234567, 777888);
 INSERT INTO public.table_to_compress VALUES ('2020-02-01', 567567, 890890);
 INSERT INTO public.table_to_compress VALUES ('2020-02-10', 1234, 5678);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -430,7 +430,7 @@ create_compressed_table_indexes(Oid compresstable_relid, CompressColInfo *compre
 		if (!HeapTupleIsValid(index_tuple))
 			elog(ERROR, "cache lookup failed for index relid %d", index_addr.objectId);
 		index_name = ((Form_pg_class) GETSTRUCT(index_tuple))->relname;
-		elog(NOTICE,
+		elog(DEBUG1,
 			 "adding index %s ON %s.%s USING BTREE(%s, %s)",
 			 NameStr(index_name),
 			 NameStr(ht->fd.schema_name),

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -432,7 +432,7 @@ mattablecolumninfo_add_mattable_index(MatTableColumnInfo *matcolinfo, Hypertable
 		if (!HeapTupleIsValid(indxtuple))
 			elog(ERROR, "cache lookup failed for index relid %d", indxaddr.objectId);
 		indxname = ((Form_pg_class) GETSTRUCT(indxtuple))->relname;
-		elog(NOTICE,
+		elog(DEBUG1,
 			 "adding index %s ON %s.%s USING BTREE(%s, %s)",
 			 NameStr(indxname),
 			 NameStr(ht->fd.schema_name),

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -39,8 +39,6 @@ insert into foo values( 10 , 10 , 20, NULL);
 insert into foo values( 20 , 11 , 20, NULL);
 insert into foo values( 30 , 12 , 20, NULL);
 alter table foo set (timescaledb.compress, timescaledb.compress_segmentby = 'a,b', timescaledb.compress_orderby = 'c desc, d asc nulls last');
-NOTICE:  adding index _compressed_hypertable_2_a__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(a, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_2_b__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(b, _ts_meta_sequence_num)
 --test self-refencing updates
 SET timescaledb.enable_transparent_decompression to ON;
 update foo set c = 40
@@ -257,7 +255,6 @@ select create_hypertable( 'conditions', 'time', chunk_time_interval=> '31days'::
 (1 row)
 
 alter table conditions set (timescaledb.compress, timescaledb.compress_segmentby = 'location', timescaledb.compress_orderby = 'time');
-NOTICE:  adding index _compressed_hypertable_6_location__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(location, _ts_meta_sequence_num)
 insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'POR', 'klick', 55, 75;
 insert into conditions
@@ -602,8 +599,6 @@ alter table test_collation set (timescaledb.compress, timescaledb.compress_segme
 ERROR:  unable to parse timescaledb.compress_orderby option 'val_1 COLLATE "POSIX", val2, time'
 \set ON_ERROR_STOP 1
 alter table test_collation set (timescaledb.compress, timescaledb.compress_segmentby='device_id, device_id_2', timescaledb.compress_orderby = 'val_1, val_2, time');
-NOTICE:  adding index _compressed_hypertable_10_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_10 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_10_device_id_2__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_10 USING BTREE(device_id_2, _ts_meta_sequence_num)
 insert into test_collation
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timestamp, '2 hour'), 'device_1', 'device_3', gen_rand_minstd(), gen_rand_minstd();
 insert into test_collation
@@ -944,10 +939,6 @@ SELECT
   avg(v1+v2) AS avg2
 FROM metrics
 GROUP BY 1 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_14_const_time_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(const, time)
-NOTICE:  adding index _materialized_hypertable_14_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(numeric, time)
-NOTICE:  adding index _materialized_hypertable_14_case_time_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(case, time)
-NOTICE:  adding index _materialized_hypertable_14_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(coalesce, time)
 CALL refresh_continuous_aggregate('cagg_expr', NULL, NULL);
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
@@ -970,7 +961,6 @@ SELECT create_hypertable('rescan_test', 't', chunk_time_interval => interval '1 
 
 -- compression
 ALTER TABLE rescan_test SET (timescaledb.compress, timescaledb.compress_segmentby = 'id');
-NOTICE:  adding index _compressed_hypertable_17_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_17 USING BTREE(id, _ts_meta_sequence_num)
 -- INSERT dummy data
 INSERT INTO rescan_test SELECT 1, time, random() FROM generate_series('2000-01-01'::timestamptz, '2000-01-05'::timestamptz, '1h'::interval) g(time);
 SELECT count(*) FROM rescan_test;
@@ -1031,7 +1021,6 @@ ALTER TABLE hyper SET (
     timescaledb.compress,
     timescaledb.compress_orderby = 'time',
     timescaledb.compress_segmentby = 'device_id');
-NOTICE:  adding index _compressed_hypertable_19_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_19 USING BTREE(device_id, _ts_meta_sequence_num)
 INSERT INTO meta VALUES (1), (2), (3), (4), (5);
 INSERT INTO hyper VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2), (11, 5, 2);
 SELECT ch1.table_name AS "CHUNK_NAME", ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_FULL_NAME"
@@ -1151,8 +1140,6 @@ ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = '
 ERROR:  constraint "fk_table1" requires column "col2" to be a timescaledb.compress_segmentby column for compression
 -- Listing all fields of the compound key should succeed:
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1,col2');
-NOTICE:  adding index _compressed_hypertable_23_col1__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_23 USING BTREE(col1, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_23_col2__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_23 USING BTREE(col2, _ts_meta_sequence_num)
 SELECT * FROM timescaledb_information.compression_settings ORDER BY table_name;
  schema_name |   table_name   |   attname   | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 -------------+----------------+-------------+------------------------+----------------------+-------------+--------------------
@@ -1363,7 +1350,6 @@ SELECT count(*) FROM approx_count;
 (1 row)
 
 ALTER TABLE approx_count SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
-NOTICE:  adding index _compressed_hypertable_30_device__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_30 USING BTREE(device, _ts_meta_sequence_num)
 SELECT approximate_row_count('approx_count');
  approximate_row_count 
 -----------------------

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -27,7 +27,6 @@ ERROR:  compression not enabled on hypertable "conditions"
 -- TEST2 --
 --add a policy to compress chunks --
 alter table conditions set (timescaledb.compress, timescaledb.compress_segmentby = 'location', timescaledb.compress_orderby = 'time');
-NOTICE:  adding index _compressed_hypertable_2_location__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(location, _ts_meta_sequence_num)
 insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'POR', 'klick', 55, 75;
 select add_compression_policy('conditions', '60d'::interval) AS compressjob_id
@@ -193,7 +192,6 @@ SELECT device,
        MIN(temperature) AS min_temperature
 FROM conditions
 GROUP BY device, time_bucket(INTERVAL '1 hour', "time") WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_8_device_day_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, day)
 CALL refresh_continuous_aggregate('conditions_summary', NULL, NULL);
 ALTER TABLE conditions SET (timescaledb.compress);
 SELECT COUNT(*) AS dropped_chunks_count

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -45,7 +45,6 @@ NOTICE:  adding not-null constraint to column "Time"
 
 INSERT INTO test1 SELECT t,  gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd()::text FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = 'b', timescaledb.compress_orderby = '"Time" DESC');
-NOTICE:  adding index _compressed_hypertable_2_b__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(b, _ts_meta_sequence_num)
 SELECT COUNT(*) AS count_compressed
 FROM
 (
@@ -615,7 +614,6 @@ WHERE chunk.id IS NULL;
 
 --can turn compression back on
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = 'b', timescaledb.compress_orderby = '"Time" DESC');
-NOTICE:  adding index _compressed_hypertable_4_b__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(b, _ts_meta_sequence_num)
 SELECT COUNT(*) AS count_compressed
 FROM
 (

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -33,11 +33,7 @@ ERROR:  the option timescaledb.compress must be set to true to enable compressio
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'c');
 ERROR:  cannot use column "c" in both timescaledb.compress_orderby and timescaledb.compress_segmentby
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'd DESC');
-NOTICE:  adding index _compressed_hypertable_4_bacB toD__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(bacB toD, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_4_c__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(c, _ts_meta_sequence_num)
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c' , timescaledb.compress_orderby = 'd');
-NOTICE:  adding index _compressed_hypertable_5_bacB toD__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(bacB toD, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_5_c__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(c, _ts_meta_sequence_num)
 create table with_rls (a integer, b integer);
 ALTER TABLE with_rls ENABLE ROW LEVEL SECURITY;
 select table_name from create_hypertable('with_rls', 'a', chunk_time_interval=> 10);
@@ -64,8 +60,6 @@ ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d DeSc
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_orderby='d Asc NullS lAsT');
 --this is ok too
 ALTER TABLE foo3 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c', timescaledb.compress_orderby = 'd DeSc NullS lAsT');
-NOTICE:  adding index _compressed_hypertable_9_bacB toD__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_9 USING BTREE(bacB toD, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_9_c__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_9 USING BTREE(c, _ts_meta_sequence_num)
 -- Negative test cases ---
 ALTER TABLE foo2 set (timescaledb.compress, timescaledb.compress_segmentby = '"bacB toD",c');
 ERROR:  need to specify timescaledb.compress_orderby if it was previously set
@@ -184,7 +178,6 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 ERROR:  chunk "_hyper_11_2_chunk" is not compressed
 --test changing the segment by columns
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
-NOTICE:  adding index _compressed_hypertable_13_b__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_13 USING BTREE(b, _ts_meta_sequence_num)
 select ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'foo' ORDER BY ch1.id limit 1 \gset
 select decompress_chunk(:'CHUNK_NAME');
@@ -234,7 +227,6 @@ FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch
 
 --should succeed
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'b');
-NOTICE:  adding index _compressed_hypertable_14_b__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_14 USING BTREE(b, _ts_meta_sequence_num)
 select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _timescaledb_catalog.hypertable h on (h.id = hc.hypertable_id) where h.table_name = 'foo' order by attname;
  hypertable_id | attname | compression_algorithm_id | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 ---------------+---------+--------------------------+------------------------+----------------------+-------------+--------------------
@@ -281,9 +273,6 @@ ERROR:  constraint table_constr_exclu is not supported for compression
 alter table table_constr drop constraint table_constr_exclu ;
 --now it works
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');
-NOTICE:  adding index _compressed_hypertable_16_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_16_location__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(location, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_16_d__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_16 USING BTREE(d, _ts_meta_sequence_num)
 --can't add fks after compression enabled
 alter table table_constr add constraint table_constr_fk_add_after FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
 ERROR:  operation not supported on hypertables that have compression enabled
@@ -304,7 +293,6 @@ SELECT create_hypertable('table_fk', 'time');
 
 ALTER TABLE table_fk DROP COLUMN id1;
 ALTER TABLE table_fk SET (timescaledb.compress,timescaledb.compress_segmentby = 'id2');
-NOTICE:  adding index _compressed_hypertable_18_id2__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_18 USING BTREE(id2, _ts_meta_sequence_num)
 -- TEST fk cascade delete behavior on compressed chunk --
 insert into fortable values(1);
 insert into fortable values(10);
@@ -348,8 +336,6 @@ INSERT INTO table_constr2 VALUES( 1000, 10, 5, 99);
 ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id');
 ERROR:  constraint "table_constr2_d_fkey" requires column "d" to be a timescaledb.compress_segmentby column for compression
  ALTER TABLE table_constr2 SET (timescaledb.compress, timescaledb.compress_segmentby = 'device_id, d');
-NOTICE:  adding index _compressed_hypertable_20_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_20 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_20_d__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_20 USING BTREE(d, _ts_meta_sequence_num)
 --compress a chunk and try to disable compression, it should fail --
 SELECT ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_NAME"
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -316,7 +316,6 @@ select create_hypertable( 'test4', 'timec', chunk_time_interval=> '1 year'::inte
 (1 row)
 
 alter table test4 set (timescaledb.compress, timescaledb.compress_segmentby = 'location', timescaledb.compress_orderby = 'timec');
-NOTICE:  adding index _compressed_hypertable_6_location__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(location, _ts_meta_sequence_num)
 insert into test4
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-31 00:00'::timestamp, '1 day'), 'NYC', 'klick', 55, 75;
 insert into test4
@@ -543,7 +542,6 @@ SELECT create_hypertable('test6', 'time', chunk_time_interval=> 50);
 
 ALTER TABLE test6 SET
   (timescaledb.compress, timescaledb.compress_segmentby='device_id', timescaledb.compress_orderby = 'time DESC');
-NOTICE:  adding index _compressed_hypertable_10_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_10 USING BTREE(device_id, _ts_meta_sequence_num)
 INSERT INTO test6 SELECT t, d, customtype_in((t + d)::TEXT::cstring)
   FROM generate_series(1, 200) t, generate_series(1, 3) d;
 INSERT INTO test6 SELECT t, NULL, customtype_in(t::TEXT::cstring)

--- a/tsl/test/expected/compression_permissions.out
+++ b/tsl/test/expected/compression_permissions.out
@@ -24,7 +24,6 @@ ERROR:  permission denied for table conditions
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 --now owner tries and succeeds --
 alter table conditions set (timescaledb.compress, timescaledb.compress_segmentby = 'location', timescaledb.compress_orderby = 'timec');
-NOTICE:  adding index _compressed_hypertable_2_location__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(location, _ts_meta_sequence_num)
 insert into conditions
 select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 'POR', 'klick', 55, 75;
 --try modifying compress properties --

--- a/tsl/test/expected/compression_qualpushdown-11.out
+++ b/tsl/test/expected/compression_qualpushdown-11.out
@@ -18,7 +18,6 @@ ALTER TABLE hyper SET (
     timescaledb.compress,
     timescaledb.compress_orderby = 'time',
     timescaledb.compress_segmentby = 'device_id');
-NOTICE:  adding index _compressed_hypertable_2_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id, _ts_meta_sequence_num)
 INSERT INTO meta VALUES (1), (2), (3), (4), (5);
 INSERT INTO hyper VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2), (11, 5, 2);
 SELECT ch1.table_name AS "CHUNK_NAME", ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_FULL_NAME"

--- a/tsl/test/expected/compression_qualpushdown-12.out
+++ b/tsl/test/expected/compression_qualpushdown-12.out
@@ -18,7 +18,6 @@ ALTER TABLE hyper SET (
     timescaledb.compress,
     timescaledb.compress_orderby = 'time',
     timescaledb.compress_segmentby = 'device_id');
-NOTICE:  adding index _compressed_hypertable_2_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id, _ts_meta_sequence_num)
 INSERT INTO meta VALUES (1), (2), (3), (4), (5);
 INSERT INTO hyper VALUES (1, 1, 1), (2, 2, 1), (3, 3, 1), (10, 3, 2), (11, 4, 2), (11, 5, 2);
 SELECT ch1.table_name AS "CHUNK_NAME", ch1.schema_name|| '.' || ch1.table_name AS "CHUNK_FULL_NAME"

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -50,7 +50,6 @@ as
 select a, count(b)
 from foo
 group by time_bucket(1, a), a WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_2_a_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(a, time_partition_col)
 SELECT add_continuous_aggregate_policy('mat_m1', NULL, 2::integer, '12 h'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
@@ -396,7 +395,6 @@ select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+
 from conditions
 group by bucket, loc
 having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_10_loc_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(loc, bucket)
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -431,7 +429,6 @@ select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), st
 from conditions
 group by 1,2
 having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_11_location_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_11 USING BTREE(location, time_bucket)
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -466,7 +463,6 @@ select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), st
 from conditions
 group by 1,2
 having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_12_loc_bucket_idx ON _timescaledb_internal._materialized_hypertable_12 USING BTREE(loc, bucket)
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
@@ -628,7 +624,6 @@ SELECT
 \gset
 \set ECHO errors
 psql:include/cont_agg_equal.sql:8: NOTICE:  drop cascades to 2 other objects
-psql:include/cont_agg_equal.sql:13: NOTICE:  adding index _materialized_hypertable_16_location_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_16 USING BTREE(location, time_bucket)
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
  Number of rows different between view and original (expect 0) |     0
@@ -862,9 +857,6 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec), location, humidity, temperature WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_20_grp_5_5_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING BTREE(grp_5_5, timec)
-NOTICE:  adding index _materialized_hypertable_20_grp_6_6_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING BTREE(grp_6_6, timec)
-NOTICE:  adding index _materialized_hypertable_20_grp_7_7_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING BTREE(grp_7_7, timec)
 SELECT add_continuous_aggregate_policy('mat_with_test', NULL, '5 h'::interval, '12 h'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
@@ -1189,7 +1181,6 @@ as
 select location, max(humidity)
 from conditions
 group by time_bucket(100, timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_29_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_29 USING BTREE(location, time_partition_col)
 insert into conditions
 select generate_series(0, 50, 10), 'NYC', 55, 75, 40, 70, NULL;
 CALL refresh_continuous_aggregate('mat_refresh_test', NULL, NULL);
@@ -1207,7 +1198,6 @@ CREATE MATERIALIZED VIEW conditions_grpby_view with (timescaledb.continuous) as
 select time_bucket(100, timec),  sum(humidity)
 from conditions
 group by time_bucket(100, timec), location;
-NOTICE:  adding index _materialized_hypertable_30_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_30 USING BTREE(grp_3_3, time_bucket)
 NOTICE:  refreshing continuous aggregate "conditions_grpby_view"
 select * from conditions_grpby_view order by 1, 2;
  time_bucket | sum 
@@ -1223,7 +1213,6 @@ select time_bucket(100, timec), sum(humidity)
 from conditions
 group by time_bucket(100, timec), location
 having avg(temperature) > 0;
-NOTICE:  adding index _materialized_hypertable_31_grp_3_3_time_bucket_idx ON _timescaledb_internal._materialized_hypertable_31 USING BTREE(grp_3_3, time_bucket)
 NOTICE:  refreshing continuous aggregate "conditions_grpby_view2"
 select * from conditions_grpby_view2 order by 1, 2;
  time_bucket | sum 

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -483,7 +483,6 @@ CREATE MATERIALIZED VIEW test_continuous_agg_view
     AS SELECT time_bucket('2', time), SUM(data) as value, get_constant_no_perms()
         FROM test_continuous_agg_table
         GROUP BY 1 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_4_get_constant_no_perms_time_bucke_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(get_constant_no_perms, time_bucket)
 SELECT add_continuous_aggregate_policy('test_continuous_agg_view', NULL, -2::integer, '12 h'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -474,10 +474,6 @@ SELECT
   avg(v1+v2) AS avg2
 FROM metrics
 GROUP BY 1 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_9_const_time_idx ON _timescaledb_internal._materialized_hypertable_9 USING BTREE(const, time)
-NOTICE:  adding index _materialized_hypertable_9_numeric_time_idx ON _timescaledb_internal._materialized_hypertable_9 USING BTREE(numeric, time)
-NOTICE:  adding index _materialized_hypertable_9_case_time_idx ON _timescaledb_internal._materialized_hypertable_9 USING BTREE(case, time)
-NOTICE:  adding index _materialized_hypertable_9_coalesce_time_idx ON _timescaledb_internal._materialized_hypertable_9 USING BTREE(coalesce, time)
 CALL refresh_continuous_aggregate('cagg_expr', NULL, NULL);
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
              time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 

--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -31,7 +31,6 @@ CREATE MATERIALIZED VIEW records_monthly
             avg(value) as value_avg,
             max(value)-min(value) as value_spread
         FROM records GROUP BY bucket, clientId WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_2_clientid_bucket_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(clientid, bucket)
 INSERT INTO clients(name) VALUES ('test-client');
 INSERT INTO records
 SELECT generate_series('2000-03-01'::timestamptz,'2000-04-01','1 day'),1,3.14;

--- a/tsl/test/expected/continuous_aggs_dump.out
+++ b/tsl/test/expected/continuous_aggs_dump.out
@@ -89,14 +89,12 @@ NOTICE:  materialized view "mat_test" does not exist, skipping
 CREATE MATERIALIZED VIEW mat_before
 WITH (timescaledb.continuous)
 AS :QUERY_BEFORE WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_3_location_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, bucket)
 --materialize this VIEW after dump this tests
 --that the partialize VIEW and refresh mechanics
 --survives the dump intact
 CREATE MATERIALIZED VIEW mat_after
 WITH (timescaledb.continuous)
 AS :QUERY_AFTER WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_4_location_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(location, bucket)
 --materialize mat_before
 SET client_min_messages TO LOG;
 CALL refresh_continuous_aggregate('mat_before', NULL, NULL);

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -83,7 +83,6 @@ AS
 SELECT time_bucket(BIGINT '10', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_3_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device, bucket)
 CREATE MATERIALIZED VIEW cond_20
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
@@ -91,7 +90,6 @@ AS
 SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_4_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, bucket)
 CREATE MATERIALIZED VIEW measure_10
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
@@ -99,7 +97,6 @@ AS
 SELECT time_bucket(10, time) AS bucket, device, avg(temp) AS avg_temp
 FROM measurements
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_5_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(device, bucket)
 -- There should be three continuous aggregates, two on one hypertable
 -- and one on the other:
 SELECT mat_hypertable_id, raw_hypertable_id, user_view_name
@@ -652,7 +649,6 @@ AS
 SELECT time_bucket(BIGINT '1', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_6_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, bucket)
 SELECT mat_hypertable_id AS cond_1_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_1' \gset

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -38,7 +38,6 @@ AS
     SELECT time_bucket(2, timeval), col1, max(col2)
     FROM continuous_agg_test
     GROUP BY 1, 2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_3_grp_timed_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(grp, timed)
 select view_name, view_owner, materialization_hypertable
 from timescaledb_information.continuous_aggregates ORDER BY 1;
  view_name |    view_owner     |            materialization_hypertable            

--- a/tsl/test/expected/continuous_aggs_permissions.out
+++ b/tsl/test/expected/continuous_aggs_permissions.out
@@ -55,7 +55,6 @@ as
 select location, max(humidity)
 from conditions
 group by time_bucket(100, timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_2_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, time_partition_col)
 SELECT add_continuous_aggregate_policy('mat_refresh_test', NULL, -200::integer, '12 h'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
@@ -153,7 +152,6 @@ as
 select location, max(humidity)
 from conditions_for_perm_check
 group by time_bucket(100, timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_5_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_5 USING BTREE(location, time_partition_col)
 ERROR:  permission denied for table conditions_for_perm_check
 --cannot create mat view in a schema without create privileges
 CREATE MATERIALIZED VIEW custom_schema.mat_perm_view_test
@@ -162,7 +160,6 @@ as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
 group by time_bucket(100, timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_6_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(location, time_partition_col)
 ERROR:  permission denied for schema custom_schema
 --cannot use a function without EXECUTE privileges
 --you can create a VIEW but cannot refresh it
@@ -172,8 +169,6 @@ as
 select location, max(humidity), get_constant()
 from conditions_for_perm_check_w_grant
 group by time_bucket(100, timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_7_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_7 USING BTREE(location, time_partition_col)
-NOTICE:  adding index _materialized_hypertable_7_get_constant_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_7 USING BTREE(get_constant, time_partition_col)
 --this should fail
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 ERROR:  permission denied for function get_constant
@@ -185,7 +180,6 @@ as
 select location, max(humidity)
 from conditions_for_perm_check_w_grant
 group by time_bucket(100, timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_8_location_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(location, time_partition_col)
 CALL refresh_continuous_aggregate('mat_perm_view_test', NULL, NULL);
 SELECT * FROM mat_perm_view_test;
  location | max 
@@ -235,7 +229,6 @@ CREATE MATERIALIZED VIEW devices_summary
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 AS SELECT time_bucket('1 day', time) AS bucket, device, MAX(temp)
 FROM devices GROUP BY bucket, device WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_10_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(device, bucket)
 \x on
 SELECT * FROM cagg_info WHERE user_view::text = 'devices_summary';
 -[ RECORD 1 ]-----+---------------------------------------

--- a/tsl/test/expected/continuous_aggs_policy.out
+++ b/tsl/test/expected/continuous_aggs_policy.out
@@ -35,7 +35,6 @@ as
 SELECT a, count(b)
 FROM int_tab
 GROUP BY time_bucket(1, a), a WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_2_a_time_partition_col_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(a, time_partition_col)
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DELETE FROM _timescaledb_config.bgw_job WHERE TRUE;
 SET ROLE :ROLE_DEFAULT_PERM_USER;

--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -47,7 +47,6 @@ as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
 --compute time_bucketted max+bucket_width for the materialized view
 SELECT time_bucket('1day' , q.timeval+ '1day'::interval)
 FROM ( select max(timec)as timeval from conditions ) as q;
@@ -64,7 +63,6 @@ as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions
 group by time_bucket('1day', timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, timec)
 --time that refresh assumes as now() for repeatability
 SELECT time_bucket('1day' , q.timeval+ '1day'::interval)
 FROM ( select max(timec)as timeval from conditions ) as q;

--- a/tsl/test/expected/continuous_aggs_query-12.out
+++ b/tsl/test/expected/continuous_aggs_query-12.out
@@ -47,7 +47,6 @@ as
 select location, time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_2_location_timec_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(location, timec)
 --compute time_bucketted max+bucket_width for the materialized view
 SELECT time_bucket('1day' , q.timeval+ '1day'::interval)
 FROM ( select max(timec)as timeval from conditions ) as q;
@@ -64,7 +63,6 @@ as
 select location, time_bucket('1day', timec), first(humidity, timec), last(humidity, timec), max(temperature), min(temperature)
 from conditions
 group by time_bucket('1day', timec), location WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_3_location_timec_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(location, timec)
 --time that refresh assumes as now() for repeatability
 SELECT time_bucket('1day' , q.timeval+ '1day'::interval)
 FROM ( select max(timec)as timeval from conditions ) as q;

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -51,7 +51,6 @@ AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_2_device_day_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(device, day)
 -- The continuous aggregate should be empty
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;
@@ -199,7 +198,6 @@ AS
 SELECT time_bucket('1 day', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions_date
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_4_device_day_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device, day)
 CALL refresh_continuous_aggregate('daily_temp_date', '2020-05-01', '2020-05-03');
 -- Try max refresh window size
 CALL refresh_continuous_aggregate('daily_temp_date', NULL, NULL);
@@ -245,7 +243,6 @@ AS
 SELECT time_bucket(SMALLINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_smallint c
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_6_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_6 USING BTREE(device, bucket)
 CALL refresh_continuous_aggregate('cond_20_smallint', 5::smallint, 50::smallint);
 SELECT * FROM cond_20_smallint
 ORDER BY 1,2;
@@ -297,7 +294,6 @@ AS
 SELECT time_bucket(INT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_int
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_8_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_8 USING BTREE(device, bucket)
 CALL refresh_continuous_aggregate('cond_20_int', 5, 50);
 SELECT * FROM cond_20_int
 ORDER BY 1,2;
@@ -349,7 +345,6 @@ AS
 SELECT time_bucket(BIGINT '20', time) AS bucket, device, avg(temp) AS avg_temp
 FROM conditions_bigint
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_10_device_bucket_idx ON _timescaledb_internal._materialized_hypertable_10 USING BTREE(device, bucket)
 CALL refresh_continuous_aggregate('cond_20_bigint', 5, 50);
 SELECT * FROM cond_20_bigint
 ORDER BY 1,2;
@@ -381,7 +376,6 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_11_device_day_idx ON _timescaledb_internal._materialized_hypertable_11 USING BTREE(device, day)
 CREATE MATERIALIZED VIEW weekly_temp_with_data
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
@@ -389,7 +383,6 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH DATA;
-NOTICE:  adding index _materialized_hypertable_12_device_day_idx ON _timescaledb_internal._materialized_hypertable_12 USING BTREE(device, day)
 NOTICE:  refreshing continuous aggregate "weekly_temp_with_data"
 SELECT * FROM weekly_temp_without_data;
  day | device | avg_temp 
@@ -460,7 +453,6 @@ SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
 END $$;
-NOTICE:  adding index _materialized_hypertable_13_device_day_idx ON _timescaledb_internal._materialized_hypertable_13 USING BTREE(device, day)
 BEGIN;
 CREATE MATERIALIZED VIEW weekly_conditions_2
 WITH (timescaledb.continuous,
@@ -469,5 +461,4 @@ AS
 SELECT time_bucket('7 days', time) AS day, device, avg(temp) AS avg_temp
 FROM conditions
 GROUP BY 1,2 WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_14_device_day_idx ON _timescaledb_internal._materialized_hypertable_14 USING BTREE(device, day)
 COMMIT;

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -30,7 +30,6 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket, device_id WITH NO DATA; --We have to group by the bucket column, but can also add other group-by columns
-NOTICE:  adding index _materialized_hypertable_2_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_2 USING BTREE(device_id, bucket)
 SELECT add_continuous_aggregate_policy('device_summary', NULL, '2 h'::interval, '2 h'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
@@ -204,7 +203,6 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket, device_id WITH NO DATA;
-NOTICE:  adding index _materialized_hypertable_3_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_3 USING BTREE(device_id, bucket)
 DROP MATERIALIZED VIEW device_summary;
 -- Option 2: Keep things as TIMESTAMPTZ in the view and convert to local time when
 -- querying from the view
@@ -222,7 +220,6 @@ SELECT
 FROM
   device_readings
 GROUP BY bucket, device_id WITH DATA;
-NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 NOTICE:  refreshing continuous aggregate "device_summary"
 SELECT min(min_time)::timestamp FROM device_summary;
            min            

--- a/tsl/test/expected/jit-11.out
+++ b/tsl/test/expected/jit-11.out
@@ -58,7 +58,6 @@ SELECT
 FROM
   jit_test_contagg
 GROUP BY bucket, device_id WITH NO DATA;
-psql:include/jit_load.sql:30: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
 INSERT INTO jit_test_contagg

--- a/tsl/test/expected/jit-12.out
+++ b/tsl/test/expected/jit-12.out
@@ -58,7 +58,6 @@ SELECT
 FROM
   jit_test_contagg
 GROUP BY bucket, device_id WITH NO DATA;
-psql:include/jit_load.sql:30: NOTICE:  adding index _materialized_hypertable_4_device_id_bucket_idx ON _timescaledb_internal._materialized_hypertable_4 USING BTREE(device_id, bucket)
 INSERT INTO jit_test_contagg
 SELECT ts, 'device_1', (EXTRACT(EPOCH FROM ts)) from generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '30 minutes') ts;
 INSERT INTO jit_test_contagg

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -126,8 +126,6 @@ ANALYZE metrics_space;
 \set ECHO none
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_5_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 SELECT compress_chunk ('_timescaledb_internal._hyper_1_1_chunk');
              compress_chunk             
 ----------------------------------------
@@ -143,8 +141,6 @@ SELECT compress_chunk ('_timescaledb_internal._hyper_1_3_chunk');
 -- compress some chunks on space partitioned hypertable
 -- we compress all chunks of first time slice, none of second, and 2 of the last time slice
 ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_6_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_6_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 SELECT compress_chunk ('_timescaledb_internal._hyper_2_4_chunk');
              compress_chunk             
 ----------------------------------------
@@ -6851,8 +6847,6 @@ SELECT create_hypertable('metrics_ordered','time');
 (1 row)
 
 ALTER TABLE metrics_ordered SET (timescaledb.compress, timescaledb.compress_orderby='time DESC',timescaledb.compress_segmentby='device_id,device_id_peer');
-psql:include/transparent_decompression_ordered.sql:10: NOTICE:  adding index _compressed_hypertable_12_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_12 USING BTREE(device_id, _ts_meta_sequence_num)
-psql:include/transparent_decompression_ordered.sql:10: NOTICE:  adding index _compressed_hypertable_12_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_12 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered SELECT * FROM metrics;
 CREATE INDEX ON metrics_ordered(device_id,device_id_peer,time);
 CREATE INDEX ON metrics_ordered(device_id,time);
@@ -7085,7 +7079,6 @@ psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null
 (1 row)
 
 ALTER TABLE readings SET (timescaledb.compress, timescaledb.compress_segmentby = 'tags_id', timescaledb.compress_orderby = 'time desc');
-psql:include/transparent_decompression_undiffed.sql:13: NOTICE:  adding index _compressed_hypertable_14_tags_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_14 USING BTREE(tags_id, _ts_meta_sequence_num)
 INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01', '2003-02-01 01:01:01', '1 day'::interval) g;
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
 FROM _timescaledb_catalog.chunk chunk

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -126,8 +126,6 @@ ANALYZE metrics_space;
 \set ECHO none
 -- compress first and last chunk on the hypertable
 ALTER TABLE metrics SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_5_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_5_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_5 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 SELECT compress_chunk ('_timescaledb_internal._hyper_1_1_chunk');
              compress_chunk             
 ----------------------------------------
@@ -143,8 +141,6 @@ SELECT compress_chunk ('_timescaledb_internal._hyper_1_3_chunk');
 -- compress some chunks on space partitioned hypertable
 -- we compress all chunks of first time slice, none of second, and 2 of the last time slice
 ALTER TABLE metrics_space SET (timescaledb.compress, timescaledb.compress_orderby = 'v0, v1 desc, time', timescaledb.compress_segmentby = 'device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_6_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_6_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_6 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 SELECT compress_chunk ('_timescaledb_internal._hyper_2_4_chunk');
              compress_chunk             
 ----------------------------------------
@@ -6780,8 +6776,6 @@ SELECT create_hypertable('metrics_ordered','time');
 (1 row)
 
 ALTER TABLE metrics_ordered SET (timescaledb.compress, timescaledb.compress_orderby='time DESC',timescaledb.compress_segmentby='device_id,device_id_peer');
-psql:include/transparent_decompression_ordered.sql:10: NOTICE:  adding index _compressed_hypertable_12_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_12 USING BTREE(device_id, _ts_meta_sequence_num)
-psql:include/transparent_decompression_ordered.sql:10: NOTICE:  adding index _compressed_hypertable_12_device_id_peer__ts_meta_sequence__idx ON _timescaledb_internal._compressed_hypertable_12 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered SELECT * FROM metrics;
 CREATE INDEX ON metrics_ordered(device_id,device_id_peer,time);
 CREATE INDEX ON metrics_ordered(device_id,time);
@@ -7014,7 +7008,6 @@ psql:include/transparent_decompression_undiffed.sql:12: NOTICE:  adding not-null
 (1 row)
 
 ALTER TABLE readings SET (timescaledb.compress, timescaledb.compress_segmentby = 'tags_id', timescaledb.compress_orderby = 'time desc');
-psql:include/transparent_decompression_undiffed.sql:13: NOTICE:  adding index _compressed_hypertable_14_tags_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_14 USING BTREE(tags_id, _ts_meta_sequence_num)
 INSERT into readings select g, 1, 1.3 from generate_series('2001-03-01 01:01:01', '2003-02-01 01:01:01', '1 day'::interval) g;
 SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name))
 FROM _timescaledb_catalog.chunk chunk

--- a/tsl/test/expected/transparent_decompression_ordered_index-11.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-11.out
@@ -21,8 +21,6 @@ SELECT create_hypertable ('metrics_ordered_idx', 'time', chunk_time_interval => 
 (1 row)
 
 ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby = 'time ASC', timescaledb.compress_segmentby = 'device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_2_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_2_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
 SELECT time,
     device_id,
@@ -111,8 +109,6 @@ SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2d
 (1 row)
 
 ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id, _ts_meta_sequence_num)
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
 SELECT
   compress_chunk(c.schema_name || '.' || c.table_name)

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -21,8 +21,6 @@ SELECT create_hypertable ('metrics_ordered_idx', 'time', chunk_time_interval => 
 (1 row)
 
 ALTER TABLE metrics_ordered_idx SET (timescaledb.compress, timescaledb.compress_orderby = 'time ASC', timescaledb.compress_segmentby = 'device_id,device_id_peer');
-NOTICE:  adding index _compressed_hypertable_2_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_2_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered_idx (time, device_id, device_id_peer, v0)
 SELECT time,
     device_id,
@@ -111,8 +109,6 @@ SELECT create_hypertable('metrics_ordered_idx2','time', chunk_time_interval=>'2d
 (1 row)
 
 ALTER TABLE metrics_ordered_idx2 SET (timescaledb.compress, timescaledb.compress_orderby='time ASC, v0 desc',timescaledb.compress_segmentby='device_id,device_id_peer');
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id, _ts_meta_sequence_num)
-psql:include/transparent_decompression_ordered_indexplan.sql:10: NOTICE:  adding index _compressed_hypertable_4_device_id_peer__ts_meta_sequence_n_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id_peer, _ts_meta_sequence_num)
 INSERT INTO metrics_ordered_idx2(time,device_id,device_id_peer,v0, v1) SELECT generate_series('2000-01-20 0:00:00+0'::timestamptz,'2000-01-20 11:55:00+0','10s') , 3, 3, generate_series(1,5,1) , generate_series(555,559,1);
 SELECT
   compress_chunk(c.schema_name || '.' || c.table_name)

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -18,7 +18,6 @@ values( 8864 , '001407000001DD2E' , 228 , '2019-12-14 02:52:05.863');
 insert into test_chartab
 values( 8890 , '001407000001DD2E' , 228 , '2019-12-20 02:52:05.863');
 ALTER TABLE test_chartab SET (timescaledb.compress, timescaledb.compress_segmentby = 'mac_id', timescaledb.compress_orderby = 'ts DESC');
-NOTICE:  adding index _compressed_hypertable_2_mac_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_2 USING BTREE(mac_id, _ts_meta_sequence_num)
 select * from test_chartab order by mac_id , ts limit 2;
  job_run_id |      mac_id      | rtt |              ts              
 ------------+------------------+-----+------------------------------
@@ -63,8 +62,6 @@ SELECT create_hypertable('merge_sort', 'time');
 (1 row)
 
 ALTER TABLE merge_sort SET (timescaledb.compress = true, timescaledb.compress_orderby = 'time', timescaledb.compress_segmentby = 'device_id, measure_id');
-NOTICE:  adding index _compressed_hypertable_4_measure_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(measure_id, _ts_meta_sequence_num)
-NOTICE:  adding index _compressed_hypertable_4_device_id__ts_meta_sequence_num_idx ON _timescaledb_internal._compressed_hypertable_4 USING BTREE(device_id, _ts_meta_sequence_num)
 INSERT INTO merge_sort SELECT time, 1, 1, extract(epoch from time) * 0.001 FROM generate_series('2000-01-01'::timestamp,'2000-02-01'::timestamp,'1h'::interval) g1(time);
 ANALYZE merge_sort;
 --compress first chunk


### PR DESCRIPTION
We have some debug messages that are printed as notices, but are more
suitable to have at `DEBUG1` level. This commit removes a notice about
indexes being added and turns it into a `DEBUG1` notice.