### PR TITLE
Remove ORDER BY clause from timescaledb_information.jobs view

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -87,8 +87,7 @@ SELECT j.id AS job_id,
   ht.table_name AS hypertable_name
 FROM _timescaledb_config.bgw_job j
   LEFT JOIN _timescaledb_catalog.hypertable ht ON ht.id = j.hypertable_id
-  LEFT JOIN _timescaledb_internal.bgw_job_stat js ON js.job_id = j.id
-ORDER BY j.id;
+  LEFT JOIN _timescaledb_internal.bgw_job_stat js ON js.job_id = j.id;
 
 -- views for continuous aggregate queries ---
 CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregates as


### PR DESCRIPTION
Remove the ORDER BY clause from timescaledb_information.jobs to
make it consistent with our other information views.