### PR TITLE
Remove unused allocation in copy path

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -127,8 +127,6 @@ static uint64
 copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*callback)(void *),
 		 void *arg)
 {
-	Datum *values;
-	bool *nulls;
 	ResultRelInfo *resultRelInfo;
 	ResultRelInfo *saved_resultRelInfo = NULL;
 	EState *estate = ccstate->estate; /* for ExecConstraints() */
@@ -274,9 +272,6 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 	 * EACH ROW triggers that we already fire on COPY.
 	 */
 	ExecBSInsertTriggers(estate, resultRelInfo);
-
-	values = (Datum *) palloc(RelationGetDescr(ccstate->rel)->natts * sizeof(Datum));
-	nulls = (bool *) palloc(RelationGetDescr(ccstate->rel)->natts * sizeof(bool));
 
 	bistate = GetBulkInsertState();
 	econtext = GetPerTupleExprContext(estate);
@@ -439,9 +434,6 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 
 	/* Handle queued AFTER triggers */
 	AfterTriggerEndQuery(estate);
-
-	pfree(values);
-	pfree(nulls);
 
 	ExecResetTupleTable(estate->es_tupleTable, false);
 

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -869,7 +869,7 @@ process_settings(Oid databaseid)
 	if (!IsUnderPostmaster)
 		return;
 
-	relsetting = heap_open(DbRoleSettingRelationId, AccessShareLock);
+	relsetting = table_open(DbRoleSettingRelationId, AccessShareLock);
 
 	/* read all the settings under the same snapshot for efficiency */
 	snapshot = RegisterSnapshot(GetCatalogSnapshot(DbRoleSettingRelationId));
@@ -879,7 +879,7 @@ process_settings(Oid databaseid)
 	ApplySetting(snapshot, InvalidOid, InvalidOid, relsetting, PGC_S_GLOBAL);
 
 	UnregisterSnapshot(snapshot);
-	heap_close(relsetting, AccessShareLock);
+	table_close(relsetting, AccessShareLock);
 }
 
 /*


### PR DESCRIPTION
This patch removes allocation of 2 arrays in the copyfrom function
that were never used.