### PR TITLE
Support compiler-agnostic annotations

### DIFF
--- a/src/annotations.h
+++ b/src/annotations.h
@@ -1,0 +1,24 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_ANNOTATIONS_H
+#define TIMESCALEDB_ANNOTATIONS_H
+
+/* Fall-through annotation */
+#if defined(__clang__)
+#if (__clang_major__ >= 12) || (__clang_analyzer__)
+#define TS_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define TS_FALLTHROUGH /* FALLTHROUGH */
+#endif				   /* __clang__ */
+#elif defined(__GNUC__)
+/* Supported since GCC 7 */
+#define TS_FALLTHROUGH __attribute__((fallthrough))
+#else
+/*  MSVC and other compilers */
+#define TS_FALLTHROUGH /* FALLTHROUGH */
+#endif
+
+#endif /* TIMESCALEDB_ANNOTATIONS_H */

--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -12,6 +12,7 @@
 #include <miscadmin.h>
 #include <utils/syscache.h>
 
+#include "annotations.h"
 #include "catalog.h"
 #include "compat.h"
 #include "extension.h"
@@ -130,6 +131,7 @@ cache_invalidate_xact_end(XactEvent event, void *arg)
 			 * backends cannot have the invalid state.
 			 */
 			cache_invalidate_relcache_all();
+			break;
 		default:
 			break;
 	}
@@ -148,6 +150,7 @@ cache_invalidate_subxact_end(SubXactEvent event, SubTransactionId mySubid,
 			 * in cache_invalidate_xact_end.
 			 */
 			cache_invalidate_relcache_all();
+			break;
 		default:
 			break;
 	}

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -22,6 +22,7 @@
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
 
+#include "annotations.h"
 #include "dimension.h"
 #include "errors.h"
 #include "hypertable_cache.h"
@@ -61,7 +62,7 @@ index_has_attribute(List *indexelems, const char *attrname)
 					break;
 				}
 			}
-			/* FALLTHROUGH */
+				TS_FALLTHROUGH;
 			default:
 				elog(ERROR, "unsupported index list element");
 		}

--- a/src/planner.c
+++ b/src/planner.c
@@ -44,6 +44,7 @@
 
 #include <math.h>
 
+#include "annotations.h"
 #include "cross_module_fn.h"
 #include "license_guc.h"
 #include "hypertable_cache.h"
@@ -791,7 +792,7 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 					ts_cm_functions->set_rel_pathlist_dml(root, rel, rti, rte, ht);
 				break;
 			}
-			/* Fall through */
+			TS_FALLTHROUGH;
 		default:
 			apply_optimizations(root, reltype, rel, rte, ht);
 			break;

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -38,6 +38,7 @@
 
 #include <miscadmin.h>
 
+#include "annotations.h"
 #include "export.h"
 #include "process_utility.h"
 #include "catalog.h"
@@ -3847,6 +3848,7 @@ process_utility_xact_abort(XactEvent event, void *arg)
 			 * transactions.
 			 */
 			expect_chunk_modification = false;
+			break;
 		default:
 			break;
 	}
@@ -3861,6 +3863,7 @@ process_utility_subxact_abort(SubXactEvent event, SubTransactionId mySubid,
 		case SUBXACT_EVENT_ABORT_SUB:
 			/* see note in process_utility_xact_abort */
 			expect_chunk_modification = false;
+			break;
 		default:
 			break;
 	}

--- a/test/src/bgw/timer_mock.c
+++ b/test/src/bgw/timer_mock.c
@@ -18,6 +18,7 @@
 #include <utils/tqual.h>
 #endif
 
+#include "annotations.h"
 #include "timer_mock.h"
 #include "log.h"
 #include "scanner.h"
@@ -60,7 +61,7 @@ mock_wait(TimestampTz until)
 				WaitForBackgroundWorkerShutdown(bgw_handle);
 				bgw_handle = NULL;
 			}
-			/* FALLTHROUGH */
+			TS_FALLTHROUGH;
 		case IMMEDIATELY_SET_UNTIL:
 			ts_params_set_time(until, false);
 			return true;

--- a/test/src/test_with_clause_parser.c
+++ b/test/src/test_with_clause_parser.c
@@ -18,6 +18,7 @@
 #include "export.h"
 #include "test_utils.h"
 #include "with_clause_parser.h"
+#include "annotations.h"
 
 static DefElem *
 def_elem_from_texts(Datum *texts, int nelems)
@@ -30,7 +31,7 @@ def_elem_from_texts(Datum *texts, int nelems)
 			break;
 		case 3:
 			elem->arg = (Node *) makeString(text_to_cstring(DatumGetTextP(texts[2])));
-			/* FALLTHROUGH */
+			TS_FALLTHROUGH;
 		case 2:
 			elem->defname = text_to_cstring(DatumGetTextP(texts[1]));
 			elem->defnamespace = text_to_cstring(DatumGetTextP(texts[0]));

--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -10,6 +10,7 @@
 #include <catalog/namespace.h>
 #include <nodes/parsenodes.h>
 
+#include <annotations.h>
 #include <guc.h>
 #include "hypertable_data_node.h"
 #include "chunk_index.h"
@@ -421,8 +422,7 @@ dist_ddl_preprocess(ProcessUtilityArgs *args)
 			/* Those commands are also targets for execute_on_start in since they
 			 * are not supported by event triggers. */
 			set_dist_exec_type(DIST_DDL_EXEC_ON_START);
-
-			/* fall through */
+			TS_FALLTHROUGH;
 		default:
 			dist_ddl_error_raise_unsupported();
 			break;


### PR DESCRIPTION
This change adds a compiler-agnostic annotation for fall-throughs in
switch statements. The definition is put in `annotations.h`, which can
be expanded to hold definitions for similar functionality in the
future.

The `clang` compiler (as of version 12) seems to have have dropped
support for the previous comment-based annotations to allow
fall-throughs in favor of native annotations or GCC-style attributes.