### PR TITLE
Rename policy parameters

### DIFF
--- a/sql/policy_api.sql
+++ b/sql/policy_api.sql
@@ -12,7 +12,7 @@
 -- might be kept, but data within the window will never be deleted.
 CREATE OR REPLACE FUNCTION add_retention_policy(
        hypertable REGCLASS,
-       retention_window "any",
+       drop_after "any",
        if_not_exists BOOL = false
 )
 RETURNS INTEGER AS '@MODULE_PATHNAME@', 'ts_policy_retention_add'
@@ -32,7 +32,7 @@ AS '@MODULE_PATHNAME@', 'ts_policy_reorder_remove'
 LANGUAGE C VOLATILE STRICT;
 
 /* compression policy */
-CREATE OR REPLACE FUNCTION add_compression_policy(hypertable REGCLASS, older_than "any", if_not_exists BOOL = false)
+CREATE OR REPLACE FUNCTION add_compression_policy(hypertable REGCLASS, compress_after "any", if_not_exists BOOL = false)
 RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_policy_compression_add'
 LANGUAGE C VOLATILE STRICT;

--- a/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
@@ -69,7 +69,7 @@ CALL refresh_continuous_aggregate('drop_chunks_view1', NULL, NULL);
 --TEST1  specify drop chunks policy on mat. hypertable by
 -- directly does not work
 \set ON_ERROR_STOP 0
-SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', retention_window=> -50) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', drop_after => -50) as drop_chunks_job_id1 \gset
 ERROR:  cannot add retention policy to materialized hypertable "_materialized_hypertable_2" 
 \set ON_ERROR_STOP 1
 --TEST2  specify drop chunks policy on cont. aggregate
@@ -95,7 +95,7 @@ WHERE hypertable_name = '_materialized_hypertable_2' ORDER BY range_start_intege
  _hyper_2_43_chunk |                  30 |                40
 (4 rows)
 
-SELECT add_retention_policy( 'drop_chunks_view1', retention_window=> 10) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( 'drop_chunks_view1', drop_after => 10) as drop_chunks_job_id1 \gset
 SELECT alter_job(:drop_chunks_job_id1, schedule_interval => INTERVAL '1 second');
                                                 alter_job                                                 
 ----------------------------------------------------------------------------------------------------------

--- a/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_bgw_drop_chunks.sql
@@ -66,7 +66,7 @@ CALL refresh_continuous_aggregate('drop_chunks_view1', NULL, NULL);
 -- directly does not work
 
 \set ON_ERROR_STOP 0
-SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', retention_window=> -50) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( '_timescaledb_internal._materialized_hypertable_2', drop_after => -50) as drop_chunks_job_id1 \gset
 \set ON_ERROR_STOP 1
 
 --TEST2  specify drop chunks policy on cont. aggregate
@@ -80,7 +80,7 @@ SELECT chunk_name, range_start_integer, range_end_integer
 FROM timescaledb_information.chunks
 WHERE hypertable_name = '_materialized_hypertable_2' ORDER BY range_start_integer;
 
-SELECT add_retention_policy( 'drop_chunks_view1', retention_window=> 10) as drop_chunks_job_id1 \gset
+SELECT add_retention_policy( 'drop_chunks_view1', drop_after => 10) as drop_chunks_job_id1 \gset
 SELECT alter_job(:drop_chunks_job_id1, schedule_interval => INTERVAL '1 second');
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(2000000);
 SELECT count(c) from show_chunks('drop_chunks_view1') as c ;


### PR DESCRIPTION
Policy parameters are renamed to be more consistent and intuitive
across different policies.

Fixes #2442