### PR TITLE
Create low end invalidation when updating caggs

### DIFF
--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -16,6 +16,9 @@ SELECT view_name, schedule_interval, materialized_only, materialization_hypertab
 
 SELECT maxtemp FROM mat_ignoreinval ORDER BY 1;
 
+SELECT materialization_id FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+WHERE lowest_modified_value = -9223372036854775808 ORDER BY 1;
+
 SELECT count(*) FROM mat_inval;
 CALL refresh_continuous_aggregate('mat_inval',NULL,NULL);
 SELECT count(*) FROM mat_inval;


### PR DESCRIPTION
This change will add an invalidation to the
materialization_invalidation_log for any region earlier than the
ignore_invalidation_older_than parameter when updating a continuous
aggregate to 2.0. This is needed as we do not record invalidations
in this region prior to 2.0 and there is no way to ensure the
aggregate is up to date within this range.

Fixes #2450