### PR TITLE
Use postgres implementation of estimate_hashagg_tablesize

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -295,6 +295,14 @@
 #define create_append_path_compat create_append_path
 #endif
 
+/*
+ * estimate_hashagg_tablesize is a static function in PG11 and earlier, so we map
+ * to our own copy when it's not available.
+ */
+#if PG11
+#define estimate_hashagg_tablesize(p, c, n) ts_estimate_hashagg_tablesize(p, c, n)
+#endif
+
 #include <commands/vacuum.h>
 #include <commands/defrem.h>
 

--- a/src/import/planner.c
+++ b/src/import/planner.c
@@ -161,6 +161,7 @@ ts_make_inh_translation_list(Relation oldrelation, Relation newrelation, Index n
 	*translated_vars = vars;
 }
 
+#if PG11
 /* copied exactly from planner.c */
 size_t
 ts_estimate_hashagg_tablesize(struct Path *path, const struct AggClauseCosts *agg_costs,
@@ -184,6 +185,7 @@ ts_estimate_hashagg_tablesize(struct Path *path, const struct AggClauseCosts *ag
 	 */
 	return hashentrysize * dNumGroups;
 }
+#endif
 
 /* copied verbatim from planner.c */
 struct PathTarget *

--- a/src/import/planner.h
+++ b/src/import/planner.h
@@ -26,9 +26,11 @@
 
 extern TSDLLEXPORT void ts_make_inh_translation_list(Relation oldrelation, Relation newrelation,
 													 Index newvarno, List **translated_vars);
+#if PG11
 extern size_t ts_estimate_hashagg_tablesize(struct Path *path,
 											const struct AggClauseCosts *agg_costs,
 											double dNumGroups);
+#endif
 
 extern struct PathTarget *ts_make_partial_grouping_target(struct PlannerInfo *root,
 														  PathTarget *grouping_target);

--- a/src/plan_add_hashagg.c
+++ b/src/plan_add_hashagg.c
@@ -17,6 +17,7 @@
 #include <optimizer/cost.h>
 #include "compat-msvc-exit.h"
 
+#include "compat.h"
 #include "plan_add_hashagg.h"
 #include "import/planner.h"
 #include "utils.h"
@@ -63,9 +64,8 @@ plan_add_parallel_hashagg(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *
 		get_agg_clause_costs(root, parse->havingQual, AGGSPLIT_FINAL_DESERIAL, &agg_final_costs);
 	}
 
-	hashagg_table_size = ts_estimate_hashagg_tablesize(cheapest_partial_path,
-													   &agg_partial_costs,
-													   d_num_partial_groups);
+	hashagg_table_size =
+		estimate_hashagg_tablesize(cheapest_partial_path, &agg_partial_costs, d_num_partial_groups);
 
 	/*
 	 * Tentatively produce a partial HashAgg Path, depending on if it looks as
@@ -146,7 +146,7 @@ ts_plan_add_hashagg(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *output
 	if (!IS_VALID_ESTIMATE(d_num_groups))
 		return;
 
-	hashaggtablesize = ts_estimate_hashagg_tablesize(cheapest_path, &agg_costs, d_num_groups);
+	hashaggtablesize = estimate_hashagg_tablesize(cheapest_path, &agg_costs, d_num_groups);
 
 	if (hashaggtablesize >= work_mem * UINT64CONST(1024))
 		return;


### PR DESCRIPTION
Only use our own implementation of estimate_hashagg_tablesize on
versions where the postgres implementation is static.