### PR TITLE
Show more information in get_git_commit

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install build dependencies
       run: |
-        apk add --no-cache --virtual .build-deps coreutils dpkg-dev findutils gcc libc-dev make util-linux-dev diffutils cmake openssl-dev sudo flex bison
+        apk add --no-cache --virtual .build-deps coreutils dpkg-dev findutils gcc libc-dev make util-linux-dev diffutils cmake openssl-dev sudo flex bison git
 
     - name: Build pg_isolation_regress
       run: |

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -54,7 +54,7 @@ create_postgres_build_image() {
     docker run -d --name ${BUILD_CONTAINER_NAME} --env POSTGRES_HOST_AUTH_METHOD=trust -v ${BASE_DIR}:/src postgres:${PG_IMAGE_TAG}
 
     # Install build dependencies
-    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps gdb git coreutils dpkg-dev gcc libc-dev make cmake util-linux-dev diffutils openssl-dev && mkdir -p /build/debug"
+    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps gdb coreutils dpkg-dev gcc git libc-dev make cmake util-linux-dev diffutils openssl-dev && mkdir -p /build/debug"
     docker commit -a $USER -m "TimescaleDB build base image version $PG_IMAGE_TAG" ${BUILD_CONTAINER_NAME} ${image}
     remove_build_container ${BUILD_CONTAINER_NAME}
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,2 +1,4 @@
 DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;
 DROP VIEW IF EXISTS timescaledb_information.job_stats;
+DROP FUNCTION IF EXISTS _timescaledb_internal.get_git_commit;
+

--- a/sql/version.sql
+++ b/sql/version.sql
@@ -2,7 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit() RETURNS TEXT
+CREATE OR REPLACE FUNCTION _timescaledb_internal.get_git_commit()
+    RETURNS TABLE(commit_tag TEXT, commit_hash TEXT, commit_time TIMESTAMPTZ)
     AS '@MODULE_PATHNAME@', 'ts_get_git_commit' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.get_os_info()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,30 +72,46 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 include(build-defs.cmake)
-set(GITCOMMIT_H ${CMAKE_CURRENT_BINARY_DIR}/gitcommit.h)
 
-if (WIN32)
-  add_custom_command(
-    OUTPUT ${GITCOMMIT_H}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E echo_append "#define EXT_GIT_COMMIT " > ${GITCOMMIT_H}
-    COMMAND (${GIT_EXECUTABLE} describe --abbrev=4 --dirty --always --tags 2> NUL || call && echo "${PROJECT_VERSION_MOD}") >> ${GITCOMMIT_H}
-    COMMENT "Generating gitcommit.h"
-    VERBATIM)
-else ()
-  add_custom_command(
-    OUTPUT ${GITCOMMIT_H}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E echo_append "#define EXT_GIT_COMMIT " > ${GITCOMMIT_H}
-    COMMAND sh -c "if `${GIT_EXECUTABLE} status > /dev/null 2>&1`; then ${GIT_EXECUTABLE} describe --abbrev=4 --dirty --always --tags ; else echo ${PROJECT_VERSION_MOD} ; fi" >> ${GITCOMMIT_H}
-    COMMENT "Generating gitcommit.h"
-    VERBATIM)
-endif (WIN32)
+if(GIT_FOUND)
+  # We use "git describe" to generate the tag. It will find the latest
+  # tag and also add some additional information if we are not on the
+  # tag.
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tags
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE EXT_GIT_COMMIT_TAG
+    RESULT_VARIABLE _describe_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # Fetch the commit HASH of head (short version) using rev-parse
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE EXT_GIT_COMMIT_HASH
+    RESULT_VARIABLE _revparse_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # Fetch the date of the head commit
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} log -1 --format=%aI
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE EXT_GIT_COMMIT_TIME
+    RESULT_VARIABLE _log_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  # Results are non-zero if there were an error
+  if(_describe_RESULT OR _revparse_RESULT OR _log_RESULT)
+    message(STATUS "Unable to get git commit information")
+  endif()
+endif()
+
+configure_file(gitcommit.h.in gitcommit.h)
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
-add_library(${PROJECT_NAME} MODULE ${SOURCES} ${GITCOMMIT_H} $<TARGET_OBJECTS:${TESTS_LIB_NAME}>)
+  add_library(${PROJECT_NAME} MODULE ${SOURCES} ${GITCOMMIT_H} $<TARGET_OBJECTS:${TESTS_LIB_NAME}>)
 else ()
-add_library(${PROJECT_NAME} MODULE ${SOURCES} ${GITCOMMIT_H})
+  add_library(${PROJECT_NAME} MODULE ${SOURCES} ${GITCOMMIT_H})
 endif ()
 
 if (SEND_TELEMETRY_DEFAULT)

--- a/src/annotations.h
+++ b/src/annotations.h
@@ -17,4 +17,14 @@
 #define TS_FALLTHROUGH /* FALLTHROUGH */
 #endif
 
+#ifdef __has_attribute
+#if __has_attribute(used)
+#define TS_USED __attribute__((used))
+#else
+#define TS_USED
+#endif
+#else
+#define TS_USED
+#endif
+
 #endif /* TIMESCALEDB_ANNOTATIONS_H */

--- a/src/gitcommit.h.in
+++ b/src/gitcommit.h.in
@@ -1,0 +1,14 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#ifndef GITCOMMIT_H_
+#define GITCOMMIT_H_
+
+#cmakedefine EXT_GIT_COMMIT_TAG "@EXT_GIT_COMMIT_TAG@"
+#cmakedefine EXT_GIT_COMMIT_HASH "@EXT_GIT_COMMIT_HASH@"
+#cmakedefine EXT_GIT_COMMIT_TIME "@EXT_GIT_COMMIT_TIME@"
+
+#endif /* GITCOMMIT_H_ */

--- a/test/expected/version.out
+++ b/test/expected/version.out
@@ -1,11 +1,14 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
--- Test that get_git_commit returns text
-select pg_typeof(git) from _timescaledb_internal.get_git_commit() AS git;
- pg_typeof 
------------
- text
+-- Check what get_git_commit returns
+SELECT pg_typeof(commit_tag) AS commit_tag_type,
+       pg_typeof(commit_hash) AS commit_hash_type,
+       pg_typeof(commit_time) AS commit_time_type
+  FROM _timescaledb_internal.get_git_commit();
+ commit_tag_type | commit_hash_type |     commit_time_type     
+-----------------+------------------+--------------------------
+ text            | text             | timestamp with time zone
 (1 row)
 
 -- Test that get_os_info returns 3 x text

--- a/test/sql/version.sql
+++ b/test/sql/version.sql
@@ -2,8 +2,11 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
--- Test that get_git_commit returns text
-select pg_typeof(git) from _timescaledb_internal.get_git_commit() AS git;
+-- Check what get_git_commit returns
+SELECT pg_typeof(commit_tag) AS commit_tag_type,
+       pg_typeof(commit_hash) AS commit_hash_type,
+       pg_typeof(commit_time) AS commit_time_type
+  FROM _timescaledb_internal.get_git_commit();
 
 -- Test that get_os_info returns 3 x text
 select pg_typeof(sysname) AS sysname_type,pg_typeof(version) AS version_type,pg_typeof(release) AS release_type from _timescaledb_internal.get_os_info();


### PR DESCRIPTION
Show more information in get_git_commit
  
The command `get_git_commit` shows quite a little information and
especially if mistakes are made it is hard to verify what the binary is
actually based on.

This commit extends the function to provide some more information:
specifically the SHA of the HEAD regardless of whether there is a tag
on it or not and the time for the HEAD commit.

```
postgres=# select * from _timescaledb_internal.get_git_commit();
        commit_tag        | commit_hash |      commit_time
--------------------------+-------------+------------------------
 1.7.4-10-g09b0b778-dirty | 09b0b778    | 2020-09-13 17:50:38+02
(1 row)
```

If git is not installed, the function `get_git_commit` will return an
error indicating that no git information is available. If some of the
fields are available, they will be emitted and the remaining fields
will be NULL.

Fixes #2457
