### PR TITLE
Fix lost notice in cagg test

### DIFF
--- a/tsl/test/expected/continuous_aggs_policy.out
+++ b/tsl/test/expected/continuous_aggs_policy.out
@@ -163,6 +163,7 @@ CREATE MATERIALIZED VIEW max_mat_view_timestamp
         GROUP BY 1 WITH NO DATA;
 SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', '10 day', '1 h'::interval , '1 h'::interval) as job_id \gset
 CALL run_job(:job_id);
+NOTICE:  continuous aggregate "max_mat_view_timestamp" is already up-to-date
 SELECT config FROM _timescaledb_config.bgw_job
 WHERE id = :job_id;
                                        config                                        


### PR DESCRIPTION
PR #2460 made changes to continuous aggregates refresh, which resulted
in a notice in continuous_aggs_policy test expected result. Later this
notice disappeared and this commit fixes it back.