### PR TITLE
Fix parameter names in policy API code

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -154,7 +154,7 @@ SET
   application_name = format('%s [%s]', 'Compression Policy', id),
   proc_schema = '_timescaledb_internal',
   proc_name = 'policy_compression',
-  config = jsonb_build_object('hypertable_id', c.hypertable_id, 'older_than', CASE WHEN (older_than).is_time_interval THEN
+  config = jsonb_build_object('hypertable_id', c.hypertable_id, 'compress_after', CASE WHEN (older_than).is_time_interval THEN
     (older_than).time_interval::text
   ELSE
     (older_than).integer_interval::text
@@ -177,7 +177,7 @@ SET
   application_name = format('%s [%s]', 'Retention Policy', id),
   proc_schema = '_timescaledb_internal',
   proc_name = 'policy_retention',
-  config = jsonb_build_object('hypertable_id', c.hypertable_id, 'retention_window', CASE WHEN (older_than).is_time_interval THEN
+  config = jsonb_build_object('hypertable_id', c.hypertable_id, 'drop_after', CASE WHEN (older_than).is_time_interval THEN
     (older_than).time_interval::text
   ELSE
     (older_than).integer_interval::text
@@ -221,19 +221,19 @@ SET
   config = 
     CASE WHEN ts_tmp_get_time_type( cagg.raw_hypertable_id ) IN  ('TIMESTAMP'::regtype, 'DATE'::regtype, 'TIMESTAMPTZ'::regtype) 
     THEN
-    jsonb_build_object('mat_hypertable_id', cagg.mat_hypertable_id, 'start_interval', 
+    jsonb_build_object('mat_hypertable_id', cagg.mat_hypertable_id, 'start_offset', 
         CASE WHEN cagg.ignore_invalidation_older_than IS NULL OR cagg.ignore_invalidation_older_than = 9223372036854775807 
             THEN NULL 
             ELSE ts_tmp_get_interval(cagg.ignore_invalidation_older_than)::TEXT 
         END 
-    , 'end_interval', ts_tmp_get_interval(cagg.refresh_lag)::TEXT)
+    , 'end_offset', ts_tmp_get_interval(cagg.refresh_lag)::TEXT)
     ELSE
-    jsonb_build_object('mat_hypertable_id', cagg.mat_hypertable_id, 'start_interval', 
+    jsonb_build_object('mat_hypertable_id', cagg.mat_hypertable_id, 'start_offset', 
         CASE WHEN cagg.ignore_invalidation_older_than IS NULL OR cagg.ignore_invalidation_older_than = 9223372036854775807 
             THEN NULL 
             ELSE cagg.ignore_invalidation_older_than::BIGINT
         END
-    , 'end_interval', cagg.refresh_lag::BIGINT)
+    , 'end_offset', cagg.refresh_lag::BIGINT)
     END,
   hypertable_id = cagg.mat_hypertable_id,
   owner = (

--- a/tsl/src/bgw_policy/compression_api.h
+++ b/tsl/src/bgw_policy/compression_api.h
@@ -17,7 +17,7 @@ extern Datum policy_compression_remove(PG_FUNCTION_ARGS);
 extern Datum policy_compression_proc(PG_FUNCTION_ARGS);
 
 int32 policy_compression_get_hypertable_id(const Jsonb *config);
-int64 policy_compression_get_older_than_int(const Jsonb *config);
-Interval *policy_compression_get_older_than_interval(const Jsonb *config);
+int64 policy_compression_get_compress_after_int(const Jsonb *config);
+Interval *policy_compression_get_compress_after_interval(const Jsonb *config);
 
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_COMPRESSION_API_H */

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -125,8 +125,8 @@ get_chunk_to_compress(const Dimension *dim, const Jsonb *config)
 
 	Datum boundary = get_window_boundary(dim,
 										 config,
-										 policy_compression_get_older_than_int,
-										 policy_compression_get_older_than_interval);
+										 policy_compression_get_compress_after_int,
+										 policy_compression_get_compress_after_interval);
 
 	return ts_dimension_slice_get_chunkid_to_compress(dim->fd.id,
 													  InvalidStrategy, /*start_strategy*/
@@ -232,8 +232,8 @@ policy_retention_execute(int32 job_id, Jsonb *config)
 	open_dim = get_open_dimension_for_hypertable(hypertable);
 	boundary = get_window_boundary(open_dim,
 								   config,
-								   policy_retention_get_retention_window_int,
-								   policy_retention_get_retention_window_interval);
+								   policy_retention_get_drop_after_int,
+								   policy_retention_get_drop_after_interval);
 	boundary_type = ts_dimension_get_partition_type(open_dim);
 
 	/* We need to do a reverse lookup here since the given hypertable

--- a/tsl/src/bgw_policy/retention_api.h
+++ b/tsl/src/bgw_policy/retention_api.h
@@ -15,7 +15,7 @@ extern Datum policy_retention_proc(PG_FUNCTION_ARGS);
 extern Datum policy_retention_remove(PG_FUNCTION_ARGS);
 
 int32 policy_retention_get_hypertable_id(const Jsonb *config);
-int64 policy_retention_get_retention_window_int(const Jsonb *config);
-Interval *policy_retention_get_retention_window_interval(const Jsonb *config);
+int64 policy_retention_get_drop_after_int(const Jsonb *config);
+Interval *policy_retention_get_drop_after_interval(const Jsonb *config);
 
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_RETENTION_API_H */

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -353,7 +353,7 @@ WARNING:  unexpected interval: smaller than one second
 \set ON_ERROR_STOP 0
 -- we cannot add a drop_chunks policy on a table whose open dimension is not time and no now_func is set
 select add_retention_policy('test_table_int', INTERVAL '4 months', true);
-ERROR:  invalid parameter value for retention_window
+ERROR:  invalid value for parameter drop_after
 \set ON_ERROR_STOP 1
 INSERT INTO test_table_int VALUES (-2, -2), (-1, -1), (0,0), (1, 1), (2, 2), (3, 3);
 \c :TEST_DBNAME :ROLE_SUPERUSER;

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -409,15 +409,15 @@ SELECT json_object_field(get_telemetry_report(always_display_report := true)::js
 (1 row)
 
 SELECT alter_job(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
-                                                     alter_job                                                      
---------------------------------------------------------------------------------------------------------------------
- (1001,"@ 1 sec","@ 5 mins",-1,"@ 5 mins",t,"{""hypertable_id"": 2, ""retention_window"": ""@ 4 mons""}",-infinity)
+                                                  alter_job                                                   
+--------------------------------------------------------------------------------------------------------------
+ (1001,"@ 1 sec","@ 5 mins",-1,"@ 5 mins",t,"{""drop_after"": ""@ 4 mons"", ""hypertable_id"": 2}",-infinity)
 (1 row)
 
 SELECT * FROM timescaledb_information.jobs WHERE job_id=:drop_chunks_job_id;
- job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                        config                        | next_start | hypertable_schema |    hypertable_name     
---------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------------+------------+-------------------+------------------------
-   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"hypertable_id": 2, "retention_window": "@ 4 mons"} |            | public            | test_drop_chunks_table
+ job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                     config                     | next_start | hypertable_schema |    hypertable_name     
+--------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------+------------+-------------------+------------------------
+   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"drop_after": "@ 4 mons", "hypertable_id": 2} |            | public            | test_drop_chunks_table
 (1 row)
 
 -- no stats
@@ -454,9 +454,9 @@ SELECT * FROM sorted_bgw_log;
 (2 rows)
 
 SELECT * FROM timescaledb_information.jobs WHERE job_id=:drop_chunks_job_id;
- job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                        config                        |          next_start          | hypertable_schema |    hypertable_name     
---------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------------+------------------------------+-------------------+------------------------
-   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"hypertable_id": 2, "retention_window": "@ 4 mons"} | Fri Dec 31 16:00:01 1999 PST | public            | test_drop_chunks_table
+ job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                     config                     |          next_start          | hypertable_schema |    hypertable_name     
+--------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------+------------------------------+-------------------+------------------------
+   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"drop_after": "@ 4 mons", "hypertable_id": 2} | Fri Dec 31 16:00:01 1999 PST | public            | test_drop_chunks_table
 (1 row)
 
 -- job ran once, successfully
@@ -493,9 +493,9 @@ SELECT * FROM sorted_bgw_log;
 (3 rows)
 
 SELECT * FROM timescaledb_information.jobs WHERE job_id=:drop_chunks_job_id;
- job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                        config                        |          next_start          | hypertable_schema |    hypertable_name     
---------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------------+------------------------------+-------------------+------------------------
-   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"hypertable_id": 2, "retention_window": "@ 4 mons"} | Fri Dec 31 16:00:01 1999 PST | public            | test_drop_chunks_table
+ job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                     config                     |          next_start          | hypertable_schema |    hypertable_name     
+--------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------+------------------------------+-------------------+------------------------
+   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"drop_after": "@ 4 mons", "hypertable_id": 2} | Fri Dec 31 16:00:01 1999 PST | public            | test_drop_chunks_table
 (1 row)
 
 -- still only 1 run
@@ -545,9 +545,9 @@ SELECT * FROM sorted_bgw_log;
 (6 rows)
 
 SELECT * FROM timescaledb_information.jobs WHERE job_id=:drop_chunks_job_id;
- job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                        config                        |          next_start          | hypertable_schema |    hypertable_name     
---------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------------+------------------------------+-------------------+------------------------
-   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"hypertable_id": 2, "retention_window": "@ 4 mons"} | Fri Dec 31 16:00:02 1999 PST | public            | test_drop_chunks_table
+ job_id |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled |                     config                     |          next_start          | hypertable_schema |    hypertable_name     
+--------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+------------------------------------------------+------------------------------+-------------------+------------------------
+   1001 | Retention Policy [1001] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         | {"drop_after": "@ 4 mons", "hypertable_id": 2} | Fri Dec 31 16:00:02 1999 PST | public            | test_drop_chunks_table
 (1 row)
 
 -- 2 runs

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -81,15 +81,15 @@ SELECT json_object_field(get_telemetry_report(always_display_report := true)::js
 (1 row)
 
 SELECT alter_job(:retention_job_id, schedule_interval => INTERVAL '1 second');
-                                                     alter_job                                                      
---------------------------------------------------------------------------------------------------------------------
- (1000,"@ 1 sec","@ 5 mins",-1,"@ 5 mins",t,"{""hypertable_id"": 1, ""retention_window"": ""@ 4 mons""}",-infinity)
+                                                  alter_job                                                   
+--------------------------------------------------------------------------------------------------------------
+ (1000,"@ 1 sec","@ 5 mins",-1,"@ 5 mins",t,"{""drop_after"": ""@ 4 mons"", ""hypertable_id"": 1}",-infinity)
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:retention_job_id;
-  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                        config                        
-------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1000 | Retention Policy [1000] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 4 mons"}
+  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                     config                     
+------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------
+ 1000 | Retention Policy [1000] | @ 1 sec           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"drop_after": "@ 4 mons", "hypertable_id": 1}
 (1 row)
 
 --turn on compression and compress all chunks

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -32,21 +32,21 @@ select generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 select add_compression_policy('conditions', '60d'::interval) AS compressjob_id
 \gset
 select * from _timescaledb_config.bgw_job where id = :compressjob_id;
-  id  |     application_name      | schedule_interval  | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                     config                      
-------+---------------------------+--------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-------------------------------------------------
- 1000 | Compression Policy [1000] | @ 15 days 12 hours | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             1 | {"older_than": "@ 60 days", "hypertable_id": 1}
+  id  |     application_name      | schedule_interval  | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                       config                        
+------+---------------------------+--------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-----------------------------------------------------
+ 1000 | Compression Policy [1000] | @ 15 days 12 hours | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             1 | {"hypertable_id": 1, "compress_after": "@ 60 days"}
 (1 row)
 
 select * from alter_job(:compressjob_id, schedule_interval=>'1s');
- job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                     config                      | next_start 
---------+-------------------+-------------+-------------+--------------+-----------+-------------------------------------------------+------------
-   1000 | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | t         | {"older_than": "@ 60 days", "hypertable_id": 1} | -infinity
+ job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled |                       config                        | next_start 
+--------+-------------------+-------------+-------------+--------------+-----------+-----------------------------------------------------+------------
+   1000 | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | t         | {"hypertable_id": 1, "compress_after": "@ 60 days"} | -infinity
 (1 row)
 
 select * from _timescaledb_config.bgw_job where id >= 1000 ORDER BY id;
-  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                     config                      
-------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-------------------------------------------------
- 1000 | Compression Policy [1000] | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             1 | {"older_than": "@ 60 days", "hypertable_id": 1}
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                       config                        
+------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-----------------------------------------------------
+ 1000 | Compression Policy [1000] | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             1 | {"hypertable_id": 1, "compress_after": "@ 60 days"}
 (1 row)
 
 insert into conditions
@@ -127,9 +127,9 @@ alter table test_table_int set (timescaledb.compress);
 select add_compression_policy('test_table_int', 2::int) AS compressjob_id
 \gset
 select * from _timescaledb_config.bgw_job where id=:compressjob_id;
-  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                config                 
-------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+---------------------------------------
- 1001 | Compression Policy [1001] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             3 | {"older_than": 2, "hypertable_id": 3}
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                  config                   
+------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-------------------------------------------
+ 1001 | Compression Policy [1001] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             3 | {"hypertable_id": 3, "compress_after": 2}
 (1 row)
 
 \gset

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -57,9 +57,9 @@ SELECT add_continuous_aggregate_policy('mat_m1', NULL, 2::integer, '12 h'::inter
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job;
-  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner       | scheduled | hypertable_id |                               config                                
-------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+-------------------+-----------+---------------+---------------------------------------------------------------------
- 1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_internal | policy_refresh_continuous_aggregate | default_perm_user | t         |             2 | {"end_interval": 2, "start_interval": null, "mat_hypertable_id": 2}
+  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner       | scheduled | hypertable_id |                             config                              
+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+-------------------+-----------+---------------+-----------------------------------------------------------------
+ 1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_internal | policy_refresh_continuous_aggregate | default_perm_user | t         |             2 | {"end_offset": 2, "start_offset": null, "mat_hypertable_id": 2}
 (1 row)
 
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
@@ -864,9 +864,9 @@ SELECT add_continuous_aggregate_policy('mat_with_test', NULL, '5 h'::interval, '
 (1 row)
 
 SELECT alter_job(id, schedule_interval => '1h') FROM _timescaledb_config.bgw_job;
-                                                                  alter_job                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------
- (1001,"@ 1 hour","@ 0",-1,"@ 12 hours",t,"{""end_interval"": ""@ 5 hours"", ""start_interval"": null, ""mat_hypertable_id"": 20}",-infinity)
+                                                                alter_job                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------
+ (1001,"@ 1 hour","@ 0",-1,"@ 12 hours",t,"{""end_offset"": ""@ 5 hours"", ""start_offset"": null, ""mat_hypertable_id"": 20}",-infinity)
 (1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
@@ -876,9 +876,9 @@ SELECT schedule_interval FROM _timescaledb_config.bgw_job;
 (1 row)
 
 SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job;
-                                                                   alter_job                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
- (1001,"@ 2 hours","@ 0",-1,"@ 12 hours",t,"{""end_interval"": ""@ 5 hours"", ""start_interval"": null, ""mat_hypertable_id"": 20}",-infinity)
+                                                                 alter_job                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ (1001,"@ 2 hours","@ 0",-1,"@ 12 hours",t,"{""end_offset"": ""@ 5 hours"", ""start_offset"": null, ""mat_hypertable_id"": 20}",-infinity)
 (1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;
@@ -960,9 +960,9 @@ SELECT add_continuous_aggregate_policy('mat_with_test', NULL, 500::integer, '12 
 (1 row)
 
 SELECT alter_job(id, schedule_interval => '2h') FROM _timescaledb_config.bgw_job;
-                                                              alter_job                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- (1002,"@ 2 hours","@ 0",-1,"@ 12 hours",t,"{""end_interval"": 500, ""start_interval"": null, ""mat_hypertable_id"": 23}",-infinity)
+                                                            alter_job                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ (1002,"@ 2 hours","@ 0",-1,"@ 12 hours",t,"{""end_offset"": 500, ""start_offset"": null, ""mat_hypertable_id"": 23}",-infinity)
 (1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job;

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -107,9 +107,9 @@ SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg \gset
 SELECT id AS job_id FROM _timescaledb_config.bgw_job where hypertable_id=:mat_hypertable_id \gset
 -- job was created
 SELECT * FROM _timescaledb_config.bgw_job where hypertable_id=:mat_hypertable_id;
-  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner       | scheduled | hypertable_id |                               config                                
-------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+-------------------+-----------+---------------+---------------------------------------------------------------------
- 1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_internal | policy_refresh_continuous_aggregate | default_perm_user | t         |             2 | {"end_interval": 4, "start_interval": null, "mat_hypertable_id": 2}
+  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner       | scheduled | hypertable_id |                             config                              
+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+-------------------+-----------+---------------+-----------------------------------------------------------------
+ 1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_internal | policy_refresh_continuous_aggregate | default_perm_user | t         |             2 | {"end_offset": 4, "start_offset": null, "mat_hypertable_id": 2}
 (1 row)
 
 -- create 10 time buckets
@@ -146,9 +146,9 @@ SELECT * FROM sorted_bgw_log;
 (3 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job where id=:job_id;
-  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner       | scheduled | hypertable_id |                               config                                
-------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+-------------------+-----------+---------------+---------------------------------------------------------------------
- 1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_internal | policy_refresh_continuous_aggregate | default_perm_user | t         |             2 | {"end_interval": 4, "start_interval": null, "mat_hypertable_id": 2}
+  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner       | scheduled | hypertable_id |                             config                              
+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+-------------------+-----------+---------------+-----------------------------------------------------------------
+ 1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_internal | policy_refresh_continuous_aggregate | default_perm_user | t         |             2 | {"end_offset": 4, "start_offset": null, "mat_hypertable_id": 2}
 (1 row)
 
 -- job ran once, successfully
@@ -255,9 +255,9 @@ SELECT ts_bgw_params_reset_time((extract(epoch from interval '12 hour')::bigint 
 
 --alter the refresh interval and check if next_scheduled_run is altered
 SELECT alter_job(:job_id, schedule_interval => '1m', retry_period => '1m');
-                                                                    alter_job                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------
- (1000,"@ 1 min","@ 0",-1,"@ 1 min",t,"{""end_interval"": 4, ""start_interval"": null, ""mat_hypertable_id"": 2}","Sat Jan 01 04:01:00 2000 PST")
+                                                                  alter_job                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------
+ (1000,"@ 1 min","@ 0",-1,"@ 1 min",t,"{""end_offset"": 4, ""start_offset"": null, ""mat_hypertable_id"": 2}","Sat Jan 01 04:01:00 2000 PST")
 (1 row)
 
 SELECT job_id, next_start - last_finish as until_next, total_runs
@@ -295,9 +295,9 @@ SELECT (next_start - '30s'::interval) AS "NEW_NEXT_START"
 FROM _timescaledb_internal.bgw_job_stat
 WHERE job_id=:job_id \gset
 SELECT alter_job(:job_id, next_start => :'NEW_NEXT_START');
-                                                                    alter_job                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------
- (1000,"@ 1 min","@ 0",-1,"@ 1 min",t,"{""end_interval"": 4, ""start_interval"": null, ""mat_hypertable_id"": 2}","Sat Jan 01 04:02:30 2000 PST")
+                                                                  alter_job                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------
+ (1000,"@ 1 min","@ 0",-1,"@ 1 min",t,"{""end_offset"": 4, ""start_offset"": null, ""mat_hypertable_id"": 2}","Sat Jan 01 04:02:30 2000 PST")
 (1 row)
 
 SELECT ts_bgw_params_reset_time((extract(epoch from interval '12 hour')::bigint * 1000000)+(extract(epoch from interval '2 minute 30 seconds')::bigint * 1000000), true);

--- a/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_bgw_drop_chunks.out
@@ -97,9 +97,9 @@ WHERE hypertable_name = '_materialized_hypertable_2' ORDER BY range_start_intege
 
 SELECT add_retention_policy( 'drop_chunks_view1', drop_after => 10) as drop_chunks_job_id1 \gset
 SELECT alter_job(:drop_chunks_job_id1, schedule_interval => INTERVAL '1 second');
-                                                alter_job                                                 
-----------------------------------------------------------------------------------------------------------
- (1000,"@ 1 sec","@ 5 mins",-1,"@ 5 mins",t,"{""hypertable_id"": 2, ""retention_window"": 10}",-infinity)
+                                             alter_job                                              
+----------------------------------------------------------------------------------------------------
+ (1000,"@ 1 sec","@ 5 mins",-1,"@ 5 mins",t,"{""drop_after"": 10, ""hypertable_id"": 2}",-infinity)
 (1 row)
 
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(2000000);

--- a/tsl/test/expected/continuous_aggs_policy.out
+++ b/tsl/test/expected/continuous_aggs_policy.out
@@ -48,11 +48,11 @@ SELECT count(*) FROM _timescaledb_config.bgw_job;
 SELECT add_continuous_aggregate_policy('int_tab', '1 day'::interval, 10 , '1 h'::interval);
 ERROR:  "int_tab" is not a continuous aggregate
 SELECT add_continuous_aggregate_policy('mat_m1', '1 day'::interval, 10 , '1 h'::interval);
-ERROR:  invalid parameter value for start_interval
+ERROR:  invalid parameter value for start_offset
 SELECT add_continuous_aggregate_policy('mat_m1', '1 day'::interval, 10 );
 ERROR:  function add_continuous_aggregate_policy(unknown, interval, integer) does not exist at character 8
 SELECT add_continuous_aggregate_policy('mat_m1', 10, '1 day'::interval, '1 h'::interval);
-ERROR:  invalid parameter value for end_interval
+ERROR:  invalid parameter value for end_offset
 --start_interval < end_interval
 SELECT add_continuous_aggregate_policy('mat_m1', 5, 10, '1h'::interval) as job_id \gset
 ERROR:  start interval should be greater than end interval
@@ -76,9 +76,9 @@ NOTICE:  refresh policy already exists on continuous aggregate "mat_m1", skippin
 
 -- modify config and try to add, should error out
 SELECT config FROM _timescaledb_config.bgw_job where id = :job_id;
-                               config                               
---------------------------------------------------------------------
- {"end_interval": 10, "start_interval": 20, "mat_hypertable_id": 2}
+                             config                             
+----------------------------------------------------------------
+ {"end_offset": 10, "start_offset": 20, "mat_hypertable_id": 2}
 (1 row)
 
 SELECT hypertable_id as mat_id FROM _timescaledb_config.bgw_job where id = :job_id \gset
@@ -94,7 +94,7 @@ SELECT config FROM _timescaledb_config.bgw_job where id = :job_id;
 (1 row)
 
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval, if_not_exists=>true);
-ERROR:  could not find start_interval in config for existing job
+ERROR:  could not find start_offset in config for existing job
 SELECT remove_continuous_aggregate_policy('int_tab');
 ERROR:  "int_tab" is not a continuous aggregate
 SELECT remove_continuous_aggregate_policy('mat_m1');
@@ -136,7 +136,7 @@ CREATE MATERIALIZED VIEW max_mat_view_date
         GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 0
 SELECT add_continuous_aggregate_policy('max_mat_view_date', '2 days', 10, '1 day'::interval);
-ERROR:  invalid parameter value for end_interval
+ERROR:  invalid parameter value for end_offset
 --start_interval < end_interval
 SELECT add_continuous_aggregate_policy('max_mat_view_date', '1 day'::interval, '2 days'::interval , '1 day'::interval) ;
 ERROR:  start interval should be greater than end interval
@@ -144,9 +144,9 @@ ERROR:  start interval should be greater than end interval
 SELECT add_continuous_aggregate_policy('max_mat_view_date', '2 days', '1 day', '1 day'::interval) as job_id \gset
 SELECT config FROM _timescaledb_config.bgw_job
 WHERE id = :job_id;
-                                      config                                       
------------------------------------------------------------------------------------
- {"end_interval": "@ 1 day", "start_interval": "@ 2 days", "mat_hypertable_id": 4}
+                                    config                                     
+-------------------------------------------------------------------------------
+ {"end_offset": "@ 1 day", "start_offset": "@ 2 days", "mat_hypertable_id": 4}
 (1 row)
 
 INSERT INTO continuous_agg_max_mat_date
@@ -198,9 +198,9 @@ CALL run_job(:job_id);
 RESET client_min_messages ;
 SELECT config FROM _timescaledb_config.bgw_job
 WHERE id = :job_id;
-                                       config                                        
--------------------------------------------------------------------------------------
- {"end_interval": "@ 1 hour", "start_interval": "@ 10 days", "mat_hypertable_id": 6}
+                                     config                                      
+---------------------------------------------------------------------------------
+ {"end_offset": "@ 1 hour", "start_offset": "@ 10 days", "mat_hypertable_id": 6}
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -216,7 +216,7 @@ SELECT config FROM _timescaledb_config.bgw_job where id = :job_id;
 
 \set ON_ERROR_STOP 0
 SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', '10 day', '1 day', '1h'::interval, if_not_exists=>true);
-ERROR:  could not find start_interval in config for job
+ERROR:  could not find start_offset in config for job
 SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', 'xyz', '1 day', '1h'::interval, if_not_exists=>true);
 ERROR:  invalid input syntax for type interval: "xyz"
 \set ON_ERROR_STOP 1
@@ -245,7 +245,7 @@ FROM smallint_tab
 GROUP BY 1 WITH NO DATA;
 \set ON_ERROR_STOP 0
 SELECT add_continuous_aggregate_policy('mat_smallint', 15, 0 , '1 h'::interval);
-ERROR:  invalid parameter value for start_interval
+ERROR:  invalid parameter value for start_offset
 SELECT add_continuous_aggregate_policy('mat_smallint', 98898::smallint , 0::smallint, '1 h'::interval);
 ERROR:  smallint out of range
 SELECT add_continuous_aggregate_policy('mat_smallint', 5::smallint, 10::smallint , '1 h'::interval) as job_id \gset
@@ -276,9 +276,9 @@ WARNING:  could not add refresh policy due to existing policy on continuous aggr
 --
 \set ON_ERROR_STOP 0
 SELECT add_continuous_aggregate_policy('mat_smallint', 15, 10, '1h'::interval, if_not_exists=>true);
-ERROR:  invalid parameter value for start_interval
+ERROR:  invalid parameter value for start_offset
 SELECT add_continuous_aggregate_policy('mat_smallint', '15', 10, '1h'::interval, if_not_exists=>true);
-ERROR:  invalid parameter value for end_interval
+ERROR:  invalid parameter value for end_offset
 SELECT add_continuous_aggregate_policy('mat_smallint', '15', '10', '1h'::interval, if_not_exists=>true);
 WARNING:  could not add refresh policy due to existing policy on continuous aggregate with different arguments
  add_continuous_aggregate_policy 

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -96,9 +96,9 @@ SELECT schedule_interval FROM _timescaledb_config.bgw_job WHERE id = 1000;
 
 -- You can change this setting with ALTER VIEW (equivalently, specify in WITH clause of CREATE VIEW)
 SELECT alter_job(1000, schedule_interval := '1h');
-                                                                 alter_job                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------
- (1000,"@ 1 hour","@ 0",-1,"@ 2 hours",t,"{""end_interval"": ""@ 2 hours"", ""start_interval"": null, ""mat_hypertable_id"": 2}",-infinity)
+                                                               alter_job                                                                
+----------------------------------------------------------------------------------------------------------------------------------------
+ (1000,"@ 1 hour","@ 0",-1,"@ 2 hours",t,"{""end_offset"": ""@ 2 hours"", ""start_offset"": null, ""mat_hypertable_id"": 2}",-infinity)
 (1 row)
 
 SELECT schedule_interval FROM _timescaledb_config.bgw_job WHERE id = 1000;

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -113,9 +113,9 @@ ERROR:  function add_retention_policy(interval) does not exist at character 8
 select add_retention_policy('test_table', INTERVAL 'haha');
 ERROR:  invalid input syntax for type interval: "haha" at character 52
 select add_retention_policy('test_table', 'haha');
-ERROR:  invalid parameter value for retention_window
+ERROR:  invalid value for parameter drop_after
 select add_retention_policy('test_table', 42);
-ERROR:  invalid parameter value for retention_window
+ERROR:  invalid value for parameter drop_after
 select add_retention_policy('fake_table', INTERVAL '3 month');
 ERROR:  relation "fake_table" does not exist at character 29
 \set ON_ERROR_STOP 1
@@ -155,9 +155,9 @@ WARNING:  could not add retention policy due to existing policy on hypertable wi
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_retention' ORDER BY id;
-  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                        config                        
-------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1002 | Retention Policy [1002] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
+  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                     config                     
+------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------
+ 1002 | Retention Policy [1002] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"drop_after": "@ 3 mons", "hypertable_id": 1}
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -167,9 +167,9 @@ select add_retention_policy('test_table', INTERVAL '3 days');
 ERROR:  retention policy already exists for hypertable "test_table"
 \set ON_ERROR_STOP 1
 SELECT * FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_retention' ORDER BY id;
-  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                        config                        
-------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1002 | Retention Policy [1002] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
+  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                     config                     
+------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------
+ 1002 | Retention Policy [1002] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"drop_after": "@ 3 mons", "hypertable_id": 1}
 (1 row)
 
 select remove_retention_policy('test_table');
@@ -228,9 +228,9 @@ select add_retention_policy('test_table', INTERVAL '3 month');
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000 ORDER BY id;
-  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                        config                        
-------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1003 | Retention Policy [1003] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 3 mons"}
+  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                     config                     
+------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------
+ 1003 | Retention Policy [1003] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"drop_after": "@ 3 mons", "hypertable_id": 1}
 (1 row)
 
 select remove_retention_policy('test_table');
@@ -251,9 +251,9 @@ select add_retention_policy('test_table_int', 1);
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000 ORDER BY id;
-  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                   config                    
-------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+---------------------------------------------
- 1004 | Retention Policy [1004] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             2 | {"hypertable_id": 2, "retention_window": 1}
+  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                config                 
+------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+---------------------------------------
+ 1004 | Retention Policy [1004] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             2 | {"drop_after": 1, "hypertable_id": 2}
 (1 row)
 
 -- Should not add new policy with different parameters
@@ -380,10 +380,10 @@ select count(*) from _timescaledb_config.bgw_job where id=:reorder_job_id;
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job ORDER BY id;
-  id  |    application_name     | schedule_interval |   max_runtime   | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                        config                        
-------+-------------------------+-------------------+-----------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------------
+  id  |    application_name     | schedule_interval |   max_runtime   | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                      config                       
+------+-------------------------+-------------------+-----------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+---------------------------------------------------
     1 | Telemetry Reporter [1]  | @ 24 hours        | @ 1 min 40 secs |          -1 | @ 1 hour     | _timescaledb_internal | policy_telemetry | super_user        | t         |               | 
- 1007 | Retention Policy [1007] | @ 1 day           | @ 5 mins        |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"hypertable_id": 1, "retention_window": "@ 2 mons"}
+ 1007 | Retention Policy [1007] | @ 1 day           | @ 5 mins        |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             1 | {"drop_after": "@ 2 mons", "hypertable_id": 1}
  1008 | Reorder Policy [1008]   | @ 84 hours        | @ 0             |          -1 | @ 5 mins     | _timescaledb_internal | policy_reorder   | default_perm_user | t         |             1 | {"index_name": "third_index", "hypertable_id": 1}
 (3 rows)
 
@@ -441,18 +441,18 @@ select add_retention_policy('test_table2', INTERVAL '1 days');
 (1 row)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000 ORDER BY id;
-  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                        config                        
-------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------------
- 1009 | Retention Policy [1009] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             4 | {"hypertable_id": 4, "retention_window": "@ 2 days"}
- 1010 | Retention Policy [1010] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             5 | {"hypertable_id": 5, "retention_window": "@ 1 day"}
+  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                     config                     
+------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+------------------------------------------------
+ 1009 | Retention Policy [1009] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             4 | {"drop_after": "@ 2 days", "hypertable_id": 4}
+ 1010 | Retention Policy [1010] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             5 | {"drop_after": "@ 1 day", "hypertable_id": 5}
 (2 rows)
 
 DROP TABLE test_table;
 DROP TABLE test_table_int;
 SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000 ORDER BY id;
-  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                       config                        
-------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+-----------------------------------------------------
- 1010 | Retention Policy [1010] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             5 | {"hypertable_id": 5, "retention_window": "@ 1 day"}
+  id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                    config                     
+------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+-----------------------------------------------
+ 1010 | Retention Policy [1010] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             5 | {"drop_after": "@ 1 day", "hypertable_id": 5}
 (1 row)
 
 DROP TABLE test_table2;
@@ -582,7 +582,7 @@ SELECT * FROM _timescaledb_config.bgw_job WHERE id >= 1000 ORDER BY id;
   id  |    application_name     | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |    proc_name     |       owner       | scheduled | hypertable_id |                          config                           
 ------+-------------------------+-------------------+-------------+-------------+--------------+-----------------------+------------------+-------------------+-----------+---------------+-----------------------------------------------------------
  1012 | Reorder Policy [1012]   | @ 84 hours        | @ 0         |          -1 | @ 5 mins     | _timescaledb_internal | policy_reorder   | default_perm_user | t         |             7 | {"index_name": "test_table_time_idx", "hypertable_id": 7}
- 1013 | Retention Policy [1013] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             7 | {"hypertable_id": 7, "retention_window": "@ 2 days"}
+ 1013 | Retention Policy [1013] | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention | default_perm_user | t         |             7 | {"drop_after": "@ 2 days", "hypertable_id": 7}
 (2 rows)
 
 -- Dropping the drop_chunks job should not affect the chunk_stats row


### PR DESCRIPTION
A previous change updated the public function definitions, but didn't
update the code, config, and error messages to match these changes.