### PR TITLE
Rename column in job_stats view

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -60,7 +60,7 @@ CREATE OR REPLACE VIEW timescaledb_information.job_stats as
     END as job_status,
     CASE WHEN js.last_finish > js.last_start THEN (js.last_finish - js.last_start)
     END as last_run_duration,
-    js.next_start as next_scheduled_run,
+    js.next_start as next_start,
     js.total_runs, js.total_successes, js.total_failures
   FROM _timescaledb_config.bgw_job j
     INNER JOIN _timescaledb_catalog.hypertable ht ON j.hypertable_id = ht.id

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -59,8 +59,8 @@ SELECT * FROM _timescaledb_config.bgw_job;
 (0 rows)
 
 SELECT * FROM timescaledb_information.job_stats;
- hypertable_schema | hypertable_name | job_id | last_run_started_at | last_successful_finish | last_run_status | job_status | last_run_duration | next_scheduled_run | total_runs | total_successes | total_failures 
--------------------+-----------------+--------+---------------------+------------------------+-----------------+------------+-------------------+--------------------+------------+-----------------+----------------
+ hypertable_schema | hypertable_name | job_id | last_run_started_at | last_successful_finish | last_run_status | job_status | last_run_duration | next_start | total_runs | total_successes | total_failures 
+-------------------+-----------------+--------+---------------------+------------------------+-----------------+------------+-------------------+------------+------------+-----------------+----------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
@@ -292,7 +292,7 @@ SELECT indexrelid::regclass, indisclustered
 
 --check that views work correctly
 SELECT * FROM timescaledb_information.job_stats;
- hypertable_schema |  hypertable_name   | job_id |       last_run_started_at       |     last_successful_finish      | last_run_status | job_status | last_run_duration |       next_scheduled_run        | total_runs | total_successes | total_failures 
+ hypertable_schema |  hypertable_name   | job_id |       last_run_started_at       |     last_successful_finish      | last_run_status | job_status | last_run_duration |           next_start            | total_runs | total_successes | total_failures 
 -------------------+--------------------+--------+---------------------------------+---------------------------------+-----------------+------------+-------------------+---------------------------------+------------+-----------------+----------------
  public            | test_reorder_table |   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Success         | Scheduled  |                   | Tue Jan 04 16:00:00.05 2000 PST |          3 |               3 |              0
 (1 row)
@@ -569,7 +569,7 @@ SELECT show_chunks('test_drop_chunks_table');
 
 --test that views work
 SELECT * FROM timescaledb_information.job_stats;
- hypertable_schema |    hypertable_name     | job_id |     last_run_started_at      |    last_successful_finish    | last_run_status | job_status | last_run_duration |      next_scheduled_run      | total_runs | total_successes | total_failures 
+ hypertable_schema |    hypertable_name     | job_id |     last_run_started_at      |    last_successful_finish    | last_run_status | job_status | last_run_duration |          next_start          | total_runs | total_successes | total_failures 
 -------------------+------------------------+--------+------------------------------+------------------------------+-----------------+------------+-------------------+------------------------------+------------+-----------------+----------------
  public            | test_drop_chunks_table |   1001 | Fri Dec 31 16:00:01 1999 PST | Fri Dec 31 16:00:01 1999 PST | Success         | Scheduled  |                   | Fri Dec 31 16:00:02 1999 PST |          2 |               2 |              0
 (1 row)

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -58,8 +58,8 @@ SELECT * FROM _timescaledb_config.bgw_job;
 (0 rows)
 
 SELECT * FROM timescaledb_information.job_stats;
- hypertable_schema | hypertable_name | job_id | last_run_started_at | last_successful_finish | last_run_status | job_status | last_run_duration | next_scheduled_run | total_runs | total_successes | total_failures 
--------------------+-----------------+--------+---------------------+------------------------+-----------------+------------+-------------------+--------------------+------------+-----------------+----------------
+ hypertable_schema | hypertable_name | job_id | last_run_started_at | last_successful_finish | last_run_status | job_status | last_run_duration | next_start | total_runs | total_successes | total_failures 
+-------------------+-----------------+--------+---------------------+------------------------+-----------------+------------+-------------------+------------+------------+-----------------+----------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_agg;
@@ -253,7 +253,7 @@ SELECT ts_bgw_params_reset_time((extract(epoch from interval '12 hour')::bigint 
  
 (1 row)
 
---alter the refresh interval and check if next_scheduled_run is altered
+--alter the refresh interval and check if next_start is altered
 SELECT alter_job(:job_id, schedule_interval => '1m', retry_period => '1m');
                                                                   alter_job                                                                   
 ----------------------------------------------------------------------------------------------------------------------------------------------

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -180,7 +180,7 @@ SELECT wait_for_job_to_run(:job_id, 2);
 --advance clock 1us to make the scheduler realize the job is done
 SELECT ts_bgw_params_reset_time((extract(epoch from interval '12 hour')::bigint * 1000000)+1, true);
 
---alter the refresh interval and check if next_scheduled_run is altered
+--alter the refresh interval and check if next_start is altered
 SELECT alter_job(:job_id, schedule_interval => '1m', retry_period => '1m');
 SELECT job_id, next_start - last_finish as until_next, total_runs
 FROM _timescaledb_internal.bgw_job_stat


### PR DESCRIPTION
Rename next_scheduled_run to next_start so that
jobs and job_stats views have the same column names