### PR TITLE
Auto-close stale issues

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,18 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Since there has been no activity on this issue for 90 days this issue will be automatically closed in 7 days. Please update with additional information if the issue is still relevant.'
+        close-issue-message: 'Message to comment on stale issues. If none provided, will not mark issues stale'
+        days-before-stale: 90
+        days-before-close: 7
+        exempt-issue-label: "enhancement"
+


### PR DESCRIPTION
THis patch adds a workflow to autoclose stale issues after 90 days.