### PR TITLE
Remove unreferenced steps from isolation tests

### DIFF
--- a/tsl/test/isolation/specs/compression_ddl.spec
+++ b/tsl/test/isolation/specs/compression_ddl.spec
@@ -20,16 +20,13 @@ teardown
 }
 
 session "I"
-step "Ib"   { BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '10ms';}
 step "I1"   { BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 100, 100); }
 step "Ic"   { COMMIT; }
 
 session "S"
-step "St" {BEGIN;}
 step "S1" { SELECT count(*) from ts_device_table; }
 step "SC1" { SELECT count(*) from _timescaledb_internal._hyper_1_1_chunk; }
 step "SH" { SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table'); }
-step "Sc" {COMMIT;}
 
 session "LC"
 step "LockChunk1" {

--- a/tsl/test/isolation/specs/continuous_aggs_concurrent_refresh.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_concurrent_refresh.spec
@@ -182,11 +182,6 @@ setup
     SET SESSION lock_timeout = '500ms';
     SET SESSION deadlock_timeout = '500ms';
 }
-step "L1_lock_threshold_table"
-{
-    LOCK _timescaledb_catalog.continuous_aggs_invalidation_threshold
-    IN ACCESS EXCLUSIVE MODE;
-}
 step "L1_unlock_threshold_table"
 {
     ROLLBACK;

--- a/tsl/test/isolation/specs/continuous_aggs_multi.spec
+++ b/tsl/test/isolation/specs/continuous_aggs_multi.spec
@@ -41,8 +41,6 @@ session "I"
 step "I1"	{ INSERT INTO ts_continuous_test SELECT 0, i*10 FROM (SELECT generate_series(0, 10) AS i) AS i; }
 step "I2"   { INSERT INTO ts_continuous_test SELECT 40, 1000 ; }
 
-step "S1"	{ SELECT count(*) FROM ts_continuous_test; }
-
 session "R1"
 setup { SET client_min_messages TO LOG; }
 step "Refresh1"	{ CALL refresh_continuous_aggregate('continuous_view_1', NULL, 30); }


### PR DESCRIPTION
Some isolation tests had steps that were not referenced in
any of the permutations so this patch removes those.