### PR TITLE
Show unscheduled jobs as paused in job_stats

### DIFF
--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -765,6 +765,31 @@ select next_start = now() from alter_job(:job_id, next_start=>now());
  t
 (1 row)
 
+--test pausing/resuming via scheduled parameter
+select job_id from alter_job(:job_id, scheduled=>false);
+ job_id 
+--------
+   1014
+(1 row)
+
+select job_status, next_start from timescaledb_information.job_stats where job_id = :job_id;
+ job_status | next_start 
+------------+------------
+ Paused     | 
+(1 row)
+
+select job_id from alter_job(:job_id, scheduled=>true);
+ job_id 
+--------
+   1014
+(1 row)
+
+select job_status from timescaledb_information.job_stats where job_id = :job_id;
+ job_status 
+------------
+ Scheduled
+(1 row)
+
 \set ON_ERROR_STOP 0
 -- negative infinity disallowed (used as special value)
 select * from alter_job(:job_id, next_start=>'-infinity');

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -299,6 +299,11 @@ select * from alter_job(:job_id, schedule_interval=>'40 min', next_start=>'2004-
 select * from alter_job(:job_id, next_start=>'infinity');
 --test that you can use now() to unpause
 select next_start = now() from alter_job(:job_id, next_start=>now());
+--test pausing/resuming via scheduled parameter
+select job_id from alter_job(:job_id, scheduled=>false);
+select job_status, next_start from timescaledb_information.job_stats where job_id = :job_id;
+select job_id from alter_job(:job_id, scheduled=>true);
+select job_status from timescaledb_information.job_stats where job_id = :job_id;
 
 \set ON_ERROR_STOP 0
 -- negative infinity disallowed (used as special value)


### PR DESCRIPTION
This change updates the timescaledb_information.job_stats view to
check whether a job is currently scheduled in the bgw_config table.
If it is not, the `job_status` field will show `Paused` and the
`next_start` field will be NULL.

Fixes #2488