### PR TITLE
Remove use of REGCLASS in views

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -89,7 +89,9 @@ FROM _timescaledb_config.bgw_job j
 
 -- views for continuous aggregate queries ---
 CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregates as
-  SELECT format('%1$I.%2$I', cagg.user_view_schema, cagg.user_view_name)::regclass as view_name,
+  SELECT
+    cagg.user_view_schema AS view_schema,
+    cagg.user_view_name AS view_name,
     viewinfo.viewowner as view_owner,
     bgwjob.schedule_interval,
     cagg.materialized_only,

--- a/tsl/test/expected/continuous_aggs_permissions.out
+++ b/tsl/test/expected/continuous_aggs_permissions.out
@@ -67,7 +67,7 @@ CALL refresh_continuous_aggregate(' mat_refresh_test', NULL, NULL);
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT format('%I.%I', materialization_hypertable_schema, materialization_hypertable_name ) as materialization_hypertable 
 FROM timescaledb_information.continuous_aggregates 
-WHERE view_name = 'mat_refresh_test'::regclass \gset
+WHERE view_name = 'mat_refresh_test' \gset
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_refresh_test' \gset
 SELECT schema_name as mat_chunk_schema, table_name as mat_chunk_table
 FROM _timescaledb_catalog.chunk

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -70,6 +70,7 @@ SELECT * FROM device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, de
 \x
 SELECT * FROM timescaledb_information.continuous_aggregates;
 -[ RECORD 1 ]---------------------+-------------------------------------------------------------------------------------------------------------
+view_schema                       | public
 view_name                         | device_summary
 view_owner                        | default_perm_user
 schedule_interval                 | @ 2 hours

--- a/tsl/test/sql/continuous_aggs_permissions.sql
+++ b/tsl/test/sql/continuous_aggs_permissions.sql
@@ -64,7 +64,7 @@ CALL refresh_continuous_aggregate(' mat_refresh_test', NULL, NULL);
 SELECT id as cagg_job_id FROM _timescaledb_config.bgw_job order by id desc limit 1 \gset
 SELECT format('%I.%I', materialization_hypertable_schema, materialization_hypertable_name ) as materialization_hypertable 
 FROM timescaledb_information.continuous_aggregates 
-WHERE view_name = 'mat_refresh_test'::regclass \gset
+WHERE view_name = 'mat_refresh_test' \gset
 
 SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg WHERE user_view_name = 'mat_refresh_test' \gset
 


### PR DESCRIPTION
Removing usage of `REGCLASS` from view `continuous_aggregates` and
splitting it into schema and name.