### PR TITLE
Use consistent column names in views

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -7,8 +7,8 @@ CREATE SCHEMA IF NOT EXISTS timescaledb_information;
 -- Convenience view to list all hypertables
 CREATE OR REPLACE VIEW timescaledb_information.hypertables AS
   SELECT
-    ht.schema_name AS table_schema,
-    ht.table_name as table_name,
+    ht.schema_name AS hypertable_schema,
+    ht.table_name as hypertable_name,
     t.tableowner AS owner,
     ht.num_dimensions,
     (SELECT count(1)
@@ -241,8 +241,8 @@ WHERE dim.hypertable_id = ht.id
 CREATE VIEW timescaledb_information.compression_settings
 AS
 SELECT
-    ht.schema_name,
-    ht.table_name,
+    ht.schema_name AS hypertable_schema,
+    ht.table_name AS hypertable_name,
     segq.attname,
     segq.segmentby_column_index,
     segq.orderby_column_index,

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -137,10 +137,11 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 (4 rows)
 
 \x
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_name;
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
 -[ RECORD 1 ]-------+--------------------------
-table_schema        | public
-table_name          | tspace_2dim
+hypertable_schema   | public
+hypertable_name     | tspace_2dim
 owner               | default_perm_user
 num_dimensions      | 2
 num_chunks          | 2

--- a/test/expected/views.out
+++ b/test/expected/views.out
@@ -2,8 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 SELECT * FROM timescaledb_information.hypertables;
- table_schema | table_name | owner | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
---------------+------------+-------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
+ hypertable_schema | hypertable_name | owner | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
+-------------------+-----------------+-------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
 (0 rows)
 
 -- create simple hypertable with 1 chunk
@@ -24,11 +24,12 @@ SELECT create_hypertable('ht2','time');
 (1 row)
 
 INSERT INTO ht2 SELECT '2000-01-01'::TIMESTAMPTZ, repeat('8k',4096);
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
- table_schema | table_name |       owner       | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
---------------+------------+-------------------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
- public       | ht1        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
- public       | ht2        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
+-------------------+-----------------+-------------------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
+ public            | ht1             | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
+ public            | ht2             | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -55,22 +56,24 @@ SELECT create_hypertable('closed.closed_ht','time');
 (1 row)
 
 INSERT INTO closed.closed_ht SELECT '2000-01-01'::TIMESTAMPTZ;
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
- table_schema | table_name |       owner       | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
---------------+------------+-------------------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
- closed       | closed_ht  | super_user        |              1 |          1 | f                   | f              |                    |            | 
- open         | open_ht    | super_user        |              1 |          3 | f                   | f              |                    |            | 
- public       | ht1        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
- public       | ht2        | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |       owner       | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
+-------------------+-----------------+-------------------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
+ closed            | closed_ht       | super_user        |              1 |          1 | f                   | f              |                    |            | 
+ open              | open_ht         | super_user        |              1 |          3 | f                   | f              |                    |            | 
+ public            | ht1             | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
+ public            | ht2             | default_perm_user |              1 |          1 | f                   | f              |                    |            | 
 (4 rows)
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 \set ON_ERROR_STOP 0
 \x
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema,table_name;
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
 -[ RECORD 1 ]-------+------------------
-table_schema        | closed
-table_name          | closed_ht
+hypertable_schema   | closed
+hypertable_name     | closed_ht
 owner               | super_user
 num_dimensions      | 1
 num_chunks          | 1
@@ -80,8 +83,8 @@ replication_factor  |
 data_nodes          | 
 tablespaces         | 
 -[ RECORD 2 ]-------+------------------
-table_schema        | open
-table_name          | open_ht
+hypertable_schema   | open
+hypertable_name     | open_ht
 owner               | super_user
 num_dimensions      | 1
 num_chunks          | 3
@@ -91,8 +94,8 @@ replication_factor  |
 data_nodes          | 
 tablespaces         | 
 -[ RECORD 3 ]-------+------------------
-table_schema        | public
-table_name          | ht1
+hypertable_schema   | public
+hypertable_name     | ht1
 owner               | default_perm_user
 num_dimensions      | 1
 num_chunks          | 1
@@ -102,8 +105,8 @@ replication_factor  |
 data_nodes          | 
 tablespaces         | 
 -[ RECORD 4 ]-------+------------------
-table_schema        | public
-table_name          | ht2
+hypertable_schema   | public
+hypertable_name     | ht2
 owner               | default_perm_user
 num_dimensions      | 1
 num_chunks          | 1
@@ -114,10 +117,12 @@ data_nodes          |
 tablespaces         | 
 
 -- filter by schema
-SELECT * FROM timescaledb_information.hypertables WHERE table_schema = 'closed' ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables
+WHERE hypertable_schema = 'closed'
+ORDER BY hypertable_schema, hypertable_name;
 -[ RECORD 1 ]-------+-----------
-table_schema        | closed
-table_name          | closed_ht
+hypertable_schema   | closed
+hypertable_name     | closed_ht
 owner               | super_user
 num_dimensions      | 1
 num_chunks          | 1
@@ -128,10 +133,12 @@ data_nodes          |
 tablespaces         | 
 
 -- filter by table name
-SELECT * FROM timescaledb_information.hypertables WHERE table_name = 'ht1' ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables
+WHERE hypertable_name = 'ht1'
+ORDER BY hypertable_schema, hypertable_name;
 -[ RECORD 1 ]-------+------------------
-table_schema        | public
-table_name          | ht1
+hypertable_schema   | public
+hypertable_name     | ht1
 owner               | default_perm_user
 num_dimensions      | 1
 num_chunks          | 1
@@ -142,10 +149,12 @@ data_nodes          |
 tablespaces         | 
 
 -- filter by owner
-SELECT * FROM timescaledb_information.hypertables WHERE owner = 'super_user' ORDER BY table_schema,table_name;
+SELECT * FROM timescaledb_information.hypertables
+WHERE owner = 'super_user'
+ORDER BY hypertable_schema, hypertable_name;
 -[ RECORD 1 ]-------+-----------
-table_schema        | closed
-table_name          | closed_ht
+hypertable_schema   | closed
+hypertable_name     | closed_ht
 owner               | super_user
 num_dimensions      | 1
 num_chunks          | 1
@@ -155,8 +164,8 @@ replication_factor  |
 data_nodes          | 
 tablespaces         | 
 -[ RECORD 2 ]-------+-----------
-table_schema        | open
-table_name          | open_ht
+hypertable_schema   | open
+hypertable_name     | open_ht
 owner               | super_user
 num_dimensions      | 1
 num_chunks          | 3

--- a/test/sql/tablespace.sql
+++ b/test/sql/tablespace.sql
@@ -85,7 +85,8 @@ SELECT * FROM test.show_subtables('tspace_2dim');
 SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%_chunk');
 
 \x
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_name;
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
 SELECT * FROM timescaledb_information.chunks ORDER BY chunk_name;
 \x
 --

--- a/test/sql/views.sql
+++ b/test/sql/views.sql
@@ -14,7 +14,8 @@ CREATE TABLE ht2(time TIMESTAMPTZ NOT NULL, data TEXT);
 SELECT create_hypertable('ht2','time');
 INSERT INTO ht2 SELECT '2000-01-01'::TIMESTAMPTZ, repeat('8k',4096);
 
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
@@ -33,21 +34,29 @@ CREATE TABLE closed.closed_ht(time TIMESTAMPTZ NOT NULL);
 SELECT create_hypertable('closed.closed_ht','time');
 INSERT INTO closed.closed_ht SELECT '2000-01-01'::TIMESTAMPTZ;
 
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 \set ON_ERROR_STOP 0
 \x
-SELECT * FROM timescaledb_information.hypertables ORDER BY table_schema,table_name;
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
 
 -- filter by schema
-SELECT * FROM timescaledb_information.hypertables WHERE table_schema = 'closed' ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables
+WHERE hypertable_schema = 'closed'
+ORDER BY hypertable_schema, hypertable_name;
 
 -- filter by table name
-SELECT * FROM timescaledb_information.hypertables WHERE table_name = 'ht1' ORDER BY table_schema, table_name;
+SELECT * FROM timescaledb_information.hypertables
+WHERE hypertable_name = 'ht1'
+ORDER BY hypertable_schema, hypertable_name;
 
 -- filter by owner
-SELECT * FROM timescaledb_information.hypertables WHERE owner = 'super_user' ORDER BY table_schema,table_name;
+SELECT * FROM timescaledb_information.hypertables
+WHERE owner = 'super_user'
+ORDER BY hypertable_schema, hypertable_name;
 \x
 
 ---Add integer table --

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -61,13 +61,13 @@ select * from _timescaledb_catalog.hypertable_compression order by hypertable_id
              1 | d       |                        4 |                        |                    2 | t           | f
 (4 rows)
 
-select * from timescaledb_information.compression_settings ;
- schema_name | table_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
--------------+------------+---------+------------------------+----------------------+-------------+--------------------
- public      | foo        | a       |                      1 |                      |             | 
- public      | foo        | b       |                      2 |                      |             | 
- public      | foo        | c       |                        |                    1 | f           | t
- public      | foo        | d       |                        |                    2 | t           | f
+select * from timescaledb_information.compression_settings ORDER BY hypertable_name;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | foo             | a       |                      1 |                      |             | 
+ public            | foo             | b       |                      2 |                      |             | 
+ public            | foo             | c       |                        |                    1 | f           | t
+ public            | foo             | d       |                        |                    2 | t           | f
 (4 rows)
 
 -- TEST2 compress-chunk for the chunks created earlier --
@@ -454,11 +454,11 @@ pg_size_pretty | 32 kB
 pg_size_pretty | 96 kB
 
 select * from timescaledb_information.hypertables
-where table_name like 'foo' or table_name like 'conditions'
-order by table_name;
+where hypertable_name like 'foo' or hypertable_name like 'conditions'
+order by hypertable_name;
 -[ RECORD 1 ]-------+------------------
-table_schema        | public
-table_name          | conditions
+hypertable_schema   | public
+hypertable_name     | conditions
 owner               | default_perm_user
 num_dimensions      | 1
 num_chunks          | 2
@@ -468,8 +468,8 @@ replication_factor  |
 data_nodes          | 
 tablespaces         | 
 -[ RECORD 2 ]-------+------------------
-table_schema        | public
-table_name          | foo
+hypertable_schema   | public
+hypertable_name     | foo
 owner               | default_perm_user
 num_dimensions      | 1
 num_chunks          | 4
@@ -1140,30 +1140,30 @@ ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = '
 ERROR:  constraint "fk_table1" requires column "col2" to be a timescaledb.compress_segmentby column for compression
 -- Listing all fields of the compound key should succeed:
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1,col2');
-SELECT * FROM timescaledb_information.compression_settings ORDER BY table_name;
- schema_name |   table_name   |   attname   | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
--------------+----------------+-------------+------------------------+----------------------+-------------+--------------------
- public      | conditions     | location    |                      1 |                      |             | 
- public      | conditions     | time        |                        |                    1 | t           | f
- public      | datatype_test  | time        |                        |                    1 | f           | t
- public      | foo            | a           |                      1 |                      |             | 
- public      | foo            | b           |                      2 |                      |             | 
- public      | foo            | c           |                        |                    1 | f           | t
- public      | foo            | d           |                        |                    2 | t           | f
- public      | ht5            | time        |                        |                    1 | f           | t
- public      | hyper          | device_id   |                      1 |                      |             | 
- public      | hyper          | time        |                        |                    1 | t           | f
- public      | metrics        | time        |                        |                    1 | f           | t
- public      | plan_inval     | time        |                        |                    1 | f           | t
- public      | rescan_test    | id          |                      1 |                      |             | 
- public      | rescan_test    | t           |                        |                    1 | f           | t
- public      | table1         | col1        |                      1 |                      |             | 
- public      | table1         | col2        |                      2 |                      |             | 
- public      | test_collation | device_id   |                      1 |                      |             | 
- public      | test_collation | device_id_2 |                      2 |                      |             | 
- public      | test_collation | val_1       |                        |                    1 | t           | f
- public      | test_collation | val_2       |                        |                    2 | t           | f
- public      | test_collation | time        |                        |                    3 | t           | f
+SELECT * FROM timescaledb_information.compression_settings ORDER BY hypertable_name;
+ hypertable_schema | hypertable_name |   attname   | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+-------------+------------------------+----------------------+-------------+--------------------
+ public            | conditions      | location    |                      1 |                      |             | 
+ public            | conditions      | time        |                        |                    1 | t           | f
+ public            | datatype_test   | time        |                        |                    1 | f           | t
+ public            | foo             | a           |                      1 |                      |             | 
+ public            | foo             | b           |                      2 |                      |             | 
+ public            | foo             | c           |                        |                    1 | f           | t
+ public            | foo             | d           |                        |                    2 | t           | f
+ public            | ht5             | time        |                        |                    1 | f           | t
+ public            | hyper           | device_id   |                      1 |                      |             | 
+ public            | hyper           | time        |                        |                    1 | t           | f
+ public            | metrics         | time        |                        |                    1 | f           | t
+ public            | plan_inval      | time        |                        |                    1 | f           | t
+ public            | rescan_test     | id          |                      1 |                      |             | 
+ public            | rescan_test     | t           |                        |                    1 | f           | t
+ public            | table1          | col1        |                      1 |                      |             | 
+ public            | table1          | col2        |                      2 |                      |             | 
+ public            | test_collation  | device_id   |                      1 |                      |             | 
+ public            | test_collation  | device_id_2 |                      2 |                      |             | 
+ public            | test_collation  | val_1       |                        |                    1 | t           | f
+ public            | test_collation  | val_2       |                        |                    2 | t           | f
+ public            | test_collation  | time        |                        |                    3 | t           | f
 (21 rows)
 
 -- test delete/update on non-compressed tables involving hypertables with compression

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -320,12 +320,12 @@ insert into test4
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-31 00:00'::timestamp, '1 day'), 'NYC', 'klick', 55, 75;
 insert into test4
 select generate_series('2018-02-01 00:00'::timestamp, '2018-02-14 00:00'::timestamp, '1 min'), 'POR', 'klick', 55, 75;
-select table_name, num_chunks
+select hypertable_name, num_chunks
 from timescaledb_information.hypertables
-where table_name like 'test4';
- table_name | num_chunks 
-------------+------------
- test4      |          1
+where hypertable_name like 'test4';
+ hypertable_name | num_chunks 
+-----------------+------------
+ test4           |          1
 (1 row)
 
 select location, count(*)

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -140,12 +140,12 @@ WHERE user_view_name = 'mat_m1'
 \gset
 -- Materialized hypertable for mat_m1 should not be visible in the
 -- hypertables view:
-SELECT table_schema, table_name
+SELECT hypertable_schema, hypertable_name
 FROM timescaledb_information.hypertables ORDER BY 1,2;
- table_schema | table_name 
---------------+------------
- public       | conditions
- public       | foo
+ hypertable_schema | hypertable_name 
+-------------------+-----------------
+ public            | conditions
+ public            | foo
 (2 rows)
 
 SET ROLE :ROLE_SUPERUSER;

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -215,10 +215,10 @@ NOTICE:  chunk "_dist_hyper_1_1_chunk" is not compressed
 
 \x
 SELECT * FROM timescaledb_information.hypertables
-WHERE table_name = 'compressed';
+WHERE hypertable_name = 'compressed';
 -[ RECORD 1 ]-------+--------------------------------------------------------------------
-table_schema        | public
-table_name          | compressed
+hypertable_schema   | public
+hypertable_name     | compressed
 owner               | test_role_1
 num_dimensions      | 2
 num_chunks          | 3

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -1398,11 +1398,11 @@ time|device|temp|Color
 
 -- The hypertable view also shows no chunks and no data
 SELECT * FROM timescaledb_information.hypertables
-ORDER BY table_schema, table_name;
- table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
---------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
- public       | underreplicated | test_role_1 |              1 |          0 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
+-------------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
+ public            | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ public            | underreplicated | test_role_1 |              1 |          0 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
 (2 rows)
 
 -- Test underreplicated chunk warning
@@ -1640,11 +1640,11 @@ SELECT * FROM create_distributed_hypertable('remotetable2', 'time', replication_
 ERROR:  invalid replication factor
 \set ON_ERROR_STOP 1
 SELECT * FROM timescaledb_information.hypertables
-ORDER BY table_schema, table_name;
- table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
---------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
- public       | underreplicated | test_role_1 |              1 |          1 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
+-------------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
+ public            | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ public            | underreplicated | test_role_1 |              1 |          1 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
 (2 rows)
 
 -- Test distributed hypertable creation with many parameters

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -1398,11 +1398,11 @@ time|device|temp|Color
 
 -- The hypertable view also shows no chunks and no data
 SELECT * FROM timescaledb_information.hypertables
-ORDER BY table_schema, table_name;
- table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
---------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
- public       | underreplicated | test_role_1 |              1 |          0 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
+-------------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
+ public            | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ public            | underreplicated | test_role_1 |              1 |          0 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
 (2 rows)
 
 -- Test underreplicated chunk warning
@@ -1640,11 +1640,11 @@ SELECT * FROM create_distributed_hypertable('remotetable2', 'time', replication_
 ERROR:  invalid replication factor
 \set ON_ERROR_STOP 1
 SELECT * FROM timescaledb_information.hypertables
-ORDER BY table_schema, table_name;
- table_schema |   table_name    |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
---------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
- public       | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
- public       | underreplicated | test_role_1 |              1 |          1 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |                       data_nodes                        | tablespaces 
+-------------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------------------------+-------------
+ public            | disttable       | test_role_1 |              2 |          0 | f                   | t              |                  1 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
+ public            | underreplicated | test_role_1 |              1 |          1 | f                   | t              |                  4 | {dist_hypertable_1,dist_hypertable_2,dist_hypertable_3} | 
 (2 rows)
 
 -- Test distributed hypertable creation with many parameters

--- a/tsl/test/expected/dist_query-11.out
+++ b/tsl/test/expected/dist_query-11.out
@@ -154,13 +154,13 @@ SELECT distributed_exec($$ SELECT setseed(1); $$);
 ANALYZE reference;
 ANALYZE hyper;
 ANALYZE hyper1d;
-SELECT table_schema, table_name, num_dimensions, num_chunks
+SELECT hypertable_schema, hypertable_name, num_dimensions, num_chunks
 FROM timescaledb_information.hypertables
 ORDER BY 1,2;
- table_schema | table_name | num_dimensions | num_chunks 
---------------+------------+----------------+------------
- public       | hyper      |              2 |         18
- public       | hyper1d    |              1 |          3
+ hypertable_schema | hypertable_name | num_dimensions | num_chunks 
+-------------------+-----------------+----------------+------------
+ public            | hyper           |              2 |         18
+ public            | hyper1d         |              1 |          3
 (2 rows)
 
 SELECT count(*) FROM hyper;

--- a/tsl/test/expected/dist_query-12.out
+++ b/tsl/test/expected/dist_query-12.out
@@ -154,13 +154,13 @@ SELECT distributed_exec($$ SELECT setseed(1); $$);
 ANALYZE reference;
 ANALYZE hyper;
 ANALYZE hyper1d;
-SELECT table_schema, table_name, num_dimensions, num_chunks
+SELECT hypertable_schema, hypertable_name, num_dimensions, num_chunks
 FROM timescaledb_information.hypertables
 ORDER BY 1,2;
- table_schema | table_name | num_dimensions | num_chunks 
---------------+------------+----------------+------------
- public       | hyper      |              2 |         18
- public       | hyper1d    |              1 |          3
+ hypertable_schema | hypertable_name | num_dimensions | num_chunks 
+-------------------+-----------------+----------------+------------
+ public            | hyper           |              2 |         18
+ public            | hyper1d         |              1 |          3
 (2 rows)
 
 SELECT count(*) FROM hyper;

--- a/tsl/test/expected/dist_util.out
+++ b/tsl/test/expected/dist_util.out
@@ -248,11 +248,11 @@ SELECT * FROM timescaledb_information.data_nodes ORDER BY node_name;
  data_node_2 | cluster_super_user | {host=localhost,port=55432,dbname=backend_x_2}
 (2 rows)
 
-SELECT * FROM timescaledb_information.hypertables;
- table_schema |  table_name  |       owner        | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |        data_nodes         | tablespaces 
---------------+--------------+--------------------+----------------+------------+---------------------+----------------+--------------------+---------------------------+-------------
- public       | nondisttable | cluster_super_user |              1 |          3 | f                   | f              |                    |                           | 
- public       | disttable    | cluster_super_user |              1 |          3 | f                   | t              |                  1 | {data_node_1,data_node_2} | 
+SELECT * FROM timescaledb_information.hypertables ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |       owner        | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |        data_nodes         | tablespaces 
+-------------------+-----------------+--------------------+----------------+------------+---------------------+----------------+--------------------+---------------------------+-------------
+ public            | disttable       | cluster_super_user |              1 |          3 | f                   | t              |                  1 | {data_node_1,data_node_2} | 
+ public            | nondisttable    | cluster_super_user |              1 |          3 | f                   | f              |                    |                           | 
 (2 rows)
 
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -67,10 +67,10 @@ LIMIT 1;
 (1 row)
 
 SELECT * FROM timescaledb_information.hypertables
-WHERE table_name = 'dist_table';
- table_schema | table_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
---------------+------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
- public       | dist_table | test_role_1 |              3 |          3 | f                   | t              |                  2 | {view_node_1,view_node_2,view_node_3} | 
+WHERE hypertable_name = 'dist_table';
+ hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
+-------------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
+ public            | dist_table      | test_role_1 |              3 |          3 | f                   | t              |                  2 | {view_node_1,view_node_2,view_node_3} | 
 (1 row)
 
 SELECT * from timescaledb_information.chunks 

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -29,7 +29,7 @@ SET timescaledb.enable_transparent_decompression to OFF;
 select id, schema_name, table_name, compressed, compressed_hypertable_id from
 _timescaledb_catalog.hypertable order by id;
 select * from _timescaledb_catalog.hypertable_compression order by hypertable_id, attname;
-select * from timescaledb_information.compression_settings ;
+select * from timescaledb_information.compression_settings ORDER BY hypertable_name;
 
 -- TEST2 compress-chunk for the chunks created earlier --
 select compress_chunk( '_timescaledb_internal._hyper_1_2_chunk');
@@ -182,8 +182,8 @@ select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
 pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('conditions');
 select * from timescaledb_information.hypertables
-where table_name like 'foo' or table_name like 'conditions'
-order by table_name;
+where hypertable_name like 'foo' or hypertable_name like 'conditions'
+order by hypertable_name;
 \x
 
 SELECT decompress_chunk(ch1.schema_name|| '.' || ch1.table_name) AS chunk
@@ -455,7 +455,7 @@ SELECT create_hypertable('table1','col1', chunk_time_interval => 10);
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1');
 -- Listing all fields of the compound key should succeed:
 ALTER TABLE table1 SET (timescaledb.compress, timescaledb.compress_segmentby = 'col1,col2');
-SELECT * FROM timescaledb_information.compression_settings ORDER BY table_name;
+SELECT * FROM timescaledb_information.compression_settings ORDER BY hypertable_name;
 
 -- test delete/update on non-compressed tables involving hypertables with compression
 CREATE TABLE uncompressed_ht (

--- a/tsl/test/sql/compression_hypertable.sql
+++ b/tsl/test/sql/compression_hypertable.sql
@@ -138,9 +138,9 @@ insert into test4
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-31 00:00'::timestamp, '1 day'), 'NYC', 'klick', 55, 75;
 insert into test4
 select generate_series('2018-02-01 00:00'::timestamp, '2018-02-14 00:00'::timestamp, '1 min'), 'POR', 'klick', 55, 75;
-select table_name, num_chunks
+select hypertable_name, num_chunks
 from timescaledb_information.hypertables
-where table_name like 'test4';
+where hypertable_name like 'test4';
 
 select location, count(*)
 from test4

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -119,7 +119,7 @@ WHERE user_view_name = 'mat_m1'
 
 -- Materialized hypertable for mat_m1 should not be visible in the
 -- hypertables view:
-SELECT table_schema, table_name
+SELECT hypertable_schema, hypertable_name
 FROM timescaledb_information.hypertables ORDER BY 1,2;
 
 SET ROLE :ROLE_SUPERUSER;

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -89,7 +89,7 @@ LIMIT 1;
 
 \x
 SELECT * FROM timescaledb_information.hypertables
-WHERE table_name = 'compressed';
+WHERE hypertable_name = 'compressed';
 SELECT * from timescaledb_information.chunks 
 ORDER BY hypertable_name, chunk_name;
 SELECT * from timescaledb_information.dimensions 

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -428,7 +428,7 @@ $$);
 
 -- The hypertable view also shows no chunks and no data
 SELECT * FROM timescaledb_information.hypertables
-ORDER BY table_schema, table_name;
+ORDER BY hypertable_schema, hypertable_name;
 
 -- Test underreplicated chunk warning
 INSERT INTO underreplicated VALUES ('2017-01-01 06:01', 1, 1.1),
@@ -487,7 +487,7 @@ SELECT * FROM create_distributed_hypertable('remotetable2', 'time', replication_
 \set ON_ERROR_STOP 1
 
 SELECT * FROM timescaledb_information.hypertables
-ORDER BY table_schema, table_name;
+ORDER BY hypertable_schema, hypertable_name;
 
 -- Test distributed hypertable creation with many parameters
 \c :DATA_NODE_1

--- a/tsl/test/sql/dist_query.sql.in
+++ b/tsl/test/sql/dist_query.sql.in
@@ -25,7 +25,7 @@ SET client_min_messages TO notice;
 
 -- Load the data
 \ir :TEST_LOAD_NAME
-SELECT table_schema, table_name, num_dimensions, num_chunks
+SELECT hypertable_schema, hypertable_name, num_dimensions, num_chunks
 FROM timescaledb_information.hypertables
 ORDER BY 1,2;
 SELECT count(*) FROM hyper;

--- a/tsl/test/sql/dist_util.sql
+++ b/tsl/test/sql/dist_util.sql
@@ -137,7 +137,7 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:05', 1, 1.4);
 
 SELECT * FROM timescaledb_information.data_nodes ORDER BY node_name;
-SELECT * FROM timescaledb_information.hypertables;
+SELECT * FROM timescaledb_information.hypertables ORDER BY hypertable_schema, hypertable_name;
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
 SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
 SELECT * FROM hypertable_size('disttable') ;

--- a/tsl/test/sql/dist_views.sql
+++ b/tsl/test/sql/dist_views.sql
@@ -38,7 +38,7 @@ ORDER BY chunk
 LIMIT 1;
 
 SELECT * FROM timescaledb_information.hypertables
-WHERE table_name = 'dist_table';
+WHERE hypertable_name = 'dist_table';
 SELECT * from timescaledb_information.chunks 
 ORDER BY hypertable_name, chunk_name;
 SELECT * from timescaledb_information.dimensions 


### PR DESCRIPTION
Make all views that reference hypertables use `hypertable_schema` and
`hypertable_name`.