### PR TITLE
Ignore memory leaks in openssl code

### DIFF
--- a/scripts/suppressions/suppr_leak.txt
+++ b/scripts/suppressions/suppr_leak.txt
@@ -25,3 +25,6 @@ leak:ShmemInitHash
 leak:deserialize_test_parameters
 leak:ts_params_get
 leak:test_job_dispatcher
+
+#openssl
+leak:CRYPTO_zalloc


### PR DESCRIPTION
Ignore memory leaks in openssl code when running sanitizer tests
in CI.