### PR TITLE
Fix timescaledb_fdw sql script

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -9,6 +9,7 @@ set(PRE_INSTALL_SOURCE_FILES
   pre_install/tables.sql
   pre_install/insert_data.sql
   pre_install/bgw_scheduler_startup.sql
+  pre_install/timescaledb_fdw.sql
 )
 
 # Things like aggregate functions cannot be REPLACEd and really
@@ -48,7 +49,6 @@ set(SOURCE_FILES
   maintenance_utils.sql
   partialize_finalize.sql
   restoring.sql
-  timescaledb_fdw.sql
   remote_txn.sql
   job_api.sql
   policy_api.sql

--- a/sql/pre_install/timescaledb_fdw.sql
+++ b/sql/pre_install/timescaledb_fdw.sql
@@ -2,12 +2,12 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE FUNCTION timescaledb_fdw_handler()
+CREATE OR REPLACE FUNCTION timescaledb_fdw_handler()
 RETURNS fdw_handler
 AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_handler'
 LANGUAGE C STRICT;
 
-CREATE FUNCTION timescaledb_fdw_validator(text[], oid)
+CREATE OR REPLACE FUNCTION timescaledb_fdw_validator(text[], oid)
 RETURNS void
 AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_validator'
 LANGUAGE C STRICT;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -407,3 +407,17 @@ BEGIN
 END
 $$;
 
+CREATE OR REPLACE FUNCTION timescaledb_fdw_handler()
+RETURNS fdw_handler
+AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_handler'
+LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION timescaledb_fdw_validator(text[], oid)
+RETURNS void
+AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_validator'
+LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER timescaledb_fdw
+  HANDLER timescaledb_fdw_handler
+  VALIDATOR timescaledb_fdw_validator;
+


### PR DESCRIPTION
Since CREATE FOREIGN DATA WRAPPER is not idempotent it must not be
grouped with the normal sql scripts but has to be in the pre_install
group.