### PR TITLE
Fix datanode sql function script

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -49,7 +49,6 @@ set(SOURCE_FILES
   maintenance_utils.sql
   partialize_finalize.sql
   restoring.sql
-  remote_txn.sql
   job_api.sql
   policy_api.sql
   policy_internal.sql

--- a/sql/data_node.sql
+++ b/sql/data_node.sql
@@ -3,5 +3,10 @@
 -- LICENSE-APACHE for a copy of the license.
 
 -- Check if a data node is up
-CREATE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME) RETURNS BOOLEAN
+CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME) RETURNS BOOLEAN
 AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.remote_txn_heal_data_node(foreign_server_oid oid)
+RETURNS INT
+AS '@MODULE_PATHNAME@', 'ts_remote_txn_heal_data_node'
+LANGUAGE C STRICT;

--- a/sql/remote_txn.sql
+++ b/sql/remote_txn.sql
@@ -1,8 +1,0 @@
--- This file and its contents are licensed under the Apache License 2.0.
--- Please see the included NOTICE for copyright information and
--- LICENSE-APACHE for a copy of the license.
-
-CREATE FUNCTION _timescaledb_internal.remote_txn_heal_data_node(foreign_server_oid oid)
-RETURNS INT
-AS '@MODULE_PATHNAME@', 'ts_remote_txn_heal_data_node'
-LANGUAGE C STRICT;


### PR DESCRIPTION
This patch merge data_node and remote_txn sql scripts and fixes
the CREATE FUNCTION statement to use CREATE OR REPLACE FUNCTION.