### PR TITLE
Block reorder policy for distributed hypertables

### DIFF
--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -147,6 +147,14 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 				 errmsg("could not add reorder policy because \"%s\" is not a hypertable",
 						get_rel_name(ht_oid))));
 
+	if (hypertable_is_distributed(ht))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("could not add reorder policy because \"%s\" is a distributed hypertable",
+						get_rel_name(ht_oid)),
+				 errdetail("Current version doesn't implement support for add_reorder_policy() on "
+						   "distributed hypertables.")));
+
 	/* Now verify that the index is an actual index on that hypertable */
 	check_valid_index(ht, index_name);
 

--- a/tsl/test/expected/dist_policy.out
+++ b/tsl/test/expected/dist_policy.out
@@ -303,3 +303,6 @@ INSERT INTO conditions
 SELECT time, device, random()*80
 FROM generate_series(1,10) AS time,
      generate_series(1,3) AS device;
+-- Make sure reorder policy is blocked for distributed hypertable
+SELECT add_reorder_policy('conditions', 'conditions_time_idx');
+ERROR:  could not add reorder policy because "conditions" is a distributed hypertable

--- a/tsl/test/sql/dist_policy.sql
+++ b/tsl/test/sql/dist_policy.sql
@@ -80,3 +80,6 @@ INSERT INTO conditions
 SELECT time, device, random()*80
 FROM generate_series(1,10) AS time,
      generate_series(1,3) AS device;
+
+-- Make sure reorder policy is blocked for distributed hypertable
+SELECT add_reorder_policy('conditions', 'conditions_time_idx');


### PR DESCRIPTION
Block for `add_reorder_policy` were missing previously for distributed hypertables, yet `reorder_chunk` and `move_chunk` are blocked when called directly.

Issue: https://github.com/timescale/timescaledb-private/issues/839