### PR TITLE
Replace check function when updating

### DIFF
--- a/sql/updates/1.5.1--1.6.0.sql
+++ b/sql/updates/1.5.1--1.6.0.sql
@@ -23,6 +23,13 @@ BEGIN
 END
 $BODY$;
 
+-- Replace the function with the version in the new shared library
+-- since it is used in a check constraint when updating the table
+-- bgw_policy_drop_chunks. Not replacing it would try to use the
+-- version in the previous library, which will fail the version check
+-- in ts_extension_check_version.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.valid_ts_interval(invl _timescaledb_catalog.ts_interval)
+RETURNS BOOLEAN AS '@MODULE_PATHNAME@', 'ts_valid_ts_interval' LANGUAGE C VOLATILE STRICT;
 
 ALTER TABLE  _timescaledb_catalog.continuous_agg
     ADD COLUMN  ignore_invalidation_older_than BIGINT NOT NULL DEFAULT BIGINT '9223372036854775807';

--- a/test/sql/updates/post.policies.sql
+++ b/test/sql/updates/post.policies.sql
@@ -2,8 +2,9 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\ir setup.v2.sql
-\ir setup.continuous_aggs.v2.sql
-\ir setup.compression.sql
-\ir setup.policies.sql
-
+SELECT
+    *
+FROM
+    _timescaledb_config.bgw_policy_drop_chunks
+ORDER BY
+    job_id;

--- a/test/sql/updates/setup.policies.sql
+++ b/test/sql/updates/setup.policies.sql
@@ -1,0 +1,15 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE TABLE policy_test_timestamptz (
+    time timestamptz,
+    device_id int,
+    value float
+);
+
+SELECT table_name FROM create_hypertable ('policy_test_timestamptz', 'time');
+
+SELECT * FROM
+    add_drop_chunks_policy ('policy_test_timestamptz', '60d'::interval,
+        cascade_to_materializations => FALSE);

--- a/test/sql/updates/setup.v6-pg11.sql
+++ b/test/sql/updates/setup.v6-pg11.sql
@@ -5,4 +5,4 @@
 \ir setup.v2.sql
 \ir setup.continuous_aggs.v2.sql
 \ir setup.compression.sql
-
+\ir setup.policies.sql


### PR DESCRIPTION
When updating from version 1.5.1 to 1.6.0 the meaning of the
`cascade_to_materialization` column in `bgw_policy_drop_chunks`
changed and `NULL` was introduced as an acceptable value. This means
that the table was updated and `false` in this column was replaced with
`NULL`.

This triggered the check function `valid_ts_interval` to execute as
part of a check constraint. However, it referred to the C version in
the old library and not the new library and therefore triggers an error
in the `ts_extension_check_version` function since the function is in
the old shared library.

This commit fixes the issue by replacing the function definition with
the same function in the new library, so that the check doesn't fail.

Closes #2513