### PR TITLE
Remove error for correct bootstrap of data node

### DIFF
--- a/tsl/test/expected/data_node_bootstrap.out
+++ b/tsl/test/expected/data_node_bootstrap.out
@@ -188,8 +188,7 @@ CREATE DATABASE bootstrap_test
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('bootstrap_test', host => 'localhost',
                             database => 'bootstrap_test', bootstrap => true);
-NOTICE:  database "bootstrap_test" already exists on data node, skipping
-ERROR:  database encoding mismatch
+ERROR:  database exists but has wrong encoding
 \set ON_ERROR_STOP 1
 DROP DATABASE bootstrap_test;
 ----------------------------------------------------------------------
@@ -224,7 +223,7 @@ SET client_min_messages TO NOTICE;
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('bootstrap_test', host => 'localhost',
                             database => 'bootstrap_test', bootstrap => false);
-ERROR:  database encoding mismatch
+ERROR:  database exists but has wrong encoding
 \set ON_ERROR_STOP 1
 DROP DATABASE bootstrap_test;
 CREATE DATABASE bootstrap_test
@@ -242,7 +241,7 @@ SET client_min_messages TO NOTICE;
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('bootstrap_test', host => 'localhost',
                             database => 'bootstrap_test', bootstrap => false);
-ERROR:  database collation mismatch
+ERROR:  database exists but has wrong collation
 \set ON_ERROR_STOP 1
 DROP DATABASE bootstrap_test;
 CREATE DATABASE bootstrap_test
@@ -260,7 +259,7 @@ SET client_min_messages TO NOTICE;
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('bootstrap_test', host => 'localhost',
                             database => 'bootstrap_test', bootstrap => false);
-ERROR:  database LC_CTYPE mismatch
+ERROR:  database exists but has wrong LC_CTYPE
 \set ON_ERROR_STOP 1
 DROP DATABASE bootstrap_test;
 -----------------------------------------------------------------------


### PR DESCRIPTION
If the database exists on the data node when executing `add_data_node`
it will generate an error in the data node log, which can cause
problems since there is an error indication in the log but there are no
failing operations.

This commit fixes this by first validating the database and only if it
does not exist, create the database.

Closes #2503