### PR TITLE
Fix validation logic when adding a new data node

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -427,12 +427,9 @@ data_node_validate_extension(TSConnection *conn)
 {
 	const char *const dbname = PQdb(remote_connection_get_pg_conn(conn));
 	const char *const host = PQhost(remote_connection_get_pg_conn(conn));
-	const char *const username = PQuser(remote_connection_get_pg_conn(conn));
 	const char *const port = PQport(remote_connection_get_pg_conn(conn));
 
-	const char *actual_username = NULL;
-
-	if (!remote_connection_check_extension(conn, &actual_username, NULL))
+	if (!remote_connection_check_extension(conn))
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_DATA_NODE_INVALID_CONFIG),
 				 errmsg("database does not have TimescaleDB extension loaded"),
@@ -441,15 +438,6 @@ data_node_validate_extension(TSConnection *conn)
 						   dbname,
 						   host,
 						   port)));
-
-	/* Check that the owner is correct */
-	if (strcmp(actual_username, username) != 0)
-		ereport(ERROR,
-				(errcode(ERRCODE_TS_DATA_NODE_INVALID_CONFIG),
-				 errmsg("invalid extension owner"),
-				 errdetail("Expected TimescaleDB owner to be %s, but was %s",
-						   username,
-						   actual_username)));
 }
 
 static void

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -68,8 +68,7 @@ extern unsigned int remote_connection_get_cursor_number(void);
 extern void remote_connection_reset_cursor_number(void);
 extern unsigned int remote_connection_get_prep_stmt_number(void);
 extern bool remote_connection_configure(TSConnection *conn);
-extern bool remote_connection_check_extension(TSConnection *conn, const char **owner_name,
-											  Oid *owner_oid);
+extern bool remote_connection_check_extension(TSConnection *conn);
 extern void remote_validate_extension_version(TSConnection *conn, const char *data_node_version);
 
 extern bool remote_connection_cancel_query(TSConnection *conn);

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -1291,9 +1291,29 @@ NOTICE:  database "db_data_node" already exists on data node, skipping
 NOTICE:  extension "timescaledb" already exists on data node, skipping
 ERROR:  [data_node_99]: cannot add the current database as a data node to itself
 \set ON_ERROR_STOP 1
+-- Test adding bootstrapped data node where extension owner is different from user adding a data node
+SET ROLE :ROLE_CLUSTER_SUPERUSER;
+CREATE DATABASE data_node_6;
+\c data_node_6
+SET client_min_messages = ERROR;
+-- Creating an extension as superuser
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SET ROLE :ROLE_1;
+-- Trying to add data node as non-superuser
+SELECT * FROM add_data_node('data_node_6', host => 'localhost', database => 'data_node_6');
+NOTICE:  database "data_node_6" already exists on data node, skipping
+NOTICE:  extension "timescaledb" already exists on data node, skipping
+  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
+-------------+-----------+-------+-------------+--------------+------------------+-------------------
+ data_node_6 | localhost | 55432 | data_node_6 | t            | f                | f
+(1 row)
+
 RESET ROLE;
 DROP DATABASE data_node_1;
 DROP DATABASE data_node_2;
 DROP DATABASE data_node_3;
 DROP DATABASE data_node_4;
 DROP DATABASE data_node_5;
+DROP DATABASE data_node_6;

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -656,9 +656,25 @@ SELECT * FROM add_data_node('data_node_1', 'localhost', database => 'data_node_1
 SELECT * FROM add_data_node('data_node_99', host => 'localhost');
 \set ON_ERROR_STOP 1
 
+
+-- Test adding bootstrapped data node where extension owner is different from user adding a data node
+SET ROLE :ROLE_CLUSTER_SUPERUSER;
+CREATE DATABASE data_node_6;
+\c data_node_6
+SET client_min_messages = ERROR;
+-- Creating an extension as superuser
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SET ROLE :ROLE_1;
+-- Trying to add data node as non-superuser
+SELECT * FROM add_data_node('data_node_6', host => 'localhost', database => 'data_node_6');
+
 RESET ROLE;
 DROP DATABASE data_node_1;
 DROP DATABASE data_node_2;
 DROP DATABASE data_node_3;
 DROP DATABASE data_node_4;
 DROP DATABASE data_node_5;
+DROP DATABASE data_node_6;


### PR DESCRIPTION
We stop enforcing an extension owner to be the same as a user adding a
data node since that's not strictly necessary. In multi-node setups
it is common that a data node is pre bootstrapped and an extension owner
is already set. This will prevent getting an error when a non
extension owner tries to add a data node.

Closes https://github.com/timescale/timescaledb/issues/2508