### PR TITLE
Fix outer join qual propagation

### DIFF
--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -1085,7 +1085,7 @@ timebucket_annotate_walker(Node *node, CollectQualCtx *ctx)
 	{
 		JoinExpr *j = castNode(JoinExpr, node);
 		j->quals = timebucket_annotate(j->quals, ctx);
-		collect_join_quals(j->quals, ctx, !IS_OUTER_JOIN(j->jointype));
+		collect_join_quals(j->quals, ctx, IS_OUTER_JOIN(j->jointype));
 	}
 
 	/* skip processing if we found a chunks_in call for current relation */

--- a/test/expected/lateral.out
+++ b/test/expected/lateral.out
@@ -97,3 +97,93 @@ ORDER BY user_id, first_order_time, time1, min_time;
 
 -- Cleanup
 DROP TABLE orders;
+---- OUTER JOIN tests ---
+--github issue 2500
+CREATE TABLE t1_timescale (a int, b int);
+CREATE TABLE t2 (a int, b int);
+SELECT create_hypertable('t1_timescale', 'a', chunk_time_interval=>1000);
+NOTICE:  adding not-null constraint to column "a"
+     create_hypertable     
+---------------------------
+ (3,public,t1_timescale,t)
+(1 row)
+
+INSERT into t2 values (3, 3), (15 , 15);
+INSERT into t1_timescale select generate_series(5, 25, 1), 77;
+UPDATE t1_timescale SET b = 15 WHERE a = 15;
+SELECT * FROM t1_timescale
+FULL OUTER JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20
+ORDER BY 1, 2, 3, 4;
+ a  | b  | a  | b  
+----+----+----+----
+  5 | 77 |    |   
+  6 | 77 |    |   
+  7 | 77 |    |   
+  8 | 77 |    |   
+  9 | 77 |    |   
+ 10 | 77 |    |   
+ 11 | 77 |    |   
+ 12 | 77 |    |   
+ 13 | 77 |    |   
+ 14 | 77 |    |   
+ 15 | 15 | 15 | 15
+ 16 | 77 |    |   
+ 17 | 77 |    |   
+ 18 | 77 |    |   
+ 19 | 77 |    |   
+ 20 | 77 |    |   
+ 21 | 77 |    |   
+ 22 | 77 |    |   
+ 23 | 77 |    |   
+ 24 | 77 |    |   
+ 25 | 77 |    |   
+    |    |  3 |  3
+(22 rows)
+
+SELECT * FROM t1_timescale
+LEFT OUTER JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20
+WHERE t1_timescale.a=5
+ORDER BY 1, 2, 3, 4;
+ a | b  | a | b 
+---+----+---+---
+ 5 | 77 |   |  
+(1 row)
+
+SELECT * FROM t1_timescale
+RIGHT JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20 
+ORDER BY 1, 2, 3, 4;
+ a  | b  | a  | b  
+----+----+----+----
+ 15 | 15 | 15 | 15
+    |    |  3 |  3
+(2 rows)
+
+SELECT * FROM t1_timescale
+RIGHT JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20
+WHERE t1_timescale.a=5
+ORDER BY 1, 2, 3, 4;
+ a | b | a | b 
+---+---+---+---
+(0 rows)
+
+SELECT * FROM t1_timescale
+LEFT OUTER JOIN  t2 on t1_timescale.a=t2.a and t2.b between 10 and 20 
+WHERE t1_timescale.a IN ( 10, 15, 20, 25) 
+ORDER BY 1, 2, 3, 4;
+ a  | b  | a  | b  
+----+----+----+----
+ 10 | 77 |    |   
+ 15 | 15 | 15 | 15
+ 20 | 77 |    |   
+ 25 | 77 |    |   
+(4 rows)
+
+SELECT * FROM t1_timescale
+RIGHT OUTER JOIN  t2 on t1_timescale.a=t2.a and t2.b between 10 and 20 
+ORDER BY 1, 2, 3, 4;
+ a  | b  | a  | b  
+----+----+----+----
+ 15 | 15 | 15 | 15
+    |    |  3 |  3
+(2 rows)
+

--- a/test/expected/plan_expand_hypertable-12.out
+++ b/test/expected/plan_expand_hypertable-12.out
@@ -952,18 +952,12 @@ must not exclude on m1
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                Order: m2."time"
                ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk m2_1
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk m2_2
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_167_chunk_metrics_timestamptz_2_time_idx on _hyper_7_167_chunk m2_3
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk m2_4
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk m2_5
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk m2_6
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(25 rows)
+(19 rows)
 
 \qecho should exclude chunks on m2
 should exclude chunks on m2
@@ -975,15 +969,10 @@ should exclude chunks on m2
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk m1_3
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk m1_4
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk m1_5
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
    ->  Materialize
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                Order: m2."time"
@@ -999,7 +988,7 @@ should exclude chunks on m2
                      Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk m2_6
                      Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(29 rows)
+(24 rows)
 
 \qecho should exclude chunks on m1
 should exclude chunks on m1
@@ -1026,18 +1015,12 @@ should exclude chunks on m1
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                      Order: m2."time"
                      ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk m2_1
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk m2_2
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_167_chunk_metrics_timestamptz_2_time_idx on _hyper_7_167_chunk m2_3
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk m2_4
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk m2_5
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk m2_6
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(31 rows)
+(25 rows)
 
 \qecho must not exclude chunks on m2
 must not exclude chunks on m2
@@ -1061,16 +1044,11 @@ must not exclude chunks on m2
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
                      Order: m1."time"
                      ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk m1_3
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk m1_4
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk m1_5
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(26 rows)
+(21 rows)
 
 \qecho time_bucket exclusion
 time_bucket exclusion
@@ -1925,9 +1903,10 @@ must not propagate
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-               Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
          ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-               Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk m1_5
    ->  Materialize
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                Order: m2."time"
@@ -1935,35 +1914,37 @@ must not propagate
                      Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
                ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk m2_2
                      Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(15 rows)
+(16 rows)
 
 \qecho test constraints in ON clause of RIGHT JOIN
 test constraints in ON clause of RIGHT JOIN
 \qecho must not propagate
 must not propagate
 :PREFIX SELECT m1.time FROM metrics_timestamptz m1 RIGHT JOIN metrics_timestamptz_2 m2 ON m1.time = m2.time AND m2.time > '2000-01-01' AND m2.time < '2000-01-10' ORDER BY m1.time;
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: m1."time"
-   ->  Hash Left Join
-         Hash Cond: (m2."time" = m1."time")
-         Join Filter: ((m2."time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND (m2."time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Append
-               ->  Seq Scan on _hyper_7_165_chunk m2
-               ->  Seq Scan on _hyper_7_166_chunk m2_1
-               ->  Seq Scan on _hyper_7_167_chunk m2_2
-               ->  Seq Scan on _hyper_7_168_chunk m2_3
-               ->  Seq Scan on _hyper_7_169_chunk m2_4
-               ->  Seq Scan on _hyper_7_170_chunk m2_5
-         ->  Hash
-               ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
-                     Order: m1."time"
-                     ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-                           Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-                           Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(19 rows)
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 2
+   ->  Sort
+         Sort Key: m1."time"
+         ->  Parallel Hash Left Join
+               Hash Cond: (m2."time" = m1."time")
+               Join Filter: ((m2."time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND (m2."time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Parallel Append
+                     ->  Parallel Seq Scan on _hyper_7_165_chunk m2
+                     ->  Parallel Seq Scan on _hyper_7_166_chunk m2_1
+                     ->  Parallel Seq Scan on _hyper_7_167_chunk m2_2
+                     ->  Parallel Seq Scan on _hyper_7_168_chunk m2_3
+                     ->  Parallel Seq Scan on _hyper_7_169_chunk m2_4
+                     ->  Parallel Seq Scan on _hyper_7_170_chunk m2_5
+               ->  Parallel Hash
+                     ->  Parallel Append
+                           ->  Parallel Seq Scan on _hyper_6_160_chunk m1
+                           ->  Parallel Seq Scan on _hyper_6_161_chunk m1_1
+                           ->  Parallel Seq Scan on _hyper_6_162_chunk m1_2
+                           ->  Parallel Seq Scan on _hyper_6_163_chunk m1_3
+                           ->  Parallel Seq Scan on _hyper_6_164_chunk m1_4
+(21 rows)
 
 \qecho test equality condition not in ON clause
 test equality condition not in ON clause

--- a/test/sql/lateral.sql
+++ b/test/sql/lateral.sql
@@ -54,3 +54,41 @@ ORDER BY user_id, first_order_time, time1, min_time;
 
 -- Cleanup
 DROP TABLE orders;
+
+---- OUTER JOIN tests ---
+--github issue 2500
+
+CREATE TABLE t1_timescale (a int, b int);
+CREATE TABLE t2 (a int, b int);
+SELECT create_hypertable('t1_timescale', 'a', chunk_time_interval=>1000);
+
+INSERT into t2 values (3, 3), (15 , 15);
+INSERT into t1_timescale select generate_series(5, 25, 1), 77;
+UPDATE t1_timescale SET b = 15 WHERE a = 15;
+
+SELECT * FROM t1_timescale
+FULL OUTER JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20
+ORDER BY 1, 2, 3, 4;
+
+SELECT * FROM t1_timescale
+LEFT OUTER JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20
+WHERE t1_timescale.a=5
+ORDER BY 1, 2, 3, 4;
+
+SELECT * FROM t1_timescale
+RIGHT JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20 
+ORDER BY 1, 2, 3, 4;
+
+SELECT * FROM t1_timescale
+RIGHT JOIN  t2 on t1_timescale.b=t2.b and t2.b between 10 and 20
+WHERE t1_timescale.a=5
+ORDER BY 1, 2, 3, 4;
+
+SELECT * FROM t1_timescale
+LEFT OUTER JOIN  t2 on t1_timescale.a=t2.a and t2.b between 10 and 20 
+WHERE t1_timescale.a IN ( 10, 15, 20, 25) 
+ORDER BY 1, 2, 3, 4;
+
+SELECT * FROM t1_timescale
+RIGHT OUTER JOIN  t2 on t1_timescale.a=t2.a and t2.b between 10 and 20 
+ORDER BY 1, 2, 3, 4;


### PR DESCRIPTION
time_bucket_annotate_walker passes an incorrect status
for outer join to the function that checks quals eligibility
for propagation.

Fixes #2500