### PR TITLE
Lock dimension slices when creating new chunk

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -110,7 +110,7 @@ extern Chunk *ts_chunk_create_from_point(Hypertable *ht, Point *p, const char *s
 
 extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id, int16 num_constraints, const char relkind);
 extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id, int16 num_constraints);
-extern Chunk *ts_chunk_find(Hypertable *ht, Point *p);
+extern Chunk *ts_chunk_find(Hypertable *ht, Point *p, bool lock_slices);
 extern Chunk **ts_chunk_find_all(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode,
 								 unsigned int *num_chunks);
 extern List *ts_chunk_find_all_oids(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -50,7 +50,7 @@ ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_str
 									int limit, ScanTupLock *tuplock);
 extern DimensionVec *ts_dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start,
 															 int64 range_end, int limit);
-extern bool ts_dimension_slice_scan_for_existing(DimensionSlice *slice);
+extern bool ts_dimension_slice_scan_for_existing(DimensionSlice *slice, ScanTupLock *tuplock);
 extern DimensionSlice *ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id,
 															  ScanTupLock *tuplock,
 															  MemoryContext mctx);

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -30,6 +30,7 @@ extern TSDLLEXPORT Hypercube *ts_hypercube_alloc(int16 num_dimensions);
 extern void ts_hypercube_free(Hypercube *hc);
 extern TSDLLEXPORT void ts_hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
 extern Hypercube *ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
+extern int ts_hypercube_find_existing_slices(Hypercube *cube, ScanTupLock *tuplock);
 extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p, ScanTupLock *tuplock);
 extern bool ts_hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
 extern TSDLLEXPORT DimensionSlice *ts_hypercube_get_slice_by_dimension_id(Hypercube *hc,

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1108,7 +1108,7 @@ hypertable_chunk_store_add(Hypertable *h, Chunk *chunk)
 }
 
 static inline Chunk *
-hypertable_get_chunk(Hypertable *h, Point *point, bool create_if_not_exists)
+hypertable_get_chunk(Hypertable *h, Point *point, bool create_if_not_exists, bool lock_chunk_slices)
 {
 	Chunk *chunk;
 	ChunkStoreEntry *cse = ts_subspace_store_get(h->chunk_cache, point);
@@ -1124,7 +1124,7 @@ hypertable_get_chunk(Hypertable *h, Point *point, bool create_if_not_exists)
 	 * allocates a lot of transient data. We don't want this allocated on
 	 * the cache's memory context.
 	 */
-	chunk = ts_chunk_find(h, point);
+	chunk = ts_chunk_find(h, point, lock_chunk_slices);
 
 	if (NULL == chunk)
 	{
@@ -1149,14 +1149,16 @@ hypertable_get_chunk(Hypertable *h, Point *point, bool create_if_not_exists)
 Chunk *
 ts_hypertable_find_chunk_if_exists(Hypertable *h, Point *point)
 {
-	return hypertable_get_chunk(h, point, false);
+	return hypertable_get_chunk(h, point, false, false);
 }
 
-/* gets the chunk for a given point, creating it if it does not exist */
+/* gets the chunk for a given point, creating it if it does not exist. If an
+ * existing chunk exists, all its dimension slices will be locked in FOR KEY
+ * SHARE mode. */
 Chunk *
 ts_hypertable_get_or_create_chunk(Hypertable *h, Point *point)
 {
-	return hypertable_get_chunk(h, point, true);
+	return hypertable_get_chunk(h, point, true, true);
 }
 
 bool

--- a/test/isolation/expected/dropchunks_race.out
+++ b/test/isolation/expected/dropchunks_race.out
@@ -1,22 +1,90 @@
-Parsed test spec with 3 sessions
+Parsed test spec with 5 sessions
 
-starting permutation: s1a s2a s3a s3b
+starting permutation: s3_chunks_found_wait s1_drop_chunks s2_drop_chunks s3_chunks_found_release s3_show_missing_slices s3_show_num_chunks s3_show_data
+step s3_chunks_found_wait: SELECT debug_waitpoint_enable('drop_chunks_chunks_found');
 debug_waitpoint_enable
 
                
-step s1a: SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
-step s2a: SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
-step s3a: SELECT debug_waitpoint_release('drop_chunks_chunks_found');
+step s1_drop_chunks: SELECT count(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
+step s2_drop_chunks: SELECT count(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
+step s3_chunks_found_release: SELECT debug_waitpoint_release('drop_chunks_chunks_found');
 debug_waitpoint_release
 
                
-step s1a: <... completed>
+step s1_drop_chunks: <... completed>
 count          
 
 1              
-step s2a: <... completed>
-error in steps s3a s1a s2a: ERROR:  some chunks could not be read since they are being concurrently updated
-step s3b: SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
+step s2_drop_chunks: <... completed>
 count          
 
 0              
+step s3_show_missing_slices: SELECT count(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
+count          
+
+0              
+step s3_show_num_chunks: SELECT count(*) FROM show_chunks('dropchunks_race_t1') ORDER BY 1;
+count          
+
+0              
+step s3_show_data: SELECT * FROM dropchunks_race_t1 ORDER BY 1;
+time           device         temp           
+
+
+starting permutation: s4_chunks_dropped_wait s1_drop_chunks s5_insert_new_chunk s4_chunks_dropped_release s3_show_missing_slices s3_show_num_chunks s3_show_data
+step s4_chunks_dropped_wait: SELECT debug_waitpoint_enable('drop_chunks_end');
+debug_waitpoint_enable
+
+               
+step s1_drop_chunks: SELECT count(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
+step s5_insert_new_chunk: INSERT INTO dropchunks_race_t1 VALUES ('2020-03-01 10:30', 1, 2.2); <waiting ...>
+step s4_chunks_dropped_release: SELECT debug_waitpoint_release('drop_chunks_end');
+debug_waitpoint_release
+
+               
+step s1_drop_chunks: <... completed>
+count          
+
+1              
+step s5_insert_new_chunk: <... completed>
+step s3_show_missing_slices: SELECT count(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
+count          
+
+0              
+step s3_show_num_chunks: SELECT count(*) FROM show_chunks('dropchunks_race_t1') ORDER BY 1;
+count          
+
+1              
+step s3_show_data: SELECT * FROM dropchunks_race_t1 ORDER BY 1;
+time           device         temp           
+
+Sun Mar 01 10:30:00 2020 PST1              2.2            
+
+starting permutation: s4_chunks_dropped_wait s1_drop_chunks s5_insert_old_chunk s4_chunks_dropped_release s3_show_missing_slices s3_show_num_chunks s3_show_data
+step s4_chunks_dropped_wait: SELECT debug_waitpoint_enable('drop_chunks_end');
+debug_waitpoint_enable
+
+               
+step s1_drop_chunks: SELECT count(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); <waiting ...>
+step s5_insert_old_chunk: INSERT INTO dropchunks_race_t1 VALUES ('2020-01-02 10:31', 1, 1.1); <waiting ...>
+step s4_chunks_dropped_release: SELECT debug_waitpoint_release('drop_chunks_end');
+debug_waitpoint_release
+
+               
+step s1_drop_chunks: <... completed>
+count          
+
+1              
+step s5_insert_old_chunk: <... completed>
+step s3_show_missing_slices: SELECT count(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
+count          
+
+0              
+step s3_show_num_chunks: SELECT count(*) FROM show_chunks('dropchunks_race_t1') ORDER BY 1;
+count          
+
+1              
+step s3_show_data: SELECT * FROM dropchunks_race_t1 ORDER BY 1;
+time           device         temp           
+
+Thu Jan 02 10:31:00 2020 PST1              1.1            

--- a/test/isolation/specs/dropchunks_race.spec.in
+++ b/test/isolation/specs/dropchunks_race.spec.in
@@ -8,10 +8,10 @@ setup {
   SELECT create_hypertable('dropchunks_race_t1', 'time', 'device', 2);
   INSERT INTO dropchunks_race_t1 VALUES ('2020-01-03 10:30', 1, 32.2);
 
-  CREATE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
   AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_enable';
 
-  CREATE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
   AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_release';
 }
 
@@ -20,14 +20,35 @@ teardown {
 }
 
 session "s1"
-step "s1a"	{ SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); }
+step "s1_drop_chunks"	{ SELECT count(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); }
 
 session "s2"
-step "s2a"	{ SELECT COUNT(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); }
+step "s2_drop_chunks"	{ SELECT count(*) FROM drop_chunks('dropchunks_race_t1', TIMESTAMPTZ '2020-03-01'); }
 
 session "s3"
-setup           { SELECT debug_waitpoint_enable('drop_chunks_chunks_found'); }
-step "s3a"      { SELECT debug_waitpoint_release('drop_chunks_chunks_found'); }
-step "s3b" 	{ SELECT COUNT(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice); }
+step "s3_chunks_found_wait"           { SELECT debug_waitpoint_enable('drop_chunks_chunks_found'); }
+step "s3_chunks_found_release"      { SELECT debug_waitpoint_release('drop_chunks_chunks_found'); }
+step "s3_show_missing_slices"	{ SELECT count(*) FROM _timescaledb_catalog.chunk_constraint WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice); }
+step "s3_show_num_chunks"  { SELECT count(*) FROM show_chunks('dropchunks_race_t1') ORDER BY 1; }
+step "s3_show_data"  { SELECT * FROM dropchunks_race_t1 ORDER BY 1; }
 
-permutation "s1a" "s2a" "s3a" "s3b"
+session "s4"
+step "s4_chunks_dropped_wait"         { SELECT debug_waitpoint_enable('drop_chunks_end'); }
+step "s4_chunks_dropped_release"      { SELECT debug_waitpoint_release('drop_chunks_end'); }
+
+session "s5"
+step "s5_insert_old_chunk" { INSERT INTO dropchunks_race_t1 VALUES ('2020-01-02 10:31', 1, 1.1); }
+step "s5_insert_new_chunk" { INSERT INTO dropchunks_race_t1 VALUES ('2020-03-01 10:30', 1, 2.2); }
+
+# Test race between two drop_chunks processes.
+permutation "s3_chunks_found_wait" "s1_drop_chunks" "s2_drop_chunks" "s3_chunks_found_release" "s3_show_missing_slices" "s3_show_num_chunks" "s3_show_data"
+
+# Test race between drop_chunks and an insert into a new chunk. The
+# new chunk will share a slice with the chunk that is about to be
+# dropped. The shared slice must persist after drop_chunks completes,
+# or otherwise the new chunk will lack one slice.
+permutation "s4_chunks_dropped_wait" "s1_drop_chunks" "s5_insert_new_chunk" "s4_chunks_dropped_release" "s3_show_missing_slices" "s3_show_num_chunks" "s3_show_data"
+
+# Test race between drop_chunks and an insert into the chunk being
+# concurrently dropped. The chunk and slices should be recreated.
+permutation "s4_chunks_dropped_wait" "s1_drop_chunks" "s5_insert_old_chunk" "s4_chunks_dropped_release" "s3_show_missing_slices" "s3_show_num_chunks" "s3_show_data"


### PR DESCRIPTION
This change makes two changes to address issues with processes doing
concurrent inserts and `drop_chunks` calls:

- When a new chunk is created, any dimension slices that existed prior
  to creating the new chunk are locked to prevent them from being
  dropped before the chunk-creating process commits.

- When a chunk is being dropped, concurrent inserts into the chunk
  that is being dropped will try to lock the dimension slices of the
  chunk. In case the locking fails (due to the slices being
  concurrently deleted), the insert process will treat the chunk as
  not existing and will instead recreate it. Previously, the chunk
  slices (and thus chunk) would be found, but the insert would fail
  when committing since the chunk was concurrently deleted.

A prior commit (PR #2150) partially solved a related problem, but
didn't lock all the slices of a chunk. That commit also threw an error
when a lock on a slice could not be taken due to the slice being
deleted by another transaction. This is now changed to treat that case
as a missing slice instead, causing it to be recreated.

Fixes #1986