### PR TITLE
Add if_attached argument to detach_data_node()

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -179,6 +179,7 @@ AS '@MODULE_PATHNAME@', 'ts_data_node_attach' LANGUAGE C VOLATILE;
 CREATE OR REPLACE FUNCTION detach_data_node(
     node_name              NAME,
     hypertable             REGCLASS = NULL,
+    if_attached            BOOLEAN = FALSE,
     force                  BOOLEAN = FALSE,
     repartition            BOOLEAN = TRUE
 ) RETURNS INTEGER

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,2 @@
+
+DROP FUNCTION IF EXISTS detach_data_node(name,regclass,boolean,boolean);

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -1026,6 +1026,8 @@ ERROR:  detaching data node "data_node_1" failed because it contains chunks for 
 -- can't detach already detached data node
 SELECT * FROM detach_data_node('data_node_2', 'disttable_2');
 ERROR:  data node "data_node_2" is not attached to hypertable "disttable_2"
+SELECT * FROM detach_data_node('data_node_2', 'disttable_2', if_attached => false);
+ERROR:  data node "data_node_2" is not attached to hypertable "disttable_2"
 -- can't detach b/c of replication factor for disttable_2
 SELECT * FROM detach_data_node('data_node_3', 'disttable_2');
 ERROR:  detaching data node "data_node_3" risks making new data for hypertable "disttable_2" under-replicated
@@ -1033,6 +1035,14 @@ ERROR:  detaching data node "data_node_3" risks making new data for hypertable "
 SELECT * FROM detach_data_node('data_node_3', 'devices');
 ERROR:  table "devices" is not a hypertable
 \set ON_ERROR_STOP 1
+-- do nothing if node is not attached
+SELECT * FROM detach_data_node('data_node_2', 'disttable_2', if_attached => true);
+NOTICE:  data node "data_node_2" is not attached to hypertable "disttable_2", skipping
+ detach_data_node 
+------------------
+                0
+(1 row)
+
 -- force detach data node to become under-replicated for new data
 SELECT * FROM detach_data_node('data_node_3', 'disttable_2', force => true);
 WARNING:  new data for hypertable "disttable_2" will be under-replicated due to detaching data node "data_node_3"
@@ -1127,7 +1137,7 @@ ORDER BY foreign_table_name;
 --------------------+---------------------
 (0 rows)
 
-SELECT * FROM detach_data_node('data_node_2', 'disttable', true);
+SELECT * FROM detach_data_node('data_node_2', 'disttable', force => true);
 WARNING:  new data for hypertable "disttable" will be under-replicated due to detaching data node "data_node_2"
 NOTICE:  the number of partitions in dimension "device" was decreased to 1
  detach_data_node 

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -508,11 +508,15 @@ SELECT * FROM detach_data_node(NULL, 'disttable');
 SELECT * FROM detach_data_node('data_node_1');
 -- can't detach already detached data node
 SELECT * FROM detach_data_node('data_node_2', 'disttable_2');
+SELECT * FROM detach_data_node('data_node_2', 'disttable_2', if_attached => false);
 -- can't detach b/c of replication factor for disttable_2
 SELECT * FROM detach_data_node('data_node_3', 'disttable_2');
 -- can't detach non hypertable
 SELECT * FROM detach_data_node('data_node_3', 'devices');
 \set ON_ERROR_STOP 1
+
+-- do nothing if node is not attached
+SELECT * FROM detach_data_node('data_node_2', 'disttable_2', if_attached => true);
 
 -- force detach data node to become under-replicated for new data
 SELECT * FROM detach_data_node('data_node_3', 'disttable_2', force => true);
@@ -547,7 +551,7 @@ SELECT foreign_table_name, foreign_server_name
 FROM information_schema.foreign_tables
 ORDER BY foreign_table_name;
 
-SELECT * FROM detach_data_node('data_node_2', 'disttable', true);
+SELECT * FROM detach_data_node('data_node_2', 'disttable', force => true);
 
 -- Let's add more data nodes
 SET ROLE :ROLE_CLUSTER_SUPERUSER;


### PR DESCRIPTION
This change makes detach_data_node() function consistent with
other data node management functions by adding missing
if_attach argument.

The function will not show an error in case if data node is not
attached and if_attached is set to true.

Issue: #2506