### PR TITLE
Fix flaky update test

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Update diff
       if: failure()
       run: |
-        find . -name "update_test.diff.*" -maxdepth 1 | xargs -IFILE sh -c "echo '\nFILE\n';cat FILE"
+        find . -name "update_test.*.diff.*" -maxdepth 1 | xargs -IFILE sh -c "echo '\nFILE\n';cat FILE"
 
     - name: Upload Artifacts
       if: failure()

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -4,6 +4,10 @@
 
 SELECT extversion < '2.0.0' AS has_refresh_mat_view from pg_extension WHERE extname = 'timescaledb' \gset
 
+-- disable background workers to prevent deadlocks between background processes
+-- on timescaledb 1.7.x
+SELECT _timescaledb_internal.stop_background_workers();
+
 CREATE TYPE custom_type AS (high int, low int);
 
 CREATE TABLE conditions_before (


### PR DESCRIPTION
Disable background workers during update tests to prevent deadlocks
in continuous aggregates on 1.7.x