### PR TITLE
Replace check function when updating

### DIFF
--- a/sql/updates/1.5.1--1.6.0.sql
+++ b/sql/updates/1.5.1--1.6.0.sql
@@ -23,6 +23,13 @@ BEGIN
 END
 $BODY$;
 
+-- Replace the function with the version in the new shared library
+-- since it is used in a check constraint when updating the table
+-- bgw_policy_drop_chunks. Not replacing it would try to use the
+-- version in the previous library, which will fail the version check
+-- in ts_extension_check_version.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.valid_ts_interval(invl _timescaledb_catalog.ts_interval)
+RETURNS BOOLEAN AS '@MODULE_PATHNAME@', 'ts_valid_ts_interval' LANGUAGE C VOLATILE STRICT;
 
 ALTER TABLE  _timescaledb_catalog.continuous_agg
     ADD COLUMN  ignore_invalidation_older_than BIGINT NOT NULL DEFAULT BIGINT '9223372036854775807';


### PR DESCRIPTION
When updating from version 1.5.1 to 1.6.0 the meaning of the
`cascade_to_materialization` column in `bgw_policy_drop_chunks`
changed and `NULL` was introduced as an acceptable value. This means
that the table was updated and `false` in this column was replaced with
`NULL`.

This triggered the check function `valid_ts_interval` to execute as
part of a check constraint. However, it referred to the C version in
the old library and not the new library and therefore triggers an error
in the `ts_extension_check_version` function since the function is in
the old shared library.

This commit fixes the issue by replacing the function definition with
the same function in the new library, so that the check doesn't fail.

Cherry-Pick: 5390cb62