### PR TITLE
Fix flaky remote_txn test

### DIFF
--- a/tsl/test/expected/remote_connection.out
+++ b/tsl/test/expected/remote_connection.out
@@ -70,17 +70,12 @@ SELECT test.remote_connection_tests();
  
 (1 row)
 
+SET client_min_messages TO ERROR;
 SELECT test.remote_async_tests();
-WARNING:  Expect warning about communication error:
-WARNING:  [testdb]: SSL connection has been closed unexpectedly
  remote_async_tests 
 --------------------
  
 (1 row)
 
-SELECT 'End Of Test';
-  ?column?   
--------------
- End Of Test
-(1 row)
-
+\echo 'End Of Test'
+End Of Test

--- a/tsl/test/expected/remote_txn.out
+++ b/tsl/test/expected/remote_txn.out
@@ -426,10 +426,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10002,1,'bleh', '2001-01-0
  
 (1 row)
 
-COMMIT;
-WARNING:  kill event: pre-prepare-transaction
-WARNING:  transaction rollback on data node "loopback" failed
-ERROR:  [loopback]: SSL connection has been closed unexpectedly
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 08006 connection_failure
+\echo 'COMMIT SQLSTATE' :SQLSTATE
+COMMIT SQLSTATE 08006
 --the connection was killed, so should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -463,10 +464,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10003,1,'bleh', '2001-01-0
  
 (1 row)
 
-COMMIT;
-WARNING:  kill event: waiting-prepare-transaction
-WARNING:  transaction rollback on data node "loopback" failed
-ERROR:  [loopback]: SSL connection has been closed unexpectedly
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 08006 connection_failure
+\echo 'COMMIT SQLSTATE' :SQLSTATE
+COMMIT SQLSTATE 08006
 --the connection should be cleared from the cache
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -516,10 +518,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10004,1,'bleh', '2001-01-0
  
 (1 row)
 
-COMMIT;
-WARNING:  kill event: post-prepare-transaction
-WARNING:  [loopback]: terminating connection due to administrator command
-WARNING:  [loopback]: SSL connection has been closed unexpectedly
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 00000 successful_completion
+\echo 'COMMIT SQLSTATE' :SQLSTATE
+COMMIT SQLSTATE 00000
 --connection should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -597,10 +600,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10006,1,'bleh', '2001-01-0
  
 (1 row)
 
-COMMIT;
-WARNING:  kill event: pre-commit-prepared
-WARNING:  [loopback]: terminating connection due to administrator command
-WARNING:  [loopback]: SSL connection has been closed unexpectedly
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 00000 successful_completion
+\echo 'COMMIT SQLSTATE' :SQLSTATE
+COMMIT SQLSTATE 00000
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
  node_name | connection_status | transaction_status | transaction_depth | processing 
@@ -665,10 +669,11 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10005,1,'bleh', '2001-01-0
  
 (1 row)
 
-COMMIT;
-WARNING:  kill event: waiting-commit-prepared
-WARNING:  [loopback]: terminating connection due to administrator command
-WARNING:  [loopback]: SSL connection has been closed unexpectedly
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 00000 successful_completion
+\echo 'COMMIT SQLSTATE' :SQLSTATE
+COMMIT SQLSTATE 00000
 --at this point the commit prepared might or might not have been executed before
 --the data node process was killed.
 --but in any case, healing the server will bring it into a known state

--- a/tsl/test/sql/remote_connection.sql
+++ b/tsl/test/sql/remote_connection.sql
@@ -68,6 +68,7 @@ SELECT test.send_remote_query_that_generates_exception();
 SELECT * FROM test.get_connection_stats();
 
 SELECT test.remote_connection_tests();
+SET client_min_messages TO ERROR;
 SELECT test.remote_async_tests();
 
-SELECT 'End Of Test';
+\echo 'End Of Test'

--- a/tsl/test/sql/remote_txn.sql
+++ b/tsl/test/sql/remote_txn.sql
@@ -217,7 +217,13 @@ FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 BEGIN;
     SELECT remote_node_killer_set_event('pre-prepare-transaction', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10002,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 08006 connection_failure
+--<exclude_from_test>
 COMMIT;
+--</exclude_from_test>
+\echo 'COMMIT SQLSTATE' :SQLSTATE
 
 --the connection was killed, so should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -229,7 +235,13 @@ SELECT count(*) FROM pg_prepared_xacts;
 BEGIN;
     SELECT remote_node_killer_set_event('waiting-prepare-transaction', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10003,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 08006 connection_failure
+--<exclude_from_test>
 COMMIT;
+--</exclude_from_test>
+\echo 'COMMIT SQLSTATE' :SQLSTATE
 
 --the connection should be cleared from the cache
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -249,7 +261,13 @@ SELECT count(*) from _timescaledb_catalog.remote_txn;
 BEGIN;
     SELECT remote_node_killer_set_event('post-prepare-transaction', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 00000 successful_completion
+--<exclude_from_test>
 COMMIT;
+--</exclude_from_test>
+\echo 'COMMIT SQLSTATE' :SQLSTATE
 
 --connection should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
@@ -279,7 +297,13 @@ select count(*) from _timescaledb_catalog.remote_txn;
 BEGIN;
     SELECT remote_node_killer_set_event('pre-commit-prepared', 'loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 00000 successful_completion
+--<exclude_from_test>
 COMMIT;
+--</exclude_from_test>
+\echo 'COMMIT SQLSTATE' :SQLSTATE
 
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -299,7 +323,14 @@ FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
 BEGIN;
     SELECT remote_node_killer_set_event('waiting-commit-prepared','loopback');
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
+-- since the error messages/warnings from this COMMIT varies between
+-- platforms/environments we remove it from test output and show SQLSTATE instead.
+-- SQLSTATE should be 00000 successful_completion
+--<exclude_from_test>
 COMMIT;
+--</exclude_from_test>
+\echo 'COMMIT SQLSTATE' :SQLSTATE
+
 --at this point the commit prepared might or might not have been executed before
 --the data node process was killed.
 --but in any case, healing the server will bring it into a known state


### PR DESCRIPTION
Change expected test output to sqlstate only in places where the
error message might differ between platforms/environments.