### PR TITLE
Cleanup public API

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -202,7 +202,7 @@ AS '@MODULE_PATHNAME@', 'ts_hypertable_distributed_set_replication_factor' LANGU
 
 -- Refresh a continuous aggregate across the given window.
 CREATE OR REPLACE PROCEDURE refresh_continuous_aggregate(
-    cagg                     REGCLASS,
+    continuous_aggregate     REGCLASS,
     window_start             "any",
     window_end               "any"
 ) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh';

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,3 +1,7 @@
 
 DROP FUNCTION IF EXISTS detach_data_node(name,regclass,boolean,boolean);
 DROP FUNCTION IF EXISTS distributed_exec;
+
+DROP PROCEDURE IF EXISTS refresh_continuous_aggregate(regclass,"any","any");
+
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -110,13 +110,11 @@ CREATE OR REPLACE VIEW timescaledb_information.continuous_aggregates AS
 SELECT cagg.user_view_schema AS view_schema,
   cagg.user_view_name AS view_name,
   viewinfo.viewowner AS view_owner,
-  bgwjob.schedule_interval,
   cagg.materialized_only,
   ht.schema_name AS materialization_hypertable_schema,
   ht.table_name AS materialization_hypertable_name,
   directview.viewdefinition AS view_definition
-FROM _timescaledb_catalog.continuous_agg cagg
-  LEFT JOIN _timescaledb_config.bgw_job bgwjob ON bgwjob.hypertable_id = cagg.mat_hypertable_id,
+FROM _timescaledb_catalog.continuous_agg cagg,
   _timescaledb_catalog.hypertable ht,
   LATERAL (
     SELECT C.oid,

--- a/test/sql/updates/post.continuous_aggs.v2.sql
+++ b/test/sql/updates/post.continuous_aggs.v2.sql
@@ -12,7 +12,13 @@ CALL refresh_continuous_aggregate('cagg.realtime_mat',NULL,NULL);
 
 SELECT * FROM cagg.realtime_mat ORDER BY bucket, location;
 
-SELECT view_name, schedule_interval, materialized_only, materialization_hypertable_name FROM timescaledb_information.continuous_aggregates ORDER BY view_name::text;
+SELECT view_name, materialized_only, materialization_hypertable_name 
+FROM timescaledb_information.continuous_aggregates 
+ORDER BY view_name::text;
+
+SELECT schedule_interval 
+FROM timescaledb_information.jobs 
+ORDER BY job_id;
 
 SELECT maxtemp FROM mat_ignoreinval ORDER BY 1;
 

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -73,7 +73,6 @@ SELECT * FROM timescaledb_information.continuous_aggregates;
 view_schema                       | public
 view_name                         | device_summary
 view_owner                        | default_perm_user
-schedule_interval                 | @ 2 hours
 materialized_only                 | t
 materialization_hypertable_schema | _timescaledb_internal
 materialization_hypertable_name   | _materialized_hypertable_2


### PR DESCRIPTION
Removes unlrelated column schedule_interval from 
timescaledb_information.continuous_aggregates view and simplifies it. 
Renames argument cagg in refresh_continuous_aggregate into 
continuous_aggregate as in add_continuous_aggregate_policy.

Part of #2521
