### PR TITLE
Fix timescaledb_fdw function handling in update script

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -9,6 +9,7 @@ set(PRE_INSTALL_SOURCE_FILES
   pre_install/tables.sql
   pre_install/insert_data.sql
   pre_install/bgw_scheduler_startup.sql
+  pre_install/fdw_functions.sql
   pre_install/timescaledb_fdw.sql
 )
 
@@ -23,6 +24,7 @@ set(IMMUTABLE_API_SOURCE_FILES
 # The rest of the source files defining mostly functions
 set(SOURCE_FILES
   pre_install/types.functions.sql
+  pre_install/fdw_functions.sql
   hypertable.sql
   chunk.sql
   ddl_internal.sql

--- a/sql/pre_install/fdw_functions.sql
+++ b/sql/pre_install/fdw_functions.sql
@@ -1,0 +1,14 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE OR REPLACE FUNCTION timescaledb_fdw_handler()
+RETURNS fdw_handler
+AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_handler'
+LANGUAGE C STRICT;
+
+CREATE OR REPLACE FUNCTION timescaledb_fdw_validator(text[], oid)
+RETURNS void
+AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_validator'
+LANGUAGE C STRICT;
+

--- a/sql/pre_install/timescaledb_fdw.sql
+++ b/sql/pre_install/timescaledb_fdw.sql
@@ -2,16 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE OR REPLACE FUNCTION timescaledb_fdw_handler()
-RETURNS fdw_handler
-AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_handler'
-LANGUAGE C STRICT;
-
-CREATE OR REPLACE FUNCTION timescaledb_fdw_validator(text[], oid)
-RETURNS void
-AS '@MODULE_PATHNAME@', 'ts_timescaledb_fdw_validator'
-LANGUAGE C STRICT;
-
 CREATE FOREIGN DATA WRAPPER timescaledb_fdw
   HANDLER timescaledb_fdw_handler
   VALIDATOR timescaledb_fdw_validator;


### PR DESCRIPTION
This patch splits the timescaledb_fdw sql file into two parts to
separate the idempotent parts from the non-idempotent ones so
the function definitions can be included in the regular update
script.