### PR TITLE
Update test dist_ddl to execute in parallel

### DIFF
--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -7,31 +7,25 @@
 \unset ECHO
 psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
 psql:include/filter_exec.sql:5: NOTICE:  schema "test" already exists, skipping
--- Cleanup from other potential tests that created these databases
-SET client_min_messages TO ERROR;
-DROP DATABASE IF EXISTS data_node_1;
-DROP DATABASE IF EXISTS data_node_2;
-DROP DATABASE IF EXISTS data_node_3;
-SET client_min_messages TO NOTICE;
-SELECT * FROM add_data_node('data_node_1', host => 'localhost',
-                            database => 'data_node_1');
-  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
--------------+-----------+-------+-------------+--------------+------------------+-------------------
- data_node_1 | localhost | 55432 | data_node_1 | t            | t                | t
+\set MY_DB1 :TEST_DBNAME _1
+\set MY_DB2 :TEST_DBNAME _2
+\set MY_DB3 :TEST_DBNAME _3
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => :'MY_DB1');
+  node_name  |   host    | port  |   database    | node_created | database_created | extension_created 
+-------------+-----------+-------+---------------+--------------+------------------+-------------------
+ data_node_1 | localhost | 55432 | db_dist_ddl_1 | t            | t                | t
 (1 row)
 
-SELECT * FROM add_data_node('data_node_2', host => 'localhost',
-                            database => 'data_node_2');
-  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
--------------+-----------+-------+-------------+--------------+------------------+-------------------
- data_node_2 | localhost | 55432 | data_node_2 | t            | t                | t
+SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => :'MY_DB2');
+  node_name  |   host    | port  |   database    | node_created | database_created | extension_created 
+-------------+-----------+-------+---------------+--------------+------------------+-------------------
+ data_node_2 | localhost | 55432 | db_dist_ddl_2 | t            | t                | t
 (1 row)
 
-SELECT * FROM add_data_node('data_node_3', host => 'localhost',
-                            database => 'data_node_3');
-  node_name  |   host    | port  |  database   | node_created | database_created | extension_created 
--------------+-----------+-------+-------------+--------------+------------------+-------------------
- data_node_3 | localhost | 55432 | data_node_3 | t            | t                | t
+SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => :'MY_DB3');
+  node_name  |   host    | port  |   database    | node_created | database_created | extension_created 
+-------------+-----------+-------+---------------+--------------+------------------+-------------------
+ data_node_3 | localhost | 55432 | db_dist_ddl_3 | t            | t                | t
 (1 row)
 
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
@@ -609,11 +603,11 @@ schemaname|tablename
 (1 row)
 
 -- CREATE and DROP SCHEMA CASCADE
-\c data_node_1
+\c :MY_DB1
 CREATE SCHEMA some_schema AUTHORIZATION :ROLE_1;
-\c data_node_2
+\c :MY_DB2
 CREATE SCHEMA some_schema AUTHORIZATION :ROLE_1;
-\c data_node_3
+\c :MY_DB3
 CREATE SCHEMA some_schema AUTHORIZATION :ROLE_1;
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 SET ROLE :ROLE_1;
@@ -1760,7 +1754,7 @@ SELECT replication_factor FROM _timescaledb_catalog.hypertable ORDER BY id;
                   2
 (1 row)
 
-\c data_node_1
+\c :MY_DB1
 SELECT schemaname, tablename FROM pg_tables WHERE tablename = 'disttable';
  schemaname | tablename 
 ------------+-----------
@@ -1844,6 +1838,6 @@ DROP TABLE disttable;
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP SCHEMA disttable_schema CASCADE;
 NOTICE:  drop cascades to table disttable_schema.disttable
-DROP DATABASE data_node_1;
-DROP DATABASE data_node_2;
-DROP DATABASE data_node_3;
+DROP DATABASE :MY_DB1;
+DROP DATABASE :MY_DB2;
+DROP DATABASE :MY_DB3;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -125,7 +125,6 @@ set(SOLO_TESTS
   debug_notice
   dist_api_calls
   dist_commands
-  dist_ddl
   dist_hypertable-11
   dist_hypertable-12
   dist_hypertable_am


### PR DESCRIPTION
Change database names to be unique over the test suite by adding the
test database name in front of the created database names in the test.
This will allow the test to be executed in parallel with other tests
since it will not have conflicting databases in the same cluster.