### PR TITLE
Use environment files for github actions

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -45,8 +45,7 @@ jobs:
     # as cache suffix
     - name: Cache suffix
       if: runner.os == 'macOS'
-      run: |
-        echo "::set-env name=CACHE_SUFFIX::-${ImageVersion}"
+      run: echo "CACHE_SUFFIX=-${ImageVersion}" >> $GITHUB_ENV
 
     # we cache the build directory instead of the install directory here
     # because extension installation will write files to install directory


### PR DESCRIPTION
GitHub deprecates use of set-env in workflows so switch to using
environment files.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/