### PR TITLE
Ensure reltuples are preserved during compression

### DIFF
--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1233,7 +1233,8 @@ ERROR:  cannot update/delete rows from chunk "_hyper_25_51_chunk" as it is compr
 \set ON_ERROR_STOP 1
 DROP TABLE compressed_ht;
 DROP TABLE uncompressed_ht;
--- Test that pg_stats for uncompressed chunks are frozen at compression time
+-- Test that pg_stats and pg_class stats for uncompressed chunks are frozen at compression time
+-- Note that approximate_row_count pulls from pg_class
 CREATE TABLE stattest(time TIMESTAMPTZ NOT NULL, c1 int);
 SELECT create_hypertable('stattest', 'time');
    create_hypertable    
@@ -1250,10 +1251,22 @@ SELECT * FROM pg_stats WHERE tablename = :statchunk;
 (0 rows)
 
 ALTER TABLE stattest SET (timescaledb.compress);
+SELECT approximate_row_count('stattest');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
 SELECT compress_chunk(c) FROM show_chunks('stattest') c;
               compress_chunk              
 ------------------------------------------
  _timescaledb_internal._hyper_27_55_chunk
+(1 row)
+
+SELECT approximate_row_count('stattest');
+ approximate_row_count 
+-----------------------
+                    26
 (1 row)
 
 SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname = 'c1';

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -1942,26 +1942,31 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=0 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
+ Merge Append (actual rows=0 loops=1)
    Sort Key: _hyper_1_1_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
+         Sort Key: _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
-         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
-               Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-               Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 2520
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
+         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+         Filter: (_hyper_1_2_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 2520
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
+         Sort Key: _hyper_1_3_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
-(19 rows)
+(24 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -2287,14 +2292,14 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=6840 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
                      ->  Sort (actual rows=1800 loops=1)
@@ -2308,22 +2313,23 @@ FROM :TEST_TABLE m1
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               ->  Hash (actual rows=6840 loops=1)
-                     Buckets: 16384  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
-                           Order: m2."time"
-                           ->  Sort (actual rows=1800 loops=1)
-                                 Sort Key: m2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
-                           ->  Sort (actual rows=2520 loops=1)
-                                 Sort Key: m2_3."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
-(34 rows)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m2."time", m2.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
+                     Order: m2."time"
+                     ->  Sort (actual rows=1800 loops=1)
+                           Sort Key: m2_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
+                           Sort Key: m2_3."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
+(35 rows)
 
 :PREFIX
 SELECT *
@@ -2507,14 +2513,14 @@ FROM :TEST_TABLE m1
 ORDER BY m1.time,
     m1.device_id
 LIMIT 10;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=6840 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
                      ->  Sort (actual rows=1800 loops=1)
@@ -2528,22 +2534,23 @@ LIMIT 10;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               ->  Hash (actual rows=6840 loops=1)
-                     Buckets: 16384  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
-                           Order: m2."time"
-                           ->  Sort (actual rows=1800 loops=1)
-                                 Sort Key: m2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
-                           ->  Sort (actual rows=2520 loops=1)
-                                 Sort Key: m2_3."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
-(34 rows)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m2."time", m2.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
+                     Order: m2."time"
+                     ->  Sort (actual rows=1800 loops=1)
+                           Sort Key: m2_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
+                           Sort Key: m2_3."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
+(35 rows)
 
 :PREFIX
 SELECT *
@@ -5523,49 +5530,70 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=0 loops=1)
-   Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
+ Merge Append (actual rows=0 loops=1)
    Sort Key: _hyper_2_4_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
+         Sort Key: _hyper_2_4_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
+         Sort Key: _hyper_2_5_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
+         Sort Key: _hyper_2_6_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+         Filter: (_hyper_2_7_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 504
+   ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
+         Filter: (_hyper_2_8_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 1512
+   ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
+         Filter: (_hyper_2_9_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 504
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
+         Sort Key: _hyper_2_10_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
+         Sort Key: _hyper_2_11_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
-(42 rows)
+   ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
+         Filter: (_hyper_2_12_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 504
+(63 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -6080,16 +6108,16 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=6840 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Hash Join (actual rows=6840 loops=1)
-                     Hash Cond: (m1."time" = m3."time")
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: (m1."time" = m3."time")
+         ->  Merge Join (actual rows=10 loops=1)
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=6840 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
@@ -6105,18 +6133,9 @@ FROM :TEST_TABLE m1
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
-                     ->  Hash (actual rows=1368 loops=1)
-                           Buckets: 2048  Batches: 1 
-                           ->  Append (actual rows=1368 loops=1)
-                                 ->  Seq Scan on _hyper_2_12_chunk m3 (actual rows=504 loops=1)
-                                       Filter: (device_id = 3)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
-                                             Filter: (device_id = 3)
-                                 ->  Seq Scan on _hyper_2_9_chunk m3_2 (actual rows=504 loops=1)
-                                       Filter: (device_id = 3)
-               ->  Hash (actual rows=6840 loops=1)
-                     Buckets: 16384  Batches: 1 
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=6840 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
@@ -6132,7 +6151,20 @@ FROM :TEST_TABLE m1
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
                                  ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
                            ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
-(50 rows)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Merge Append (actual rows=3 loops=1)
+                     Sort Key: m3."time"
+                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3 (actual rows=1 loops=1)
+                           Filter: (device_id = 3)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m3_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
+                           Filter: (device_id = 3)
+(54 rows)
 
 :PREFIX
 SELECT *

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -1928,26 +1928,31 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=0 loops=1)
-   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
+ Merge Append (actual rows=0 loops=1)
    Sort Key: _hyper_1_1_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
+         Sort Key: _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
-         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
-               Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-               Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-               Rows Removed by Filter: 2520
+   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
+         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+         Filter: (_hyper_1_2_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 2520
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
+         Sort Key: _hyper_1_3_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
-(19 rows)
+(24 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -2258,14 +2263,14 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=6840 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
                      ->  Sort (actual rows=1800 loops=1)
@@ -2279,22 +2284,23 @@ FROM :TEST_TABLE m1
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               ->  Hash (actual rows=6840 loops=1)
-                     Buckets: 16384  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
-                           Order: m2."time"
-                           ->  Sort (actual rows=1800 loops=1)
-                                 Sort Key: m2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
-                           ->  Sort (actual rows=2520 loops=1)
-                                 Sort Key: m2_3."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
-(34 rows)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m2."time", m2.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
+                     Order: m2."time"
+                     ->  Sort (actual rows=1800 loops=1)
+                           Sort Key: m2_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
+                           Sort Key: m2_3."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
+(35 rows)
 
 :PREFIX
 SELECT *
@@ -2478,14 +2484,14 @@ FROM :TEST_TABLE m1
 ORDER BY m1.time,
     m1.device_id
 LIMIT 10;
-                                                                  QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=6840 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
                      ->  Sort (actual rows=1800 loops=1)
@@ -2499,22 +2505,23 @@ LIMIT 10;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-               ->  Hash (actual rows=6840 loops=1)
-                     Buckets: 16384  Batches: 1 
-                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
-                           Order: m2."time"
-                           ->  Sort (actual rows=1800 loops=1)
-                                 Sort Key: m2_1."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
-                           ->  Sort (actual rows=2520 loops=1)
-                                 Sort Key: m2_3."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
-                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
-(34 rows)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m2."time", m2.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
+                     Order: m2."time"
+                     ->  Sort (actual rows=1800 loops=1)
+                           Sort Key: m2_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                     ->  Sort (actual rows=2520 loops=1)
+                           Sort Key: m2_3."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
+(35 rows)
 
 :PREFIX
 SELECT *
@@ -5483,49 +5490,70 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                   QUERY PLAN                                                                                                                                                   
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort (actual rows=0 loops=1)
-   Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
+ Merge Append (actual rows=0 loops=1)
    Sort Key: _hyper_2_4_chunk."time"
-   Sort Method: quicksort 
-   ->  Append (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
+         Sort Key: _hyper_2_4_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
+         Sort Key: _hyper_2_5_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
+         Sort Key: _hyper_2_6_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
+   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+         Filter: (_hyper_2_7_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 504
+   ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
+         Filter: (_hyper_2_8_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 1512
+   ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
+         Filter: (_hyper_2_9_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 504
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
+         Sort Key: _hyper_2_10_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
+   ->  Sort (actual rows=0 loops=1)
+         Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
+         Sort Key: _hyper_2_11_chunk."time"
+         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id__1 on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
-               Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
-(42 rows)
+   ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+         Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
+         Filter: (_hyper_2_12_chunk.device_id_peer = 1)
+         Rows Removed by Filter: 504
+(63 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -6009,16 +6037,16 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=6840 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Hash Join (actual rows=6840 loops=1)
-                     Hash Cond: (m1."time" = m3."time")
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: (m1."time" = m3."time")
+         ->  Merge Join (actual rows=10 loops=1)
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=6840 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
@@ -6034,18 +6062,9 @@ FROM :TEST_TABLE m1
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
-                     ->  Hash (actual rows=1368 loops=1)
-                           Buckets: 2048  Batches: 1 
-                           ->  Append (actual rows=1368 loops=1)
-                                 ->  Seq Scan on _hyper_2_12_chunk m3 (actual rows=504 loops=1)
-                                       Filter: (device_id = 3)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
-                                             Filter: (device_id = 3)
-                                 ->  Seq Scan on _hyper_2_9_chunk m3_2 (actual rows=504 loops=1)
-                                       Filter: (device_id = 3)
-               ->  Hash (actual rows=6840 loops=1)
-                     Buckets: 16384  Batches: 1 
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=6840 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
@@ -6061,7 +6080,20 @@ FROM :TEST_TABLE m1
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
                                  ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
                            ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
-(50 rows)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Merge Append (actual rows=3 loops=1)
+                     Sort Key: m3."time"
+                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3 (actual rows=1 loops=1)
+                           Filter: (device_id = 3)
+                     ->  Sort (actual rows=3 loops=1)
+                           Sort Key: m3_1."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
+                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
+                           Filter: (device_id = 3)
+(54 rows)
 
 :PREFIX
 SELECT *

--- a/tsl/test/shared/expected/ordered_append_join.out
+++ b/tsl/test/shared/expected/ordered_append_join.out
@@ -2557,14 +2557,14 @@ FROM :TEST_TABLE o1
     AND o1.time = o2.time
   ORDER BY o1.time
   LIMIT 100;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
-         Merge Cond: ((o1."time" = o2."time") AND (o1.device_id = o2.device_id))
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o1."time", o1.device_id
-               Sort Method: quicksort 
+   ->  Sort (actual rows=100 loops=1)
+         Sort Key: o1."time"
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=68370 loops=1)
+               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_3_13_chunk o1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_4_18_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_18_chunk (actual rows=20 loops=1)
@@ -2572,17 +2572,16 @@ FROM :TEST_TABLE o1
                            ->  Index Scan using compress_hyper_4_17_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_17_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_3_15_chunk o1_2 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_4_16_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_16_chunk (actual rows=30 loops=1)
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o2."time", o2.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_13_chunk o2 (actual rows=17990 loops=1)
-                           ->  Index Scan using compress_hyper_4_18_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_18_chunk compress_hyper_4_18_chunk_1 (actual rows=20 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_14_chunk o2_1 (actual rows=25190 loops=1)
-                           ->  Index Scan using compress_hyper_4_17_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_17_chunk compress_hyper_4_17_chunk_1 (actual rows=30 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_3_15_chunk o2_2 (actual rows=25190 loops=1)
-                           ->  Index Scan using compress_hyper_4_16_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_16_chunk compress_hyper_4_16_chunk_1 (actual rows=30 loops=1)
-(23 rows)
+               ->  Hash (actual rows=68370 loops=1)
+                     Buckets: 131072  Batches: 1 
+                     ->  Append (actual rows=68370 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_13_chunk o2 (actual rows=17990 loops=1)
+                                 ->  Index Scan using compress_hyper_4_18_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_18_chunk compress_hyper_4_18_chunk_1 (actual rows=20 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_14_chunk o2_1 (actual rows=25190 loops=1)
+                                 ->  Index Scan using compress_hyper_4_17_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_17_chunk compress_hyper_4_17_chunk_1 (actual rows=30 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_3_15_chunk o2_2 (actual rows=25190 loops=1)
+                                 ->  Index Scan using compress_hyper_4_16_chunk__compressed_hypertable_4_device_id__t on compress_hyper_4_16_chunk compress_hyper_4_16_chunk_1 (actual rows=30 loops=1)
+(22 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -3671,14 +3670,14 @@ FROM :TEST_TABLE o1
     AND o1.time = o2.time
   ORDER BY o1.time
   LIMIT 100;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=100 loops=1)
-   ->  Merge Join (actual rows=100 loops=1)
-         Merge Cond: ((o1."time" = o2."time") AND (o1.device_id = o2.device_id))
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o1."time", o1.device_id
-               Sort Method: quicksort 
+   ->  Sort (actual rows=100 loops=1)
+         Sort Key: o1."time"
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=68370 loops=1)
+               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_5_19_chunk o1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_6_36_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_36_chunk (actual rows=4 loops=1)
@@ -3698,29 +3697,28 @@ FROM :TEST_TABLE o1
                            ->  Index Scan using compress_hyper_6_29_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_29_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_5_27_chunk o1_8 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_6_28_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_28_chunk (actual rows=6 loops=1)
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o2."time", o2.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_19_chunk o2 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_6_36_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_36_chunk compress_hyper_6_36_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_20_chunk o2_1 (actual rows=10794 loops=1)
-                           ->  Index Scan using compress_hyper_6_35_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_35_chunk compress_hyper_6_35_chunk_1 (actual rows=12 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_21_chunk o2_2 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_6_34_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_34_chunk compress_hyper_6_34_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_22_chunk o2_3 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_6_33_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_33_chunk compress_hyper_6_33_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_23_chunk o2_4 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_6_32_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_32_chunk compress_hyper_6_32_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_24_chunk o2_5 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_6_31_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_31_chunk compress_hyper_6_31_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_25_chunk o2_6 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_6_30_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_30_chunk compress_hyper_6_30_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_26_chunk o2_7 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_6_29_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_29_chunk compress_hyper_6_29_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_5_27_chunk o2_8 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_6_28_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_28_chunk compress_hyper_6_28_chunk_1 (actual rows=6 loops=1)
-(47 rows)
+               ->  Hash (actual rows=68370 loops=1)
+                     Buckets: 131072  Batches: 1 
+                     ->  Append (actual rows=68370 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_19_chunk o2 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_6_36_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_36_chunk compress_hyper_6_36_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_20_chunk o2_1 (actual rows=10794 loops=1)
+                                 ->  Index Scan using compress_hyper_6_35_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_35_chunk compress_hyper_6_35_chunk_1 (actual rows=12 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_21_chunk o2_2 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_6_34_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_34_chunk compress_hyper_6_34_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_22_chunk o2_3 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_6_33_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_33_chunk compress_hyper_6_33_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_23_chunk o2_4 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_6_32_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_32_chunk compress_hyper_6_32_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_24_chunk o2_5 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_6_31_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_31_chunk compress_hyper_6_31_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_25_chunk o2_6 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_6_30_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_30_chunk compress_hyper_6_30_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_26_chunk o2_7 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_6_29_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_29_chunk compress_hyper_6_29_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_5_27_chunk o2_8 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_6_28_chunk__compressed_hypertable_6_device_id__t on compress_hyper_6_28_chunk compress_hyper_6_28_chunk_1 (actual rows=6 loops=1)
+(46 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable


### PR DESCRIPTION
This change captures the reltuples and relpages (and relallvisible)
statistics from the pg_class table for chunks immediately before
truncating them during the compression code path.  It then restores
the values after truncating, as there is no way to keep postgresql
from clearing these values during this operation.  It also properly
uses these values properly during planning, working around some
postgresql code which substitutes in arbitrary sizing for tables
which don't see to hold data.

Fixes #2524