### PR TITLE
Remove modification time from invalidation log

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -281,7 +281,6 @@ SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs
 -- table are performance critical
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log (
   hypertable_id integer NOT NULL,
-  modification_time bigint NOT NULL, --now time for txn when the raw table was modified
   lowest_modified_value bigint NOT NULL,
   greatest_modified_value bigint NOT NULL
 );
@@ -293,7 +292,6 @@ CREATE INDEX continuous_aggs_hypertable_invalidation_log_idx ON _timescaledb_cat
 -- per cagg copy of invalidation log
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (
   materialization_id integer REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE,
-  modification_time bigint NOT NULL, --now time for txn when the raw table was modified
   lowest_modified_value bigint NOT NULL,
   greatest_modified_value bigint NOT NULL
 );

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -5,3 +5,61 @@ DROP FUNCTION IF EXISTS distributed_exec;
 DROP PROCEDURE IF EXISTS refresh_continuous_aggregate(regclass,"any","any");
 
 DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;
+
+-- Rebuild hypertable invalidation log
+CREATE TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log_tmp AS
+SELECT hypertable_id, lowest_modified_value, greatest_modified_value
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+ALTER EXTENSION timescaledb
+      DROP TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+DROP TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
+
+CREATE TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log (
+  hypertable_id integer NOT NULL,
+  lowest_modified_value bigint NOT NULL,
+  greatest_modified_value bigint NOT NULL
+);
+
+INSERT INTO _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+SELECT * FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log_tmp;
+
+DROP TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log_tmp;
+
+SELECT pg_catalog.pg_extension_config_dump(
+       '_timescaledb_catalog.continuous_aggs_hypertable_invalidation_log', '');
+
+CREATE INDEX continuous_aggs_hypertable_invalidation_log_idx ON
+    _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log (
+        hypertable_id, lowest_modified_value ASC);
+GRANT SELECT ON  _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log TO PUBLIC;
+
+-- Rebuild materialization invalidation log
+CREATE TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log_tmp AS
+SELECT materialization_id, lowest_modified_value, greatest_modified_value
+FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+
+ALTER EXTENSION timescaledb
+      DROP TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+DROP TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log;
+
+CREATE TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (
+  materialization_id integer
+      REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE,
+  lowest_modified_value bigint NOT NULL,
+  greatest_modified_value bigint NOT NULL
+);
+
+INSERT INTO _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
+SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log_tmp;
+
+DROP TABLE _timescaledb_catalog.continuous_aggs_materialization_invalidation_log_tmp;
+
+SELECT pg_catalog.pg_extension_config_dump(
+       '_timescaledb_catalog.continuous_aggs_materialization_invalidation_log',
+       '');
+
+CREATE INDEX continuous_aggs_materialization_invalidation_log_idx ON
+    _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (
+        materialization_id, lowest_modified_value ASC);
+GRANT SELECT ON  _timescaledb_catalog.continuous_aggs_materialization_invalidation_log TO PUBLIC;

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -929,7 +929,6 @@ typedef enum Anum_continuous_agg_raw_hypertable_id_idx
 typedef enum Anum_continuous_aggs_hypertable_invalidation_log
 {
 	Anum_continuous_aggs_hypertable_invalidation_log_hypertable_id = 1,
-	Anum_continuous_aggs_hypertable_invalidation_log_modification_time,
 	Anum_continuous_aggs_hypertable_invalidation_log_lowest_modified_value,
 	Anum_continuous_aggs_hypertable_invalidation_log_greatest_modified_value,
 	_Anum_continuous_aggs_hypertable_invalidation_log_max,
@@ -941,7 +940,6 @@ typedef enum Anum_continuous_aggs_hypertable_invalidation_log
 typedef struct FormData_continuous_aggs_hypertable_invalidation_log
 {
 	int32 hypertable_id;
-	int64 modification_time;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;
 } FormData_continuous_aggs_hypertable_invalidation_log;
@@ -1005,7 +1003,6 @@ typedef enum Anum_continuous_aggs_invalidation_threshold_pkey
 typedef enum Anum_continuous_aggs_materialization_invalidation_log
 {
 	Anum_continuous_aggs_materialization_invalidation_log_materialization_id = 1,
-	Anum_continuous_aggs_materialization_invalidation_log_modification_time,
 	Anum_continuous_aggs_materialization_invalidation_log_lowest_modified_value,
 	Anum_continuous_aggs_materialization_invalidation_log_greatest_modified_value,
 	_Anum_continuous_aggs_materialization_invalidation_log_max,
@@ -1017,7 +1014,6 @@ typedef enum Anum_continuous_aggs_materialization_invalidation_log
 typedef struct FormData_continuous_aggs_materialization_invalidation_log
 {
 	int32 materialization_id;
-	int64 modification_time;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;
 } FormData_continuous_aggs_materialization_invalidation_log;

--- a/src/utils.h
+++ b/src/utils.h
@@ -85,7 +85,6 @@ extern TSDLLEXPORT Oid ts_get_cast_func(Oid source, Oid target);
 typedef struct Dimension Dimension;
 
 extern TSDLLEXPORT Oid ts_get_integer_now_func(const Dimension *open_dim);
-extern TSDLLEXPORT int64 ts_get_now_internal(const Dimension *open_dim);
 
 extern void *ts_create_struct_from_slot(TupleTableSlot *slot, MemoryContext mctx, size_t alloc_size,
 										size_t copy_size);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -480,10 +480,8 @@ mattablecolumninfo_create_materialization_table(MatTableColumnInfo *matcolinfo, 
 	int32 mat_htid;
 	Oid mat_relid;
 	Cache *hcache;
-	Hypertable *ht = NULL, *mat_ht = NULL;
+	Hypertable *mat_ht = NULL;
 	Oid owner = GetUserId();
-	int64 current_time;
-	Dimension *ht_time_dim;
 
 	create = makeNode(CreateStmt);
 	create->relation = mat_rel;
@@ -525,19 +523,10 @@ mattablecolumninfo_create_materialization_table(MatTableColumnInfo *matcolinfo, 
 		mattablecolumninfo_add_mattable_index(matcolinfo, mat_ht);
 
 	/* Initialize the invalidation log for the cagg. Initially, everything is
-	 * invalid.
-	 * Integer time dimensions have now functions. These settings
-	 * are derived from the original hypertable since they are not explicitly
-	 * set on the materialization hypertable
-	 */
-	ht = ts_hypertable_cache_get_entry(hcache, origquery_tblinfo->htoid, CACHE_FLAG_NONE);
-	ht_time_dim = hyperspace_get_open_dimension(ht->space, 0);
-	Assert(ht_time_dim != NULL);
-	current_time = ts_get_now_internal(ht_time_dim);
-
-	/* Add an infinite invalidation for the continuous aggregate. This is the
-	 * initial state of the aggregate before any refreshes. */
-	invalidation_cagg_log_add_entry(mat_htid, current_time, TS_TIME_NOBEGIN, TS_TIME_NOEND);
+	 * invalid. Add an infinite invalidation for the continuous
+	 * aggregate. This is the initial state of the aggregate before any
+	 * refreshes. */
+	invalidation_cagg_log_add_entry(mat_htid, TS_TIME_NOBEGIN, TS_TIME_NOEND);
 
 	ts_cache_release(hcache);
 	return mat_htid;

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -61,7 +61,6 @@ typedef struct ContinuousAggsCacheInvalEntry
 	int32 hypertable_id;
 	Oid hypertable_relid;
 	Dimension hypertable_open_dimension;
-	int64 modification_time;
 	Oid previous_chunk_relid;
 	AttrNumber previous_chunk_open_dimension;
 	bool value_is_set;
@@ -147,7 +146,6 @@ cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry, int32 hyperta
 		*open_dim_part_info = *cache_entry->hypertable_open_dimension.partitioning;
 		cache_entry->hypertable_open_dimension.partitioning = open_dim_part_info;
 	}
-	cache_entry->modification_time = ts_get_now_internal(&cache_entry->hypertable_open_dimension);
 	cache_entry->previous_chunk_relid = InvalidOid;
 	cache_entry->value_is_set = false;
 	cache_entry->lowest_modified_value = PG_INT64_MAX;
@@ -268,7 +266,6 @@ cache_inval_entry_write(ContinuousAggsCacheInvalEntry *entry)
 	if (IsolationUsesXactSnapshot())
 	{
 		invalidation_hyper_log_add_entry(entry->hypertable_id,
-										 entry->modification_time,
 										 entry->lowest_modified_value,
 										 entry->greatest_modified_value);
 		return;
@@ -278,7 +275,6 @@ cache_inval_entry_write(ContinuousAggsCacheInvalEntry *entry)
 
 	if (entry->lowest_modified_value < liv)
 		invalidation_hyper_log_add_entry(entry->hypertable_id,
-										 entry->modification_time,
 										 entry->lowest_modified_value,
 										 entry->greatest_modified_value);
 };

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -20,7 +20,6 @@
 typedef struct Invalidation
 {
 	int32 hyper_id;
-	int64 modification_time;
 	int64 lowest_modified_value;
 	int64 greatest_modified_value;
 	bool is_modified;
@@ -35,9 +34,8 @@ typedef struct InvalidationStore
 
 typedef struct Hypertable Hypertable;
 
-extern void invalidation_cagg_log_add_entry(int32 cagg_hyper_id, int64 modtime, int64 start,
-											int64 end);
-extern void invalidation_hyper_log_add_entry(int32 hyper_id, int64 modtime, int64 start, int64 end);
+extern void invalidation_cagg_log_add_entry(int32 cagg_hyper_id, int64 start, int64 end);
+extern void invalidation_hyper_log_add_entry(int32 hyper_id, int64 start, int64 end);
 extern void invalidation_add_entry(const Hypertable *ht, int64 start, int64 end);
 extern void invalidation_entry_set_from_hyper_invalidation(Invalidation *entry, const TupleInfo *ti,
 														   int32 hyper_id);

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -427,9 +427,9 @@ as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
-ERROR:  invalid integer_now function
 \set ON_ERROR_STOP 0
 DROP TABLE conditions cascade;
+NOTICE:  drop cascades to 3 other objects
 CREATE TABLE conditions (
       timec       BIGINT       NOT NULL,
       location    TEXT              NOT NULL,

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -300,12 +300,12 @@ select * from _timescaledb_catalog.continuous_aggs_invalidation_threshold order 
 (1 row)
 
 select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
- materialization_id | modification_time | lowest_modified_value | greatest_modified_value 
---------------------+-------------------+-----------------------+-------------------------
-                  5 |                16 |  -9223372036854775808 |             -2147483649
-                  5 |                16 |                    18 |     9223372036854775807
-                  6 |                16 |  -9223372036854775808 |             -2147483649
-                  6 |                16 |                    14 |     9223372036854775807
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
+                  5 |  -9223372036854775808 |             -2147483649
+                  5 |                    18 |     9223372036854775807
+                  6 |  -9223372036854775808 |             -2147483649
+                  6 |                    14 |     9223372036854775807
 (4 rows)
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
@@ -337,10 +337,10 @@ select * from cagg_2 order by 1;
 insert into continuous_agg_test values( 18, -2, 100);
 insert into continuous_agg_test values( 18, -2, 100);
 select * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log order by 1;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             4 |                18 |                    18 |                      18
-             4 |                18 |                    18 |                      18
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             4 |                    18 |                      18
+             4 |                    18 |                      18
 (2 rows)
 
 CALL refresh_continuous_aggregate('cagg_1', NULL, NULL);
@@ -352,13 +352,13 @@ select * from cagg_1 where timed = 18 ;
 
 --copied over for cagg_2 to process later?
 select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_log order by 1;
- materialization_id | modification_time | lowest_modified_value | greatest_modified_value 
---------------------+-------------------+-----------------------+-------------------------
-                  5 |                16 |  -9223372036854775808 |             -2147483649
-                  5 |                16 |                    20 |     9223372036854775807
-                  6 |                16 |  -9223372036854775808 |             -2147483649
-                  6 |                16 |                    16 |     9223372036854775807
-                  6 |                18 |                    18 |                      18
+ materialization_id | lowest_modified_value | greatest_modified_value 
+--------------------+-----------------------+-------------------------
+                  5 |  -9223372036854775808 |             -2147483649
+                  5 |                    20 |     9223372036854775807
+                  6 |  -9223372036854775808 |             -2147483649
+                  6 |                    16 |     9223372036854775807
+                  6 |                    18 |                      18
 (5 rows)
 
 DROP MATERIALIZED VIEW cagg_1;

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -23,8 +23,8 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
 (0 rows)
 
 -- inserting into a table that does not have continuous_agg_insert_trigger doesn't change the watermark
@@ -35,8 +35,8 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -65,8 +65,8 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
 (0 rows)
 
 -- set the continuous_aggs_invalidation_threshold to 15, any insertions below that value need an invalidation
@@ -81,9 +81,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
 (1 row)
 
 -- INSERTs only above the continuous_aggs_invalidation_threshold won't change the continuous_aggs_hypertable_invalidation_log
@@ -95,9 +95,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
 (1 row)
 
 -- INSERTs only below the continuous_aggs_invalidation_threshold will change the continuous_aggs_hypertable_invalidation_log
@@ -109,10 +109,10 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
-             1 |                22 |                    10 |                      11
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
+             1 |                    10 |                      11
 (2 rows)
 
 -- test INSERTing other values
@@ -124,11 +124,11 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
-             1 |                22 |                    10 |                      11
-             1 |                22 |                     1 |                      51
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
+             1 |                    10 |                      11
+             1 |                     1 |                      51
 (3 rows)
 
 -- INSERT after dropping a COLUMN
@@ -141,12 +141,12 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
-             1 |                22 |                    10 |                      11
-             1 |                22 |                     1 |                      51
-             1 |                51 |                    -4 |                      -1
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
+             1 |                    10 |                      11
+             1 |                     1 |                      51
+             1 |                    -4 |                      -1
 (4 rows)
 
 INSERT INTO continuous_agg_test VALUES (100);
@@ -157,12 +157,12 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
-             1 |                22 |                    10 |                      11
-             1 |                22 |                     1 |                      51
-             1 |                51 |                    -4 |                      -1
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
+             1 |                    10 |                      11
+             1 |                     1 |                      51
+             1 |                    -4 |                      -1
 (4 rows)
 
 -- INSERT after adding a COLUMN
@@ -175,13 +175,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
-             1 |                22 |                    10 |                      11
-             1 |                22 |                     1 |                      51
-             1 |                51 |                    -4 |                      -1
-             1 |               100 |                    -7 |                      -3
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
+             1 |                    10 |                      11
+             1 |                     1 |                      51
+             1 |                    -4 |                      -1
+             1 |                    -7 |                      -3
 (5 rows)
 
 INSERT INTO continuous_agg_test VALUES (120, false), (200, true);
@@ -192,13 +192,13 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             1 |                22 |                    10 |                      22
-             1 |                22 |                    10 |                      11
-             1 |                22 |                     1 |                      51
-             1 |                51 |                    -4 |                      -1
-             1 |               100 |                    -7 |                      -3
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             1 |                    10 |                      22
+             1 |                    10 |                      11
+             1 |                     1 |                      51
+             1 |                    -4 |                      -1
+             1 |                    -7 |                      -3
 (5 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -238,8 +238,8 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -253,9 +253,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             3 |                 5 |                     5 |                      15
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             3 |                     5 |                      15
 (1 row)
 
 INSERT INTO ca_inval_test SELECT generate_series(16, 20);
@@ -266,9 +266,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             3 |                 5 |                     5 |                      15
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             3 |                     5 |                      15
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -289,12 +289,12 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             3 |                20 |                     5 |                       6
-             3 |                20 |                     5 |                       7
-             3 |                20 |                    14 |                      17
-             3 |                20 |                    12 |                      16
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             3 |                     5 |                       6
+             3 |                     5 |                       7
+             3 |                    14 |                      17
+             3 |                    12 |                      16
 (4 rows)
 
 DROP TABLE ca_inval_test CASCADE;
@@ -333,8 +333,8 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
 (0 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -348,9 +348,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             5 |                29 |                     1 |                       1
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             5 |                     1 |                       1
 (1 row)
 
 -- aborts don't get written
@@ -364,9 +364,9 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 (1 row)
 
 SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
- hypertable_id | modification_time | lowest_modified_value | greatest_modified_value 
----------------+-------------------+-----------------------+-------------------------
-             5 |                29 |                     1 |                       1
+ hypertable_id | lowest_modified_value | greatest_modified_value 
+---------------+-----------------------+-------------------------
+             5 |                     1 |                       1
 (1 row)
 
 DROP TABLE ts_continuous_test CASCADE;


### PR DESCRIPTION
The `modification_time` column is hard to maintain with any level of consistency over merges and splits of
invalidation ranges so this commit removes it from the invalidation log entries for both hypertables and continuous aggregates. If the modification
time is needed in the future, we need to re-introduce it in a manner
that can maintain it over both merges and splits.

Part of #2521