### PR TITLE
Assume custom time type range is same as bigint

### DIFF
--- a/src/dimension.h
+++ b/src/dimension.h
@@ -14,7 +14,7 @@
 
 #include "catalog.h"
 #include "export.h"
-#include "utils.h"
+#include "time_utils.h"
 
 typedef struct PartitioningInfo PartitioningInfo;
 typedef struct DimensionSlice DimensionSlice;
@@ -37,13 +37,7 @@ typedef struct Dimension
 } Dimension;
 
 #define IS_OPEN_DIMENSION(d) ((d)->type == DIMENSION_TYPE_OPEN)
-
 #define IS_CLOSED_DIMENSION(d) ((d)->type == DIMENSION_TYPE_CLOSED)
-
-#define IS_INTEGER_TYPE(type) (type == INT2OID || type == INT4OID || type == INT8OID)
-
-#define IS_TIMESTAMP_TYPE(type) (type == TIMESTAMPOID || type == TIMESTAMPTZOID || type == DATEOID)
-
 #define IS_VALID_OPEN_DIM_TYPE(type)                                                               \
 	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type) || ts_type_is_int8_binary_compatible(type))
 

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -40,38 +40,33 @@
 #define TS_TIME_NOBEGIN (PG_INT64_MIN)
 #define TS_TIME_NOEND (PG_INT64_MAX)
 
-#define TS_TIME_IS_INTEGER_TIME(type) (type == INT2OID || type == INT4OID || type == INT8OID)
-#define TS_TIME_IS_DATE_TIMESTAMP_TIME(type)                                                       \
-	(type == TIMESTAMPTZOID || type == TIMESTAMPOID || type == DATEOID)
-
-#define TS_TIME_IS_VALID_TYPE(type)                                                                \
-	(TS_TIME_IS_INTEGER_TIME(type) || TS_TIME_IS_DATE_TIMESTAMP_TIME(type))
+#define IS_INTEGER_TYPE(type) (type == INT2OID || type == INT4OID || type == INT8OID)
+#define IS_TIMESTAMP_TYPE(type) (type == TIMESTAMPOID || type == TIMESTAMPTZOID || type == DATEOID)
+#define IS_VALID_TIME_TYPE(type) (IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type))
 
 #define TS_TIME_DATUM_IS_MIN(timeval, type) (timeval == ts_time_datum_get_min(type))
 #define TS_TIME_DATUM_IS_MAX(timeval, type) (timeval == ts_time_datum_get_max(type))
 #define TS_TIME_DATUM_IS_END(timeval, type)                                                        \
-	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_datum_get_end(type)))
+	(IS_TIMESTAMP_TYPE(type) && timeval == ts_time_datum_get_end(type)))
 #define TS_TIME_DATUM_IS_NOBEGIN(timeval, type)                                                    \
-	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && (timeval == ts_time_datum_get_nobegin(type)))
+	(IS_TIMESTAMP_TYPE(type) && (timeval == ts_time_datum_get_nobegin(type)))
 #define TS_TIME_DATUM_IS_NOEND(timeval, type)                                                      \
-	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && (timeval == ts_time_datum_get_noend(type)))
+	(IS_TIMESTAMP_TYPE(type) && (timeval == ts_time_datum_get_noend(type)))
 
 #define TS_TIME_DATUM_NOT_FINITE(timeval, type)                                                    \
-	(TS_TIME_IS_INTEGER_TIME(type) || TS_TIME_DATUM_IS_NOBEGIN(timeval, type) ||                   \
+	(IS_INTEGER_TYPE(type) || TS_TIME_DATUM_IS_NOBEGIN(timeval, type) ||                           \
 	 TS_TIME_DATUM_IS_NOEND(timeval, type))
 
 #define TS_TIME_IS_MIN(timeval, type) (timeval == ts_time_get_min(type))
 #define TS_TIME_IS_MAX(timeval, type) (timeval == ts_time_get_max(type))
-#define TS_TIME_IS_END(timeval, type)                                                              \
-	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_get_end(type))
+#define TS_TIME_IS_END(timeval, type) (IS_TIMESTAMP_TYPE(type) && timeval == ts_time_get_end(type))
 #define TS_TIME_IS_NOBEGIN(timeval, type)                                                          \
-	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_get_nobegin(type))
+	(IS_TIMESTAMP_TYPE(type) && timeval == ts_time_get_nobegin(type))
 #define TS_TIME_IS_NOEND(timeval, type)                                                            \
-	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_get_noend(type))
+	(IS_TIMESTAMP_TYPE(type) && timeval == ts_time_get_noend(type))
 
 #define TS_TIME_NOT_FINITE(timeval, type)                                                          \
-	(TS_TIME_IS_INTEGER_TIME(type) || TS_TIME_IS_NOBEGIN(timeval, type) ||                         \
-	 TS_TIME_IS_NOEND(timeval, type))
+	(IS_INTEGER_TYPE(type) || TS_TIME_IS_NOBEGIN(timeval, type) || TS_TIME_IS_NOEND(timeval, type))
 
 extern TSDLLEXPORT int64 ts_time_value_from_arg(Datum arg, Oid argtype, Oid timetype);
 extern TSDLLEXPORT Datum ts_time_datum_convert_arg(Datum arg, Oid *argtype, Oid timetype);

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -41,14 +41,20 @@
 #define TS_TIME_NOEND (PG_INT64_MAX)
 
 #define TS_TIME_IS_INTEGER_TIME(type) (type == INT2OID || type == INT4OID || type == INT8OID)
+#define TS_TIME_IS_DATE_TIMESTAMP_TIME(type)                                                       \
+	(type == TIMESTAMPTZOID || type == TIMESTAMPOID || type == DATEOID)
+
+#define TS_TIME_IS_VALID_TYPE(type)                                                                \
+	(TS_TIME_IS_INTEGER_TIME(type) || TS_TIME_IS_DATE_TIMESTAMP_TIME(type))
+
 #define TS_TIME_DATUM_IS_MIN(timeval, type) (timeval == ts_time_datum_get_min(type))
 #define TS_TIME_DATUM_IS_MAX(timeval, type) (timeval == ts_time_datum_get_max(type))
 #define TS_TIME_DATUM_IS_END(timeval, type)                                                        \
-	(!TS_TIME_IS_INTEGER_TIME(type) && (timeval == ts_time_datum_get_end(type)))
+	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_datum_get_end(type)))
 #define TS_TIME_DATUM_IS_NOBEGIN(timeval, type)                                                    \
-	(!TS_TIME_IS_INTEGER_TIME(type) && (timeval == ts_time_datum_get_nobegin(type)))
+	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && (timeval == ts_time_datum_get_nobegin(type)))
 #define TS_TIME_DATUM_IS_NOEND(timeval, type)                                                      \
-	(!TS_TIME_IS_INTEGER_TIME(type) && (timeval == ts_time_datum_get_noend(type)))
+	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && (timeval == ts_time_datum_get_noend(type)))
 
 #define TS_TIME_DATUM_NOT_FINITE(timeval, type)                                                    \
 	(TS_TIME_IS_INTEGER_TIME(type) || TS_TIME_DATUM_IS_NOBEGIN(timeval, type) ||                   \
@@ -57,11 +63,11 @@
 #define TS_TIME_IS_MIN(timeval, type) (timeval == ts_time_get_min(type))
 #define TS_TIME_IS_MAX(timeval, type) (timeval == ts_time_get_max(type))
 #define TS_TIME_IS_END(timeval, type)                                                              \
-	(!TS_TIME_IS_INTEGER_TIME(type) && timeval == ts_time_get_end(type))
+	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_get_end(type))
 #define TS_TIME_IS_NOBEGIN(timeval, type)                                                          \
-	(!TS_TIME_IS_INTEGER_TIME(type) && timeval == ts_time_get_nobegin(type))
+	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_get_nobegin(type))
 #define TS_TIME_IS_NOEND(timeval, type)                                                            \
-	(!TS_TIME_IS_INTEGER_TIME(type) && timeval == ts_time_get_noend(type))
+	(TS_TIME_IS_DATE_TIMESTAMP_TIME(type) && timeval == ts_time_get_noend(type))
 
 #define TS_TIME_NOT_FINITE(timeval, type)                                                          \
 	(TS_TIME_IS_INTEGER_TIME(type) || TS_TIME_IS_NOBEGIN(timeval, type) ||                         \

--- a/src/utils.c
+++ b/src/utils.c
@@ -121,7 +121,7 @@ ts_time_value_to_internal(Datum time_val, Oid type_oid)
 
 	/* Handle custom time types. We currently only support binary coercible
 	 * types */
-	if (!TS_TIME_IS_VALID_TYPE(type_oid))
+	if (!IS_VALID_TIME_TYPE(type_oid))
 	{
 		if (ts_type_is_int8_binary_compatible(type_oid))
 			return DatumGetInt64(time_val);
@@ -129,7 +129,7 @@ ts_time_value_to_internal(Datum time_val, Oid type_oid)
 		elog(ERROR, "unknown time type OID %d", type_oid);
 	}
 
-	if (TS_TIME_IS_INTEGER_TIME(type_oid))
+	if (IS_INTEGER_TYPE(type_oid))
 	{
 		/* Integer time types have no distinction between min, max and
 		 * infinity. We don't want min and max to be turned into infinity for

--- a/src/utils.c
+++ b/src/utils.c
@@ -119,6 +119,16 @@ ts_time_value_to_internal(Datum time_val, Oid type_oid)
 {
 	Datum res, tz;
 
+	/* Handle custom time types. We currently only support binary coercible
+	 * types */
+	if (!TS_TIME_IS_VALID_TYPE(type_oid))
+	{
+		if (ts_type_is_int8_binary_compatible(type_oid))
+			return DatumGetInt64(time_val);
+
+		elog(ERROR, "unknown time type OID %d", type_oid);
+	}
+
 	if (TS_TIME_IS_INTEGER_TIME(type_oid))
 	{
 		/* Integer time types have no distinction between min, max and
@@ -161,9 +171,6 @@ ts_time_value_to_internal(Datum time_val, Oid type_oid)
 
 			return DatumGetInt64(res);
 		default:
-			if (ts_type_is_int8_binary_compatible(type_oid))
-				return DatumGetInt64(time_val);
-
 			elog(ERROR, "unknown time type OID %d", type_oid);
 			return -1;
 	}

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -210,10 +210,10 @@ select set_chunk_time_interval(NULL,NULL::interval);
 ERROR:  invalid main_table: cannot be NULL
 -- should fail since time column is an int
 SELECT set_chunk_time_interval('chunk_test', INTERVAL '1 minute');
-ERROR:  invalid interval: must be an integer type for integer dimensions
+ERROR:  invalid interval type for integer dimension
 -- should fail since its not a valid way to represent time
 SELECT set_chunk_time_interval('chunk_test', 'foo'::TEXT);
-ERROR:  invalid interval: must be an interval or integer type
+ERROR:  invalid interval type for integer dimension
 SELECT set_chunk_time_interval('chunk_test', NULL::BIGINT);
 ERROR:  invalid interval: an explicit interval must be specified
 SELECT set_chunk_time_interval('chunk_test2', NULL::BIGINT);

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -184,10 +184,10 @@ NOTICE:  adding not-null constraint to column "time2"
 -- Test add_dimension: only integral should work on BIGINT columns
 \set ON_ERROR_STOP 0
 SELECT add_dimension('dim_test_time', 'time3', chunk_time_interval => INTERVAL '1 day');
-ERROR:  invalid interval: must be an integer type for integer dimensions
+ERROR:  invalid interval type for bigint dimension
 -- string is not a valid type
 SELECT add_dimension('dim_test_time', 'time3', chunk_time_interval => 'foo'::TEXT);
-ERROR:  invalid interval: must be an interval or integer type
+ERROR:  invalid interval type for bigint dimension
 \set ON_ERROR_STOP 1
 SELECT add_dimension('dim_test_time', 'time3', chunk_time_interval => 500);
 NOTICE:  adding not-null constraint to column "time3"

--- a/test/expected/custom_type-11.out
+++ b/test/expected/custom_type-11.out
@@ -59,6 +59,11 @@ CREATE OPERATOR >= (
 );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE customtype_test(time_custom customtype, val int);
+\set ON_ERROR_STOP 0
+-- Using interval type for chunk time interval should fail with custom time type
+SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => INTERVAL '1 day', create_default_indexes=>false);
+ERROR:  invalid interval type for customtype dimension
+\set ON_ERROR_STOP 1
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time_custom"
       create_hypertable       

--- a/test/expected/custom_type-11.out
+++ b/test/expected/custom_type-11.out
@@ -25,35 +25,39 @@ CREATE TYPE customtype (
  SEND = customtype_send,
  LIKE = TIMESTAMPTZ
 );
+CREATE CAST (customtype AS bigint)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (bigint AS customtype)
+WITHOUT FUNCTION AS IMPLICIT;
+CREATE CAST (customtype AS timestamptz)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (timestamptz AS customtype)
+WITHOUT FUNCTION AS ASSIGNMENT;
 CREATE OR REPLACE FUNCTION customtype_lt(customtype, customtype) RETURNS bool AS
 'timestamp_lt'
 LANGUAGE internal IMMUTABLE STRICT;
 CREATE OPERATOR < (
-    LEFTARG = customtype,
-    RIGHTARG = customtype,
-    PROCEDURE = customtype_lt,
-    COMMUTATOR = >,
-    NEGATOR = >=,
-    RESTRICT = scalarltsel,
-    JOIN = scalarltjoinsel
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_lt,
+	COMMUTATOR = >,
+	NEGATOR = >=,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
 );
 CREATE OR REPLACE FUNCTION customtype_ge(customtype, customtype) RETURNS bool AS
 'timestamp_ge'
 LANGUAGE internal IMMUTABLE STRICT;
 CREATE OPERATOR >= (
-    LEFTARG = customtype,
-    RIGHTARG = customtype,
-    PROCEDURE = customtype_ge,
-    COMMUTATOR = <=,
-    NEGATOR = <,
-    RESTRICT = scalargtsel,
-    JOIN = scalargtjoinsel
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_ge,
+	COMMUTATOR = <=,
+	NEGATOR = <,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
 );
-CREATE CAST (customtype AS bigint)
-WITHOUT FUNCTION AS ASSIGNMENT;
-CREATE CAST (bigint AS customtype)
-WITHOUT FUNCTION AS ASSIGNMENT;
-SET ROLE :ROLE_DEFAULT_PERM_USER;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE customtype_test(time_custom customtype, val int);
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time_custom"
@@ -62,17 +66,8 @@ NOTICE:  adding not-null constraint to column "time_custom"
  (1,public,customtype_test,t)
 (1 row)
 
-\set ON_ERROR_STOP 0
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
-ERROR:  unsupported time type "customtype"
-\set ON_ERROR_STOP 1
--- Add implicit casts
-RESET ROLE;
-CREATE CAST (customtype AS timestamptz)
-WITHOUT FUNCTION AS IMPLICIT;
-CREATE CAST (timestamptz AS customtype)
-WITHOUT FUNCTION AS IMPLICIT;
-SET ROLE :ROLE_DEFAULT_PERM_USER;
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
 EXPLAIN (costs off) SELECT * FROM customtype_test;
              QUERY PLAN             
@@ -94,6 +89,8 @@ SELECT * FROM customtype_test;
          time_custom          | val 
 ------------------------------+-----
  Mon Jan 01 01:02:03 2001 PST |  10
+ Mon Jan 01 01:02:03 2001 PST |  10
+ Mon Jan 01 01:02:03 2001 PST |  10
  Mon Jan 01 01:02:23 2001 PST |  11
-(2 rows)
+(4 rows)
 

--- a/test/expected/custom_type-12.out
+++ b/test/expected/custom_type-12.out
@@ -59,6 +59,11 @@ CREATE OPERATOR >= (
 );
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE customtype_test(time_custom customtype, val int);
+\set ON_ERROR_STOP 0
+-- Using interval type for chunk time interval should fail with custom time type
+SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => INTERVAL '1 day', create_default_indexes=>false);
+ERROR:  invalid interval type for customtype dimension
+\set ON_ERROR_STOP 1
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time_custom"
       create_hypertable       

--- a/test/expected/custom_type-12.out
+++ b/test/expected/custom_type-12.out
@@ -25,35 +25,39 @@ CREATE TYPE customtype (
  SEND = customtype_send,
  LIKE = TIMESTAMPTZ
 );
+CREATE CAST (customtype AS bigint)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (bigint AS customtype)
+WITHOUT FUNCTION AS IMPLICIT;
+CREATE CAST (customtype AS timestamptz)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (timestamptz AS customtype)
+WITHOUT FUNCTION AS ASSIGNMENT;
 CREATE OR REPLACE FUNCTION customtype_lt(customtype, customtype) RETURNS bool AS
 'timestamp_lt'
 LANGUAGE internal IMMUTABLE STRICT;
 CREATE OPERATOR < (
-    LEFTARG = customtype,
-    RIGHTARG = customtype,
-    PROCEDURE = customtype_lt,
-    COMMUTATOR = >,
-    NEGATOR = >=,
-    RESTRICT = scalarltsel,
-    JOIN = scalarltjoinsel
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_lt,
+	COMMUTATOR = >,
+	NEGATOR = >=,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
 );
 CREATE OR REPLACE FUNCTION customtype_ge(customtype, customtype) RETURNS bool AS
 'timestamp_ge'
 LANGUAGE internal IMMUTABLE STRICT;
 CREATE OPERATOR >= (
-    LEFTARG = customtype,
-    RIGHTARG = customtype,
-    PROCEDURE = customtype_ge,
-    COMMUTATOR = <=,
-    NEGATOR = <,
-    RESTRICT = scalargtsel,
-    JOIN = scalargtjoinsel
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_ge,
+	COMMUTATOR = <=,
+	NEGATOR = <,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
 );
-CREATE CAST (customtype AS bigint)
-WITHOUT FUNCTION AS ASSIGNMENT;
-CREATE CAST (bigint AS customtype)
-WITHOUT FUNCTION AS ASSIGNMENT;
-SET ROLE :ROLE_DEFAULT_PERM_USER;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 CREATE TABLE customtype_test(time_custom customtype, val int);
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time_custom"
@@ -62,17 +66,8 @@ NOTICE:  adding not-null constraint to column "time_custom"
  (1,public,customtype_test,t)
 (1 row)
 
-\set ON_ERROR_STOP 0
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
-ERROR:  unsupported time type "customtype"
-\set ON_ERROR_STOP 1
--- Add implicit casts
-RESET ROLE;
-CREATE CAST (customtype AS timestamptz)
-WITHOUT FUNCTION AS IMPLICIT;
-CREATE CAST (timestamptz AS customtype)
-WITHOUT FUNCTION AS IMPLICIT;
-SET ROLE :ROLE_DEFAULT_PERM_USER;
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
 EXPLAIN (costs off) SELECT * FROM customtype_test;
           QUERY PLAN          
@@ -93,6 +88,8 @@ SELECT * FROM customtype_test;
          time_custom          | val 
 ------------------------------+-----
  Mon Jan 01 01:02:03 2001 PST |  10
+ Mon Jan 01 01:02:03 2001 PST |  10
+ Mon Jan 01 01:02:03 2001 PST |  10
  Mon Jan 01 01:02:23 2001 PST |  11
-(2 rows)
+(4 rows)
 

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -1274,5 +1274,5 @@ ERROR:  invalid interval: must be between 1 and 32767
 SELECT test.interval_to_internal('TEXT'::regtype, 32768::bigint);
 ERROR:  invalid dimension type: "testcol" must be an integer, date or timestamp
 SELECT test.interval_to_internal('INT'::regtype, INTERVAL '1 day');
-ERROR:  invalid interval: must be an integer type for integer dimensions
+ERROR:  invalid interval type for integer dimension
 \set ON_ERROR_STOP 1

--- a/test/sql/custom_type.sql.in
+++ b/test/sql/custom_type.sql.in
@@ -26,55 +26,49 @@ CREATE TYPE customtype (
  LIKE = TIMESTAMPTZ
 );
 
+CREATE CAST (customtype AS bigint)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (bigint AS customtype)
+WITHOUT FUNCTION AS IMPLICIT;
+
+CREATE CAST (customtype AS timestamptz)
+WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (timestamptz AS customtype)
+WITHOUT FUNCTION AS ASSIGNMENT;
 
 CREATE OR REPLACE FUNCTION customtype_lt(customtype, customtype) RETURNS bool AS
 'timestamp_lt'
 LANGUAGE internal IMMUTABLE STRICT;
 CREATE OPERATOR < (
-    LEFTARG = customtype,
-    RIGHTARG = customtype,
-    PROCEDURE = customtype_lt,
-    COMMUTATOR = >,
-    NEGATOR = >=,
-    RESTRICT = scalarltsel,
-    JOIN = scalarltjoinsel
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_lt,
+	COMMUTATOR = >,
+	NEGATOR = >=,
+	RESTRICT = scalarltsel,
+	JOIN = scalarltjoinsel
 );
 
 CREATE OR REPLACE FUNCTION customtype_ge(customtype, customtype) RETURNS bool AS
 'timestamp_ge'
 LANGUAGE internal IMMUTABLE STRICT;
 CREATE OPERATOR >= (
-    LEFTARG = customtype,
-    RIGHTARG = customtype,
-    PROCEDURE = customtype_ge,
-    COMMUTATOR = <=,
-    NEGATOR = <,
-    RESTRICT = scalargtsel,
-    JOIN = scalargtjoinsel
+	LEFTARG = customtype,
+	RIGHTARG = customtype,
+	PROCEDURE = customtype_ge,
+	COMMUTATOR = <=,
+	NEGATOR = <,
+	RESTRICT = scalargtsel,
+	JOIN = scalargtjoinsel
 );
 
-CREATE CAST (customtype AS bigint)
-WITHOUT FUNCTION AS ASSIGNMENT;
-CREATE CAST (bigint AS customtype)
-WITHOUT FUNCTION AS ASSIGNMENT;
-
-SET ROLE :ROLE_DEFAULT_PERM_USER;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 CREATE TABLE customtype_test(time_custom customtype, val int);
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
 
-\set ON_ERROR_STOP 0
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
-\set ON_ERROR_STOP 1
-
--- Add implicit casts
-RESET ROLE;
-CREATE CAST (customtype AS timestamptz)
-WITHOUT FUNCTION AS IMPLICIT;
-CREATE CAST (timestamptz AS customtype)
-WITHOUT FUNCTION AS IMPLICIT;
-SET ROLE :ROLE_DEFAULT_PERM_USER;
-
+INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);
 EXPLAIN (costs off) SELECT * FROM customtype_test;
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:23'::customtype, 11);

--- a/test/sql/custom_type.sql.in
+++ b/test/sql/custom_type.sql.in
@@ -65,6 +65,11 @@ CREATE OPERATOR >= (
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 CREATE TABLE customtype_test(time_custom customtype, val int);
+\set ON_ERROR_STOP 0
+-- Using interval type for chunk time interval should fail with custom time type
+SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => INTERVAL '1 day', create_default_indexes=>false);
+\set ON_ERROR_STOP 1
+
 SELECT create_hypertable('customtype_test', 'time_custom', chunk_time_interval => 10e6::bigint, create_default_indexes=>false);
 
 INSERT INTO customtype_test VALUES ('2001-01-01 01:02:03'::customtype, 10);

--- a/test/src/test_time_utils.c
+++ b/test/src/test_time_utils.c
@@ -295,11 +295,11 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 					  ts_time_get_max(INT8OID));
 	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_max(DATEOID), 1, DATEOID),
 					  ts_time_get_noend(DATEOID));
-	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_end(DATEOID) - 1, 1, DATEOID),
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_max(DATEOID), 1, DATEOID),
 					  ts_time_get_noend(DATEOID));
-	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_end(TIMESTAMPOID) - 1, 1, TIMESTAMPOID),
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_max(TIMESTAMPOID), 1, TIMESTAMPOID),
 					  ts_time_get_noend(TIMESTAMPOID));
-	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_end(TIMESTAMPTZOID) - 1, 1, TIMESTAMPOID),
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_max(TIMESTAMPTZOID), 1, TIMESTAMPOID),
 					  ts_time_get_noend(TIMESTAMPOID));
 	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_end(DATEOID) - 2, 1, DATEOID),
 					  ts_time_get_max(DATEOID));
@@ -307,6 +307,21 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 					  ts_time_get_max(TIMESTAMPOID));
 	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_end(TIMESTAMPTZOID) - 2, 1, TIMESTAMPOID),
 					  ts_time_get_max(TIMESTAMPOID));
+
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_min(INT2OID), -1, INT2OID),
+					  ts_time_get_min(INT2OID));
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_min(INT4OID), -1, INT4OID),
+					  ts_time_get_min(INT4OID));
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_min(INT8OID), -1, INT8OID),
+					  ts_time_get_min(INT8OID));
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_min(DATEOID), -1, DATEOID),
+					  ts_time_get_nobegin(DATEOID));
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_min(DATEOID), -1, DATEOID),
+					  ts_time_get_nobegin(DATEOID));
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_min(TIMESTAMPOID), -1, TIMESTAMPOID),
+					  ts_time_get_nobegin(TIMESTAMPOID));
+	TestAssertInt64Eq(ts_time_saturating_add(ts_time_get_min(TIMESTAMPTZOID), -1, TIMESTAMPOID),
+					  ts_time_get_nobegin(TIMESTAMPOID));
 
 	/* Test saturating subtraction */
 	TestAssertInt64Eq(ts_time_saturating_sub(ts_time_get_min(INT2OID), 1, INT2OID),
@@ -329,6 +344,19 @@ ts_test_time_utils(PG_FUNCTION_ARGS)
 											 1,
 											 TIMESTAMPTZOID),
 					  ts_time_get_min(TIMESTAMPTZOID));
+
+	TestAssertInt64Eq(ts_time_saturating_sub(ts_time_get_max(INT2OID), -1, INT2OID),
+					  ts_time_get_max(INT2OID));
+	TestAssertInt64Eq(ts_time_saturating_sub(ts_time_get_max(INT4OID), -1, INT4OID),
+					  ts_time_get_max(INT4OID));
+	TestAssertInt64Eq(ts_time_saturating_sub(ts_time_get_max(INT8OID), -1, INT8OID),
+					  ts_time_get_max(INT8OID));
+	TestAssertInt64Eq(ts_time_saturating_sub(ts_time_get_max(DATEOID), -1, DATEOID),
+					  ts_time_get_noend(DATEOID));
+	TestAssertInt64Eq(ts_time_saturating_sub(ts_time_get_max(TIMESTAMPOID), -1, TIMESTAMPOID),
+					  ts_time_get_noend(TIMESTAMPOID));
+	TestAssertInt64Eq(ts_time_saturating_sub(ts_time_get_max(TIMESTAMPTZOID), -1, TIMESTAMPTZOID),
+					  ts_time_get_noend(TIMESTAMPTZOID));
 
 	PG_RETURN_VOID();
 }

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -281,11 +281,11 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 	bool max_refresh = false;
 	Hypertable *ht = ts_hypertable_get_by_id(cagg->data.raw_hypertable_id);
 
-	if (TS_TIME_IS_INTEGER_TIME(refresh_window->type))
-		max_refresh = TS_TIME_IS_MAX(refresh_window->end, refresh_window->type);
-	else
+	if (IS_TIMESTAMP_TYPE(refresh_window->type))
 		max_refresh = TS_TIME_IS_END(refresh_window->end, refresh_window->type) ||
 					  TS_TIME_IS_NOEND(refresh_window->end, refresh_window->type);
+	else
+		max_refresh = TS_TIME_IS_MAX(refresh_window->end, refresh_window->type);
 
 	if (max_refresh)
 	{


### PR DESCRIPTION
The database must know the valid time range of a custom time type,
similar to how it knows the time ranges of officially supported time
types. However, the only way to "know" the valid time range of a
custom time type is to assume it is the same as the one of a supported
time type.

A previous commit tried to make such assumptions by finding an
appropriate cast from the custom time type to a supported time
type. However, this fails in case there are multiple casts available
that each could return a different type and range.

This change restricts the choice of valid time ranges to only that of
the bigint time type.

Fixes #2523