### PR TITLE
Suspend retention policies with caggs conflicts

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -63,3 +63,24 @@ CREATE INDEX continuous_aggs_materialization_invalidation_log_idx ON
     _timescaledb_catalog.continuous_aggs_materialization_invalidation_log (
         materialization_id, lowest_modified_value ASC);
 GRANT SELECT ON  _timescaledb_catalog.continuous_aggs_materialization_invalidation_log TO PUBLIC;
+
+-- Suspend any running retention policies that conflict with continuous aggs
+-- Note that this approach will work for both timestamp and integer time columns
+DO $$
+DECLARE
+  jobid INTEGER;
+BEGIN
+    FOR jobid IN
+        SELECT c.id
+        FROM _timescaledb_config.bgw_job a
+        LEFT JOIN _timescaledb_catalog.continuous_agg b ON a.hypertable_id = b.mat_hypertable_id
+        INNER JOIN _timescaledb_config.bgw_job c ON c.hypertable_id = b.raw_hypertable_id
+        WHERE a.proc_name = 'policy_refresh_continuous_aggregate' AND c.proc_name = 'policy_retention' AND c.scheduled
+            AND ((a.config->'start_offset') = NULL OR (a.config->'start_offset')::text::interval > (c.config->'drop_after')::text::interval)
+    LOOP
+        RAISE NOTICE 'suspending data retention policy with job id %.', jobid
+            USING DETAIL = 'The retention policy (formerly drop_chunks policy) will drop chunks while a continuous aggregate is still running on them. This will likely result in overwriting the aggregate with empty data.',
+            HINT = ('To restore the retention policy, with the possibility of updating aggregates with dropped data, run: SELECT alter_job(%, scheduled=>true);  Otherwise, please create a new rention_policy with a larger drop_after parameter and remove the old policy with: SELECT delete_job(%);', jobid, jobid);
+        UPDATE _timescaledb_config.bgw_job SET scheduled = false WHERE id = jobid;
+    END LOOP;
+END $$;


### PR DESCRIPTION
When upgrading from 1.7, it's possible to have retention policies
which overlap with continuous aggregates.  These make use of the
cascade_to_materializations parameter to avoid invalidating the
aggregate.

In 2.0 there is no equivalent behavior to prevent the retention from
disrupting the aggregate.  So during the 2.0 upgrade, check for any
running retention policies that are dropping chunks still used by a
continuous aggregate and suspend them (scheduled=>false).  This will
also print a notice informing the user of what happened and how to
resume the retention policy if that's what they truly want.

Fixes #2530