### PR TITLE
Move chunk size arguments to the end

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -34,11 +34,11 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     if_not_exists           BOOLEAN = FALSE,
     partitioning_func       REGPROC = NULL,
     migrate_data            BOOLEAN = FALSE,
-    chunk_target_size       TEXT = NULL,
-    chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc,
     time_partitioning_func  REGPROC = NULL,
     replication_factor      INTEGER = NULL,
-    data_nodes              NAME[] = NULL
+    data_nodes              NAME[] = NULL,
+    chunk_target_size       TEXT = NULL,
+    chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc
 ) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create' LANGUAGE C VOLATILE;
 
 -- Same functionality as create_hypertable, only must have a replication factor > 0 (defaults to 1)
@@ -54,11 +54,11 @@ CREATE OR REPLACE FUNCTION  create_distributed_hypertable(
     if_not_exists           BOOLEAN = FALSE,
     partitioning_func       REGPROC = NULL,
     migrate_data            BOOLEAN = FALSE,
-    chunk_target_size       TEXT = NULL,
-    chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc,
     time_partitioning_func  REGPROC = NULL,
     replication_factor      INTEGER = 1,
-    data_nodes              NAME[] = NULL
+    data_nodes              NAME[] = NULL,
+    chunk_target_size       TEXT = NULL,
+    chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc
 ) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_distributed_create' LANGUAGE C VOLATILE;
 
 -- Set adaptive chunking. To disable, set chunk_target_size => 'off'.

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,6 +1,8 @@
 
 DROP FUNCTION IF EXISTS detach_data_node(name,regclass,boolean,boolean);
 DROP FUNCTION IF EXISTS distributed_exec;
+DROP FUNCTION IF EXISTS create_hypertable;
+DROP FUNCTION IF EXISTS create_distributed_hypertable;
 
 DROP PROCEDURE IF EXISTS refresh_continuous_aggregate(regclass,"any","any");
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1802,16 +1802,16 @@ ts_hypertable_create_internal(PG_FUNCTION_ARGS, bool is_dist_call)
 									  PG_ARGISNULL(6) ? InvalidOid :
 														get_fn_expr_argtype(fcinfo->flinfo, 6),
 									  /* partitioning func */
-									  PG_ARGISNULL(13) ? InvalidOid : PG_GETARG_OID(13));
+									  PG_ARGISNULL(11) ? InvalidOid : PG_GETARG_OID(11));
 	DimensionInfo *space_dim_info = NULL;
-	bool replication_factor_is_null = PG_ARGISNULL(14);
-	int32 replication_factor_in = replication_factor_is_null ? 0 : PG_GETARG_INT32(14);
+	bool replication_factor_is_null = PG_ARGISNULL(12);
+	int32 replication_factor_in = replication_factor_is_null ? 0 : PG_GETARG_INT32(12);
 	int16 replication_factor;
-	ArrayType *data_node_arr = PG_ARGISNULL(15) ? NULL : PG_GETARG_ARRAYTYPE_P(15);
+	ArrayType *data_node_arr = PG_ARGISNULL(13) ? NULL : PG_GETARG_ARRAYTYPE_P(13);
 	ChunkSizingInfo chunk_sizing_info = {
 		.table_relid = table_relid,
-		.target_size = PG_ARGISNULL(11) ? NULL : PG_GETARG_TEXT_P(11),
-		.func = PG_ARGISNULL(12) ? InvalidOid : PG_GETARG_OID(12),
+		.target_size = PG_ARGISNULL(14) ? NULL : PG_GETARG_TEXT_P(14),
+		.func = PG_ARGISNULL(15) ? InvalidOid : PG_GETARG_OID(15),
 		.colname = PG_ARGISNULL(1) ? NULL : PG_GETARG_CSTRING(1),
 		.check_for_index = !create_default_indexes,
 	};


### PR DESCRIPTION
Arguments chunk_target_size and chunk_sizing_func of create_hypertable
and create_distributed_hypertable are deprecated and undocumented.
Thus moving them to the end of the definitions to avoid confusions
with arguments in the documentation and in the definitions are not
following the same order.