### PR TITLE
Fix DecompressChunk path generation

### DIFF
--- a/tsl/test/shared/expected/decompress_placeholdervar.out
+++ b/tsl/test/shared/expected/decompress_placeholdervar.out
@@ -76,3 +76,64 @@ ORDER BY 1,2;
 
 DROP TABLE decompress_phv_ping;
 DROP TABLE decompress_phv_device;
+-- test assertion failure in bitmapheapscan path creation
+-- GH Issue #2211
+CREATE TABLE tickers (
+  time TIMESTAMPTZ,
+  microseconds INT,
+  fk_exchange SMALLINT,
+  fk_trade_pair SMALLINT
+);
+CREATE INDEX ON tickers (fk_exchange, fk_trade_pair, time DESC, microseconds DESC);
+SELECT
+  table_name
+FROM
+  create_hypertable('tickers', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ tickers
+(1 row)
+
+ALTER TABLE tickers SET (timescaledb.compress, timescaledb.compress_segmentby = 'fk_exchange,
+  fk_trade_pair', timescaledb.compress_orderby = 'time DESC, microseconds DESC');
+INSERT INTO tickers
+SELECT
+  '2000-01-01',
+  0,
+  i,
+  j
+FROM
+  generate_series(1, 20) i,
+  generate_series(1, 40) j;
+SELECT
+  substr(compress_chunk(tableoid::REGCLASS)::TEXT, 1, 29)
+FROM
+  tickers
+GROUP BY
+  tableoid;
+            substr             
+-------------------------------
+ _timescaledb_internal._hyper_
+(1 row)
+
+-- make sure we get bitmapheapscan
+SET enable_indexscan TO FALSE;
+SELECT
+  *
+FROM
+  tickers
+WHERE
+  time >= '2000-01-01'
+  AND time < '2020-08-02T00:00Z'
+  AND fk_exchange = 4
+  AND fk_trade_pair = 29
+ORDER BY
+  time DESC,
+  microseconds DESC;
+             time             | microseconds | fk_exchange | fk_trade_pair 
+------------------------------+--------------+-------------+---------------
+ Sat Jan 01 00:00:00 2000 PST |            0 |           4 |            29
+(1 row)
+
+DROP TABLE tickers;


### PR DESCRIPTION
The non-parallel pathes generated by DecompressChunk were
incorrectly marked as parallel_safe even when the child scan
was not parallel aware. Leading to incorrect query results
when those pathes were used in a parallel plan.
Additionaly DecompressChunk code didnt set total_table_pages on
PlannerInfo leading to an assertion failure in BitmapHeapscan
path creation.

Fixes #2211
Fixes #2424