### PR TITLE
Improve cagg datatype handling

### DIFF
--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -1230,3 +1230,49 @@ SELECT test.continuous_aggs_find_view('mat_refresh_test');
  
 (1 row)
 
+-- Test pseudotype/enum handling
+CREATE TYPE status_enum AS ENUM (
+  'red',
+  'yellow',
+  'green'
+);
+CREATE TABLE cagg_types (
+  time TIMESTAMPTZ NOT NULL,
+  status status_enum,
+  names NAME[],
+  floats FLOAT[]
+);
+SELECT
+  table_name
+FROM
+  create_hypertable('cagg_types', 'time');
+ table_name 
+------------
+ cagg_types
+(1 row)
+
+INSERT INTO cagg_types
+SELECT
+  '2000-01-01',
+  'yellow',
+  '{foo,bar,baz}',
+  '{1,2.5,3}';
+CREATE MATERIALIZED VIEW mat_types WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket('1d', time),
+  min(status) AS status,
+  max(names) AS names,
+  min(floats) AS floats
+FROM
+  cagg_types
+GROUP BY
+  1;
+NOTICE:  refreshing continuous aggregate "mat_types"
+CALL refresh_continuous_aggregate('mat_types',NULL,NULL);
+NOTICE:  continuous aggregate "mat_types" is already up-to-date
+SELECT * FROM mat_types;
+         time_bucket          | status |     names     |  floats   
+------------------------------+--------+---------------+-----------
+ Fri Dec 31 16:00:00 1999 PST | yellow | {foo,bar,baz} | {1,2.5,3}
+(1 row)
+


### PR DESCRIPTION
This patch improves datatype handling when the aggregate function
argument type is a pseudotype.

Fixes #2455