### PR TITLE
Change use of ssl_dir GUC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -119,7 +119,7 @@ build_script:
 
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "ssl_key_file='C:/projects/timescaledb/build/tsl/test/ts_data_node.key'"
 
-    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.ssl_dir='C:/projects/timescaledb/build/tsl/test'"
+    Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.ssl_dir='C:/projects/timescaledb/build/tsl/test/timescaledb/certs'"
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.passfile='C:/projects/timescaledb/build/tsl/test/pgpass.conf'"
 
     Add-Content "C:\Program Files\postgresql\12\data\postgresql.conf" "timescaledb.license = 'apache'"

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -1055,20 +1055,22 @@ report_path_error(PathKind path_kind, const char *user_name)
 static StringInfo
 make_user_path(const char *user_name, PathKind path_kind)
 {
-	const char *ssl_dir = ts_guc_ssl_dir ? ts_guc_ssl_dir : DataDir;
 	char ret_path[MAXPGPATH];
 	char hexsum[33];
 	StringInfo result;
 
 	pg_md5_hash(user_name, strlen(user_name), hexsum);
 
-	if (strlcpy(ret_path, ssl_dir, MAXPGPATH) > MAXPGPATH)
+	if (strlcpy(ret_path, ts_guc_ssl_dir ? ts_guc_ssl_dir : DataDir, MAXPGPATH) > MAXPGPATH)
 		report_path_error(path_kind, user_name);
-
 	canonicalize_path(ret_path);
 
-	join_path_components(ret_path, ret_path, EXTENSION_NAME);
-	join_path_components(ret_path, ret_path, "certs");
+	if (!ts_guc_ssl_dir)
+	{
+		join_path_components(ret_path, ret_path, EXTENSION_NAME);
+		join_path_components(ret_path, ret_path, "certs");
+	}
+
 	join_path_components(ret_path, ret_path, hexsum);
 
 	result = makeStringInfo();

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -23,5 +23,5 @@ ssl=on
 ssl_ca_file='@TEST_OUTPUT_DIR@/ts_root.crt'
 ssl_cert_file='@TEST_OUTPUT_DIR@/ts_data_node.crt'
 ssl_key_file='@TEST_OUTPUT_DIR@/ts_data_node.key'
-timescaledb.ssl_dir='@TEST_OUTPUT_DIR@'
+timescaledb.ssl_dir='@TEST_OUTPUT_DIR@/timescaledb/certs'
 timescaledb.passfile='@TEST_PASSFILE@'


### PR DESCRIPTION
By default, user certificates are placed in the directory
`timescaledb/certs` relative to the data directory. This location can,
however, be changed by setting `timescaledb.ssl_dir` to another value.
If `timescaledb.ssl_dir` is set, user certificates will be
`timescaledb/certs` relative to this location.

This commit changes the usage of `timescaledb.ssl_dir` to point to the
actual directory for the user SSL certificates and keys rather than the
subdirectory `timescaledb/certs` under that directory.

The default location of the user certificates and keys are unchanged.

Closes #2568