### PR TITLE
Add missing increment for PG11 decompression

### DIFF
--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -8,6 +8,7 @@
  *  compress and decompress chunks
  */
 #include <postgres.h>
+#include <access/xact.h>
 #include <catalog/dependency.h>
 #include <commands/tablecmds.h>
 #include <commands/trigger.h>
@@ -240,6 +241,7 @@ preserve_uncompressed_chunk_stats(Oid chunk_relid)
 	ExecVacuum(NULL, &vs, true);
 #else
 	ExecVacuum(&vs, true);
+	CommandCounterIncrement();
 #endif
 	AlterTableInternal(chunk_relid, list_make1(&at_cmd), false);
 }


### PR DESCRIPTION
There is a bug in some versions of PG11 where ANALYZE was not
calling CommandCounterIncrement.  This is causing us to fail to
update pg_class statistics during compression for those versions.
To work around this, this change adds an explicit
CommandCounterIncrement call after ExecVacuum in PG11.

Fixes #2581