### PR TITLE
Read function name dynamically

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3404,7 +3404,7 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 	Dimension *time_dim;
 	Oid time_type;
 
-	PreventCommandIfReadOnly(DROP_CHUNKS_FUNCNAME "()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	/*
 	 * When past the first call of the SRF, dropping has already been completed,

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -750,8 +750,7 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 	Datum values[2];
 	bool nulls[2] = { false, false };
 
-	PreventCommandIfReadOnly("set_adaptive_chunking()");
-
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/compat.h
+++ b/src/compat.h
@@ -19,6 +19,9 @@
 
 #include "export.h"
 
+#define TS_PREVENT_FUNC_IF_READ_ONLY()                                                             \
+	(PreventCommandIfReadOnly(psprintf("%s()", get_func_name(FC_FN_OID(fcinfo)))))
+
 #define is_supported_pg_version_11(version) ((version >= 110000) && (version < 120000))
 #define is_supported_pg_version_12(version) ((version >= 120000) && (version < 130000))
 

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1145,7 +1145,7 @@ ts_dimension_set_num_slices(PG_FUNCTION_ARGS)
 	int16 num_slices;
 	Hypertable *ht;
 
-	PreventCommandIfReadOnly("set_number_partitions()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
@@ -1197,7 +1197,7 @@ ts_dimension_set_interval(PG_FUNCTION_ARGS)
 	Cache *hcache = ts_hypertable_cache_pin();
 	Hypertable *ht;
 
-	PreventCommandIfReadOnly("set_chunk_time_interval()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,
@@ -1475,7 +1475,7 @@ ts_dimension_add(PG_FUNCTION_ARGS)
 	};
 	Datum retval = 0;
 
-	PreventCommandIfReadOnly("add_dimension()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR,

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1817,8 +1817,7 @@ ts_hypertable_create_internal(PG_FUNCTION_ARGS, bool is_dist_call)
 	uint32 flags = 0;
 	List *data_nodes = NIL;
 
-	PreventCommandIfReadOnly(is_dist_call ? "create_distributed_hypertable()" :
-											"create_hypertable()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (!OidIsValid(table_relid))
 		ereport(ERROR,

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -486,7 +486,7 @@ ts_tablespace_attach(PG_FUNCTION_ARGS)
 	bool if_not_attached = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 	Relation rel;
 
-	PreventCommandIfReadOnly("attach_tablespace()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (PG_NARGS() < 2 || PG_NARGS() > 3)
 		elog(ERROR, "invalid number of arguments");
@@ -673,7 +673,7 @@ ts_tablespace_detach(PG_FUNCTION_ARGS)
 	Oid tspcoid;
 	int ret;
 
-	PreventCommandIfReadOnly("detach_tablespace()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (PG_NARGS() < 1 || PG_NARGS() > 3)
 		elog(ERROR, "invalid number of arguments");
@@ -726,7 +726,7 @@ ts_tablespace_detach_all_from_hypertable(PG_FUNCTION_ARGS)
 	cmd->subtype = AT_SetTableSpace;
 	cmd->name = "pg_default";
 
-	PreventCommandIfReadOnly("detach_tablespaces()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (PG_NARGS() != 1)
 		elog(ERROR, "invalid number of arguments");

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -87,7 +87,7 @@ policy_compression_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
-	PreventCommandIfReadOnly("policy_compression()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	policy_compression_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
 
@@ -111,7 +111,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 	Dimension *dim;
 	Oid owner_id;
 
-	PreventCommandIfReadOnly("add_compression_policy()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	/* check if this is a table with compression enabled */
 	hypertable = ts_hypertable_cache_get_cache_and_entry(ht_oid, CACHE_FLAG_NONE, &hcache);
@@ -256,7 +256,7 @@ policy_compression_remove(PG_FUNCTION_ARGS)
 	Hypertable *ht;
 	Cache *hcache;
 
-	PreventCommandIfReadOnly("remove_compression_policy()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_oid, CACHE_FLAG_NONE, &hcache);
 

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -109,7 +109,7 @@ policy_refresh_cagg_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
-	PreventCommandIfReadOnly("policy_refresh_continuous_aggregate()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 	policy_refresh_cagg_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
 
 	PG_RETURN_VOID();

--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -53,7 +53,7 @@ job_add(PG_FUNCTION_ARGS)
 	Jsonb *config = PG_ARGISNULL(2) ? NULL : PG_GETARG_JSONB_P(2);
 	bool scheduled = PG_ARGISNULL(4) ? true : PG_GETARG_BOOL(4);
 
-	PreventCommandIfReadOnly("add_job()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	func_name = get_func_name(proc);
 	if (func_name == NULL)
@@ -107,7 +107,7 @@ job_delete(PG_FUNCTION_ARGS)
 {
 	int32 job_id = PG_GETARG_INT32(0);
 
-	PreventCommandIfReadOnly("delete_job()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	BgwJob *job = ts_bgw_job_find(job_id, CurrentMemoryContext, true);
 	Oid owner = get_role_oid(NameStr(job->fd.owner), false);
@@ -173,7 +173,7 @@ job_alter(PG_FUNCTION_ARGS)
 	int job_id = PG_GETARG_INT32(0);
 	bool if_exists = PG_GETARG_BOOL(8);
 
-	PreventCommandIfReadOnly("alter_job()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	BgwJob *job = ts_bgw_job_find(job_id, CurrentMemoryContext, false);
 

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -111,7 +111,7 @@ policy_reorder_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
-	PreventCommandIfReadOnly("policy_reorder()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	policy_reorder_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
 
@@ -137,7 +137,7 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 	Oid owner_id;
 	List *jobs;
 
-	PreventCommandIfReadOnly("add_reorder_policy()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	ht = ts_hypertable_cache_get_cache_and_entry(ht_oid, CACHE_FLAG_NONE, &hcache);
 	Assert(ht != NULL);
@@ -248,7 +248,7 @@ policy_reorder_remove(PG_FUNCTION_ARGS)
 	Hypertable *ht;
 	Cache *hcache;
 
-	PreventCommandIfReadOnly("remove_reorder_policy()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	ht = ts_hypertable_cache_get_cache_and_entry(hypertable_oid, CACHE_FLAG_NONE, &hcache);
 

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -36,7 +36,7 @@ policy_retention_proc(PG_FUNCTION_ARGS)
 	if (PG_NARGS() != 2 || PG_ARGISNULL(0) || PG_ARGISNULL(1))
 		PG_RETURN_VOID();
 
-	PreventCommandIfReadOnly("policy_retention()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	policy_retention_execute(PG_GETARG_INT32(0), PG_GETARG_JSONB_P(1));
 
@@ -157,7 +157,7 @@ policy_retention_add(PG_FUNCTION_ARGS)
 	/* Right now, there is an infinite number of retries for drop_chunks jobs */
 	int default_max_retries = -1;
 
-	PreventCommandIfReadOnly("add_retention_policy()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	/* Verify that the hypertable owner can create a background worker */
 	ts_bgw_job_validate_job_owner(owner_id);
@@ -289,7 +289,7 @@ policy_retention_remove(PG_FUNCTION_ARGS)
 	Cache *hcache;
 	Hypertable *hypertable;
 
-	PreventCommandIfReadOnly("remove_retention_policy()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	hypertable = ts_hypertable_cache_get_cache_and_entry(table_oid, CACHE_FLAG_MISSING_OK, &hcache);
 	if (!hypertable)

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -634,7 +634,7 @@ data_node_add_internal(PG_FUNCTION_ARGS, bool set_distid)
 	bool PG_USED_FOR_ASSERTS_ONLY result;
 	DbInfo database;
 
-	PreventCommandIfReadOnly("add_data_node()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	namestrcpy(&database.name, dbname);
 
@@ -780,7 +780,7 @@ data_node_attach(PG_FUNCTION_ARGS)
 	int num_nodes;
 	ListCell *lc;
 
-	PreventCommandIfReadOnly("attach_data_node()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (PG_ARGISNULL(1))
 		ereport(ERROR,
@@ -1188,7 +1188,7 @@ data_node_allow_new_chunks(PG_FUNCTION_ARGS)
 	const char *node_name = PG_ARGISNULL(0) ? NULL : NameStr(*PG_GETARG_NAME(0));
 	Oid table_id = PG_ARGISNULL(1) ? InvalidOid : PG_GETARG_OID(1);
 
-	PreventCommandIfReadOnly("allow_new_chunks()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	return data_node_block_or_allow_new_chunks(node_name, table_id, false, false);
 }
@@ -1200,7 +1200,7 @@ data_node_block_new_chunks(PG_FUNCTION_ARGS)
 	Oid table_id = PG_ARGISNULL(1) ? InvalidOid : PG_GETARG_OID(1);
 	bool force = PG_ARGISNULL(2) ? false : PG_GETARG_BOOL(2);
 
-	PreventCommandIfReadOnly("block_new_chunks()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	return data_node_block_or_allow_new_chunks(node_name, table_id, force, true);
 }
@@ -1218,7 +1218,7 @@ data_node_detach(PG_FUNCTION_ARGS)
 	List *hypertable_data_nodes = NIL;
 	ForeignServer *server;
 
-	PreventCommandIfReadOnly("detach_data_node()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	server = data_node_get_foreign_server(node_name, ACL_USAGE, true, false);
 	Assert(NULL != server);
@@ -1272,7 +1272,7 @@ data_node_delete(PG_FUNCTION_ARGS)
 	TSConnectionId cid;
 	ForeignServer *server;
 
-	PreventCommandIfReadOnly("delete_data_node()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	/* Need USAGE to detach. Further owner check done when executing the DROP
 	 * statement. */

--- a/tsl/src/hypertable.c
+++ b/tsl/src/hypertable.c
@@ -246,7 +246,7 @@ hypertable_set_replication_factor(PG_FUNCTION_ARGS)
 	Cache *hcache;
 	Hypertable *ht;
 
-	PreventCommandIfReadOnly("set_replication_factor()");
+	TS_PREVENT_FUNC_IF_READ_ONLY();
 
 	if (!OidIsValid(table_relid))
 		ereport(ERROR,


### PR DESCRIPTION
The function name is hard-coded in some cases in the C function, so
this commit instead extract the function name from the `fcinfo`
structure. This prevents mismatches between the hard-coded names and
the actual function name.

Closes #2579