### PR TITLE
Add test for continuous agg policies

### DIFF
--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -12,8 +12,9 @@
 #include <parser/parse_coerce.h>
 #include <fmgr.h>
 
-#include "time_utils.h"
 #include "dimension.h"
+#include "guc.h"
+#include "time_utils.h"
 #include "utils.h"
 
 static Datum
@@ -535,3 +536,22 @@ ts_subtract_integer_from_now_saturating(Oid now_func, int64 interval, Oid timety
 		res = nowval - interval;
 	return res;
 }
+
+#ifdef TS_DEBUG
+/* return mock time for testing */
+Datum
+ts_get_mock_time_or_current_time(void)
+{
+	Datum res;
+	if (ts_current_timestamp_mock != NULL && strlen(ts_current_timestamp_mock) != 0)
+	{
+		res = DirectFunctionCall3(timestamptz_in,
+								  CStringGetDatum(ts_current_timestamp_mock),
+								  0,
+								  Int32GetDatum(-1));
+		return res;
+	}
+	res = TimestampTzGetDatum(GetCurrentTimestamp());
+	return res;
+}
+#endif

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -87,4 +87,8 @@ extern TSDLLEXPORT int64 ts_time_saturating_add(int64 timeval, int64 interval, O
 extern TSDLLEXPORT int64 ts_time_saturating_sub(int64 timeval, int64 interval, Oid timetype);
 extern TSDLLEXPORT int64 ts_subtract_integer_from_now_saturating(Oid now_func, int64 interval,
 																 Oid timetype);
+#if TS_DEBUG
+extern TSDLLEXPORT Datum ts_get_mock_time_or_current_time(void);
+#endif
+
 #endif /* TIMESCALEDB_TIME_UTILS_H */

--- a/tsl/src/bgw_policy/policy_utils.c
+++ b/tsl/src/bgw_policy/policy_utils.c
@@ -7,8 +7,10 @@
 #include <postgres.h>
 #include <utils/builtins.h>
 #include "dimension.h"
+#include "guc.h"
 #include "jsonb_utils.h"
 #include "policy_utils.h"
+#include "time_utils.h"
 
 /* Helper function to compare jsonb label value in the config
  * with passed in value.
@@ -109,7 +111,11 @@ subtract_integer_from_now(int64 interval, Oid time_dim_type, Oid now_func)
 Datum
 subtract_interval_from_now(Interval *lag, Oid time_dim_type)
 {
+#ifdef TS_DEBUG
+	Datum res = ts_get_mock_time_or_current_time();
+#else
 	Datum res = TimestampTzGetDatum(GetCurrentTimestamp());
+#endif
 
 	switch (time_dim_type)
 	{

--- a/tsl/test/expected/continuous_aggs_policy_run.out
+++ b/tsl/test/expected/continuous_aggs_policy_run.out
@@ -1,0 +1,71 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- The tests in this file use mock timestamps to test policies
+-- for timestamp based tables and can be run only with debug builds.
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--- code coverage tests : add policy for timestamp and date based table ---
+CREATE TABLE continuous_agg_max_mat_date(time DATE);
+SELECT create_hypertable('continuous_agg_max_mat_date', 'time');
+NOTICE:  adding not-null constraint to column "time"
+            create_hypertable             
+------------------------------------------
+ (1,public,continuous_agg_max_mat_date,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW max_mat_view_date
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+    AS SELECT time_bucket('1 days', time), count(*)
+        FROM continuous_agg_max_mat_date
+        GROUP BY 1 WITH NO DATA;
+SELECT add_continuous_aggregate_policy('max_mat_view_date', '3 days', '1 day', '1 day'::interval) as job_id \gset
+SELECT config FROM _timescaledb_config.bgw_job
+WHERE id = :job_id;
+                                    config                                     
+-------------------------------------------------------------------------------
+ {"end_offset": "@ 1 day", "start_offset": "@ 3 days", "mat_hypertable_id": 2}
+(1 row)
+
+INSERT INTO continuous_agg_max_mat_date
+    SELECT generate_series('2019-09-01'::date, '2019-09-10'::date, '1 day');
+--- to prevent NOTICES set message level to warning
+SET client_min_messages TO warning; 
+SET timescaledb.current_timestamp_mock = '2019-09-10 00:00';
+CALL run_job(:job_id);
+SELECT * FROM max_mat_view_date order by 1;
+ time_bucket | count 
+-------------+-------
+ 09-07-2019  |     1
+ 09-08-2019  |     1
+(2 rows)
+
+RESET client_min_messages ;
+DROP MATERIALIZED VIEW max_mat_view_date;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
+CREATE TABLE continuous_agg_timestamp(time TIMESTAMP);
+SELECT create_hypertable('continuous_agg_timestamp', 'time');
+NOTICE:  adding not-null constraint to column "time"
+           create_hypertable           
+---------------------------------------
+ (3,public,continuous_agg_timestamp,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW max_mat_view_timestamp
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+    AS SELECT time_bucket('7 days', time), count(*)
+        FROM continuous_agg_timestamp
+        GROUP BY 1 WITH NO DATA;
+SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', '10 day', '1 h'::interval , '1 h'::interval) as job_id \gset
+INSERT INTO continuous_agg_timestamp
+    SELECT generate_series('2019-09-01 00:00'::timestamp, '2019-09-10 00:00'::timestamp, '1 day');
+--- to prevent NOTICES set message level to warning
+SET client_min_messages TO warning; 
+SET timescaledb.current_timestamp_mock = '2019-09-11 00:00';
+CALL run_job(:job_id);
+SELECT * FROM max_mat_view_timestamp;
+       time_bucket        | count 
+--------------------------+-------
+ Mon Sep 02 00:00:00 2019 |     7
+(1 row)
+
+RESET client_min_messages ;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_FILES_DEBUG
   continuous_aggs_multi.sql
   continuous_aggs.sql
   continuous_aggs_usage.sql
+  continuous_aggs_policy_run.sql
   data_fetcher.sql
   data_node_bootstrap.sql
   data_node.sql

--- a/tsl/test/sql/continuous_aggs_policy_run.sql
+++ b/tsl/test/sql/continuous_aggs_policy_run.sql
@@ -1,0 +1,52 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- The tests in this file use mock timestamps to test policies
+-- for timestamp based tables and can be run only with debug builds.
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+
+--- code coverage tests : add policy for timestamp and date based table ---
+CREATE TABLE continuous_agg_max_mat_date(time DATE);
+SELECT create_hypertable('continuous_agg_max_mat_date', 'time');
+CREATE MATERIALIZED VIEW max_mat_view_date
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+    AS SELECT time_bucket('1 days', time), count(*)
+        FROM continuous_agg_max_mat_date
+        GROUP BY 1 WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('max_mat_view_date', '3 days', '1 day', '1 day'::interval) as job_id \gset
+SELECT config FROM _timescaledb_config.bgw_job
+WHERE id = :job_id;
+
+INSERT INTO continuous_agg_max_mat_date
+    SELECT generate_series('2019-09-01'::date, '2019-09-10'::date, '1 day');
+--- to prevent NOTICES set message level to warning
+SET client_min_messages TO warning; 
+SET timescaledb.current_timestamp_mock = '2019-09-10 00:00';
+CALL run_job(:job_id);
+SELECT * FROM max_mat_view_date order by 1;
+RESET client_min_messages ;
+DROP MATERIALIZED VIEW max_mat_view_date;
+
+CREATE TABLE continuous_agg_timestamp(time TIMESTAMP);
+SELECT create_hypertable('continuous_agg_timestamp', 'time');
+
+CREATE MATERIALIZED VIEW max_mat_view_timestamp
+    WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+    AS SELECT time_bucket('7 days', time), count(*)
+        FROM continuous_agg_timestamp
+        GROUP BY 1 WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('max_mat_view_timestamp', '10 day', '1 h'::interval , '1 h'::interval) as job_id \gset
+INSERT INTO continuous_agg_timestamp
+    SELECT generate_series('2019-09-01 00:00'::timestamp, '2019-09-10 00:00'::timestamp, '1 day');
+--- to prevent NOTICES set message level to warning
+SET client_min_messages TO warning; 
+SET timescaledb.current_timestamp_mock = '2019-09-11 00:00';
+CALL run_job(:job_id);
+SELECT * FROM max_mat_view_timestamp;
+RESET client_min_messages ;
+


### PR DESCRIPTION
Add mock timestamp support for subtract_from_now.
Use mock timestamp to execute cont. agg policies for
date and timestamp based tables.