### PR TITLE
Add user-defined actions to telemetry

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -213,6 +213,27 @@ ts_bgw_job_get_scheduled(size_t alloc_size, MemoryContext mctx)
 	return jobs;
 }
 
+List *
+ts_bgw_job_get_all(size_t alloc_size, MemoryContext mctx)
+{
+	Catalog *catalog = ts_catalog_get();
+	AccumData list_data = {
+		.list = NIL,
+		.alloc_size = sizeof(BgwJob),
+	};
+	ScannerCtx scanctx = {
+		.table = catalog_get_table_id(catalog, BGW_JOB),
+		.data = &list_data,
+		.tuple_found = bgw_job_accum_tuple_found,
+		.lockmode = AccessShareLock,
+		.result_mctx = mctx,
+		.scandirection = ForwardScanDirection,
+	};
+
+	ts_scanner_scan(&scanctx);
+	return list_data.list;
+}
+
 static void
 init_scan_by_proc_name(ScanKeyData *scankey, const char *proc_name)
 {

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -23,6 +23,7 @@ typedef bool (*scheduler_test_hook_type)(BgwJob *job);
 
 extern BackgroundWorkerHandle *ts_bgw_job_start(BgwJob *job, Oid user_oid);
 
+extern List *ts_bgw_job_get_all(size_t alloc_size, MemoryContext mctx);
 extern List *ts_bgw_job_get_scheduled(size_t alloc_size, MemoryContext mctx);
 
 extern TSDLLEXPORT List *ts_bgw_job_find_by_proc(const char *proc_name, const char *proc_schema);

--- a/src/bgw_policy/policy.c
+++ b/src/bgw_policy/policy.c
@@ -61,8 +61,6 @@ ts_bgw_job_type_counts()
 				counts.policy_retention++;
 			else if (namestrcmp(&job->fd.proc_name, "policy_telemetry") == 0)
 				counts.policy_telemetry++;
-			else
-				Assert(false);
 		}
 		else
 		{

--- a/src/bgw_policy/policy.h
+++ b/src/bgw_policy/policy.h
@@ -11,10 +11,20 @@
 #include "catalog.h"
 #include "export.h"
 
+typedef struct BgwJobTypeCount
+{
+	int32 policy_cagg;
+	int32 policy_compression;
+	int32 policy_reorder;
+	int32 policy_retention;
+	int32 policy_telemetry;
+	int32 user_defined_action;
+} BgwJobTypeCount;
+
 extern ScanTupleResult ts_bgw_policy_delete_row_only_tuple_found(TupleInfo *ti, void *const data);
 
 extern void ts_bgw_policy_delete_by_hypertable_id(int32 hypertable_id);
-extern int32 ts_bgw_policy_reorder_count(void);
-extern int32 ts_bgw_policy_retention_count(void);
+
+extern BgwJobTypeCount ts_bgw_job_type_counts(void);
 
 #endif /* TIMESCALEDB_BGW_POLICY_POLICY_H */

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -54,8 +54,11 @@
 #define REQ_NUM_HYPERTABLES "num_hypertables"
 #define REQ_NUM_COMPRESSED_HYPERTABLES "num_compressed_hypertables"
 #define REQ_NUM_CONTINUOUS_AGGS "num_continuous_aggs"
-#define REQ_NUM_REORDER_POLICIES "num_reorder_policies"
-#define REQ_NUM_DROP_CHUNKS_POLICIES "num_drop_chunks_policies"
+#define REQ_NUM_POLICY_CAGG "num_continuous_aggs_policies"
+#define REQ_NUM_POLICY_COMPRESSION "num_compression_policies"
+#define REQ_NUM_POLICY_REORDER "num_reorder_policies"
+#define REQ_NUM_POLICY_RETENTION "num_retention_policies"
+#define REQ_NUM_USER_DEFINED_ACTIONS "num_user_defined_actions"
 #define REQ_RELATED_EXTENSIONS "related_extensions"
 #define REQ_METADATA "db_metadata"
 #define REQ_LICENSE_EDITION_APACHE "apache_only"
@@ -227,22 +230,16 @@ get_num_continuous_aggs()
 	return buf->data;
 }
 
-static char *
-get_num_drop_chunks_policies()
+static void
+add_job_counts(JsonbParseState *state)
 {
-	StringInfo buf = makeStringInfo();
+	BgwJobTypeCount counts = ts_bgw_job_type_counts();
 
-	appendStringInfo(buf, "%d", ts_bgw_policy_retention_count());
-	return buf->data;
-}
-
-static char *
-get_num_reorder_policies()
-{
-	StringInfo buf = makeStringInfo();
-
-	appendStringInfo(buf, "%d", ts_bgw_policy_reorder_count());
-	return buf->data;
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_CAGG, counts.policy_cagg);
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_COMPRESSION, counts.policy_compression);
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_REORDER, counts.policy_reorder);
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_RETENTION, counts.policy_retention);
+	ts_jsonb_add_int32(state, REQ_NUM_USER_DEFINED_ACTIONS, counts.user_defined_action);
 }
 
 static char *
@@ -355,8 +352,8 @@ build_version_body(void)
 	ts_jsonb_add_str(parse_state, REQ_NUM_HYPERTABLES, get_num_hypertables());
 	ts_jsonb_add_str(parse_state, REQ_NUM_COMPRESSED_HYPERTABLES, get_num_compressed_hypertables());
 	ts_jsonb_add_str(parse_state, REQ_NUM_CONTINUOUS_AGGS, get_num_continuous_aggs());
-	ts_jsonb_add_str(parse_state, REQ_NUM_REORDER_POLICIES, get_num_reorder_policies());
-	ts_jsonb_add_str(parse_state, REQ_NUM_DROP_CHUNKS_POLICIES, get_num_drop_chunks_policies());
+
+	add_job_counts(parse_state);
 
 	ts_jsonb_add_str(parse_state, REQ_COMPRESSED_HEAP_SIZE, get_size(sizes.compressed_heap_size));
 	ts_jsonb_add_str(parse_state, REQ_COMPRESSED_INDEX_SIZE, get_size(sizes.compressed_index_size));

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -378,8 +378,8 @@ INFO:  Telemetry is disabled. Call get_telemetry_report(always_display_report :=
 
 SELECT * FROM json_object_keys(get_telemetry_report(always_display_report := true)::json) AS key
 WHERE key != 'os_name_pretty' AND key != 'distributed_db';
-             key             
------------------------------
+             key              
+------------------------------
  db_uuid
  license
  os_name
@@ -405,20 +405,23 @@ WHERE key != 'os_name_pretty' AND key != 'distributed_db';
  num_reorder_policies
  compressed_index_size
  compressed_toast_size
+ num_retention_policies
  uncompressed_heap_size
  uncompressed_index_size
  uncompressed_toast_size
- num_drop_chunks_policies
+ num_compression_policies
+ num_user_defined_actions
  num_compressed_hypertables
  build_architecture_bit_size
-(31 rows)
+ num_continuous_aggs_policies
+(34 rows)
 
 -- Test telemetry report contents
 SET timescaledb.telemetry_level=basic;
 SELECT * FROM json_object_keys(get_telemetry_report()::json) AS key
 WHERE key != 'os_name_pretty' AND key != 'distributed_db';
-             key             
------------------------------
+             key              
+------------------------------
  db_uuid
  license
  os_name
@@ -444,13 +447,16 @@ WHERE key != 'os_name_pretty' AND key != 'distributed_db';
  num_reorder_policies
  compressed_index_size
  compressed_toast_size
+ num_retention_policies
  uncompressed_heap_size
  uncompressed_index_size
  uncompressed_toast_size
- num_drop_chunks_policies
+ num_compression_policies
+ num_user_defined_actions
  num_compressed_hypertables
  build_architecture_bit_size
-(31 rows)
+ num_continuous_aggs_policies
+(34 rows)
 
 -- check telemetry picks up flagged content from metadata
 SELECT json_object_field(get_telemetry_report()::json,'db_metadata');

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -67,6 +67,13 @@ SELECT * FROM timescaledb_information.jobs ORDER BY 1;
    1004 | User-Defined Action [1004] | @ 1 hour          | @ 0             |          -1 | @ 5 mins     | public                | custom_func_definer | default_perm_user | t         | {"type": "function"}  |            |                   | 
 (6 rows)
 
+-- check for corrects counts in telemetry
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_user_defined_actions');
+ json_object_field 
+-------------------
+ 5
+(1 row)
+
 CALL run_job(1000);
 CALL run_job(1001);
 CALL run_job(1002);

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -609,4 +609,13 @@ ERROR:  must be owner of hypertable "test_table_perm"
 select remove_retention_policy('test_table');
 ERROR:  must be owner of hypertable "test_table"
 \set ON_ERROR_STOP 1
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SELECT * FROM json_each(get_telemetry_report(always_display_report:=true)::JSON) WHERE KEY ~ '(policies|actions)$' ORDER BY 1;
+             key              | value 
+------------------------------+-------
+ num_compression_policies     | 0
+ num_continuous_aggs_policies | 0
+ num_reorder_policies         | 1
+ num_retention_policies       | 2
+ num_user_defined_actions     | 0
+(5 rows)
+

--- a/tsl/test/expected/bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/bgw_reorder_drop_chunks.out
@@ -90,14 +90,14 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
 SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_reorder_policies');
  json_object_field 
 -------------------
- "0"
+ 0
 (1 row)
 
 select add_reorder_policy('test_reorder_table', 'test_reorder_table_time_idx') as reorder_job_id \gset
 SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_reorder_policies');
  json_object_field 
 -------------------
- "1"
+ 1
 (1 row)
 
 -- job was created
@@ -395,17 +395,17 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
      5
 (1 row)
 
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
  json_object_field 
 -------------------
- "0"
+ 0
 (1 row)
 
 SELECT add_retention_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
  json_object_field 
 -------------------
- "1"
+ 1
 (1 row)
 
 SELECT alter_job(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');

--- a/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
+++ b/tsl/test/expected/compress_bgw_reorder_drop_chunks.out
@@ -67,17 +67,17 @@ SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hyper
      5
 (1 row)
 
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
  json_object_field 
 -------------------
- "0"
+ 0
 (1 row)
 
 SELECT add_retention_policy('test_retention_table', INTERVAL '4 months') as retention_job_id \gset
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
  json_object_field 
 -------------------
- "1"
+ 1
 (1 row)
 
 SELECT alter_job(:retention_job_id, schedule_interval => INTERVAL '1 second');

--- a/tsl/test/expected/continuous_aggs_bgw.out
+++ b/tsl/test/expected/continuous_aggs_bgw.out
@@ -646,3 +646,10 @@ SELECT * from sorted_bgw_log;
       1 | 43200000000 | Refresh Continuous Aggregate Policy [1003] | permission denied for table test_continuous_agg_table_w_grant
 (7 rows)
 
+-- check for corrects counts in telemetry
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs_policies');
+ json_object_field 
+-------------------
+ 1
+(1 row)
+

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -40,6 +40,8 @@ SELECT add_job('custom_func', '1h', config:='{"type":"function"}'::jsonb);
 SELECT add_job('custom_func_definer', '1h', config:='{"type":"function"}'::jsonb);
 
 SELECT * FROM timescaledb_information.jobs ORDER BY 1;
+-- check for corrects counts in telemetry
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_user_defined_actions');
 
 CALL run_job(1000);
 CALL run_job(1001);

--- a/tsl/test/sql/bgw_policy.sql
+++ b/tsl/test/sql/bgw_policy.sql
@@ -321,4 +321,7 @@ select add_retention_policy('test_table_perm', INTERVAL '4 months', true);
 select remove_retention_policy('test_table');
 
 \set ON_ERROR_STOP 1
-\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+SELECT * FROM json_each(get_telemetry_report(always_display_report:=true)::JSON) WHERE KEY ~ '(policies|actions)$' ORDER BY 1;
+
+

--- a/tsl/test/sql/bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/bgw_reorder_drop_chunks.sql
@@ -219,9 +219,9 @@ INSERT INTO test_drop_chunks_table VALUES (now() - INTERVAL '8 months', 1);
 SELECT show_chunks('test_drop_chunks_table');
 SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_drop_chunks_table';
 
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
 SELECT add_retention_policy('test_drop_chunks_table', INTERVAL '4 months') as drop_chunks_job_id \gset
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
 
 SELECT alter_job(:drop_chunks_job_id, schedule_interval => INTERVAL '1 second');
 

--- a/tsl/test/sql/compress_bgw_reorder_drop_chunks.sql
+++ b/tsl/test/sql/compress_bgw_reorder_drop_chunks.sql
@@ -52,9 +52,9 @@ INSERT INTO test_retention_table VALUES (now() - INTERVAL '8 months', 1);
 SELECT show_chunks('test_retention_table');
 SELECT COUNT(*) FROM _timescaledb_catalog.chunk as c, _timescaledb_catalog.hypertable as ht where c.hypertable_id = ht.id and ht.table_name='test_retention_table';
 
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
 SELECT add_retention_policy('test_retention_table', INTERVAL '4 months') as retention_job_id \gset
-SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_drop_chunks_policies');
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_retention_policies');
 SELECT alter_job(:retention_job_id, schedule_interval => INTERVAL '1 second');
 SELECT * FROM _timescaledb_config.bgw_job where id=:retention_job_id;
 

--- a/tsl/test/sql/continuous_aggs_bgw.sql
+++ b/tsl/test/sql/continuous_aggs_bgw.sql
@@ -368,3 +368,7 @@ SELECT * FROM test_continuous_agg_view_user_2;
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT * from sorted_bgw_log;
+
+-- check for corrects counts in telemetry
+SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_continuous_aggs_policies');
+


### PR DESCRIPTION
This patch adjusts the telemetry code to the job refactorings.
Additionally it adds telemetry entries for user-defined actions,
continuous aggregate policies, compression policies and renames
drop_chunks to retention to match the new policy names.

Fixes #2596