### PR TITLE
Fix chunk creation on hypertables with foreign key constraints

### DIFF
--- a/sql/chunk_constraint.sql
+++ b/sql/chunk_constraint.sql
@@ -35,7 +35,7 @@ BEGIN
 
         SELECT T.spcname INTO indx_tablespace 
         FROM pg_constraint C, pg_class I, pg_tablespace T
-        WHERE C.oid = constraint_oid AND I.oid = C.conindid AND I.reltablespace = T.oid;
+        WHERE C.oid = constraint_oid AND C.contype IN ('p', 'u') AND I.oid = C.conindid AND I.reltablespace = T.oid;
 
         IF indx_tablespace IS NOT NULL THEN
             tablespace_def := format(' USING INDEX TABLESPACE %I', indx_tablespace);

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -799,3 +799,31 @@ UPDATE test_validate SET c = '';
 ALTER TABLE test_validate
 VALIDATE CONSTRAINT c_not_null;
 DROP TABLE test_validate;
+-- test for hypetables constraints both using index tablespaces and not See #2604
+CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+CREATE TABLE fk_tbl (
+id int,
+CONSTRAINT pkfk PRIMARY KEY (id) USING INDEX TABLESPACE tablespace1);
+CREATE TABLE tbl (
+fk_id int,
+id int,
+time timestamp,
+CONSTRAINT pk PRIMARY KEY (time, id) USING INDEX TABLESPACE tablespace1);
+SELECT create_hypertable('tbl', 'time');
+ create_hypertable 
+-------------------
+ (15,public,tbl,t)
+(1 row)
+
+ALTER TABLE tbl
+ADD CONSTRAINT fk_con
+FOREIGN KEY (fk_id) REFERENCES fk_tbl(id)
+ON UPDATE SET NULL
+ON DELETE SET NULL;
+INSERT INTO fk_tbl VALUES(1);
+INSERT INTO tbl VALUES (
+1, 1, now()
+);
+DROP TABLE tbl;
+DROP TABLE fk_tbl;
+DROP TABLESPACE IF EXISTS tablespace1;


### PR DESCRIPTION
This resolves an issue when using both constraints with index
tablespaces AND constraints that have no indexes on a single hypertable.

chunk_constraint_add_table_constraint() was attempting to add
`USING INDEX TABLESPACE` to all constraints when a given hypertable had
any constraint configured to use a tablespace, resulting in a SYNTAX
error and blocking the creation of new chunks.

The solution here is to limit index tablespace lookups to only the
constraint types which use indexes: primary key and unique so that only
those constraits will have `USING INDEX TABLESPACE` prepended when
necessary.