### PR TITLE
Add test to verify refresh on drop in caggs

### DIFF
--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -193,6 +193,9 @@ SELECT * FROM see_cagg;
      63 | 21.98 |     7
 (10 rows)
 
+-- This is the simplest case, when the updated bucket is inside chunk, so it is expected
+-- always reflected.
+UPDATE conditions SET value = 4.00 WHERE time_int = 2;
 SELECT drop_chunks('conditions', 20);
                drop_chunks               
 -----------------------------------------
@@ -203,7 +206,7 @@ SELECT drop_chunks('conditions', 20);
 SELECT * FROM see_cagg;
  bucket |  sum  | count 
 --------+-------+-------
-      0 | 21.98 |     7
+      0 | 22.84 |     7
       7 | 21.98 |     7
      14 | 21.98 |     7
      21 | 21.98 |     7
@@ -215,6 +218,9 @@ SELECT * FROM see_cagg;
      63 | 21.98 |     7
 (10 rows)
 
+-- This case is update in a bucket, which crosses two chunks, which exist and both is going
+-- to be dropped.
+UPDATE conditions SET value = 4.00 WHERE time_int = 31;
 -- Now outliers will be present after this second drop_chunks
 SELECT drop_chunks('conditions', 40);
                drop_chunks               
@@ -226,11 +232,11 @@ SELECT drop_chunks('conditions', 40);
 SELECT * FROM see_cagg;
  bucket |  sum  | count 
 --------+-------+-------
-      0 | 21.98 |     7
+      0 | 22.84 |     7
       7 | 21.98 |     7
      14 |  3.14 |     1
      21 | 21.98 |     7
-     28 | 21.98 |     7
+     28 | 22.84 |     7
      35 | 21.98 |     7
      42 | 21.98 |     7
      49 | 21.98 |     7
@@ -238,6 +244,9 @@ SELECT * FROM see_cagg;
      63 | 21.98 |     7
 (10 rows)
 
+-- This update is in the bucket, which crosses two chunks, where one chunk was already dropped
+-- and empty, while the other will be dropped.
+UPDATE conditions SET value = 4.00 WHERE time_int = 41;
 SELECT drop_chunks('conditions', 60);
                drop_chunks               
 -----------------------------------------
@@ -248,12 +257,12 @@ SELECT drop_chunks('conditions', 60);
 SELECT * FROM see_cagg;
  bucket |  sum  | count 
 --------+-------+-------
-      0 | 21.98 |     7
+      0 | 22.84 |     7
       7 | 21.98 |     7
      14 |  3.14 |     1
      21 | 21.98 |     7
-     28 | 21.98 |     7
-     35 |  6.28 |     2
+     28 | 22.84 |     7
+     35 |  7.14 |     2
      42 | 21.98 |     7
      49 | 21.98 |     7
      56 | 21.98 |     7

--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -139,3 +139,124 @@ SELECT drop_chunks('records', '2000-03-16'::timestamptz);
  _timescaledb_internal._hyper_1_15_chunk
 (15 rows)
 
+\set VERBOSITY terse
+DROP MATERIALIZED VIEW records_monthly;
+NOTICE:  drop cascades to 32 other objects
+DROP TABLE records;
+DROP TABLE clients;
+\set VERBOSITY default
+-- Test how caggs are afected by drop_chunk due to refresh on drop
+-- Demonstrates issue #2592
+CREATE OR REPLACE FUNCTION test_int_now() returns INT LANGUAGE SQL STABLE as 
+    $$ SELECT 125 $$;
+CREATE TABLE conditions(time_int INT NOT NULL, device INT, value FLOAT);
+SELECT create_hypertable('conditions', 'time_int', chunk_time_interval => 10);
+    create_hypertable    
+-------------------------
+ (3,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions
+SELECT time_val, time_val % 4, 3.14 FROM generate_series(0,100,1) AS time_val;
+SELECT set_integer_now_func('conditions', 'test_int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW conditions_7
+    WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE)
+    AS
+        SELECT time_bucket(7, time_int) as bucket,
+            SUM(value), COUNT(value)
+        FROM conditions GROUP BY bucket WITH DATA;
+NOTICE:  refreshing continuous aggregate "conditions_7"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+SELECT materialization_hypertable_schema||'.'||materialization_hypertable_name AS mat_hyper
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name = 'conditions_7' \gset
+CREATE VIEW see_cagg AS SELECT * FROM conditions_7 WHERE bucket < 70 ORDER BY bucket;
+--CREATE VIEW see_mat AS SELECT bucket, count(*) FROM :mat_hyper WHERE bucket < 70 
+--GROUP BY bucket ORDER BY bucket;
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 21.98 |     7
+      7 | 21.98 |     7
+     14 | 21.98 |     7
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 | 21.98 |     7
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+
+SELECT drop_chunks('conditions', 20);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_3_65_chunk
+ _timescaledb_internal._hyper_3_66_chunk
+(2 rows)
+
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 21.98 |     7
+      7 | 21.98 |     7
+     14 | 21.98 |     7
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 | 21.98 |     7
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+
+-- Now outliers will be present after this second drop_chunks
+SELECT drop_chunks('conditions', 40);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_3_67_chunk
+ _timescaledb_internal._hyper_3_68_chunk
+(2 rows)
+
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 21.98 |     7
+      7 | 21.98 |     7
+     14 |  3.14 |     1
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 | 21.98 |     7
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+
+SELECT drop_chunks('conditions', 60);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_3_69_chunk
+ _timescaledb_internal._hyper_3_70_chunk
+(2 rows)
+
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 21.98 |     7
+      7 | 21.98 |     7
+     14 |  3.14 |     1
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 |  6.28 |     2
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+

--- a/tsl/test/sql/continuous_aggs_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_drop_chunks.sql
@@ -87,12 +87,24 @@ CREATE VIEW see_cagg AS SELECT * FROM conditions_7 WHERE bucket < 70 ORDER BY bu
 
 SELECT * FROM see_cagg;
 
+-- This is the simplest case, when the updated bucket is inside chunk, so it is expected
+-- always reflected.
+UPDATE conditions SET value = 4.00 WHERE time_int = 2;
+
 SELECT drop_chunks('conditions', 20);
 SELECT * FROM see_cagg;
+
+-- This case is update in a bucket, which crosses two chunks, which exist and both is going
+-- to be dropped.
+UPDATE conditions SET value = 4.00 WHERE time_int = 31;
 
 -- Now outliers will be present after this second drop_chunks
 SELECT drop_chunks('conditions', 40);
 SELECT * FROM see_cagg;
+
+-- This update is in the bucket, which crosses two chunks, where one chunk was already dropped
+-- and empty, while the other will be dropped.
+UPDATE conditions SET value = 4.00 WHERE time_int = 41;
 
 SELECT drop_chunks('conditions', 60);
 SELECT * FROM see_cagg;


### PR DESCRIPTION
When drop_chunks is called on a hypertable, it will initiate refresh
in hypertable's continuous aggregates. The refresh will include all
buckets covering dropped chunks. If buckets are not aligned with
chunks, it results in outliers. This test demonstrates this. See #2592
for details.