### PR TITLE
Support analyze of internal compression table

### DIFF
--- a/src/compression_chunk_size.h
+++ b/src/compression_chunk_size.h
@@ -21,5 +21,6 @@ typedef struct TotalSizes
 } TotalSizes;
 
 extern TSDLLEXPORT TotalSizes ts_compression_chunk_size_totals(void);
+extern TSDLLEXPORT int64 ts_compression_chunk_size_row_count(int32 uncompressed_chunk_id);
 
 #endif

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -268,6 +268,12 @@ func_call_on_data_nodes_default(FunctionCallInfo finfo, List *data_node_oids)
 	pg_unreachable();
 }
 
+static void
+update_compressed_chunk_relstats_default(Oid uncompressed_relid, Oid compressed_relid)
+{
+	error_no_default_fn_community();
+}
+
 TS_FUNCTION_INFO_V1(ts_tsl_loaded);
 
 PGDLLEXPORT Datum
@@ -388,6 +394,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.chunk_get_relstats = error_no_default_fn_pg_community,
 	.chunk_get_colstats = error_no_default_fn_pg_community,
 	.hypertable_distributed_set_replication_factor = error_no_default_fn_pg_community,
+	.update_compressed_chunk_relstats = update_compressed_chunk_relstats_default,
 };
 
 TSDLLEXPORT CrossModuleFunctions *ts_cm_functions = &ts_cm_functions_default;

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -156,6 +156,7 @@ typedef struct CrossModuleFunctions
 	PGFunction chunk_get_relstats;
 	PGFunction chunk_get_colstats;
 	PGFunction hypertable_distributed_set_replication_factor;
+	void (*update_compressed_chunk_relstats)(Oid uncompressed_relid, Oid compressed_relid);
 } CrossModuleFunctions;
 
 extern TSDLLEXPORT CrossModuleFunctions *ts_cm_functions;

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -149,5 +149,6 @@ extern void decompress_chunk(Oid in_table, Oid out_table);
 
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(
 	CompressionAlgorithms algorithm, bool reverse))(Datum, Oid element_type);
+extern void update_compressed_chunk_relstats(Oid uncompressed_relid, Oid compressed_relid);
 
 #endif

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -182,6 +182,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.chunk_get_colstats = chunk_api_get_chunk_colstats,
 	.hypertable_distributed_set_replication_factor = hypertable_set_replication_factor,
 	.cache_syscache_invalidate = cache_syscache_invalidate,
+	.update_compressed_chunk_relstats = update_compressed_chunk_relstats,
 };
 
 TS_FUNCTION_INFO_V1(ts_module_init);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1281,6 +1281,17 @@ SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname =
  {0,250,500,750,1000,1250,1500,1750,2000,2250,2500,2750,3000,3250,3500,3750,4000,4250,4500,4750,5000,5250,5500,5750,6000,6250}
 (1 row)
 
+SELECT compch.table_name  as "STAT_COMP_CHUNK_NAME"
+FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch 
+       , _timescaledb_catalog.chunk compch 
+  WHERE ht.table_name = 'stattest' AND ch.hypertable_id = ht.id
+        AND compch.id = ch.compressed_chunk_id AND ch.compressed_chunk_id > 0  \gset
+SELECT relpages, reltuples FROM pg_class WHERE relname = :'STAT_COMP_CHUNK_NAME';
+ relpages | reltuples 
+----------+-----------
+        0 |         0
+(1 row)
+
 -- Now verify stats are not changed when we analyze the hypertable
 ANALYZE stattest;
 SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname = 'c1';
@@ -1299,6 +1310,13 @@ SELECT relpages, reltuples FROM pg_class WHERE relname = :statchunk;
  relpages | reltuples 
 ----------+-----------
         1 |        26
+(1 row)
+
+-- verify that corresponding compressed chunk's stats is updated as well.
+SELECT relpages, reltuples FROM pg_class WHERE relname = :'STAT_COMP_CHUNK_NAME';
+ relpages | reltuples 
+----------+-----------
+        1 |         1
 (1 row)
 
 -- Verify that even a global analyze doesn't affect the chunk stats, changing message scope here
@@ -1363,13 +1381,116 @@ SELECT reloptions FROM pg_class WHERE relname = :statchunk;
 (1 row)
 
 DROP TABLE stattest;
+--- Test that analyze on compression internal table updates stats on original chunks
+CREATE TABLE stattest2(time TIMESTAMPTZ NOT NULL, c1 int, c2 int);
+SELECT create_hypertable('stattest2', 'time', chunk_time_interval=>'1 day'::interval);
+    create_hypertable    
+-------------------------
+ (29,public,stattest2,t)
+(1 row)
+
+ALTER TABLE stattest2 SET (timescaledb.compress, timescaledb.compress_segmentby='c1');
+INSERT INTO stattest2 SELECT '2020/06/20 01:00'::TIMESTAMPTZ ,1 , generate_series(1, 200, 1);
+INSERT INTO stattest2 SELECT '2020/07/20 01:00'::TIMESTAMPTZ ,1 , generate_series(1, 200, 1);
+SELECT  compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
+FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht 
+WHERE ch1.hypertable_id = ht.id and ht.table_name like 'stattest2'
+ ORDER BY ch1.id limit 1;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_29_58_chunk
+(1 row)
+
+SELECT relname, reltuples, relpages, relallvisible FROM pg_class
+ WHERE relname in ( SELECT ch.table_name FROM 
+                   _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+  WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id )
+order by relname;
+      relname       | reltuples | relpages | relallvisible 
+--------------------+-----------+----------+---------------
+ _hyper_29_58_chunk |       200 |        2 |             0
+ _hyper_29_59_chunk |         0 |        0 |             0
+(2 rows)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+--overwrite pg_class stats for the compressed chunk.
+UPDATE pg_class
+SET reltuples = 0, relpages = 0
+ WHERE relname in ( SELECT ch.table_name FROM 
+    _timescaledb_catalog.chunk ch, 
+    _timescaledb_catalog.hypertable ht
+  WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id 
+        AND ch.compressed_chunk_id > 0 );
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+SELECT relname, reltuples, relpages, relallvisible FROM pg_class
+ WHERE relname in ( SELECT ch.table_name FROM 
+                   _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+  WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id )
+order by relname;
+      relname       | reltuples | relpages | relallvisible 
+--------------------+-----------+----------+---------------
+ _hyper_29_58_chunk |         0 |        0 |             0
+ _hyper_29_59_chunk |         0 |        0 |             0
+(2 rows)
+
+SELECT '_timescaledb_internal.' || compht.table_name as "STAT_COMP_TABLE",
+             compht.table_name  as "STAT_COMP_TABLE_NAME"
+FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.hypertable compht
+WHERE ht.table_name = 'stattest2' AND ht.compressed_hypertable_id = compht.id \gset
+--analyze the compressed table, will update stats for the raw table.
+ANALYZE :STAT_COMP_TABLE;
+SELECT relname, reltuples, relpages, relallvisible FROM pg_class
+ WHERE relname in ( SELECT ch.table_name FROM 
+                   _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+  WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id )
+ORDER BY relname;
+      relname       | reltuples | relpages | relallvisible 
+--------------------+-----------+----------+---------------
+ _hyper_29_58_chunk |       200 |        1 |             0
+ _hyper_29_59_chunk |         0 |        0 |             0
+(2 rows)
+
+SELECT relname, reltuples, relpages, relallvisible FROM pg_class
+ WHERE relname in ( SELECT ch.table_name FROM 
+                   _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+  WHERE ht.table_name = :'STAT_COMP_TABLE_NAME' AND ch.hypertable_id = ht.id )
+ORDER BY relname;
+          relname           | reltuples | relpages | relallvisible 
+----------------------------+-----------+----------+---------------
+ compress_hyper_30_60_chunk |         1 |        1 |             0
+(1 row)
+
+--analyze on stattest2 should not overwrite
+ANALYZE stattest2;
+SELECT relname, reltuples, relpages, relallvisible FROM pg_class
+ WHERE relname in ( SELECT ch.table_name FROM 
+                   _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+  WHERE ht.table_name = 'stattest2' AND ch.hypertable_id = ht.id )
+ORDER BY relname;
+      relname       | reltuples | relpages | relallvisible 
+--------------------+-----------+----------+---------------
+ _hyper_29_58_chunk |       200 |        1 |             0
+ _hyper_29_59_chunk |       200 |        2 |             0
+(2 rows)
+
+SELECT relname, reltuples, relpages, relallvisible FROM pg_class
+ WHERE relname in ( SELECT ch.table_name FROM 
+                   _timescaledb_catalog.chunk ch, _timescaledb_catalog.hypertable ht
+  WHERE ht.table_name = :'STAT_COMP_TABLE_NAME' AND ch.hypertable_id = ht.id )
+ORDER BY relname;
+          relname           | reltuples | relpages | relallvisible 
+----------------------------+-----------+----------+---------------
+ compress_hyper_30_60_chunk |         1 |        1 |             0
+(1 row)
+
+-- analyze on compressed hypertable should restore stats
 -- Test approximate_row_count() with compressed hypertable
 --
 CREATE TABLE approx_count(time timestamptz not null, device int, temp float);
 SELECT create_hypertable('approx_count', 'time');
      create_hypertable      
 ----------------------------
- (29,public,approx_count,t)
+ (31,public,approx_count,t)
 (1 row)
 
 INSERT INTO approx_count SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, random()*80


### PR DESCRIPTION
When an internal compression table is analyzed,
statistics from the compressed chunk (such as page count and
tuple count) is used to update the
statistics of the corresponding chunk parent.