### PR TITLE
Optimize internal cagg_watermark function

### DIFF
--- a/tsl/test/expected/continuous_aggs_union_view-11.out
+++ b/tsl/test/expected/continuous_aggs_union_view-11.out
@@ -906,7 +906,7 @@ ORDER BY 1,2;
 -------------------------------------
 -- Non-existing materialized hypertable
 SELECT _timescaledb_internal.cagg_watermark(100);
-ERROR:  100 is not a materialized hypertable
+ERROR:  invalid materialized hypertable ID: 100
 -- NULL hypertable ID. Function is STRICT, so does nothing:
 SELECT _timescaledb_internal.cagg_watermark(NULL);
  cagg_watermark 

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -909,7 +909,7 @@ ORDER BY 1,2;
 -------------------------------------
 -- Non-existing materialized hypertable
 SELECT _timescaledb_internal.cagg_watermark(100);
-ERROR:  100 is not a materialized hypertable
+ERROR:  invalid materialized hypertable ID: 100
 -- NULL hypertable ID. Function is STRICT, so does nothing:
 SELECT _timescaledb_internal.cagg_watermark(NULL);
  cagg_watermark 


### PR DESCRIPTION
The internal function `cagg_watermark` is often used as part of an
index scan condition and is therefore called on every row of such a
scan. Ideally, the planner should be able to reuse the result of
repeated calls of the same function since it is marked STABLE, but
this doesn't seem to be the case for C functions, making scans very
slow.

To deal with this, we cache the watermark value in the `fn_extra`
field of the function call info context. This avoids row-by-row max
value calculations, which otherwise makes things very slow.

The function could be optimized further by making the scan for the max
value faster (e.g., by doing an internal scan for max instead of
relying on SPI). However, by caching the max value, this is already
faster than the corresponding watermark function in 1.7.x.

Fixes #2602