### PR TITLE
Refresh correct partial during refresh on drop

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3231,7 +3231,7 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 			 * refresh. However, such merging needs to account for
 			 * multi-dimensional tables where some chunks have the same
 			 * primary dimension ranges. */
-			ts_cm_functions->continuous_agg_refresh_all(ht, start, end);
+			ts_cm_functions->continuous_agg_refresh_all(ht, start, end, chunks[i].fd.id);
 
 			/* Invalidate the dropped region to indicate that it was
 			 * modified. The invalidation will allow the refresh command on a

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -207,7 +207,14 @@ continuous_agg_update_options_default(ContinuousAgg *cagg, WithClauseResult *wit
 }
 
 static void
-continuous_agg_invalidate_or_refresh_all_default(const Hypertable *ht, int64 start, int64 end)
+continuous_agg_refresh_all_default(const Hypertable *ht, int64 start, int64 end, int32 chunk_id)
+{
+	error_no_default_fn_community();
+	pg_unreachable();
+}
+
+static void
+continuous_agg_invalidate_all_default(const Hypertable *ht, int64 start, int64 end)
 {
 	error_no_default_fn_community();
 	pg_unreachable();
@@ -322,8 +329,8 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.process_cagg_viewstmt = process_cagg_viewstmt_default,
 	.continuous_agg_invalidation_trigger = error_no_default_fn_pg_community,
 	.continuous_agg_refresh = error_no_default_fn_pg_community,
-	.continuous_agg_refresh_all = continuous_agg_invalidate_or_refresh_all_default,
-	.continuous_agg_invalidate = continuous_agg_invalidate_or_refresh_all_default,
+	.continuous_agg_refresh_all = continuous_agg_refresh_all_default,
+	.continuous_agg_invalidate = continuous_agg_invalidate_all_default,
 	.continuous_agg_update_options = continuous_agg_update_options_default,
 
 	/* compression */

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -87,7 +87,8 @@ typedef struct CrossModuleFunctions
 									   WithClauseResult *with_clause_options);
 	PGFunction continuous_agg_invalidation_trigger;
 	PGFunction continuous_agg_refresh;
-	void (*continuous_agg_refresh_all)(const Hypertable *ht, int64 start, int64 end);
+	void (*continuous_agg_refresh_all)(const Hypertable *ht, int64 start, int64 end,
+									   int32 chunk_id);
 	void (*continuous_agg_invalidate)(const Hypertable *ht, int64 start, int64 end);
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -40,7 +40,7 @@ void continuous_agg_update_materialization(SchemaAndName partial_view,
 										   SchemaAndName materialization_table,
 										   Name time_column_name,
 										   InternalTimeRange new_materialization_range,
-										   InternalTimeRange invalidation_range,
-										   int64 bucket_width);
+										   InternalTimeRange invalidation_range, int64 bucket_width,
+										   int32 chunk_id);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H */

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -15,6 +15,7 @@
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window, bool verbose);
-extern void continuous_agg_refresh_all(const Hypertable *ht, int64 start, int64 end);
+extern void continuous_agg_refresh_all(const Hypertable *ht, int64 start, int64 end,
+									   int32 chunk_id);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_REFRESH_H */

--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -139,3 +139,136 @@ SELECT drop_chunks('records', '2000-03-16'::timestamptz);
  _timescaledb_internal._hyper_1_15_chunk
 (15 rows)
 
+\set VERBOSITY terse
+DROP MATERIALIZED VIEW records_monthly;
+NOTICE:  drop cascades to 32 other objects
+DROP TABLE records;
+DROP TABLE clients;
+\set VERBOSITY default
+-- Test how caggs are affected by drop_chunk due to refresh on drop.
+-- Demonstrates fix of issue #2592.
+CREATE OR REPLACE FUNCTION test_int_now() returns INT LANGUAGE SQL STABLE as 
+    $$ SELECT 125 $$;
+CREATE TABLE conditions(time_int INT NOT NULL, device INT, value FLOAT);
+SELECT create_hypertable('conditions', 'time_int', chunk_time_interval => 10);
+    create_hypertable    
+-------------------------
+ (3,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions
+SELECT time_val, time_val % 4, 3.14 FROM generate_series(0,100,1) AS time_val;
+SELECT set_integer_now_func('conditions', 'test_int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW conditions_7
+    WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE)
+    AS
+        SELECT time_bucket(7, time_int) as bucket,
+            SUM(value), COUNT(value)
+        FROM conditions GROUP BY bucket WITH DATA;
+NOTICE:  refreshing continuous aggregate "conditions_7"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE VIEW see_cagg AS SELECT * FROM conditions_7 WHERE bucket < 70 ORDER BY bucket;
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 21.98 |     7
+      7 | 21.98 |     7
+     14 | 21.98 |     7
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 | 21.98 |     7
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+
+-- This is the simplest case, when the updated bucket is inside a chunk, so it is expected
+-- that the update is always reflected after the refresh on drop.
+UPDATE conditions SET value = 4.00 WHERE time_int = 2;
+-- This case updates values in the bucket, which affects two different partials in
+-- two different chunks, which are dropped in the same call to drop_chunks.
+UPDATE conditions SET value = 4.00 WHERE time_int = 9;
+UPDATE conditions SET value = 4.00 WHERE time_int = 11;
+SELECT drop_chunks('conditions', 20);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_3_65_chunk
+ _timescaledb_internal._hyper_3_66_chunk
+(2 rows)
+
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 22.84 |     7
+      7 |  23.7 |     7
+     14 | 21.98 |     7
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 | 21.98 |     7
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+
+-- This case is an update at the beginning of a bucket, which crosses two chunks. The update 
+-- is in the first chunk, which is going to be dropped, and the update will be present.
+UPDATE conditions SET value = 4.00 WHERE time_int = 39;
+-- This update is in the bucket, which crosses two chunks. The first chunk is going to be 
+-- dropped now and the update is outside it, and thus should not be reflected. The second 
+-- chunk contains the update and will be dropped on the next call, thus it should be reflected 
+-- in the continuous aggregate only after the last drop.
+UPDATE conditions SET value = 4.00 WHERE time_int = 41;
+-- After the call to drop_chunks the update in 39 will be refreshed and present in the cagg, 
+-- but not the update in 41.
+SELECT drop_chunks('conditions', 40);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_3_67_chunk
+ _timescaledb_internal._hyper_3_68_chunk
+(2 rows)
+
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 22.84 |     7
+      7 |  23.7 |     7
+     14 | 21.98 |     7
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 | 22.84 |     7
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+
+-- Now drop_chunks refreshes the update in 41.
+SELECT drop_chunks('conditions', 60);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_3_69_chunk
+ _timescaledb_internal._hyper_3_70_chunk
+(2 rows)
+
+SELECT * FROM see_cagg;
+ bucket |  sum  | count 
+--------+-------+-------
+      0 | 22.84 |     7
+      7 |  23.7 |     7
+     14 | 21.98 |     7
+     21 | 21.98 |     7
+     28 | 21.98 |     7
+     35 |  23.7 |     7
+     42 | 21.98 |     7
+     49 | 21.98 |     7
+     56 | 21.98 |     7
+     63 | 21.98 |     7
+(10 rows)
+

--- a/tsl/test/sql/continuous_aggs_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_drop_chunks.sql
@@ -51,3 +51,64 @@ CALL refresh_continuous_aggregate('records_monthly', NULL, NULL);
 
 \set VERBOSITY default
 SELECT drop_chunks('records', '2000-03-16'::timestamptz);
+
+\set VERBOSITY terse
+DROP MATERIALIZED VIEW records_monthly;
+DROP TABLE records;
+DROP TABLE clients;
+\set VERBOSITY default
+
+-- Test how caggs are affected by drop_chunk due to refresh on drop.
+-- Demonstrates fix of issue #2592.
+
+CREATE OR REPLACE FUNCTION test_int_now() returns INT LANGUAGE SQL STABLE as 
+    $$ SELECT 125 $$;
+
+CREATE TABLE conditions(time_int INT NOT NULL, device INT, value FLOAT);
+SELECT create_hypertable('conditions', 'time_int', chunk_time_interval => 10);
+
+INSERT INTO conditions
+SELECT time_val, time_val % 4, 3.14 FROM generate_series(0,100,1) AS time_val;
+
+SELECT set_integer_now_func('conditions', 'test_int_now');
+CREATE MATERIALIZED VIEW conditions_7
+    WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE)
+    AS
+        SELECT time_bucket(7, time_int) as bucket,
+            SUM(value), COUNT(value)
+        FROM conditions GROUP BY bucket WITH DATA;
+
+CREATE VIEW see_cagg AS SELECT * FROM conditions_7 WHERE bucket < 70 ORDER BY bucket;
+
+SELECT * FROM see_cagg;
+
+-- This is the simplest case, when the updated bucket is inside a chunk, so it is expected
+-- that the update is always reflected after the refresh on drop.
+UPDATE conditions SET value = 4.00 WHERE time_int = 2;
+
+-- This case updates values in the bucket, which affects two different partials in
+-- two different chunks, which are dropped in the same call to drop_chunks.
+UPDATE conditions SET value = 4.00 WHERE time_int = 9;
+UPDATE conditions SET value = 4.00 WHERE time_int = 11;
+
+SELECT drop_chunks('conditions', 20);
+SELECT * FROM see_cagg;
+
+-- This case is an update at the beginning of a bucket, which crosses two chunks. The update 
+-- is in the first chunk, which is going to be dropped, and the update will be present.
+UPDATE conditions SET value = 4.00 WHERE time_int = 39;
+
+-- This update is in the bucket, which crosses two chunks. The first chunk is going to be 
+-- dropped now and the update is outside it, and thus should not be reflected. The second 
+-- chunk contains the update and will be dropped on the next call, thus it should be reflected 
+-- in the continuous aggregate only after the last drop.
+UPDATE conditions SET value = 4.00 WHERE time_int = 41;
+
+-- After the call to drop_chunks the update in 39 will be refreshed and present in the cagg, 
+-- but not the update in 41.
+SELECT drop_chunks('conditions', 40);
+SELECT * FROM see_cagg;
+
+-- Now drop_chunks refreshes the update in 41.
+SELECT drop_chunks('conditions', 60);
+SELECT * FROM see_cagg;


### PR DESCRIPTION
When drop_chunks is called on a hypertable manually or through
a retention policy, it initiates refresh in hypertable's continuous
aggregates. The refresh includes all buckets of each dropped chunk.
Some buckets are inside a dropped chunk only partially. In such case,
this commit fixes to refresh only the correct partials of the buckets.

The fix passes chunk id to refresh on drop of a chunk. The chunk id is
used to identify and update correct partials. This is a workaround
that the invalidation outside of the refreshed chunk doesn't update
the other partial, which is outside the refreshed chunk.

The commit also adds the test demonstrating correct refresh.

Fixes #2592