### PR TITLE
Fix validation of available extensions on data node

### DIFF
--- a/tsl/src/dist_util.c
+++ b/tsl/src/dist_util.c
@@ -340,6 +340,7 @@ dist_util_is_compatible_version(const char *data_node_version, const char *acces
 	unsigned int access_node_major, access_node_minor, access_node_patch;
 
 	Assert(is_old_version);
+	Assert(data_node_version);
 
 	if (sscanf(data_node_version,
 			   "%u.%u.%u",


### PR DESCRIPTION
We want to check all available extension versions
and not just the installed one. This is because we
might be setting up a cluster for a database that
has different extension version then the `postgres` or
`template1` database which  we actually use to perform
this validation.
So instead of using `pg_available_extensions` view we
use `pg_available_extension_versions` that should return
the same list of extension versions no matter which database
we connect to.