### PR TITLE
Fix DROP CASCADE for continuous aggregate

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1278,9 +1278,6 @@ process_drop_continuous_aggregates(ProcessUtilityArgs *args, DropStmt *stmt)
 	ListCell *lc;
 	int caggs_count = 0;
 
-	if (stmt->behavior == DROP_CASCADE)
-		return;
-
 	foreach (lc, stmt->objects)
 	{
 		List *const object = lfirst(lc);
@@ -1289,16 +1286,6 @@ process_drop_continuous_aggregates(ProcessUtilityArgs *args, DropStmt *stmt)
 
 		if (cagg)
 		{
-			/* Add the materialization table to the arguments so that the
-			 * continuous aggregate and associated materialization table is
-			 * dropped together.
-			 *
-			 * If the table is missing, something is wrong, but we proceed
-			 * with dropping the view anyway since the user cannot get rid of
-			 * the broken view if we generate an error. */
-			Hypertable *ht = ts_hypertable_get_by_id(cagg->data.mat_hypertable_id);
-			if (ht)
-				process_add_hypertable(args, ht);
 			/* If there is at least one cagg, the drop should be treated as a
 			 * DROP VIEW. */
 			stmt->removeType = OBJECT_VIEW;

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -1110,5 +1110,67 @@ partial_view_owner | test_role_1
 tablespace         | 
 
 \x off
+--
+-- Test drop continuous aggregate cases
+--
+-- Issue: #2608
+--
+CREATE OR REPLACE FUNCTION test_int_now()
+  RETURNS INT LANGUAGE SQL STABLE AS
+$BODY$
+  SELECT 50;
+$BODY$;
+CREATE TABLE conditionsnm(time_int INT NOT NULL, device INT, value FLOAT);
+SELECT create_hypertable('conditionsnm', 'time_int', chunk_time_interval => 10);
+     create_hypertable      
+----------------------------
+ (25,public,conditionsnm,t)
+(1 row)
+
+SELECT set_integer_now_func('conditionsnm', 'test_int_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO conditionsnm
+SELECT time_val, time_val % 4, 3.14 FROM generate_series(0,100,1) AS time_val;
+-- Case 1: DROP
+CREATE MATERIALIZED VIEW conditionsnm_4
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE)
+AS
+SELECT time_bucket(7, time_int) as bucket,
+SUM(value), COUNT(value)
+FROM conditionsnm GROUP BY bucket WITH DATA;
+NOTICE:  refreshing continuous aggregate "conditionsnm_4"
+DROP materialized view conditionsnm_4;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_26_37_chunk
+-- Case 2: DROP CASCADE should have similar behaviour as DROP
+CREATE MATERIALIZED VIEW conditionsnm_4
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE)
+AS
+SELECT time_bucket(7, time_int) as bucket,
+SUM(value), COUNT(value)
+FROM conditionsnm GROUP BY bucket WITH DATA;
+NOTICE:  refreshing continuous aggregate "conditionsnm_4"
+DROP materialized view conditionsnm_4 CASCADE;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_38_chunk
+-- Case 3: require CASCADE in case of dependent object
+CREATE MATERIALIZED VIEW conditionsnm_4
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE)
+AS
+SELECT time_bucket(7, time_int) as bucket,
+SUM(value), COUNT(value)
+FROM conditionsnm GROUP BY bucket WITH DATA;
+NOTICE:  refreshing continuous aggregate "conditionsnm_4"
+CREATE VIEW see_cagg as select * from conditionsnm_4;
+\set ON_ERROR_STOP 0
+DROP MATERIALIZED VIEW conditionsnm_4;
+ERROR:  cannot drop view conditionsnm_4 because other objects depend on it
+\set ON_ERROR_STOP 1
+-- Case 4: DROP CASCADE with dependency
+DROP MATERIALIZED VIEW conditionsnm_4 CASCADE;
+NOTICE:  drop cascades to view see_cagg
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_39_chunk
 DROP TABLESPACE tablespace1;
 DROP TABLESPACE tablespace2;


### PR DESCRIPTION
Currently we treat cagg materialized view as a view internally, but that was missed in case of the drop cascade.

Issue: #2608