### PR TITLE
Improve error when converting time arguments

### DIFF
--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -85,7 +85,7 @@ ts_time_datum_convert_arg(Datum arg, Oid *argtype, Oid timetype)
  * Get the internal time value from a pseudo-type function argument.
  *
  * API functions that take supported time types as arguments often use a
- * pseudo-type paremeter to represent these. For instance, the "any"
+ * pseudo-type parameter to represent these. For instance, the "any"
  * pseudo-type is often used to represent any of these supported types.
  *
  * The downside of "any", however, is that it lacks type information and often
@@ -133,9 +133,8 @@ ts_time_value_from_arg(Datum arg, Oid argtype, Oid timetype)
 	else if (argtype != timetype && !can_coerce_type(1, &argtype, &timetype, COERCION_IMPLICIT))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("invalid type of time argument"),
-				 errhint("The argument type should be compatible with type \"%s\".",
-						 format_type_be(timetype))));
+				 errmsg("invalid time argument type \"%s\"", format_type_be(argtype)),
+				 errhint("Try casting the argument to \"%s\".", format_type_be(timetype))));
 
 	return ts_time_value_to_internal(arg, argtype);
 }

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -195,9 +195,9 @@ ERROR:  invalid time range for dropping chunks
 DROP VIEW dependent_view;
 -- should error because wrong time type
 SELECT drop_chunks('drop_chunk_test1', older_than => now());
-ERROR:  invalid type of time argument
+ERROR:  invalid time argument type "timestamp with time zone"
 SELECT show_chunks('drop_chunk_test3', now());
-ERROR:  invalid type of time argument
+ERROR:  invalid time argument type "timestamp with time zone"
 -- should error because of wrong relative order of time constraints
 SELECT show_chunks('drop_chunk_test1', older_than=>3, newer_than=>4);
 ERROR:  invalid time range
@@ -987,7 +987,7 @@ ERROR:  function drop_chunks(interval) does not exist at character 8
 SELECT drop_chunks('drop_chunk_test3', interval '1 minute');
 ERROR:  can only use an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
 SELECT drop_chunks('drop_chunk_test_ts', (now()-interval '1 minute'));
-ERROR:  invalid type of time argument
+ERROR:  invalid time argument type "timestamp with time zone"
 SELECT drop_chunks('drop_chunk_test3', verbose => true);
 ERROR:  invalid time range for dropping chunks
 \set ON_ERROR_STOP 1

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -179,9 +179,9 @@ CALL refresh_continuous_aggregate('daily_temp', '2020-05-03', '2020-05-01');
 ERROR:  invalid refresh window
 -- Bad time input
 CALL refresh_continuous_aggregate('daily_temp', '2020-05-01'::text, '2020-05-03'::text);
-ERROR:  invalid type of time argument
+ERROR:  invalid time argument type "text"
 CALL refresh_continuous_aggregate('daily_temp', 0, '2020-05-01');
-ERROR:  invalid type of time argument
+ERROR:  invalid time argument type "integer"
 \set ON_ERROR_STOP 1
 -- Test different time types
 CREATE TABLE conditions_date (time date NOT NULL, device int, temp float);


### PR DESCRIPTION
API functions that take "any" type to support any supported time
argument type sometimes do implicit conversion to the "right" type
when a type coercion path exists. This change improves the error
message when such a path does not exist.

Closes #2614